### PR TITLE
Make host.docker.internal ip work for local minio setup

### DIFF
--- a/supabase/functions/_utils/r2.ts
+++ b/supabase/functions/_utils/r2.ts
@@ -31,9 +31,14 @@ function upload(fileId: string, file: Uint8Array) {
   return client.putObject(fileId, file)
 }
 
-function getUploadUrl(fileId: string, expirySeconds = 60) {
+async function getUploadUrl(fileId: string, expirySeconds = 60) {
   const client = initR2()
-  return client.getPresignedUrl('PUT', fileId, { expirySeconds })
+
+  const url = new URL(await client.getPresignedUrl('PUT', fileId, { expirySeconds }))
+  if (url.hostname === 'host.docker.internal')
+    url.hostname = '0.0.0.0'
+
+  return url.toString()
 }
 
 function deleteObject(fileId: string) {
@@ -46,9 +51,13 @@ function checkIfExist(fileId: string) {
   return client.exists(fileId)
 }
 
-function getSignedUrl(fileId: string, expirySeconds: number) {
+async function getSignedUrl(fileId: string, expirySeconds: number) {
   const client = initR2()
-  return client.getPresignedUrl('GET', fileId, { expirySeconds })
+  const url = new URL(await client.getPresignedUrl('GET', fileId, { expirySeconds }))
+  if (url.hostname === 'host.docker.internal')
+    url.hostname = '0.0.0.0'
+
+  return url.toString()
 }
 // get the size from r2
 async function getSizeChecksum(fileId: string) {


### PR DESCRIPTION
## Summary

Allow usage of the `host.docker.internal` in the minio local setup. Makes setting up minio easier

## Test plan

Set `S3_ENDPOINT=host.docker.internal` in the `.env` file and setup minio following the documentation. Then just check if this works.

## Screenshots

![image](https://github.com/Cap-go/capgo/assets/50914789/7d041f06-96c0-49f6-ba38-1626b50571f2)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `bun run lint-backend && bun run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/Cap-go/website) accordingly. Available [here](https://github.com/Cap-go/website/pull/176)
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests 
