### PR TITLE
Fix: Current tier/trial banner with multiple orgs

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -323,7 +323,8 @@ plan-inactive: Plan inactive
 plan-is-the-best-pla: plan is the best plan for your needs.
 plan-maker: Best for small business owners
 plan-member: plan member.
-plan-page-warn: Buying a plan will not affect the organizations your are invited to
+plan-page-warn: Buying a plan will not affect the organizations your are invited to.
+plan-page-warn-2: Learn more about it.
 plan-payasyougo: Best for scalling enterprises
 plan-pricing-plans: Pricing Plans
 plan-progressive-deploy: Progressive deploy
@@ -331,7 +332,7 @@ plan-solo: Best for indies
 plan-storage: GB Storage
 plan-team: Best for big business owners
 plan-updates: Updates
-plan-upgrade: Subcribes
+plan-upgrade: Subscribe
 plan-whats-included: What's included
 plans: Plans
 platform: Platform

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -166,6 +166,9 @@ device: Device
 device-id: Device ID
 devices: Devices
 devices-using-this-b: Devices using this bundle
+dialog-warning-msg: |-
+  This information comes from the organization owner.
+  You cannot upgrade the capgo tier for this app
 did-not-recive-confirm-email: Didn't receive confirmation email?
 disable: Disable
 disable-ab-testing: Disabled AB testing
@@ -320,6 +323,7 @@ plan-inactive: Plan inactive
 plan-is-the-best-pla: plan is the best plan for your needs.
 plan-maker: Best for small business owners
 plan-member: plan member.
+plan-page-warn: Buying a plan will not affect the organizations your are invited to
 plan-payasyougo: Best for scalling enterprises
 plan-pricing-plans: Pricing Plans
 plan-progressive-deploy: Progressive deploy
@@ -437,6 +441,7 @@ version-builtin: Version builtin
 version-linked: Version link
 version-linking: Link to bundle
 versions: Versions
+warning: Warning!
 welcome-to: Welcome to
 welcome-to-your-capg: Welcome to your Capgo Dashboard
 yearly: Yearly

--- a/src/pages/dashboard/settings/Plans.vue
+++ b/src/pages/dashboard/settings/Plans.vue
@@ -11,6 +11,8 @@ import { useLogSnag } from '~/services/logsnag'
 import { openMessenger } from '~/services/chatwoot'
 import type { Database } from '~/types/supabase.types'
 import type { Stat } from '~/components/comp_def'
