### PR TITLE
add resend email + auto translate

### DIFF
--- a/locales/README.md
+++ b/locales/README.md
@@ -5,3 +5,24 @@ This directory is to serve your locale translation files. YAML under this folder
 Check out [`vue-i18n`](https://github.com/intlify/vue-i18n-next) for more details.
 
 If you are using VS Code, [`i18n Ally`](https://github.com/lokalise/i18n-ally) is recommended to make the i18n experience better.
+
+
+## Generating Translations
+
+To generate translations, follow these steps:
+
+1. Add your English text to be translated in `translate-data.json` file.
+2. If you haven't installed TSX, install it by running 
+```bash
+ npm install -g tsx
+ ```
+3. Run the `translate.ts` script by using the command 
+```bash
+OPENAI_API_KEY=MY_OPENAI_KY tsx translate.ts
+```
+
+This script uses OpenAI to translate the text from English to the target language.
+
+The translated text will be saved in the respective `.yml` file for each locale.
+
+Please ensure you have the OpenAI API key set in your environment variables.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -348,3 +348,9 @@ your-api-key: 'Ihr API-Schlüssel:'
 your-are-a: Dein Gebiet
 your-current-plan-is: Ihr aktueller Plan ist
 your-current-suggested-plan-is: Ihr aktuell vorgeschlagener Plan ist
+resend-email: Bestätigungs-E-Mail erneut senden
+confirm-email-sent: >-
+  Eine Bestätigungs-E-Mail wurde gesendet. Klicken Sie auf den Link, um Ihre
+  E-Mail zu bestätigen.
+did-not-recive-confirm-email: Haben Sie die Bestätigungs-E-Mail nicht erhalten?
+resend: Erneut senden

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -149,6 +149,10 @@ dont-have-an-account: Don’t have an account?
 download: Download
 email: Email
 email-address: Email address
+resend-email: Resend Confirmation Email
+confirm-email-sent: A confirmation email was sent click to link to confirm your email
+did-not-recive-confirm-email: Didn't receive confirmation email?
+resend: Resend
 enabled-ab-testing: Enabled AB testing
 enabled-progressive-deploy: Enabled progressive deploy
 encrypted: Encrypted bundles

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -346,3 +346,9 @@ your-api-key: 'Su clave API:'
 your-are-a: Tu area
 your-current-plan-is: Su plan actual es
 your-current-suggested-plan-is: Su plan sugerido actual es
+resend-email: Reenviar Correo Electrónico de Confirmación
+confirm-email-sent: >-
+  Se envió un correo electrónico de confirmación, haz clic en el enlace para
+  confirmar tu correo electrónico.
+did-not-recive-confirm-email: ¿No recibiste el correo electrónico de confirmación?
+resend: Reenviar

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -342,3 +342,9 @@ your-api-key: "Votre clé API\_:"
 your-are-a: Vous êtes un
 your-current-plan-is: Votre plan actuel est
 your-current-suggested-plan-is: Votre plan suggéré est
+resend-email: Renvoyer l'email de confirmation
+confirm-email-sent: >-
+  Un email de confirmation a été envoyé, cliquez sur le lien pour confirmer
+  votre email.
+did-not-recive-confirm-email: Vous n'avez pas reçu d'email de confirmation?
+resend: Renvoyer

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -340,3 +340,9 @@ your-api-key: 'Kunci API Anda:'
 your-are-a: Anda adalah
 your-current-plan-is: Rencana Anda saat ini adalah
 your-current-suggested-plan-is: Rencana yang Anda sarankan saat ini adalah
+resend-email: Kirim Ulang Email Konfirmasi
+confirm-email-sent: >-
+  Sebuah email konfirmasi telah dikirim, klik tautan untuk mengkonfirmasi email
+  Anda
+did-not-recive-confirm-email: Tidak menerima email konfirmasi?
+resend: Kirim ulang

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -340,3 +340,11 @@ your-api-key: 'La tua chiave API:'
 your-are-a: Sei un
 your-current-plan-is: Il tuo piano attuale è
 your-current-suggested-plan-is: Il tuo attuale piano suggerito è
+resend-email: Reenviar correo electrónico de confirmación
+confirm-email-sent: >-
+  Se envió un correo electrónico de confirmación, haz clic en el enlace para
+  confirmar tu correo electrónico.
+did-not-recive-confirm-email: ¿No recibiste el correo electrónico de confirmación?
+resend: >-
+  I am sorry, but it seems like you've missed mentioning the language you want
+  me to translate "Resend" into. Could you please clarify?

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -330,3 +330,7 @@ your-api-key: 'API キー:'
 your-are-a: あなたは
 your-current-plan-is: 現在のプランは
 your-current-suggested-plan-is: 現在お勧めのプランは
+resend-email: 確認メールを再送してください
+confirm-email-sent: 確認メールが送信されました。リンクをクリックしてメールアドレスを確認してください。
+did-not-recive-confirm-email: 確認メールが届きませんでしたか？
+resend: 再送信してください

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -330,3 +330,7 @@ your-api-key: '귀하의 API 키:'
 your-are-a: 당신은
 your-current-plan-is: 현재 계획은
 your-current-suggested-plan-is: 현재 제안된 계획은 다음과 같습니다.
+resend-email: 확인 이메일 재전송
+confirm-email-sent: 확인 이메일이 전송되었습니다. 이메일을 확인하려면 링크를 클릭하세요.
+did-not-recive-confirm-email: 확인 이메일을 받지 못하셨나요?
+resend: 재전송

--- a/locales/package.json
+++ b/locales/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "locales",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "translate.js",
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "openai": "^4.12.3"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.7"
+  }
+}

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -353,3 +353,9 @@ your-api-key: 'Twój klucz API:'
 your-are-a: Twoja okolica
 your-current-plan-is: Twój obecny plan to
 your-current-suggested-plan-is: Twój aktualny sugerowany plan to
