### PR TITLE
Delete on channel self default

### DIFF
--- a/supabase/functions/channel_self/index.ts
+++ b/supabase/functions/channel_self/index.ts
@@ -197,7 +197,10 @@ async function put(body: DeviceLink): Promise<Response> {
   }
   else {
     console.error('Cannot find version', { version_build })
-    return sendRes({ message: `Native version: ${version_build} doesn't follow semver convention, please follow https://semver.org to allow Capgo compare version number` }, 400)
+    return sendRes({
+      message: `Native version: ${version_build} doesn't follow semver convention, please follow https://semver.org to allow Capgo compare version number`,
+      error: 'semver_error',
+    }, 400)
   }
   version_name = (version_name === 'builtin' || !version_name) ? version_build : version_name
   if (!device_id || !app_id) {

--- a/supabase/functions/channel_self/index.ts
+++ b/supabase/functions/channel_self/index.ts
@@ -30,7 +30,7 @@ export const jsonRequestSchema = z.object({
   }),
   is_emulator: z.boolean().default(false),
   is_prod: z.boolean().default(true),
-}).refine(data => reverseDomainRegex.test(data.app_id), {
+}).passthrough().refine(data => reverseDomainRegex.test(data.app_id), {
   message: INVALID_STRING_APP_ID,
 }).refine(data => deviceIdRegex.test(data.device_id), {
   message: INVALID_STRING_DEVICE_ID,
@@ -43,7 +43,7 @@ export const jsonRequestSchema = z.object({
 
 async function post(body: DeviceLink): Promise<Response> {
   console.log('body', body)
-  const parseResult: any = jsonRequestSchema.safeParse(body)
+  const parseResult = jsonRequestSchema.safeParse(body)
   if (!parseResult.success) {
     console.error('Cannot parse json', { parseResult })
     return sendRes({ error: `Cannot parse json: ${parseResult.error}` }, 400)
@@ -77,13 +77,6 @@ async function post(body: DeviceLink): Promise<Response> {
   }
   version_name = (version_name === 'builtin' || !version_name) ? version_build : version_name
 
-  if (!device_id || !app_id) {
-    console.error('Cannot find device_id or appi_id', { device_id, app_id, body })
-    return sendRes({
-      message: 'Cannot find device_id or appi_id',
-      error: 'missing_info',
-    }, 400)
-  }
   const { data: version } = await supabaseAdmin()
     .from('app_versions')
     .select('id')

--- a/supabase/migrations/20231029143350_delete_default_channel_from_overwrites.sql
+++ b/supabase/migrations/20231029143350_delete_default_channel_from_overwrites.sql
@@ -1,0 +1,16 @@
+DO $$
+DECLARE
+  app_record RECORD;
+  app_channels channels[];
+BEGIN
+    FOR app_record IN 
+      SELECT * FROM apps
+    LOOP
+      select array(select row (channels.*) from channels where channels.app_id = app_record.app_id and channels.public = true) into app_channels;
+
+      -- Do not run for apps that do not have a clear public channel
+      continue when ((array_length(app_channels, 1)) != 1);
+
+      DELETE FROM channel_devices WHERE channel_devices.app_id=app_record.app_id and channel_devices.channel_id=app_channels[1].id;
+    END LOOP;
+END $$;

--- a/tests_backend/tests/backend/self_assign.ts
+++ b/tests_backend/tests/backend/self_assign.ts
@@ -1,8 +1,8 @@
-import { type RunnableTest, type SupabaseType, responseOk, assert, getResponseError, getUpdateBaseData, responseStatusCode } from '../../utils.ts'
+import { type RunnableTest, type SupabaseType, assert, getResponseError, getUpdateBaseData, responseOk, responseStatusCode } from '../../utils.ts'
 
 const baseData = {
   channel: 'production',
-  ...getUpdateBaseData()
+  ...getUpdateBaseData(),
 }
 
 const getBaseData = (): typeof baseData => structuredClone(baseData)
@@ -32,17 +32,17 @@ export function getTest(): RunnableTest {
       {
         name: 'Test post without field (device_id) (post)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'POST')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'POST'),
       },
       {
         name: 'Test post without field (app_id) (post)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'POST')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'POST'),
       },
       {
         name: 'Test with a version that does not exist (post)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testWithNotExistingVersion(backendBaseUrl, supabase, 'POST')
+        test: (backendBaseUrl, supabase) => testWithNotExistingVersion(backendBaseUrl, supabase, 'POST'),
       },
       {
         name: 'Test without channel (post)',
@@ -64,6 +64,11 @@ export function getTest(): RunnableTest {
         timesToExecute: 1,
         test: testOkPost,
       },
+      {
+        name: 'Test post with default channel',
+        timesToExecute: 1,
+        test: testPostWithDefaultChannel,
+      },
       // Put from this point on
       {
         name: 'Test invalid semver (put)',
@@ -73,17 +78,17 @@ export function getTest(): RunnableTest {
       {
         name: 'Test post without field (device_id) (put)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'PUT')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'PUT'),
       },
       {
         name: 'Test post without field (app_id) (put)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'PUT')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'PUT'),
       },
       {
         name: 'Test with a version that does not exist (put)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testWithNotExistingVersion(backendBaseUrl, supabase, 'PUT')
+        test: (backendBaseUrl, supabase) => testWithNotExistingVersion(backendBaseUrl, supabase, 'PUT'),
       },
       {
         name: 'Test without overwrite (put)',
@@ -93,7 +98,7 @@ export function getTest(): RunnableTest {
       {
         name: 'Test with overwrite (put)',
         timesToExecute: 1,
-        test: testPutWithOverwrite
+        test: testPutWithOverwrite,
       },
       // Delete from this point on
       {
@@ -104,12 +109,12 @@ export function getTest(): RunnableTest {
       {
         name: 'Test post without field (device_id) (delete)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'DELETE')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'DELETE'),
       },
       {
         name: 'Test post without field (app_id) (delete)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'DELETE')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'DELETE'),
       },
       {
         name: 'Test delete with an overwrite that does not exist',
@@ -120,7 +125,7 @@ export function getTest(): RunnableTest {
         name: 'Test delete with an overwrite',
         timesToExecute: 1,
         test: testDeleteWithOverwrite,
-      }
+      },
     ],
   }
 }
@@ -134,13 +139,12 @@ function fetchEndpoint(backendBaseUrl: URL, method: HttpMethod, body: object) {
 
   // DELETE has the body in the url
   if (method === 'DELETE') {
-    for (const [key, value] of Object.entries(body)) {
+    for (const [key, value] of Object.entries(body))
       url.searchParams.append(key, value.toString())
-    }
   }
 
   return fetch(url, {
-    method: method,
+    method,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -160,8 +164,6 @@ async function testPostInvalidJson(backendBaseUrl: URL, _supabase: SupabaseType)
   assert(response.ok === false, `The response should not be ok, response: ${response}`)
 }
 
-
-
 async function testEmptyJson(backendBaseUrl: URL, _supabase: SupabaseType) {
   // This is a simple test, for more please take a look at zod.ts
   const response = await fetchEndpoint(backendBaseUrl, 'POST', {})
@@ -175,8 +177,8 @@ async function testInvalidSemver(backendBaseUrl: URL, _supabase: SupabaseType, m
   baseData.version_build = 'invalid semver'
 
   const response = await fetchEndpoint(backendBaseUrl, method, baseData)
-  //responseOk(response, 'Test invalid semver')
-  
+  // responseOk(response, 'Test invalid semver')
+
   const error = await getResponseError(response)
   assert(error === 'semver_error', `Response error ${error} is not equal to semver_error`)
 }
@@ -205,34 +207,35 @@ async function testWithNotExistingVersion(backendBaseUrl: URL, supabase: Supabas
     .eq('name', 'builtin')
     .select('id')
     .single()
-    
+
   assert (error === null && !!data, `Error while updating version: ${JSON.stringify(error)}`)
 
   try {
     const response = await fetchEndpoint(backendBaseUrl, method, baseData)
     responseStatusCode(response, 400, 'Test with not existing version')
-  
+
     const responseRrror = await getResponseError(response)
     assert(responseRrror === 'version_error', `Response error ${error} is not equal to version_error`)
-  } finally {
-      // We rename the 'build_not_in' version back to 'buildin'
-      const { error } = await supabase.from('app_versions')
-        .update({ name: 'builtin' })
-        .eq('id', data!.id)
-        .select('id')
-        .single()
-      
-      assert (error === null, `Error while updating version: ${error}`)
+  }
+  finally {
+    // We rename the 'build_not_in' version back to 'buildin'
+    const { error } = await supabase.from('app_versions')
+      .update({ name: 'builtin' })
+      .eq('id', data!.id)
+      .select('id')
+      .single()
+
+    assert (error === null, `Error while updating version: ${error}`)
   }
 }
 
 async function testNoChannel(backendBaseUrl: URL, _supabase: SupabaseType) {
   // Dirty, tho should work
   const baseData = getBaseData() as any
-  delete baseData['channel']
+  delete baseData.channel
 
   const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
-  responseStatusCode(response, 400, `Test post without field channel`)
+  responseStatusCode(response, 400, 'Test post without field channel')
 
   const error = await getResponseError(response)
   assert(error === 'cannot_override', `Response error ${error} is not equal to cannot_override`)
@@ -243,7 +246,7 @@ async function testUnexistingChannel(backendBaseUrl: URL, _supabase: SupabaseTyp
   baseData.channel = 'unexisting_channel'
 
   const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
-  responseStatusCode(response, 400, `Test post with unexisting channel`)
+  responseStatusCode(response, 400, 'Test post with unexisting channel')
 
   const error = await getResponseError(response)
   assert(error === 'channel_not_found', `Response error ${error} is not equal to channel_not_found`)
@@ -262,11 +265,12 @@ async function testPostWithChannelDisabledUpdate(backendBaseUrl: URL, supabase: 
 
   try {
     const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
-    responseStatusCode(response, 400, `Test post with channel disabled update`)
+    responseStatusCode(response, 400, 'Test post with channel disabled update')
 
     const error = await getResponseError(response)
     assert(error === 'channel_not_found', `Response error ${error} is not equal to channel_not_found`)
-  } finally {
+  }
+  finally {
     const { error } = await supabase.from('channels')
       .update({ allow_device_self_set: true })
       .eq('name', baseData.channel)
@@ -280,27 +284,43 @@ async function testPostWithChannelDisabledUpdate(backendBaseUrl: URL, supabase: 
 async function testOkPost(backendBaseUrl: URL, supabase: SupabaseType) {
   const baseData = getBaseData()
   baseData.device_id = crypto.randomUUID()
+  baseData.channel = 'no_access'
 
-  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
-  responseOk(response, 'Test ok post')
+  const { error: channelUpdateError } = await supabase.from('channels')
+    .update({ allow_device_self_set: true })
+    .eq('name', 'no_access')
 
-  const { error, data } = await supabase.from('channel_devices')
-    .select('*')
-    .eq('device_id', baseData.device_id)
-    .eq('app_id', baseData.app_id)
-    .single()
+  assert (channelUpdateError === null, `Error while updating no_access channel: ${channelUpdateError}`)
 
-  assert(!!data && !error, `Error while fetching channel_devices: ${error}`)
+  try {
+    const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+    responseOk(response, 'Test ok post')
 
-  const { error: error2, data: prodChannelData } = await supabase.from('channels')
-    .select('*')
-    .eq('name', baseData.channel)
-    .eq('app_id', baseData.app_id)
-    .single()
+    const { error, data } = await supabase.from('channel_devices')
+      .select('*')
+      .eq('device_id', baseData.device_id)
+      .eq('app_id', baseData.app_id)
+      .single()
 
-  assert (!!prodChannelData && !error2, `Error while fetching channel: ${error2}`)
+    assert(!!data && !error, `Error while fetching channel_devices: ${error}`)
 
-  assert(data?.channel_id === prodChannelData?.id, `Channel id ${data?.channel_id} is not equal to ${prodChannelData?.id}`)
+    const { error: error2, data: prodChannelData } = await supabase.from('channels')
+      .select('*')
+      .eq('name', baseData.channel)
+      .eq('app_id', baseData.app_id)
+      .single()
+
+    assert (!!prodChannelData && !error2, `Error while fetching channel: ${error2}`)
+
+    assert(data?.channel_id === prodChannelData?.id, `Channel id ${data?.channel_id} is not equal to ${prodChannelData?.id}`)
+  }
+  finally {
+    const { error: channelUpdateError } = await supabase.from('channels')
+      .update({ allow_device_self_set: false })
+      .eq('name', 'no_access')
+
+    assert (channelUpdateError === null, `Error while updating (revert) no_access channel: ${channelUpdateError}`)
+  }
 }
 
 // PUT = GET
@@ -342,7 +362,7 @@ async function testPutWithOverwrite(backendBaseUrl: URL, supabase: SupabaseType)
       app_id: baseData.app_id,
       channel_id: noAccessId,
       device_id: baseData.device_id,
-      created_by
+      created_by,
     })
 
   assert (error === null, `Error while inserting channel_device: ${error}`)
@@ -350,17 +370,18 @@ async function testPutWithOverwrite(backendBaseUrl: URL, supabase: SupabaseType)
   try {
     const response = await fetchEndpoint(backendBaseUrl, 'PUT', baseData)
     responseOk(response, 'Test PUT (with overwrite)')
-  
+
     const responseJSON = await response.json()
     const channel = responseJSON.channel
     const status = responseJSON.status
-  
+
     assert(!!channel, `Channel is not defined (${channel})`)
     assert(!!status, `Channel is not defined (${status})`)
-  
+
     assert(status === 'override', `Status is not equal to override (status = ${status})`)
     assert(channel === 'no_access', `Channel is not equal to no_access (Channel = ${channel})`)
-  } finally {
+  }
+  finally {
     const { error } = await supabase.from('channel_devices')
       .delete()
       .eq('device_id', baseData.device_id)
@@ -388,22 +409,22 @@ async function testDeleteWithOverwrite(backendBaseUrl: URL, supabase: SupabaseTy
   const baseData = getBaseData()
   baseData.device_id = crypto.randomUUID()
 
-  const { data: noAccessChannel, error: noAccessChannelError } = await supabase.from('channels')
+  const { data: productionChannel, error: productionChannelError } = await supabase.from('channels')
     .select('id, created_by')
-    .eq('name', 'no_access')
+    .eq('name', 'production')
     .single()
 
-  assert (!!noAccessChannel && !noAccessChannelError, `Error while fetching no_access channel: ${noAccessChannelError}`)
+  assert (!!productionChannel && !productionChannelError, `Error while fetching no_access channel: ${productionChannelError}`)
 
-  const noAccessId = noAccessChannel!.id
-  const created_by = noAccessChannel!.created_by
+  const productionId = productionChannel!.id
+  const created_by = productionChannel!.created_by
 
   const { error } = await supabase.from('channel_devices')
     .upsert({
       app_id: baseData.app_id,
-      channel_id: noAccessId,
+      channel_id: productionId,
       device_id: baseData.device_id,
-      created_by
+      created_by,
     })
 
   assert (error === null, `Error while inserting channel_device: ${error}`)
@@ -411,7 +432,7 @@ async function testDeleteWithOverwrite(backendBaseUrl: URL, supabase: SupabaseTy
   try {
     const response = await fetchEndpoint(backendBaseUrl, 'DELETE', baseData)
     responseOk(response, 'Test DELETE (with overwrite)')
-  
+
     const { data: channelDevice, error: channelDeviceError } = await supabase.from('channel_devices')
       .select('*')
       .eq('device_id', baseData.device_id)
@@ -419,16 +440,74 @@ async function testDeleteWithOverwrite(backendBaseUrl: URL, supabase: SupabaseTy
 
     assert(channelDeviceError === null, `Error while fetching channel_device: ${channelDeviceError}`)
     assert(channelDevice?.length === 0, `Channel device length is not 0 (It is ${channelDevice?.length}). Data: ${JSON.stringify(channelDevice)}`)
-  } catch (e) {
+  }
+  catch (e) {
     const { error } = await supabase.from('channel_devices')
       .delete()
       .eq('device_id', baseData.device_id)
       .eq('app_id', baseData.app_id)
       .eq('created_by', created_by)
-      .eq('channel_id', noAccessId)
+      .eq('channel_id', productionId)
       .single()
 
     assert (error === null, `Error while deleting channel_device: ${error}, ${e}`)
     throw e
+  }
+}
+
+async function testPostWithDefaultChannel(backendBaseUrl: URL, supabase: SupabaseType) {
+  // Couple of steps:
+  // 1. Allow 'no_access' channel to be self assigned
+  // 2. Create a device with 'no_access' channel
+  // 3. Post to the self_channel with the same device BUT the `production` channel
+  // 4. Check if the device was removed from the DB
+
+  const baseData = getBaseData()
+  baseData.device_id = crypto.randomUUID()
+
+  // Step 1
+  const { error: channelUpdateError, data: noAccessData } = await supabase.from('channels')
+    .update({ allow_device_self_set: true })
+    .eq('name', 'no_access')
+    .eq('app_id', baseData.app_id)
+    .select('id, created_by')
+    .single()
+
+  assert (channelUpdateError === null, `Error while updating no_access channel: ${channelUpdateError}`)
+
+  try {
+    // Step 2
+    // We will not bother to revert step 2. It is not needed
+    const { error: overwriteUpsertError } = await supabase.from('channel_devices')
+      .upsert({
+        app_id: baseData.app_id,
+        channel_id: noAccessData!.id,
+        device_id: baseData.device_id,
+        created_by: noAccessData!.created_by,
+      })
+
+    assert(overwriteUpsertError === null, `Error while inserting channel_device: ${overwriteUpsertError}`)
+
+    // Step 3
+    baseData.channel = 'production'
+    const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+    responseOk(response, 'Test post with default channel')
+
+    // Step 4
+    const { data: channelDevice, error: channelDeviceError } = await supabase.from('channel_devices')
+      .select('*')
+      .eq('device_id', baseData.device_id)
+      .eq('app_id', baseData.app_id)
+
+    assert(channelDeviceError === null, `Error while fetching channel_device: ${channelDeviceError}`)
+    assert(channelDevice?.length === 0, `Channel device length is not 0 (It is ${channelDevice?.length}). Data: ${JSON.stringify(channelDevice)}`)
+  }
+  finally {
+    // Undo step 1
+    const { error: channelUpdateError } = await supabase.from('channels')
+      .update({ allow_device_self_set: false })
+      .eq('name', 'no_access')
+
+    assert (channelUpdateError === null, `Error while updating no_access channel: ${channelUpdateError}`)
   }
 }

--- a/tests_backend/tests/cli/test_cli.ts
+++ b/tests_backend/tests/cli/test_cli.ts
@@ -140,7 +140,7 @@ async function prepareCli(backendBaseUrl: URL, supabase: SupabaseType) {
 
 async function pnpmInstall() {
   const pnpmInstallCommand = new Deno.Command('pnpm', {
-    args: ['install'],
+    args: ['install', '--no-frozen-lockfile'],
     cwd: tempFileFolder,
   })
 

--- a/tests_backend/tests/temp/self_assign.ts
+++ b/tests_backend/tests/temp/self_assign.ts
@@ -7,6 +7,8 @@ const baseData = {
 
 const getBaseData = (): typeof baseData => structuredClone(baseData)
 
+type HttpMethod = 'POST' | 'PUT' | 'DELETE'
+
 export function getTest(): RunnableTest {
   return {
     fullName: 'Test self assign endpoint',
@@ -25,23 +27,59 @@ export function getTest(): RunnableTest {
       {
         name: 'Test invalid semver (post)',
         timesToExecute: 1,
-        test: testInvalidSemverPost,
+        test: (backendBaseUrl, supabase) => testInvalidSemver(backendBaseUrl, supabase, 'POST'),
       },
       {
-        name: 'Test post without field (device_id)',
+        name: 'Test post without field (device_id) (post)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'POST')
       },
       {
-        name: 'Test post without field (app_id)',
+        name: 'Test post without field (app_id) (post)',
         timesToExecute: 1,
-        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id')
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'POST')
       },
       {
         name: 'Test with a version that does not exist (post)',
         timesToExecute: 1,
         test: testWithNotExistingVersion,
-      }
+      },
+      {
+        name: 'Test without channel (post)',
+        timesToExecute: 1,
+        test: testNoChannel,
+      },
+      {
+        name: 'Test with a channel that does not exist (post)',
+        timesToExecute: 1,
+        test: testUnexistingChannel,
+      },
+      {
+        name: 'Test with a channel that does not allow self assign (post)',
+        timesToExecute: 1,
+        test: testPostWithChannelDisabledUpdate,
+      },
+      {
+        name: 'Test ok post',
+        timesToExecute: 1,
+        test: testOkPost,
+      },
+      // Put from this point on
+      {
+        name: 'Test invalid semver (put)',
+        timesToExecute: 1,
+        test: (backendBaseUrl, supabase) => testInvalidSemver(backendBaseUrl, supabase, 'PUT'),
+      },
+      {
+        name: 'Test post without field (device_id) (put)',
+        timesToExecute: 1,
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id', 'PUT')
+      },
+      {
+        name: 'Test post without field (app_id) (put)',
+        timesToExecute: 1,
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id', 'PUT')
+      },
     ],
   }
 }
@@ -50,7 +88,7 @@ function getEndpointUrl(backendBaseUrl: URL) {
   return new URL('channel_self', backendBaseUrl)
 }
 
-function fetchEndpoint(backendBaseUrl: URL, method: 'POST' | 'PUT' | 'DELETE', body: object) {
+function fetchEndpoint(backendBaseUrl: URL, method: HttpMethod, body: object) {
   return fetch(getEndpointUrl(backendBaseUrl), {
     method: method,
     headers: {
@@ -82,27 +120,28 @@ async function testEmptyJson(backendBaseUrl: URL, _supabase: SupabaseType) {
   assert(error.includes('Cannot parse json'), `Error ${error} does not inclue 'Cannot parse json'`)
 }
 
-async function testInvalidSemverPost(backendBaseUrl: URL, _supabase: SupabaseType) {
+async function testInvalidSemver(backendBaseUrl: URL, _supabase: SupabaseType, method: HttpMethod) {
   const baseData = getBaseData()
   baseData.version_build = 'invalid semver'
 
-  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  const response = await fetchEndpoint(backendBaseUrl, method, baseData)
   //responseOk(response, 'Test invalid semver')
   
   const error = await getResponseError(response)
   assert(error === 'semver_error', `Response error ${error} is not equal to semver_error`)
 }
 
-async function testPostWithoutField(backendBaseUrl: URL, _supabase: SupabaseType, field: string) {
+async function testPostWithoutField(backendBaseUrl: URL, _supabase: SupabaseType, field: string, method: HttpMethod) {
   // Dirty, tho should work
   const baseData = getBaseData() as any
   delete baseData[field]
 
-  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  const response = await fetchEndpoint(backendBaseUrl, method, baseData)
   responseStatusCode(response, 400, `Test post without field ${field}`)
 
+  // ZOD is used for post, but put has a custom validation. We test both here
   const error = await getResponseError(response)
-  assert(error.includes('Cannot parse json'), `Response error ${error} is not equal to missing_info`)
+  assert(error.includes('Cannot parse json') || error.includes('missing_info'), `Response error ${error} is not equal to missing_info`)
 }
 
 // Enough for JSON tests, let's move on
@@ -135,5 +174,81 @@ async function testWithNotExistingVersion(backendBaseUrl: URL, supabase: Supabas
       
       assert (error === null, `Error while updating version: ${error}`)
   }
+}
 
+async function testNoChannel(backendBaseUrl: URL, supabase: SupabaseType) {
+  // Dirty, tho should work
+  const baseData = getBaseData() as any
+  delete baseData['channel']
+
+  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  responseStatusCode(response, 400, `Test post without field channel`)
+
+  const error = await getResponseError(response)
+  assert(error === 'cannot_override', `Response error ${error} is not equal to cannot_override`)
+}
+
+async function testUnexistingChannel(backendBaseUrl: URL, supabase: SupabaseType) {
+  const baseData = getBaseData()
+  baseData.channel = 'unexisting_channel'
+
+  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  responseStatusCode(response, 400, `Test post with unexisting channel`)
+
+  const error = await getResponseError(response)
+  assert(error === 'channel_not_found', `Response error ${error} is not equal to channel_not_found`)
+}
+
+async function testPostWithChannelDisabledUpdate(backendBaseUrl: URL, supabase: SupabaseType) {
+  const baseData = getBaseData()
+
+  const { error } = await supabase.from('channels')
+    .update({ allow_device_self_set: false })
+    .eq('name', baseData.channel)
+    .select('id')
+    .single()
+
+  assert (error === null, `Error while updating channel: ${error}`)
+
+  try {
+    const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+    responseStatusCode(response, 400, `Test post with channel disabled update`)
+
+    const error = await getResponseError(response)
+    assert(error === 'channel_not_found', `Response error ${error} is not equal to channel_not_found`)
+  } finally {
+    const { error } = await supabase.from('channels')
+      .update({ allow_device_self_set: true })
+      .eq('name', baseData.channel)
+      .select('id')
+      .single()
+
+    assert (error === null, `Error while updating channel (undo changes): ${error}`)
+  }
+}
+
+async function testOkPost(backendBaseUrl: URL, supabase: SupabaseType) {
+  const baseData = getBaseData()
+  baseData.device_id = crypto.randomUUID()
+
+  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  responseOk(response, 'Test ok post')
+
+  const { error, data } = await supabase.from('channel_devices')
+    .select('*')
+    .eq('device_id', baseData.device_id)
+    .eq('app_id', baseData.app_id)
+    .single()
+
+  assert(!!data && !error, `Error while fetching channel_devices: ${error}`)
+
+  const { error: error2, data: prodChannelData } = await supabase.from('channels')
+    .select('*')
+    .eq('name', baseData.channel)
+    .eq('app_id', baseData.app_id)
+    .single()
+
+  assert (!!prodChannelData && !error2, `Error while fetching channel: ${error2}`)
+
+  assert(data?.channel_id === prodChannelData?.id, `Channel id ${data?.channel_id} is not equal to ${prodChannelData?.id}`)
 }

--- a/tests_backend/tests/temp/self_assign.ts
+++ b/tests_backend/tests/temp/self_assign.ts
@@ -1,0 +1,103 @@
+import { type RunnableTest, type SupabaseType, responseOk, assert, getResponseError, getUpdateBaseData } from '../../utils.ts'
+
+const baseData = {
+  channel: 'production',
+  ...getUpdateBaseData()
+}
+
+const getBaseData = (): typeof baseData => structuredClone(baseData)
+
+export function getTest(): RunnableTest {
+  return {
+    fullName: 'Test self assign endpoint',
+    testWithRedis: true,
+    tests: [
+      {
+        name: 'Test POST invalid json',
+        timesToExecute: 1,
+        test: testPostInvalidJson,
+      },
+      {
+        name: 'Test empty POST empty json',
+        timesToExecute: 1,
+        test: testEmptyJson,
+      },
+      {
+        name: 'Test invalid semver (post)',
+        timesToExecute: 1,
+        test: testInvalidSemverPost,
+      },
+      {
+        name: 'Test post without field (device_id)',
+        timesToExecute: 1,
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'device_id')
+      },
+      {
+        name: 'Test post without field (app_id)',
+        timesToExecute: 1,
+        test: (backendBaseUrl, supabase) => testPostWithoutField(backendBaseUrl, supabase, 'app_id')
+      }
+    ],
+  }
+}
+
+function getEndpointUrl(backendBaseUrl: URL) {
+  return new URL('channel_self', backendBaseUrl)
+}
+
+function fetchEndpoint(backendBaseUrl: URL, method: 'POST' | 'PUT' | 'DELETE', body: object) {
+  return fetch(getEndpointUrl(backendBaseUrl), {
+    method: method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+async function testPostInvalidJson(backendBaseUrl: URL, _supabase: SupabaseType) {
+  const response = await fetch(getEndpointUrl(backendBaseUrl), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: 'invalid json ;-)',
+  })
+
+  assert(response.ok === false, `The response should not be ok, response: ${response}`)
+}
+
+
+
+async function testEmptyJson(backendBaseUrl: URL, _supabase: SupabaseType) {
+  // This is a simple test, for more please take a look at zod.ts
+  const response = await fetchEndpoint(backendBaseUrl, 'POST', {})
+  const error = await getResponseError(response)
+
+  assert(error.includes('Cannot parse json'), `Error ${error} does not inclue 'Cannot parse json'`)
+}
+
+async function testInvalidSemverPost(backendBaseUrl: URL, _supabase: SupabaseType) {
+  const baseData = getBaseData()
+  baseData.version_build = 'invalid semver'
+
+  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  //responseOk(response, 'Test invalid semver')
+  
+  const error = await getResponseError(response)
+  assert(error === 'semver_error', `Response error ${error} is not equal to semver_error`)
+}
+
+async function testPostWithoutField(backendBaseUrl: URL, _supabase: SupabaseType, field: string) {
+  // Dirty, tho should work
+  const baseData = getBaseData() as any
+  delete baseData[field]
+
+  console.log(baseData)
+
+  const response = await fetchEndpoint(backendBaseUrl, 'POST', baseData)
+  responseOk(response, `Test post without field ${field}`)
+
+  const error = await getResponseError(response)
+  assert(error === 'missing_info', `Response error ${error} is not equal to missing_info`)
+}

--- a/tests_backend/utils.ts
+++ b/tests_backend/utils.ts
@@ -64,6 +64,11 @@ export async function responseOk(response: Response, requestName: string) {
   assert(cloneResponse.ok, `${requestName} response not ok: ${cloneResponse.status} ${cloneResponse.statusText} ${await cloneResponse.text()}`)
 }
 
+export async function responseStatusCode(response: Response, statusCode: number, requestName: string) {
+  const cloneResponse = response.clone()
+  assert(cloneResponse.status === statusCode, `${requestName} response does not have status code ${statusCode}: ${cloneResponse.status} ${cloneResponse.statusText} ${await cloneResponse.text()}`)
+}
+
 export async function sendUpdate(baseUrl: URL, data: typeof updateAndroidBaseData): Promise<Response> {
   return await fetch(new URL('updates', baseUrl), {
     method: 'POST',


### PR DESCRIPTION
Prevents self assigning to the default channel from spamming the `channel_devices` table. 
If the channel that you are trying to set = main app channel then it will just remove the overwrite from the `channel_devices`

Depends on [this](https://github.com/Cap-go/capgo/pull/440)

[Here](https://bpa.st/F3CA) is the test output

/claim #431