### PR TITLE
S3 self hosted

### DIFF
--- a/supabase/functions/_utils/r2.ts
+++ b/supabase/functions/_utils/r2.ts
@@ -11,7 +11,7 @@ const storageUseSsl = getEnv('S3_SSL').toLocaleLowerCase() === 'true' ?? false
 const bucket = 'capgo'
 
 function initR2() {
-  const data = {
+  const params = {
     endPoint: accountid ? `${accountid}.r2.cloudflarestorage.com` : storageEndpoint,
     region: storageRegion ?? 'us-east-1',
     useSSL: storageUseSsl,
@@ -20,8 +20,8 @@ function initR2() {
     accessKey: access_key_id,
     secretKey: access_key_secret,
   }
-  console.log(`SETUP DATA: ${JSON.stringify(data)}`)
-  return new S3Client(data)
+
+  return new S3Client(params)
 }
 
 function upload(fileId: string, file: Uint8Array) {
@@ -52,9 +52,6 @@ function getSignedUrl(fileId: string, expirySeconds: number) {
 async function getSizeChecksum(fileId: string) {
   const client = initR2()
   const { size, metadata } = await client.statObject(fileId)
-  console.log('meta')
-  console.log(size)
-  console.log(metadata)
   const checksum = metadata['x-amz-meta-crc32']
   return { size, checksum }
 }

--- a/supabase/functions/_utils/r2.ts
+++ b/supabase/functions/_utils/r2.ts
@@ -7,7 +7,7 @@ const access_key_secret = getEnv('R2_SECRET_ACCESS_KEY')
 const storageEndpoint = getEnv('S3_ENDPOINT')
 const storageRegion = getEnv('S3_REGION')
 const storagePort = parseInt(getEnv('S3_PORT'))
-const storageUseSsl = getEnv('S3_SSL').toLocaleLowerCase() === 'true' ?? false
+const storageUseSsl = getEnv('S3_SSL').toLocaleLowerCase() === 'true'
 const bucket = 'capgo'
 
 function initR2() {


### PR DESCRIPTION
This PR adds the functionality required to self host S3.

This is required to solve [this](https://github.com/Cap-go/website/issues/110)

Note: By default anything other then R3 or S3 (as far as I know) is not really supported due to the way how files are uploaded from the CLI. If we want to support [minio](min.io) we need to change the CLI