+resend-email: Wyślij ponownie email z potwierdzeniem
+confirm-email-sent: >-
+  Wysłano email z potwierdzeniem, kliknij link, aby potwierdzić swój adres
+  email.
+did-not-recive-confirm-email: ¿No recibiste el correo electrónico de confirmación?
+resend: Ponownie wyślij

--- a/locales/pnpm-lock.yaml
+++ b/locales/pnpm-lock.yaml
@@ -1,0 +1,214 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  js-yaml:
+    specifier: ^4.1.0
+    version: 4.1.0
+  openai:
+    specifier: ^4.12.3
+    version: 4.12.3
+
+devDependencies:
+  '@types/js-yaml':
+    specifier: ^4.0.7
+    version: 4.0.7
+
+packages:
+
+  /@types/js-yaml@4.0.7:
+    resolution: {integrity: sha512-RJZP9WAMMr1514KbdSXkLRrKvYQacjr1+HWnY8pui/uBTBoSgD9ZGR17u/d4nb9NpERp0FkdLBe7hq8NIPBgkg==}
+    dev: true
+
+  /@types/node-fetch@2.6.6:
+    resolution: {integrity: sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==}
+    dependencies:
+      '@types/node': 18.18.5
+      form-data: 4.0.0
+    dev: false
+
+  /@types/node@18.18.5:
+    resolution: {integrity: sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==}
+    dev: false
+
+  /abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: false
+
+  /agentkeepalive@4.5.0:
+    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      humanize-ms: 1.2.1
+    dev: false
+
+  /argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: false
+
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
+  /base-64@0.1.0:
+    resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
+    dev: false
+
+  /charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+    dev: false
+
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
+  /crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+    dev: false
+
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /digest-fetch@1.3.0:
+    resolution: {integrity: sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==}
+    dependencies:
+      base-64: 0.1.0
+      md5: 2.3.0
+    dev: false
+
+  /event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+    dev: false
+
+  /form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
+  /formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+    dev: false
+
+  /humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    dependencies:
+      ms: 2.1.3
+    dev: false
+
+  /is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+    dev: false
+
+  /js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+    dev: false
+
+  /md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+    dev: false
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
+
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /openai@4.12.3:
+    resolution: {integrity: sha512-Kw8M8qioKg+iw2tCpdJ1G772uV0tk4SRF1MtySYSPr82YH+Csl61kYv2KzKAOqINcOVn5eSN26t0ImIsdJexfw==}
+    hasBin: true
+    dependencies:
+      '@types/node': 18.18.5
+      '@types/node-fetch': 2.6.6
+      abort-controller: 3.0.0
+      agentkeepalive: 4.5.0
+      digest-fetch: 1.3.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+      web-streams-polyfill: 3.2.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
+  /web-streams-polyfill@3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+    dev: false
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -336,3 +336,7 @@ your-api-key: 'Sua chave de API:'
 your-are-a: Sua área
 your-current-plan-is: Seu plano atual é
 your-current-suggested-plan-is: Seu plano sugerido atual é
