### PR TITLE
🐛 (fix): Fix storage in clickhouse

### DIFF
--- a/supabase/functions/_backend/utils/clickhouse.ts
+++ b/supabase/functions/_backend/utils/clickhouse.ts
@@ -158,8 +158,8 @@ SELECT
   SUM(COALESCE(logs_daily.fail, 0)) AS fail,
   SUM(COALESCE(logs_daily.install, 0)) AS install,
   SUM(COALESCE(logs_daily.uninstall, 0)) AS uninstall,
-  SUM(app_storage_daily.storage_added) AS storage_added,
-  SUM(app_storage_daily.storage_deleted) AS storage_deleted
+  MAX(app_storage_daily.storage_added) AS storage_added,
+  MAX(app_storage_daily.storage_deleted) AS storage_deleted
 FROM 
   (SELECT 
       daily_device.app_id,


### PR DESCRIPTION
Currently there exists a really strange bug breaking the `storage` stat. 

Here capgo is reporting 4gb of storage
![image](https://github.com/Cap-go/capgo/assets/50914789/0c9b372b-7704-417f-a2fe-548817c0b813)

But for the same app clickhouse app storage reports something completely different

![image](https://github.com/Cap-go/capgo/assets/50914789/61d458ab-6ac4-4896-9224-6974785da8ad)

After some debugging in prod I ran the following query
```sql
WITH 
  '2024-03-09' AS start_period,
  '2024-04-09' AS end_period,
  ['REDACTED'] AS app_id_list
SELECT 
  first_device_logs.app_id as app_id,
  first_device_logs.first_log_date AS date,
  toJSONString(groupArray(app_storage_daily.storage_added)) AS storage_added
FROM 
  (SELECT 
      daily_device.app_id,
      daily_device.device_id,
      MIN(daily_device.date) as first_log_date
  FROM daily_device
  WHERE 
      daily_device.date >= start_period AND 
      daily_device.date < end_period AND
      daily_device.app_id IN app_id_list
  GROUP BY daily_device.app_id, daily_device.device_id) as first_device_logs
LEFT JOIN logs_daily ON first_device_logs.app_id = logs_daily.app_id AND first_device_logs.first_log_date = logs_daily.date
LEFT JOIN app_storage_daily ON (first_device_logs.app_id = app_storage_daily.app_id AND first_device_logs.first_log_date = app_storage_daily.date)
GROUP BY 
  first_device_logs.app_id, 
  first_device_logs.first_log_date
ORDER BY 
  first_device_logs.app_id, 
  first_device_logs.first_log_date
  ```

This showed me the following result
![image](https://github.com/Cap-go/capgo/assets/50914789/b69387ae-300a-4bb3-a41d-f4a94120862c)

It would suggest that the query for some unknown reason has duplicated `storage_added`. When we call `SUM` the result we get is simply not correct. This PR aims to fix this issue
