### PR TITLE
Update chatgpt-review.yml

### DIFF
--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           submodules: false
 
-      - uses: unsafecoerce/chatgpt-action@main
+      - uses: coderabbitai/ai-pr-reviewer@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -29,13 +29,7 @@ jobs:
           debug: false
           action: review
           path_filters: '**/*'
+          review_simple_changes: false
           review_comment_lgtm: false
-
-      - uses: unsafecoerce/chatgpt-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        with:
-          debug: false
-          action: score
-          path_filters: '**/*'
+          openai_heavy_model: 'gpt-4'
+          openai_light_model: 'gpt-3.5-turbo'


### PR DESCRIPTION
This PR switches the current GPT review action with [coderabbitai/ai-pr-reviewer](https://github.com/coderabbitai/ai-pr-reviewer), which serves as a drop-in replacement. This new action is actively maintained and comes with lots of  improvements:
- Uses GPT-4 for code review
- uses GPT-3.5 for summarizing diffs.