### PR TITLE
Mau fixes v3

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -404,6 +404,7 @@ thank-you-for-choosi: Thank you for choosing Capgo !
 the: The
 this-page-will-self-: This page will self refresh
 title: title
+tmp-disabled: (Temporary disabled)
 to: to
 to-live-reload: to live reload.
 to-open-encrypted-bu: 'To open Encrypted bundle use the command:'

--- a/src/components/dashboard/Usage.vue
+++ b/src/components/dashboard/Usage.vue
@@ -111,10 +111,16 @@ loadData()
 <template>
   <div v-if="!noData || isLoading" class="grid grid-cols-12 gap-6 mb-6" :class="appId ? 'grid-cols-16' : ''">
     <UsageCard
-      v-if="!isLoading" id="mau-stat" :limits="allLimits.mau" :colors="colors.emerald"
+      v-if="!isLoading && props.appId" id="mau-stat" :limits="allLimits.mau" :colors="colors.emerald"
       :datas="datas.mau"
       :accumulated="false"
-      :title="t('montly-active')" unit="Users"
+      :title="`${t('montly-active')}`" unit="Users"
+    />
+    <UsageCard
+      v-else-if="!isLoading && !props.appId" id="mau-stat" :limits="allLimits.mau" :colors="colors.emerald"
+      :datas="undefined"
+      :accumulated="false"
+      :title="`${t('montly-active')} ${t('tmp-disabled')}`" unit="Users"
     />
     <div
       v-else

