### PR TITLE
fix: Drop unused jobqueue triggers

### DIFF
--- a/supabase/migrations/20240211054205_drop_unused_jobqueue_triggers.sql
+++ b/supabase/migrations/20240211054205_drop_unused_jobqueue_triggers.sql
@@ -1,0 +1,7 @@
+drop trigger on_app_delete_sql on apps;
+drop trigger on_app_versions_delete_sql on app_versions;
+drop trigger on_device_delete_sql on devices;
+
+DROP FUNCTION on_app_version_delete_sql();
+DROP FUNCTION on_app_delete_sql();
+DROP FUNCTION on_device_delete_sql();

--- a/supabase/migrations/20240211054205_drop_unused_jobqueue_triggers.sql
+++ b/supabase/migrations/20240211054205_drop_unused_jobqueue_triggers.sql
@@ -2,6 +2,6 @@ drop trigger on_app_delete_sql on apps;
 drop trigger on_app_versions_delete_sql on app_versions;
 drop trigger on_device_delete_sql on devices;
 
-DROP FUNCTION on_app_version_delete_sql();
-DROP FUNCTION on_app_delete_sql();
-DROP FUNCTION on_device_delete_sql();
+drop function on_app_version_delete_sql();
+drop function on_app_delete_sql();
+drop function on_device_delete_sql();


### PR DESCRIPTION
## Summary

Fixes #547 by removing the triggers that were causing this issue. Those triggers were unused as can be seen on this screenshot
![image](https://github.com/Cap-go/capgo/assets/50914789/f61e33e7-0af6-4806-b9d2-c1de5bdd3cb8)

There isn't a `APP_DELETE`, `APP_VERSION_DELETE` or `DEVICE_DELETE` as originally designed in the job queue. After clickhouse integration those triggers were deleted from the job queue.

Dropping those triggers will not have any negative effect on the project 

## Test plan

Please see the video

## Screenshots

https://github.com/Cap-go/capgo/assets/50914789/8d3630e9-169c-4bfc-8cca-a4ea2e78355f

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `bun run lint-backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests 

/claim #547