### PR TITLE
fix: handle delete account

### DIFF
--- a/src/pages/dashboard/settings/Account.vue
+++ b/src/pages/dashboard/settings/Account.vue
@@ -132,13 +132,13 @@ async function deleteAccount() {
         handler: async () => {
           if (!main.auth || main.auth?.email == null)
             return
-          const { error } = await supabase
-            .from('deleted_account')
-            .insert({
-              email: main.auth.email,
-            })
-          if (error) {
-            console.error(error)
+          const { error: userDeleteError } = await supabase
+            .from('users')
+            .delete()
+            .eq('id', main.auth.id)
+
+          if (userDeleteError) {
+            console.error(userDeleteError)
             setErrors('update-account', [t('something-went-wrong-try-again-later')], {})
           }
           else {

--- a/supabase/migrations/20230815171919_base.sql
+++ b/supabase/migrations/20230815171919_base.sql
@@ -865,7 +865,7 @@ Begin
   SELECT count(*)
   INTO is_found
   FROM (SELECT PGP_SYM_DECRYPT(email::bytea, 'bf') as email from deleted_account) as decrypted
-  WHERE email=email_check;
+  WHERE decrypted.email=email_check;
   RETURN is_found = 0;
 End; 
 $$;


### PR DESCRIPTION
- created a trigger upon user delete.
- The above trigger is responsible for creating a hash of email and storing into deleted_account table
- updated account.vue to actually delete the user

/claim #278 