### PR TITLE
Fix Pipeline is empty exception

### DIFF
--- a/supabase/functions/_utils/redis.ts
+++ b/supabase/functions/_utils/redis.ts
@@ -1,4 +1,4 @@
-import type { Redis, RedisPipeline } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
+import type { Integer, Redis, RedisPipeline } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
 import { Redis as RedisUpstash } from 'https://deno.land/x/upstash_redis/mod.ts'
 import { connect, parseURL } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
 import type { Pipeline as UpstashPipeline } from 'https://deno.land/x/upstash_redis@v1.22.0/pkg/pipeline.ts'
@@ -42,18 +42,23 @@ class RedisRedisPipeline implements RedisPipelineInterface {
 }
 
 class RedisUpstashPipeline implements RedisPipelineInterface {
+  size: Integer
   pipeline: UpstashPipeline<[]>
 
   constructor(pipeline: UpstashPipeline<[]>) {
     this.pipeline = pipeline
+    this.size = 0
   }
 
   async hdel(key: string, ...fields: string[]): Promise<number> {
     await this.pipeline.hdel(key, ...fields)
+    this.size++
     return 0
   }
 
   async flush(): Promise<void> {
+    if (this.size === 0)
+      return
     await this.pipeline.exec()
   }
 
@@ -61,6 +66,7 @@ class RedisUpstashPipeline implements RedisPipelineInterface {
     const object: { [field: string]: RedisValue } = {}
     object[field] = value
     await this.pipeline.hset(key, object)
+    this.size++
   }
 }
 

--- a/supabase/functions/_utils/redis.ts
+++ b/supabase/functions/_utils/redis.ts
@@ -1,4 +1,4 @@
-import type { Integer, Redis, RedisPipeline } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
+import type { Redis, RedisPipeline } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
 import { Redis as RedisUpstash } from 'https://deno.land/x/upstash_redis/mod.ts'
 import { connect, parseURL } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
 import type { Pipeline as UpstashPipeline } from 'https://deno.land/x/upstash_redis@v1.22.0/pkg/pipeline.ts'
@@ -42,7 +42,7 @@ class RedisRedisPipeline implements RedisPipelineInterface {
 }
 
 class RedisUpstashPipeline implements RedisPipelineInterface {
-  size: Integer
+  size: number
   pipeline: UpstashPipeline<[]>
 
   constructor(pipeline: UpstashPipeline<[]>) {


### PR DESCRIPTION
Sometimes when device was overwritten redis caching would fail with the following exception
```
[Error] Error: Pipeline is empty
    at Pipeline.exec (https://deno.land/x/upstash_redis@v1.22.0/pkg/pipeline.ts:67:19)
    at RedisUpstashPipeline.flush (file:///home/deno/functions/_utils/redis.ts:29:29)
    at main (file:///home/deno/functions/updates/index.ts:93:14)
    at async Server.#respond (https://deno.land/std@0.200.0/http/server.ts:222:24)
```

This PR makes sure that if  pipeline is empty the `pipeline#exec` function is not called.
I tested my changes, and they resolve this exception