### PR TITLE
Add native_files_sha256 into schema

### DIFF
--- a/supabase/migrations/20230815171919_base.sql
+++ b/supabase/migrations/20230815171919_base.sql
@@ -982,6 +982,7 @@ CREATE TABLE "public"."app_versions" (
     "checksum" character varying,
     "session_key" character varying,
     "storage_provider" "text" DEFAULT 'r2'::"text" NOT NULL
+    "native_files_sha256" array NULL,
 );
 
 


### PR DESCRIPTION
This is required to make [this cli PR](https://github.com/Cap-go/CLI/pull/126#issuecomment-1689879391) work