### PR TITLE
Fix CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           version: 1.68.6 
 
       - name: Run Supabase Start
-        run: ENV=local supabase start -x studio,imgproxy,inbucket,storage-api,logflare --ignore-health-check
+        run: ENV=local supabase start -x studio,imgproxy,inbucket,logflare --ignore-health-check
       - name: Configure frontend env
         run: cp .env.exemple .env
 


### PR DESCRIPTION
This PR fixes CI/CD by running `storage-api`. Before CI/CD failed because `seed.sql` tried to add data into some bucket and supabase bucket functionality was disabled in CI/CD