+resend-email: Reenviar Email de Confirmação
+confirm-email-sent: Um email de confirmação foi enviado, clique no link para confirmar seu email.
+did-not-recive-confirm-email: Não recebeu o email de confirmação?
+resend: Reenviar

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -338,3 +338,9 @@ your-api-key: 'Ваш ключ API:'
 your-are-a: Вы
 your-current-plan-is: Ваш текущий план
 your-current-suggested-plan-is: 'Ваш текущий предлагаемый план:'
+resend-email: Отправить письмо подтверждения еще раз
+confirm-email-sent: >-
+  Подтверждающее письмо было отправлено, нажмите на ссылку, чтобы подтвердить
+  свой электронный адрес.
+did-not-recive-confirm-email: Не получили подтверждающее письмо?
+resend: Повторно отправить

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -338,3 +338,7 @@ your-api-key: 'API anahtarınız:'
 your-are-a: Senin alanın
 your-current-plan-is: Mevcut planınız
 your-current-suggested-plan-is: 'Mevcut önerilen planınız:'
+resend-email: Yeniden Onay E-postası Gönder
+confirm-email-sent: Onaylama e-postası gönderildi, e-postanızı onaylamak için linke tıklayın.
+did-not-recive-confirm-email: Onay e-postası almadınız mı?
+resend: Tekrar gönder

--- a/locales/translate-data.json
+++ b/locales/translate-data.json
@@ -1,0 +1,3 @@
+{
+    "translation-key": "Value"
+}

--- a/locales/translate.ts
+++ b/locales/translate.ts
@@ -1,0 +1,61 @@
+import * as fs from 'node:fs'
+import { basename, dirname, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as yaml from 'js-yaml'
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+  // eslint-disable-next-line n/prefer-global/process
+  apiKey: process.env.OPENAI_API_KEY,
+})
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+async function translateText(text: string, targetLanguage: string) {
+  const chatCompletion = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages: [
+      {
+        role: 'system',
+        content: `You are a helpful assistant that translates text. translate the following text from English to ${targetLanguage}`,
+      },
+      { role: 'user', content: text },
+    ],
+  })
+  return chatCompletion.choices[0].message.content
+}
+
+const supported_locales: string[] = []
+
+fs.readdirSync(__dirname).forEach((file) => {
+  if (extname(file) === '.yml' && !file.includes('en'))
+    supported_locales.push(basename(file, '.yml'))
+})
+
+async function translateAndSaveLocales() {
+  const text = JSON.parse(
+    fs.readFileSync(`${__dirname}/translate-data.json`, 'utf8'),
+  ) as Record<string, string>
+
+  for (const locale of supported_locales) {
+    console.log(`Translating ${locale}`)
+
+    const localeFile = `${__dirname}/${locale}.yml`
+    if (!fs.existsSync(localeFile))
+      return
+
+    const localeData = yaml.load(fs.readFileSync(localeFile, 'utf8')) as Record<string, string>
+
+    for (const key in text) {
+      const translatedText = await translateText(text[key], locale)
+      localeData[key] = translatedText!
+    }
+
+    fs.writeFileSync(localeFile, yaml.dump(localeData))
+  }
+}
+
+translateAndSaveLocales().then(() => {
+  console.log('Successfully translated to all locales')
+}).catch(console.error)

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -340,3 +340,7 @@ your-api-key: 'Khóa API của bạn:'
 your-are-a: bạn là một
 your-current-plan-is: Kế hoạch hiện tại của bạn là
 your-current-suggested-plan-is: Gói đề xuất hiện tại của bạn là
+resend-email: Gửi lại email xác nhận
+confirm-email-sent: Đã gửi một email xác nhận, hãy nhấp vào liên kết để xác nhận email của bạn
+did-not-recive-confirm-email: Không nhận được email xác nhận?
+resend: Gửi lại

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -330,3 +330,7 @@ your-api-key: 您的 API 密钥：
 your-are-a: 你是一个
 your-current-plan-is: 你目前的计划是
 your-current-suggested-plan-is: 您目前建议的计划是