+import HeroiconsExclamationTriangleSolid from '~icons/heroicons/exclamation-triangle-solid'
+import { useOrganizationStore } from '~/stores/organization'
 
 function openSupport() {
   openMessenger()
@@ -36,6 +38,7 @@ const segmentVal = ref<'m' | 'y'>('y')
 const isYearly = computed(() => segmentVal.value === 'y')
 const route = useRoute()
 const main = useMainStore()
+const organizationStore = useOrganizationStore()
 const isMobile = Capacitor.isNativePlatform()
 
 function planFeatures(plan: Database['public']['Tables']['plans']['Row']) {
@@ -177,6 +180,13 @@ const hightLights = computed<Stat[]>(() => ([
         <p class="mt-5 text-xl text-gray-700 sm:text-center dark:text-white">
           {{ t('plan-desc') }}<br>
         </p>
+        <div v-if="organizationStore.organizations.length > 1" class="flex flex-row ml-auto mr-auto">
+          <HeroiconsExclamationTriangleSolid class="h-[35px] w-[35px] mt-1 mb-0 pr-2" style="color: #ea590b" />
+          <p class="mt-2 text-lg sm:text-center text-orange-600 w-fit">
+            {{ t('plan-page-warn') }}<br>
+          </p>
+          <HeroiconsExclamationTriangleSolid class="h-[35px] w-[35px] mt-1 mb-0 pl-2" style="color: #ea590b" />
+        </div>
       </div>
       <section class="px-8 pt-4 sm:px-0">
         <BlurBg :mini="true">

--- a/src/pages/dashboard/settings/Plans.vue
+++ b/src/pages/dashboard/settings/Plans.vue
@@ -11,7 +11,6 @@ import { useLogSnag } from '~/services/logsnag'
 import { openMessenger } from '~/services/chatwoot'
 import type { Database } from '~/types/supabase.types'
 import type { Stat } from '~/components/comp_def'
-import HeroiconsExclamationTriangleSolid from '~icons/heroicons/exclamation-triangle-solid'
 import { useOrganizationStore } from '~/stores/organization'
 
 function openSupport() {
@@ -181,11 +180,11 @@ const hightLights = computed<Stat[]>(() => ([
           {{ t('plan-desc') }}<br>
         </p>
         <div v-if="organizationStore.organizations.length > 1" class="flex flex-row ml-auto mr-auto">
-          <HeroiconsExclamationTriangleSolid class="h-[35px] w-[35px] mt-1 mb-0 pr-2" style="color: #ea590b" />
-          <p class="mt-2 text-lg sm:text-center text-orange-600 w-fit">
-            {{ t('plan-page-warn') }}<br>
+          <p class="mt-2 text-lg sm:text-center text-gray-700 dark:text-white w-fit">
+            {{ t('plan-page-warn') }}
+            <a class="text-blue-600" href="https://capgo.app/docs/docs/webapp/payment/">{{ t('plan-page-warn-2') }}</a>
+            <br>
           </p>
-          <HeroiconsExclamationTriangleSolid class="h-[35px] w-[35px] mt-1 mb-0 pl-2" style="color: #ea590b" />
         </div>
       </div>
       <section class="px-8 pt-4 sm:px-0">

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -1,12 +1,13 @@
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
+import { or } from 'drizzle-orm'
 import { useMainStore } from './main'
 import type { Database } from '~/types/supabase.types'
 import { useSupabase } from '~/services/supabase'
 import type { ArrayElement, Concrete, Merge } from '~/services/types'
 
-export type Organization = ArrayElement<Database['public']['Functions']['get_orgs_v2']['Returns']>
+export type Organization = ArrayElement<Database['public']['Functions']['get_orgs_v3']['Returns']>
 export type OrganizationRole = Database['public']['Enums']['user_min_right'] | 'owner'
 export type ExtendedOrganizationMember = Concrete<Merge<ArrayElement<Database['public']['Functions']['get_org_members']['Returns']>, { id: number }>>
 export type ExtendedOrganizationMembers = ExtendedOrganizationMember[]
@@ -17,6 +18,7 @@ const supabase = useSupabase()
 
 export const useOrganizationStore = defineStore('organization', () => {
   const _organizations: Ref<Map<string, Organization>> = ref(new Map())
+  const _organizationsByAppId: Ref<Map<string, Organization>> = ref(new Map())
 
   const organizations: ComputedRef<Organization[]> = computed(
     () => {
@@ -51,6 +53,35 @@ export const useOrganizationStore = defineStore('organization', () => {
 
     currentRole.value = await getCurrentRole(currentOrganization.created_by, undefined, undefined)
   })
+
+  watch(_organizations, async (organizationsMap) => {
+    const organizations = Array.from(organizationsMap.values())
+    const { error, data: allAppsByOwner } = await supabase.from('apps').select('app_id, user_id')
+    if (error) {
+      console.error('Cannot get app apps for org store', error)
+      return
+    }
+
+    const organizationsByAppId = new Map<string, Organization>()
+
+    for (const app of allAppsByOwner) {
+      // For each app find the org_id that owns said app
+      // This is needed for the "banner"
+      const org = organizations.find(org => org.created_by === app.user_id)
+      if (!org) {
+        console.error(`Cannot find organization for app ${app}`)
+        return
+      }
+
+      organizationsByAppId.set(app.app_id, org)
+    }
+
+    _organizationsByAppId.value = organizationsByAppId
+  })
+
+  const getOrgByAppId = (appId: string) => {
+    return _organizationsByAppId.value.get(appId)
+  }
 
   const setCurrentOrganization = (id: string) => {
     currentOrganization.value = organizations.value.find(org => org.gid === id)
@@ -109,7 +140,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 
     // We have RLS that ensure that we only selct rows where we are member or owner
     const { data, error } = await supabase
-      .rpc('get_orgs_v2', {
+      .rpc('get_orgs_v3', {
         userid: userId,
       })
 
@@ -148,5 +179,6 @@ export const useOrganizationStore = defineStore('organization', () => {
     hasPermisisonsInRole,
     fetchOrganizations,
     dedupFetchOrganizations,
+    getOrgByAppId,
   }
 })

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -39,7 +39,7 @@ export interface Database {
           created_at: string | null
           id: number
           key: string
-          mode: Database['public']['Enums']['key_mode']
+          mode: Database["public"]["Enums"]["key_mode"]
           updated_at: string | null
           user_id: string
         }
@@ -47,7 +47,7 @@ export interface Database {
           created_at?: string | null
           id?: number
           key: string
-          mode: Database['public']['Enums']['key_mode']
+          mode: Database["public"]["Enums"]["key_mode"]
           updated_at?: string | null
           user_id: string
         }
@@ -55,18 +55,18 @@ export interface Database {
           created_at?: string | null
           id?: number
           key?: string
-          mode?: Database['public']['Enums']['key_mode']
+          mode?: Database["public"]["Enums"]["key_mode"]
           updated_at?: string | null
           user_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: 'apikeys_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "apikeys_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       app_usage: {
@@ -162,19 +162,19 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'app_versions_app_id_fkey'
-            columns: ['app_id']
+            foreignKeyName: "app_versions_app_id_fkey"
+            columns: ["app_id"]
             isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
           },
           {
-            foreignKeyName: 'app_versions_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "app_versions_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       app_versions_meta: {
@@ -219,26 +219,26 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'app_versions_meta_app_id_fkey'
-            columns: ['app_id']
+            foreignKeyName: "app_versions_meta_app_id_fkey"
+            columns: ["app_id"]
             isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
           },
           {
-            foreignKeyName: 'app_versions_meta_id_fkey'
-            columns: ['id']
+            foreignKeyName: "app_versions_meta_id_fkey"
+            columns: ["id"]
             isOneToOne: true
-            referencedRelation: 'app_versions'
-            referencedColumns: ['id']
+            referencedRelation: "app_versions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'app_versions_meta_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "app_versions_meta_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       apps: {
@@ -246,10 +246,11 @@ export interface Database {
           app_id: string
           created_at: string | null
           icon_url: string
-          id: string | null
+          id: number
           last_version: string | null
           name: string | null
           retention: number
+          tmp_id: string | null
           updated_at: string | null
           user_id: string
         }
@@ -257,10 +258,11 @@ export interface Database {
           app_id: string
           created_at?: string | null
           icon_url: string
-          id?: string | null
+          id?: number
           last_version?: string | null
           name?: string | null
           retention?: number
+          tmp_id?: string | null
           updated_at?: string | null
           user_id: string
         }
@@ -268,21 +270,22 @@ export interface Database {
           app_id?: string
           created_at?: string | null
           icon_url?: string
-          id?: string | null
+          id?: number
           last_version?: string | null
           name?: string | null
           retention?: number
+          tmp_id?: string | null
           updated_at?: string | null
           user_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: 'apps_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "apps_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       channel_devices: {
@@ -292,6 +295,7 @@ export interface Database {
           created_at: string | null
           created_by: string
           device_id: string
+          id: number
           updated_at: string
         }
         Insert: {
@@ -300,6 +304,7 @@ export interface Database {
           created_at?: string | null
           created_by: string
           device_id: string
+          id?: number
           updated_at?: string
         }
         Update: {
@@ -308,89 +313,31 @@ export interface Database {
           created_at?: string | null
           created_by?: string
           device_id?: string
+          id?: number
           updated_at?: string
         }
         Relationships: [
           {
-            foreignKeyName: 'channel_devices_app_id_fkey'
-            columns: ['app_id']
+            foreignKeyName: "channel_devices_app_id_fkey"
+            columns: ["app_id"]
             isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
           },
           {
-            foreignKeyName: 'channel_devices_channel_id_fkey'
-            columns: ['channel_id']
+            foreignKeyName: "channel_devices_channel_id_fkey"
+            columns: ["channel_id"]
             isOneToOne: false
-            referencedRelation: 'channels'
-            referencedColumns: ['id']
+            referencedRelation: "channels"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'channel_devices_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "channel_devices_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-        ]
-      }
-      channel_users: {
-        Row: {
-          app_id: string
-          channel_id: number
-          created_at: string | null
-          created_by: string | null
-          id: number
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          app_id: string
-          channel_id: number
-          created_at?: string | null
-          created_by?: string | null
-          id?: number
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          app_id?: string
-          channel_id?: number
-          created_at?: string | null
-          created_by?: string | null
-          id?: number
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'channel_users_app_id_fkey'
-            columns: ['app_id']
-            isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
-          },
-          {
-            foreignKeyName: 'channel_users_channel_id_fkey'
-            columns: ['channel_id']
-            isOneToOne: false
-            referencedRelation: 'channels'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'channel_users_created_by_fkey'
-            columns: ['created_by']
-            isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'channel_users_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       channels: {
@@ -403,7 +350,7 @@ export interface Database {
           beta: boolean
           created_at: string
           created_by: string
-          disableAutoUpdate: Database['public']['Enums']['disable_update']
+          disableAutoUpdate: Database["public"]["Enums"]["disable_update"]
           disableAutoUpdateUnderNative: boolean
           enable_progressive_deploy: boolean
           enableAbTesting: boolean
@@ -425,7 +372,7 @@ export interface Database {
           beta?: boolean
           created_at?: string
           created_by: string
-          disableAutoUpdate?: Database['public']['Enums']['disable_update']
+          disableAutoUpdate?: Database["public"]["Enums"]["disable_update"]
           disableAutoUpdateUnderNative?: boolean
           enable_progressive_deploy?: boolean
           enableAbTesting?: boolean
@@ -447,7 +394,7 @@ export interface Database {
           beta?: boolean
           created_at?: string
           created_by?: string
-          disableAutoUpdate?: Database['public']['Enums']['disable_update']
+          disableAutoUpdate?: Database["public"]["Enums"]["disable_update"]
           disableAutoUpdateUnderNative?: boolean
           enable_progressive_deploy?: boolean
           enableAbTesting?: boolean
@@ -462,33 +409,33 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'channels_app_id_fkey'
-            columns: ['app_id']
+            foreignKeyName: "channels_app_id_fkey"
+            columns: ["app_id"]
             isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
           },
           {
-            foreignKeyName: 'channels_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "channels_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'channels_secondVersion_fkey'
-            columns: ['secondVersion']
+            foreignKeyName: "channels_secondVersion_fkey"
+            columns: ["secondVersion"]
             isOneToOne: false
-            referencedRelation: 'app_versions'
-            referencedColumns: ['id']
+            referencedRelation: "app_versions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'channels_version_fkey'
-            columns: ['version']
+            foreignKeyName: "channels_version_fkey"
+            columns: ["version"]
             isOneToOne: false
-            referencedRelation: 'app_versions'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "app_versions"
+            referencedColumns: ["id"]
+          }
         ]
       }
       deleted_account: {
@@ -518,7 +465,7 @@ export interface Database {
           is_emulator: boolean | null
           is_prod: boolean | null
           os_version: string | null
-          platform: Database['public']['Enums']['platform_os'] | null
+          platform: Database["public"]["Enums"]["platform_os"] | null
           plugin_version: string
           updated_at: string
           version: number
@@ -532,7 +479,7 @@ export interface Database {
           is_emulator?: boolean | null
           is_prod?: boolean | null
           os_version?: string | null
-          platform?: Database['public']['Enums']['platform_os'] | null
+          platform?: Database["public"]["Enums"]["platform_os"] | null
           plugin_version?: string
           updated_at: string
           version: number
@@ -546,7 +493,7 @@ export interface Database {
           is_emulator?: boolean | null
           is_prod?: boolean | null
           os_version?: string | null
-          platform?: Database['public']['Enums']['platform_os'] | null
+          platform?: Database["public"]["Enums"]["platform_os"] | null
           plugin_version?: string
           updated_at?: string
           version?: number
@@ -560,6 +507,7 @@ export interface Database {
           created_at: string | null
           created_by: string | null
           device_id: string
+          id: number
           updated_at: string | null
           version: number
         }
@@ -568,6 +516,7 @@ export interface Database {
           created_at?: string | null
           created_by?: string | null
           device_id: string
+          id?: number
           updated_at?: string | null
           version: number
         }
@@ -576,31 +525,32 @@ export interface Database {
           created_at?: string | null
           created_by?: string | null
           device_id?: string
+          id?: number
           updated_at?: string | null
           version?: number
         }
         Relationships: [
           {
-            foreignKeyName: 'devices_override_app_id_fkey'
-            columns: ['app_id']
+            foreignKeyName: "devices_override_app_id_fkey"
+            columns: ["app_id"]
             isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
           },
           {
-            foreignKeyName: 'devices_override_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "devices_override_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'devices_override_version_fkey'
-            columns: ['version']
+            foreignKeyName: "devices_override_version_fkey"
+            columns: ["version"]
             isOneToOne: false
-            referencedRelation: 'app_versions'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "app_versions"
+            referencedColumns: ["id"]
+          }
         ]
       }
       global_stats: {
@@ -648,27 +598,36 @@ export interface Database {
       job_queue: {
         Row: {
           created_at: string | null
+          extra_info: Json
           function_name: string | null
           function_type: string | null
           job_id: number
           job_type: string
           payload: string
+          request_id: number | null
+          status: Database["public"]["Enums"]["queue_job_status"]
         }
         Insert: {
           created_at?: string | null
+          extra_info?: Json
           function_name?: string | null
           function_type?: string | null
           job_id?: number
           job_type: string
           payload: string
+          request_id?: number | null
+          status?: Database["public"]["Enums"]["queue_job_status"]
         }
         Update: {
           created_at?: string | null
+          extra_info?: Json
           function_name?: string | null
           function_type?: string | null
           job_id?: number
           job_type?: string
           payload?: string
+          request_id?: number | null
+          status?: Database["public"]["Enums"]["queue_job_status"]
         }
         Relationships: []
       }
@@ -699,12 +658,12 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'notifications_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "notifications_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       org_users: {
@@ -716,7 +675,7 @@ export interface Database {
           org_id: string
           updated_at: string | null
           user_id: string
-          user_right: Database['public']['Enums']['user_min_right'] | null
+          user_right: Database["public"]["Enums"]["user_min_right"] | null
         }
         Insert: {
           app_id?: string | null
@@ -726,7 +685,7 @@ export interface Database {
           org_id: string
           updated_at?: string | null
           user_id: string
-          user_right?: Database['public']['Enums']['user_min_right'] | null
+          user_right?: Database["public"]["Enums"]["user_min_right"] | null
         }
         Update: {
           app_id?: string | null
@@ -736,37 +695,37 @@ export interface Database {
           org_id?: string
           updated_at?: string | null
           user_id?: string
-          user_right?: Database['public']['Enums']['user_min_right'] | null
+          user_right?: Database["public"]["Enums"]["user_min_right"] | null
         }
         Relationships: [
           {
-            foreignKeyName: 'org_users_app_id_fkey'
-            columns: ['app_id']
+            foreignKeyName: "org_users_app_id_fkey"
+            columns: ["app_id"]
             isOneToOne: false
-            referencedRelation: 'apps'
-            referencedColumns: ['app_id']
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
           },
           {
-            foreignKeyName: 'org_users_channel_id_fkey'
-            columns: ['channel_id']
+            foreignKeyName: "org_users_channel_id_fkey"
+            columns: ["channel_id"]
             isOneToOne: false
-            referencedRelation: 'channels'
-            referencedColumns: ['id']
+            referencedRelation: "channels"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'org_users_org_id_fkey'
-            columns: ['org_id']
+            foreignKeyName: "org_users_org_id_fkey"
+            columns: ["org_id"]
             isOneToOne: false
-            referencedRelation: 'orgs'
-            referencedColumns: ['id']
+            referencedRelation: "orgs"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'org_users_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "org_users_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       orgs: {
@@ -796,12 +755,12 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'orgs_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "orgs_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       plans: {
@@ -900,7 +859,7 @@ export interface Database {
           app_id: string
           created_at: string
           device_id: string
-          platform: Database['public']['Enums']['platform_os']
+          platform: Database["public"]["Enums"]["platform_os"]
           version: number
           version_build: string
         }
@@ -909,7 +868,7 @@ export interface Database {
           app_id: string
           created_at: string
           device_id: string
-          platform: Database['public']['Enums']['platform_os']
+          platform: Database["public"]["Enums"]["platform_os"]
           version: number
           version_build: string
         }
@@ -918,7 +877,7 @@ export interface Database {
           app_id?: string
           created_at?: string
           device_id?: string
-          platform?: Database['public']['Enums']['platform_os']
+          platform?: Database["public"]["Enums"]["platform_os"]
           version?: number
           version_build?: string
         }
@@ -1031,7 +990,7 @@ export interface Database {
           plan_usage: number | null
           price_id: string | null
           product_id: string
-          status: Database['public']['Enums']['stripe_status'] | null
+          status: Database["public"]["Enums"]["stripe_status"] | null
           subscription_anchor_end: string
           subscription_anchor_start: string
           subscription_id: string | null
@@ -1046,7 +1005,7 @@ export interface Database {
           plan_usage?: number | null
           price_id?: string | null
           product_id?: string
-          status?: Database['public']['Enums']['stripe_status'] | null
+          status?: Database["public"]["Enums"]["stripe_status"] | null
           subscription_anchor_end?: string
           subscription_anchor_start?: string
           subscription_id?: string | null
@@ -1061,7 +1020,7 @@ export interface Database {
           plan_usage?: number | null
           price_id?: string | null
           product_id?: string
-          status?: Database['public']['Enums']['stripe_status'] | null
+          status?: Database["public"]["Enums"]["stripe_status"] | null
           subscription_anchor_end?: string
           subscription_anchor_start?: string
           subscription_id?: string | null
@@ -1071,12 +1030,12 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'stripe_info_product_id_fkey'
-            columns: ['product_id']
+            foreignKeyName: "stripe_info_product_id_fkey"
+            columns: ["product_id"]
             isOneToOne: false
-            referencedRelation: 'plans'
-            referencedColumns: ['stripe_id']
-          },
+            referencedRelation: "plans"
+            referencedColumns: ["stripe_id"]
+          }
         ]
       }
       users: {
@@ -1127,19 +1086,19 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'users_customer_id_fkey'
-            columns: ['customer_id']
+            foreignKeyName: "users_customer_id_fkey"
+            columns: ["customer_id"]
             isOneToOne: true
-            referencedRelation: 'stripe_info'
-            referencedColumns: ['customer_id']
+            referencedRelation: "stripe_info"
+            referencedColumns: ["customer_id"]
           },
           {
-            foreignKeyName: 'users_id_fkey'
-            columns: ['id']
+            foreignKeyName: "users_id_fkey"
+            columns: ["id"]
             isOneToOne: true
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
         ]
       }
       workers: {
@@ -1170,24 +1129,24 @@ export interface Database {
       }
       check_min_rights:
         | {
-          Args: {
-            min_right: Database['public']['Enums']['user_min_right']
-            org_id: string
-            app_id: string
-            channel_id: number
+            Args: {
+              min_right: Database["public"]["Enums"]["user_min_right"]
+              org_id: string
+              app_id: string
+              channel_id: number
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            min_right: Database['public']['Enums']['user_min_right']
-            user_id: string
-            org_id: string
-            app_id: string
-            channel_id: number
+            Args: {
+              min_right: Database["public"]["Enums"]["user_min_right"]
+              user_id: string
+              org_id: string
+              app_id: string
+              channel_id: number
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
       convert_bytes_to_gb: {
         Args: {
           byt: number
@@ -1306,47 +1265,47 @@ export interface Database {
       }
       get_current_plan_max:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: string
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: string
           }
-          Returns: {
-            mau: number
-            bandwidth: number
-            storage: number
-          }[]
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: {
+              mau: number
+              bandwidth: number
+              storage: number
+            }[]
+          }
       get_current_plan_name:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: string
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: string
           }
-          Returns: string
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: string
+          }
       get_cycle_info:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: {
-            subscription_anchor_start: string
-            subscription_anchor_end: string
-          }[]
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: {
+              subscription_anchor_start: string
+              subscription_anchor_end: string
+            }[]
           }
-          Returns: {
-            subscription_anchor_start: string
-            subscription_anchor_end: string
-          }[]
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: {
+              subscription_anchor_start: string
+              subscription_anchor_end: string
+            }[]
+          }
       get_db_url: {
         Args: Record<PropertyKey, never>
         Returns: string
@@ -1364,34 +1323,34 @@ export interface Database {
       }
       get_max_plan:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: {
-            mau: number
-            storage: number
-            bandwidth: number
-          }[]
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: {
+              mau: number
+              storage: number
+              bandwidth: number
+            }[]
           }
-          Returns: {
-            mau: number
-            storage: number
-            bandwidth: number
-          }[]
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: {
+              mau: number
+              storage: number
+              bandwidth: number
+            }[]
+          }
       get_metered_usage:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: number
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: number
           }
-          Returns: Database['public']['CompositeTypes']['stats_table']
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: Database["public"]["CompositeTypes"]["stats_table"]
+          }
       get_org_members: {
         Args: {
           guild_id: string
@@ -1432,104 +1391,130 @@ export interface Database {
           role: string
         }[]
       }
+      get_orgs_v3: {
+        Args: {
+          userid: string
+        }
+        Returns: {
+          gid: string
+          created_by: string
+          logo: string
+          name: string
+          role: string
+          paying: boolean
+          trial_left: number
+          can_use_more: boolean
+          is_canceled: boolean
+        }[]
+      }
       get_plan_usage_percent:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: number
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: number
           }
-          Returns: number
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: number
+          }
       get_total_app_storage_size:
         | {
-          Args: {
-            app_id: string
+            Args: {
+              app_id: string
+            }
+            Returns: number
           }
-          Returns: number
-        }
         | {
-          Args: {
-            userid: string
-            app_id: string
+            Args: {
+              userid: string
+              app_id: string
+            }
+            Returns: number
           }
-          Returns: number
-        }
       get_total_stats_v2:
         | {
-          Args: {
-            dateid: string
+            Args: {
+              dateid: string
+            }
+            Returns: {
+              mau: number
+              bandwidth: number
+              storage: number
+            }[]
           }
-          Returns: {
-            mau: number
-            bandwidth: number
-            storage: number
-          }[]
-        }
         | {
-          Args: {
-            userid: string
-            dateid: string
+            Args: {
+              userid: string
+              dateid: string
+            }
+            Returns: {
+              mau: number
+              bandwidth: number
+              storage: number
+            }[]
           }
-          Returns: {
-            mau: number
-            bandwidth: number
-            storage: number
-          }[]
-        }
       get_total_stats_v3:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: {
-            mau: number
-            bandwidth: number
-            storage: number
-          }[]
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: {
+              mau: number
+              bandwidth: number
+              storage: number
+            }[]
           }
-          Returns: {
-            mau: number
-            bandwidth: number
-            storage: number
-          }[]
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: {
+              mau: number
+              bandwidth: number
+              storage: number
+            }[]
+          }
+      get_total_stats_v4: {
+        Args: {
+          userid: string
         }
+        Returns: {
+          mau: number
+          bandwidth: number
+          storage: number
+        }[]
+      }
       get_total_storage_size:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: number
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: number
           }
-          Returns: number
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: number
+          }
       get_usage_mode_and_last_saved: {
         Args: Record<PropertyKey, never>
         Returns: {
-          usage_mode: Database['public']['Enums']['usage_mode']
+          usage_mode: Database["public"]["Enums"]["usage_mode"]
           last_saved: string
         }[]
       }
       get_user_id:
         | {
-          Args: {
-            apikey: string
+            Args: {
+              apikey: string
+            }
+            Returns: string
           }
-          Returns: string
-        }
         | {
-          Args: {
-            apikey: string
-            app_id: string
+            Args: {
+              apikey: string
+              app_id: string
+            }
+            Returns: string
           }
-          Returns: string
-        }
       get_user_main_org_id: {
         Args: {
           user_id: string
@@ -1556,7 +1541,7 @@ export interface Database {
         Args: {
           _userid: string
           _orgid: string
-          _right: Database['public']['Enums']['user_min_right']
+          _right: Database["public"]["Enums"]["user_min_right"]
           _appid?: string
           _channelid?: number
         }
@@ -1581,183 +1566,148 @@ export interface Database {
         Args: {
           email: string
           org_id: string
-          invite_type: Database['public']['Enums']['user_min_right']
+          invite_type: Database["public"]["Enums"]["user_min_right"]
         }
         Returns: string
       }
       is_admin:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_allowed_action:
         | {
-          Args: {
-            apikey: string
+            Args: {
+              apikey: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            apikey: string
-            appid: string
+            Args: {
+              apikey: string
+              appid: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
-        | {
-          Args: {
-            apikey: string
-            appid: string
-          }
-          Returns: boolean
-        }
       is_allowed_action_user:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_allowed_capgkey:
         | {
-          Args: {
-            apikey: string
-            keymode: Database['public']['Enums']['key_mode'][]
+            Args: {
+              apikey: string
+              keymode: Database["public"]["Enums"]["key_mode"][]
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            apikey: string
-            keymode: Database['public']['Enums']['key_mode'][]
-            app_id: string
+            Args: {
+              apikey: string
+              keymode: Database["public"]["Enums"]["key_mode"][]
+              app_id: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            apikey: string
-            keymode: Database['public']['Enums']['key_mode'][]
-            app_id: string
-            channel_id: number
-            right: Database['public']['Enums']['user_min_right']
-            user_id: string
+            Args: {
+              apikey: string
+              keymode: Database["public"]["Enums"]["key_mode"][]
+              app_id: string
+              channel_id: number
+              right: Database["public"]["Enums"]["user_min_right"]
+              user_id: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            apikey: string
-            keymode: Database['public']['Enums']['key_mode'][]
-            app_id: string
-            right: Database['public']['Enums']['user_min_right']
-            user_id: string
+            Args: {
+              apikey: string
+              keymode: Database["public"]["Enums"]["key_mode"][]
+              app_id: string
+              right: Database["public"]["Enums"]["user_min_right"]
+              user_id: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
       is_app_owner:
         | {
-          Args: {
-            apikey: string
-            appid: string
+            Args: {
+              apikey: string
+              appid: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            appid: string
+            Args: {
+              appid: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
         | {
-          Args: {
-            userid: string
-            appid: string
+            Args: {
+              userid: string
+              appid: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
-      is_app_shared:
-        | {
-          Args: {
-            appid: string
-          }
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
-            appid: string
-          }
-          Returns: boolean
-        }
       is_canceled:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_free_usage:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_good_plan_v3:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_good_plan_v4:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
-      is_in_channel:
         | {
-          Args: {
-            userid: string
+            Args: {
+              userid: string
+            }
+            Returns: boolean
           }
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
-            ownerid: string
-          }
-          Returns: boolean
-        }
       is_member_of_org: {
         Args: {
           user_id: string
@@ -1773,26 +1723,26 @@ export interface Database {
       }
       is_onboarded:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_onboarding_needed:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_owner_of_org: {
         Args: {
           user_id: string
@@ -1802,58 +1752,62 @@ export interface Database {
       }
       is_paying:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_paying_and_good_plan:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: boolean
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: boolean
           }
-          Returns: boolean
-        }
+        | {
+            Args: {
+              userid: string
+            }
+            Returns: boolean
+          }
       is_trial:
         | {
-          Args: Record<PropertyKey, never>
-          Returns: number
-        }
-        | {
-          Args: {
-            userid: string
+            Args: Record<PropertyKey, never>
+            Returns: number
           }
-          Returns: number
-        }
-      is_version_shared:
         | {
-          Args: {
-            userid: string
-            versionid: number
+            Args: {
+              userid: string
+            }
+            Returns: number
           }
-          Returns: boolean
-        }
-        | {
-          Args: {
-            versionid: number
-          }
-          Returns: boolean
-        }
       one_month_ahead: {
         Args: Record<PropertyKey, never>
         Returns: string
       }
+      post_replication_sql:
+        | {
+            Args: {
+              sql_query: string
+            }
+            Returns: undefined
+          }
+        | {
+            Args: {
+              sql_query: string
+              params: string[]
+            }
+            Returns: undefined
+          }
       process_current_jobs_if_unlocked: {
         Args: Record<PropertyKey, never>
         Returns: number[]
+      }
+      process_requested_jobs: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
       }
       remove_enum_value: {
         Args: {
@@ -1862,33 +1816,42 @@ export interface Database {
         }
         Returns: undefined
       }
+      retry_failed_jobs: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       schedule_jobs: {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      verify_mfa: {
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
     }
     Enums: {
-      disable_update: 'major' | 'minor' | 'version_number' | 'none'
-      key_mode: 'read' | 'write' | 'all' | 'upload'
-      platform_os: 'ios' | 'android'
+      disable_update: "major" | "minor" | "version_number" | "none"
+      key_mode: "read" | "write" | "all" | "upload"
+      platform_os: "ios" | "android"
+      queue_job_status: "inserted" | "requested" | "failed"
       stripe_status:
-        | 'created'
-        | 'succeeded'
-        | 'updated'
-        | 'failed'
-        | 'deleted'
-        | 'canceled'
-      usage_mode: 'last_saved' | '5min' | 'day' | 'cycle'
+        | "created"
+        | "succeeded"
+        | "updated"
+        | "failed"
+        | "deleted"
+        | "canceled"
+      usage_mode: "last_saved" | "5min" | "day" | "cycle"
       user_min_right:
-        | 'invite_read'
-        | 'invite_upload'
-        | 'invite_write'
-        | 'invite_admin'
-        | 'read'
-        | 'upload'
-        | 'write'
-        | 'admin'
-      user_role: 'read' | 'upload' | 'write' | 'admin'
+        | "invite_read"
+        | "invite_upload"
+        | "invite_write"
+        | "invite_admin"
+        | "read"
+        | "upload"
+        | "write"
+        | "admin"
+      user_role: "read" | "upload" | "write" | "admin"
     }
     CompositeTypes: {
       orgs_table: {
@@ -2017,12 +1980,12 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: 'objects_bucketId_fkey'
-            columns: ['bucket_id']
+            foreignKeyName: "objects_bucketId_fkey"
+            columns: ["bucket_id"]
             isOneToOne: false
-            referencedRelation: 'buckets'
-            referencedColumns: ['id']
-          },
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          }
         ]
       }
     }
@@ -2096,80 +2059,81 @@ export interface Database {
 
 export type Tables<
   PublicTableNameOrOptions extends
-  | keyof (Database['public']['Tables'] & Database['public']['Views'])
-  | { schema: keyof Database },
+    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-    Database[PublicTableNameOrOptions['schema']]['Views'])
-    : never = never,
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-  Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
-      ? R
-      : never
-  : PublicTableNameOrOptions extends keyof (Database['public']['Tables'] &
-  Database['public']['Views'])
-    ? (Database['public']['Tables'] &
-    Database['public']['Views'])[PublicTableNameOrOptions] extends {
-        Row: infer R
-      }
-        ? R
-        : never
+    ? R
     : never
+  : PublicTableNameOrOptions extends keyof (Database["public"]["Tables"] &
+      Database["public"]["Views"])
+  ? (Database["public"]["Tables"] &
+      Database["public"]["Views"])[PublicTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-  | keyof Database['public']['Tables']
-  | { schema: keyof Database },
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
-    : never = never,
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-    Insert: infer I
-  }
-    ? I
-    : never
-  : PublicTableNameOrOptions extends keyof Database['public']['Tables']
-    ? Database['public']['Tables'][PublicTableNameOrOptions] extends {
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
-      ? I
-      : never
+    ? I
     : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-  | keyof Database['public']['Tables']
-  | { schema: keyof Database },
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
-    : never = never,
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-    Update: infer U
-  }
-    ? U
-    : never
-  : PublicTableNameOrOptions extends keyof Database['public']['Tables']
-    ? Database['public']['Tables'][PublicTableNameOrOptions] extends {
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
-      ? U
-      : never
+    ? U
     : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
 
 export type Enums<
   PublicEnumNameOrOptions extends
-  | keyof Database['public']['Enums']
-  | { schema: keyof Database },
+    | keyof Database["public"]["Enums"]
+    | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
-    : never = never,
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : PublicEnumNameOrOptions extends keyof Database['public']['Enums']
-    ? Database['public']['Enums'][PublicEnumNameOrOptions]
-    : never
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
+  ? Database["public"]["Enums"][PublicEnumNameOrOptions]
+  : never
+

--- a/supabase/migrations/20240211075041_fix_organization_paying_banner.sql
+++ b/supabase/migrations/20240211075041_fix_organization_paying_banner.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION "public"."get_orgs_v3"("userid" "uuid") RETURNS TABLE(gid uuid, created_by uuid, logo text, name text, role varchar, paying boolean, trial_left integer, can_use_more boolean, is_canceled boolean)
+    LANGUAGE "plpgsql"
+    AS $$
+BEGIN
+  return query select 
+  o.id as gid, 
+  o.created_by, 
+  o.logo, 
+  o.name, 
+  org_users.user_right::varchar, 
+  is_paying(o.created_by) as paying, 
+  is_trial(o.created_by) as trial_left, 
+  is_allowed_action_user(o.created_by) as can_use_more,
+  is_canceled(o.created_by) as is_canceled
+  from orgs as o
+  join org_users on org_users.user_id=get_orgs_v3.userid
+  where o.created_by != get_orgs_v3.userid
+  union all
+  select o.id as gid, 
+  o.created_by, 
+  o.logo, 
+  o.name, 'owner' as "role", 
+  is_paying(o.created_by), 
+  is_trial(o.created_by) as trial_left, 
+  is_allowed_action_user(o.created_by) as can_use_more,
+  is_canceled(o.created_by) as is_canceled
+  from orgs as o
+  where o.created_by = get_orgs_v3.userid;
+END;  
+$$;


### PR DESCRIPTION
## Summary

This PR solves the issue https://github.com/Cap-go/capgo/issues/526. It does so by making the following changes:

The banner will NEVER appear on this screen:
![image](https://github.com/Cap-go/capgo/assets/50914789/699ad9bc-ba30-40f7-9f82-21fe35d17c68)

A banner will appear for the appropriate trial/tier on the app page. What I mean by that is that if user A own app `com.demo.app` and invites user B that owns `com.apple.stock` and user A has a valid plan but user B does not when user B clicks on `com.demo.app` he will see the banner that user A would see.

For the owner it will look something like this:
![image](https://github.com/Cap-go/capgo/assets/50914789/2963e41e-7302-4cb0-b4a4-b9991de016ce)

But for the invited user it will look like this:

![image](https://github.com/Cap-go/capgo/assets/50914789/2e76f526-bd31-4724-a5c8-00e9e27c47a5)

As you can see, there is a difference. This is because the user B (the invited one) CANNOT upgrade the tier of the organization owner. If you click on the information icon you will be informed about it.

![image](https://github.com/Cap-go/capgo/assets/50914789/3d61666b-552e-430c-b94d-983afa9af82b)

If, however you still try to upgrade the capgo tier you will be warned that it's only going to affect the apps you own

![image](https://github.com/Cap-go/capgo/assets/50914789/601ef69e-526c-4701-a816-9709264dc790)

This warning does not appear if you are not invited to any organizations

![image](https://github.com/Cap-go/capgo/assets/50914789/d7009afc-16c3-4502-9f5f-9d81550a986a)


## Test plan

<!-- Include the steps to test your PR -->
<!-- Any PR that requires a complex setup to test MUST include this -->

## Screenshots

See above

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `bun run lint-backend && bun run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly. (TODO)
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests 

/claim #526