### PR TITLE
Make admin accounts use accual JWT

### DIFF
--- a/src/layouts/settings.vue
+++ b/src/layouts/settings.vue
@@ -15,6 +15,7 @@ import IconAdmin from '~icons/eos-icons/admin'
 import type { Tab } from '~/components/comp_def'
 import { useMainStore } from '~/stores/main'
 import { openPortal } from '~/services/stripe'
+import { isSpoofed } from '~/services/supabase'
 
 const { t } = useI18n()
 const main = useMainStore()
@@ -92,7 +93,7 @@ watchEffect(() => {
   else if (!main.paying && tabs.value.find(tab => tab.label === 'usage')) {
     tabs.value = tabs.value.filter(tab => tab.label !== 'usage')
   }
-  if (main.isAdmin && !tabs.value.find(tab => tab.label === 'admin')) {
+  if ((main.isAdmin || isSpoofed()) && !tabs.value.find(tab => tab.label === 'admin')) {
     tabs.value.push({
       label: 'admin',
       icon: shallowRef(IconAdmin) as any,

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -1,4 +1,4 @@
-import { isAdmin, isSpoofed, spoofUser } from './../services/supabase'
+import { isAdmin } from './../services/supabase'
 import type { UserModule } from '~/types'
 import { useMainStore } from '~/stores/main'
 import { isAllowedAction, isCanceled, isGoodPlan, isPaying, isTrial, useSupabase } from '~/services/supabase'
@@ -16,8 +16,6 @@ async function guard(next: any, to: string, from: string) {
   const main = useMainStore()
 
   if (auth.user && !main.auth) {
-    if (isSpoofed())
-      auth.user.id = spoofUser()
     main.auth = auth.user
     // console.log('set auth', auth)
     if (!main.user) {

--- a/src/pages/dashboard/settings/Admin.vue
+++ b/src/pages/dashboard/settings/Admin.vue
@@ -12,6 +12,9 @@ const oldId = ref(isSpoofed())
 async function setLogAs(id: string) {
   console.log('setLogAs', id)
 
+  if (isSpoofed())
+  unspoofUser()
+
   const supabase = await useSupabase()
   const { data, error } = await supabase.functions.invoke('login_admin', {
     body: {

--- a/src/pages/dashboard/settings/Admin.vue
+++ b/src/pages/dashboard/settings/Admin.vue
@@ -2,20 +2,64 @@
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { FormKitMessages } from '@formkit/vue'
-import { isSpoofed, saveSpoof, spoofUser, unspoofUser } from '~/services/supabase'
+import { useSupabase, isSpoofed, saveSpoof, spoofUser, unspoofUser } from '~/services/supabase'
+import { toast } from 'vue-sonner';
 
 const route = useRoute()
 const isLoading = ref(false)
 const oldId = ref(isSpoofed())
 
-function setLogAs(id: string) {
+async function setLogAs(id: string) {
   console.log('setLogAs', id)
-  saveSpoof(id)
-  if (!spoofUser()) {
+
+  const supabase = await useSupabase()
+  const { data, error } = await supabase.functions.invoke('login_admin', {
+    body: {
+      user_id: id
+    }
+  })
+
+  if (error) {
+    toast.error('cannot log in, see console')
     isLoading.value = false
+    console.error(error)
     return
   }
-  // reload page
+
+  const newJwt = data.jwt
+  const newRereshToken = data.refreshToken
+
+  if (!data || !newJwt || !newRereshToken) {
+    toast.error('cannot log in, see console')
+    isLoading.value = false
+    console.error('no data or token?', data)
+    return
+  }
+
+  const { data: currentSession, error: sessionError } = await supabase.auth.getSession()
+  if (sessionError || !currentSession || !currentSession.session) {
+    console.error('no current session', sessionError)
+    isLoading.value = false
+    toast.error('cannot log in, see console')
+    return
+  }
+
+  const currentJwt = currentSession.session.access_token
+  const currentRefreshToken = currentSession.session.refresh_token
+
+  const { error: authError } = await supabase.auth.setSession({ access_token: newJwt, refresh_token: newRereshToken })
+  if (authError) {
+    isLoading.value = false
+    console.error('Auth error', authError)
+    toast.error('cannot log in, see console')
+    return
+  }
+
+  saveSpoof(currentJwt, currentRefreshToken)
+
+  console.log('ok')
+  
+  isLoading.value = false
   setTimeout(() => {
     isLoading.value = false
     window.location.reload()
@@ -43,6 +87,7 @@ function reset() {
   if (isLoading.value)
     return
   isLoading.value = true
+  
   if (!unspoofUser()) {
     isLoading.value = false
     return

--- a/supabase/functions/_utils/supabase.ts
+++ b/supabase/functions/_utils/supabase.ts
@@ -43,6 +43,17 @@ export function supabaseClient(auth: string) {
   return createClient<Database>(getEnv('SUPABASE_URL'), getEnv('SUPABASE_ANON_KEY'), options)
 }
 
+export function emptySupabase() {
+  const options = {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  }
+  return createClient<Database>(getEnv('SUPABASE_URL'), getEnv('SUPABASE_ANON_KEY'), options)
+}
+
 // WARNING: The service role key has admin priviliges and should only be used in secure server environments!
 export function supabaseAdmin() {
   const options = {

--- a/supabase/functions/login_admin/index.ts
+++ b/supabase/functions/login_admin/index.ts
@@ -1,0 +1,95 @@
+import { serve } from 'https://deno.land/std@0.200.0/http/server.ts'
+import { z } from 'https://deno.land/x/zod@v3.22.2/mod.ts'
+import type { BaseHeaders } from '../_utils/types.ts'
+import { methodJson, sendOptionsRes, sendRes } from '../_utils/utils.ts'
+import { supabaseAdmin as useSupabaseAdmin, supabaseClient as useSupabaseClient, emptySupabase } from '../_utils/supabase.ts'
+
+const bodySchema = z.object({
+  user_id: z.string(),
+})
+
+async function main(_url: URL, headers: BaseHeaders, method: string, body: any) {
+  if (method === 'OPTIONS')
+    return sendOptionsRes()
+  const authToken = headers.authorization
+
+  if (!authToken) {
+    return sendRes({ error: 'no_authorization_header' }, 400)
+  }
+
+  const parsedBodyResult = bodySchema.safeParse(body)
+  if (!parsedBodyResult.success) {
+    console.log(body)
+    console.log(parsedBodyResult.error)
+    return sendRes({ error: 'invalid_json_body' }, 400)
+  }
+
+  const supabaseAdmin = await useSupabaseAdmin()
+  const supabaseClient = useSupabaseClient(authToken)
+
+  const { data: isAdmin, error: adminError } = await supabaseClient.rpc('is_admin')
+  if (adminError) {
+    console.error('is_admin_error', adminError)
+    return sendRes({ error: 'is_admin_error' }, 500)
+  }
+
+  if (!isAdmin) {
+    return sendRes({ error: 'not_admin' }, 401)
+  }
+
+  const user_id = parsedBodyResult.data.user_id
+
+  const { data: userData, count: userCount, error: userError } = await supabaseAdmin.from('users')
+    .select('email', { count: 'exact' })
+    .eq('id', user_id)
+    .single()
+
+  if (userError) {
+    console.error(JSON.stringify(userError))
+    return sendRes({ error: 'user_does_not_exist' }, 400)
+  }
+
+  const userEmail = userData?.email
+
+  const { data: magicLink, error: magicError } = await supabaseAdmin.auth.admin.generateLink({
+    type: 'magiclink',
+    email: userEmail,
+  })
+
+  if (magicError) {
+    console.error(JSON.stringify(magicError))
+    return sendRes({ error: 'generate_magic_link_error'}, 500)
+  }
+
+  const tmpSupabaseClient = emptySupabase()
+  const { data: authData, error: authError } = await tmpSupabaseClient.auth.verifyOtp({ token_hash: magicLink.properties.hashed_token, type: 'email' })
+
+  if (authError) {
+    console.error(JSON.stringify(authError))
+    return sendRes({ error: 'auth_error' }, 500)
+  }
+
+  const jwt = authData.session?.access_token
+  const refreshToken = authData.session?.refresh_token
+
+  if (!jwt) {
+    console.error('No JWT?', authData)
+    return sendRes({ error: 'no_jwt' }, 500)
+  }
+
+  return sendRes({ jwt, refreshToken })
+}
+
+// await supabase.auth.verifyOtp({ token_hash: responseJson.token, type: 'email'})
+serve(async (event: Request) => {
+  try {
+    const url: URL = new URL(event.url)
+    const headers: BaseHeaders = Object.fromEntries(event.headers.entries())
+    const method: string = event.method
+    const body: any = methodJson.includes(method) ? await event.json() : Object.fromEntries(url.searchParams.entries())
+    return main(url, headers, method, body)
+  }
+  catch (e) {
+    return sendRes({ status: 'Error', error: JSON.stringify(e) }, 500)
+  }
+})


### PR DESCRIPTION
## Summary

This PR makes it so that capgo's admin will use JWT instead of the buggy change_id spoofing method. This is quite important given the recent addition of the org system. I have tested this for security vulnerabilities 

## Test plan

See the video

## Screenshots

https://github.com/Cap-go/capgo/assets/50914789/b5c60e52-ba1c-495b-bf06-d85b5fe6527d


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `bun run lint-backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests 