+resend-email: 重新发送确认邮件
+confirm-email-sent: 已发送确认邮件，请点击链接确认您的电子邮件。
+did-not-recive-confirm-email: 没有收到确认邮件吗？
+resend: 重新发送

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -175,6 +175,14 @@ onMounted(checkLogin)
                       {{ t('create-a-free-accoun') }}
                     </router-link>
                   </p>
+                  <p class="text-base text-gray-600">
+                    {{ t('did-not-recive-confirm-email') }} <br> <router-link
+                      to="/resend_email"
+                      class="font-medium text-orange-500 transition-all duration-200 hover:text-orange-600 hover:underline"
+                    >
+                      {{ t('resend') }}
+                    </router-link>
+                  </p>
                   <p class="pt-2 text-gray-300">
                     {{ version }}
                   </p>

--- a/src/pages/onboarding/confirm_email.vue
+++ b/src/pages/onboarding/confirm_email.vue
@@ -1,7 +1,26 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { useSupabase } from '~/services/supabase'
 
 const { t } = useI18n()
+const route = useRoute()
+const supabase = useSupabase()
+
+const email = route.query.email
+
+async function resendEmail() {
+  const { error } = await supabase.auth.resend({
+    type: 'signup',
+    email,
+  })
+  if (error)
+    toast.error(error.message)
+
+  else
+    toast.success(t('confirm-email-sent'))
+}
 </script>
 
 <template>
@@ -19,6 +38,18 @@ const { t } = useI18n()
             <p class="mt-3 text-sm font-medium text-gray-500">
               {{ t('check-email') }}
             </p>
+            <div class="flex gap-2 justify-center">
+              <p class="text-sm font-medium text-gray-500">
+                {{ t('did-not-recive-confirm-email') }}
+              </p>
+              <p
+                to="/resend_email"
+                class="text-sm font-medium text-blue-600 transition-all duration-200 hover:text-blue-500 hover:underline cursor-pointer"
+                @click="resendEmail"
+              >
+                {{ t('resend') }}
+              </p>
+            </div>
             <div class="mt-8">
               <span
                 class="inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-semibold leading-5 text-blue-600 transition-all duration-200"

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -60,12 +60,12 @@ async function submit(form: { first_name: string; last_name: string; password: s
     setErrors('register-account', [error?.message || 'user not found'], {})
     return
   }
-  router.push('/onboarding/confirm_email')
+  router.push(`/onboarding/confirm_email?email=${form.email}`)
 }
 </script>
 
 <template>