--- a/supabase/clickhouse-local.sql
+++ b/supabase/clickhouse-local.sql
@@ -54,23 +54,6 @@ create foreign table clickhouse_devices (
 --  DROP FOREIGN TABLE "public"."clickhouse_app_usage";
 -- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/aggregatingmergetree
 
-create foreign table clickhouse_app_usage (
-  date date,
-  app_id text,
-  bandwidth bigint,
-  mau bigint,
-  get bigint,
-  fail bigint,
-  uninstall bigint,
-  install bigint,
-  storage_added bigint,
-  storage_deleted bigint
-)
-server clickhouse_server
-options (
-  table 'mau_final'
-);
-
 create foreign table clickhouse_app_usage_parm (
   date date,
   app_id text,
@@ -90,11 +73,6 @@ server clickhouse_server
 options (
   table '(select * from mau_final_param(app_list=${_app_list}, start_date=${_start_date}, end_date=${_end_date}))'
 );
-
-create materialized view clickhouse_app_usage_view as 
-select * from clickhouse_app_usage;
-
-SELECT cron.schedule('Refresh stats materialized view', '*/5 * * * *', $$CALL REFRESH MATERIALIZED VIEW clickhouse_app_usage_view;$$);
 
 -- select uniqMerge(mau), app_id, date from mau group by app_id, date;
 

--- a/supabase/clickhouse-local.sql
+++ b/supabase/clickhouse-local.sql
@@ -71,6 +71,26 @@ options (
   table 'mau_final'
 );
 
+create foreign table clickhouse_app_usage_parm (
+  date date,
+  app_id text,
+  bandwidth bigint,
+  mau bigint,
+  get bigint,
+  fail bigint,
+  uninstall bigint,
+  install bigint,
+  storage_added bigint,
+  storage_deleted bigint,
+  _app_list text,
+  _start_date Date,
+  _end_date Date
+)
+server clickhouse_server
+options (
+  table '(select * from mau_final_param(app_list=${_app_list}, start_date=${_start_date}, end_date=${_end_date}))'
+);
+
 create materialized view clickhouse_app_usage_view as 
 select * from clickhouse_app_usage;
 

--- a/supabase/migrations/20240218035933_fix_mau_v3.sql
+++ b/supabase/migrations/20240218035933_fix_mau_v3.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE FUNCTION public.get_total_stats_v4(userid uuid)
+RETURNS TABLE(mau bigint, bandwidth double precision, storage double precision)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+    anchor_start date;
+    anchor_end date;
+    apps text;
+BEGIN
+    SELECT subscription_anchor_start, subscription_anchor_end INTO anchor_start, anchor_end
+    FROM stripe_info
+    WHERE customer_id=(SELECT customer_id from users where id=userid);
+
+    select (SELECT json_agg(app_id) from apps where user_id=userid)::text into apps;
+
+    -- Use the app_ids variable in the query
+    RETURN QUERY 
+    SELECT 
+        COALESCE(SUM(raw_data.mau), 0)::bigint as mau,
+        COALESCE(ROUND(convert_bytes_to_gb(SUM(raw_data.bandwidth))::numeric,2), 0)::float AS bandwidth,
+        COALESCE(ROUND(convert_bytes_to_gb(SUM(raw_data.storage_added - raw_data.storage_deleted))::numeric,2), 0)::float AS storage
+    FROM (
+    SELECT app_id,
+        COALESCE(MAX(clickhouse_app_usage_parm.mau), 0) as mau,
+        COALESCE(SUM(clickhouse_app_usage_parm.bandwidth), 0) as bandwidth,
+        COALESCE(SUM(clickhouse_app_usage_parm.storage_added), 0) as storage_added,
+        COALESCE(SUM(clickhouse_app_usage_parm.storage_deleted), 0) as storage_deleted
+        FROM clickhouse_app_usage_parm
+        WHERE _app_list=apps
+        AND _start_date=anchor_start
+        AND _end_date=anchor_end
+        GROUP BY app_id
+    ) AS raw_data;
+END;  
+$$;


### PR DESCRIPTION
## Summary

This plan fixed mau - this time for good.

## Test setup

This PR was tested A LOT with A LOT of edge cases. The setup for this looks like this

![image](https://github.com/Cap-go/capgo/assets/50914789/3ce0ff4e-b3bc-49a3-8947-45600e6e5296)

Let me break this down day by day:

 - 18th: 1 new device was created for `com.demo.app` (total mau: 1)
 - 19th: 3 new devices were created for `com.demo.app` (total mau: 4)
 - 20th
   - 2 new devices were created for `com.demo.app` (total mau: 6)
   - 5 new devices were created for `com.demoadmin.app` (total mau: 11)
  - 21th: No new devices were created, total mau: 11
  - 22th: One new device was created for `com.demo.app`
    - total mau: 7 (from `com.demo.app` and 5 from `com.demoadmin.app` = 12
  - 23th: 
    - 1 new device was created for `com.demo.app`
    - 1 new device was created for `com.demoadmin.app`
    - total mau: 14 (8 from `com.demo.app` and 6 from `com.demoadmin.app`
  - 24th: 1 new device was created for `com.demo.app` - total mau: 15
  
  This however is an edge case. Let's assume `22th` is the last day of the users plan. How do we calculate the MAU?
  Obviously we have to take the mau for `com.demo.app` from the 23th and add it with mau for `com.demoadmin.app` from `22th`. 
  
 And this is what the new `get_total_stats_v4` does - exactly that.
 
 Now, I have disabled the graph on the main dashboard
 
![image](https://github.com/Cap-go/capgo/assets/50914789/74f5d705-d641-4bd1-a19c-99e326a4294d)

Let me show you why:

![image](https://github.com/Cap-go/capgo/assets/50914789/a9108039-6f5c-4f8e-8ce5-e1505d488bd9)

Here on the 22th the mau goes down to 7. Why? Because on the graph sees that on the `22th` mau was 7 for `com.demo.app`, it does not see that no new devices were created for `com.demoadmin.app` so the value HAS TO BE the previous one. From the graph's perspective the `com.demoadmin.app` is not in the dataset for this specific day so it does not add it properly. Since mau CANNOT go down I had to disable this graph


 Here is a detailed migration guide for prod:
  - Rename `clickhouse_app_usage` into `clickhouse_app_usage_tmp`
  - Apply the migration that is included in this PR