-  <script async src="https://reflio.com/js/reflio.min.js" data-reflio="hi8q6z93wyt147h" data-domain="https://capgo.app,https://web.capgo.app" />
+  <!-- <script async src="https://reflio.com/js/reflio.min.js" data-reflio="hi8q6z93wyt147h" data-domain="https://capgo.app,https://web.capgo.app" /> -->
   <section class="flex w-full min-h-screen py-10 my-auto overflow-y-auto lg:py-8 sm:py-8">
     <div class="px-4 mx-auto max-w-7xl lg:px-8 sm:px-6">
       <div class="max-w-2xl mx-auto text-center">

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -65,7 +65,7 @@ async function submit(form: { first_name: string; last_name: string; password: s
 </script>
 
 <template>
-  <!-- <script async src="https://reflio.com/js/reflio.min.js" data-reflio="hi8q6z93wyt147h" data-domain="https://capgo.app,https://web.capgo.app" /> -->
+  <script async src="https://reflio.com/js/reflio.min.js" data-reflio="hi8q6z93wyt147h" data-domain="https://capgo.app,https://web.capgo.app" />
   <section class="flex w-full min-h-screen py-10 my-auto overflow-y-auto lg:py-8 sm:py-8">
     <div class="px-4 mx-auto max-w-7xl lg:px-8 sm:px-6">
       <div class="max-w-2xl mx-auto text-center">

--- a/src/pages/resend_email.vue
+++ b/src/pages/resend_email.vue
@@ -1,0 +1,102 @@
+<!-- eslint-disable unused-imports/no-unused-vars -->
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import { setErrors } from '@formkit/core'
+import { FormKitMessages } from '@formkit/vue'
+import { toast } from 'vue-sonner'
+import { useSupabase } from '~/services/supabase'
+import Spinner from '~/components/Spinner.vue'
+import { iconEmail, iconPassword } from '~/services/icons'
+
+const { t } = useI18n()
+const router = useRouter()
+const route = useRoute()
+const supabase = useSupabase()
+const isLoading = ref(false)
+const isLoadingMain = ref(false)
+
+async function submit(form: { email: string; password: string }) {
+  isLoading.value = true
+  const { error } = await supabase.auth.resend({
+    type: 'signup',
+    email: form.email,
+  })
+  isLoading.value = false
+  if (error)
+    setErrors('resend-email', [error.message], {})
+  else toast.success(t('confirm-email-sent'))
+}
+</script>
+
+<template>
+  <section v-if="isLoadingMain" class="flex justify-center">
+    <Spinner size="w-40 h-40" class="my-auto" />
+  </section>
+  <div v-else>
+    <section class="flex w-full h-full py-10 my-auto overflow-y-auto lg:py-2 sm:py-8">
+      <div class="px-4 mx-auto my-auto max-w-7xl lg:px-8 sm:px-6">
+        <div class="max-w-2xl mx-auto text-center">
+          <img src="/capgo.webp" alt="logo" class="w-1/6 mx-auto mb-6 rounded invert dark:invert-0">
+          <h1 class="text-3xl font-bold leading-tight text-black lg:text-5xl sm:text-4xl dark:text-white">
+            {{ t('resend-email') }}
+          </h1>
+        </div>
+
+        <div class="relative max-w-md mx-auto mt-8 md:mt-4">
+          <div class="overflow-hidden bg-white rounded-md shadow-md">
+            <div class="px-4 py-6 sm:px-8 sm:py-7">
+              <FormKit id="resend-email" type="form" :actions="false" @submit="submit">
+                <div class="space-y-5">
+                  <FormKit
+                    type="email"
+                    name="email"
+                    :label="t('email')"
+                    input-class="!text-black"
+                    :disabled="isLoading"
+                    :prefix-icon="iconEmail"
+                    inputmode="email"
+                    autocomplete="email"
+                    validation="required:trim"
+                  />
+
+                  <FormKitMessages />
+
+                  <div>
+                    <button type="submit" class="inline-flex items-center justify-center w-full">
+                      <svg v-if="isLoading" class="inline-block w-5 h-5 mr-3 -ml-1 text-gray-900 align-middle animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle
+                          class="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          stroke-width="4"
+                        />
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                      </svg>
+                      <button v-if="!isLoading" type="submit" class="inline-flex items-center justify-center w-full px-4 py-4 text-base font-semibold text-white transition-all duration-200 border border-transparent rounded-md bg-muted-blue-700 focus:bg-blue-700 hover:bg-blue-700 focus:outline-none">
+                        Submit
+                      </button>
+                    </button>
+                  </div>
+                </div>
+              </FormKit>
+            </div>
+          </div>
+          <div class="flex flex-row justify-center w-full mt-5">
+            <router-link to="/login" class="font-medium text-orange-500 transition-all duration-200 hover:text-orange-600 hover:underline">
+              {{ t('back-to-login-page') }}
+            </router-link>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: naked
+</route>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import path from 'node:path'
 import Vue from '@vitejs/plugin-vue'
+
 // import veauryVitePlugins from 'veaury/vite/index'
 import { defineConfig } from 'vite'
 import Pages from 'vite-plugin-pages'
@@ -32,7 +33,7 @@ readdirSync('./locales/')
       locales.push(file.split('.')[0])
   })
 // const markdownWrapperClasses = 'prose prose-xl m-auto text-left'
-const guestPath = ['/login', '/register', '/forgot_password', '/onboarding/confirm_email', '/onboarding/verify_email', '/onboarding/activation', '/onboarding/set_password']
+const guestPath = ['/login', '/register', '/forgot_password', '/resend_email', '/onboarding/confirm_email', '/onboarding/verify_email', '/onboarding/activation', '/onboarding/set_password']
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
This PR adds a page to resend confirmation email and also on confirm_email.
(Was reported by a Capgo user on discord)

Also adds translate.ts to auto translate text to all locales.


<img width="1496" alt="Screenshot 2023-10-18 at 2 21 09 AM" src="https://github.com/Cap-go/capgo/assets/62795688/388b6ddd-9192-43f8-a42d-e477d1bf6f85">


https://github.com/Cap-go/capgo/assets/62795688/5f7ad9b7-abb9-46ec-95fa-9deb9741a988

