### PR TITLE
feat: add new usage chart

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -281,6 +281,7 @@ last-name: Familienname, Nachname
 last-update: Letztes Update
 last-upload: Letzter Upload
 last-version: Letzte Version
+latest_version: Neuestes Paket
 launch-bundle: Bündel starten
 leaving: Verlassen
 limit-reached: Limit erreicht

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -32,6 +32,7 @@ activation-notification-desc: >-
   Ich akzeptiere, Benachrichtigungen zu erhalten, wenn neue App-Versionen
   verfügbar sind
 activation-validate: Bestätigen
+active_users_by_version: Aktives Gerät nach Bundle
 add: Hinzufügen
 add-another-app: Fügen Sie Ihre Anwendung hinzu
 add-api-key: Neuer API-Schlüssel erfolgreich hinzugefügt

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -26,6 +26,7 @@ activation-legal-desc: I accept Capgo app privacy policy and terms of use
 activation-notification: Notifications
 activation-notification-desc: I accept to receive notification when new app version are available
 activation-validate: Validate
+active_users_by_version: Active device by bundle
 add: Add
 add-another-app: Add your app
 add-api-key: Added new API key successfully

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -262,6 +262,7 @@ last-name: Last name
 last-update: Last update
 last-upload: Last upload
 last-version: Last version
+latest_version: Latest bundle
 launch-bundle: Launch bundle
 leaving: Leaving
 limit-reached: Limit reached

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -281,6 +281,7 @@ last-name: Apellido
 last-update: Última actualización
 last-upload: última carga
 last-version: Última versión
+latest_version: Último paquete
 launch-bundle: Paquete de lanzamiento
 leaving: Partida
 limit-reached: Límite alcanzado

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -32,6 +32,7 @@ activation-notification-desc: >-
   Acepto recibir notificaciones cuando haya una nueva versión de la aplicación
   disponible
 activation-validate: Validar
+active_users_by_version: Dispositivo activo por paquete
 add: Agregar
 add-another-app: Agrega tu aplicación
 add-api-key: Se agregó una nueva clave API con éxito

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -279,6 +279,7 @@ last-name: Nom de famille
 last-update: Dernière mise à jour
 last-upload: Dernier téléchargement
 last-version: Dernière version
+latest_version: Dernier forfait
 launch-bundle: Lancer le bundle
 leaving: Sortie
 limit-reached: Limite atteinte

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -32,6 +32,7 @@ activation-notification-desc: >-
   J'accepte de recevoir une notification lorsqu'une nouvelle version de
   l'application est disponible
 activation-validate: Valider
+active_users_by_version: Appareil actif par bundle
 add: Ajouter
 add-another-app: Ajoutez votre application
 add-api-key: Nouvelle clé API ajoutée avec succès

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -273,6 +273,7 @@ last-name: nama keluarga
 last-update: Pembaharuan Terakhir
 last-upload: Unggahan terakhir
 last-version: Versi terakhir
+latest_version: Paket terbaru
 launch-bundle: Luncurkan bundel
 leaving: Meninggalkan
 limit-reached: Batas tercapai

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -26,6 +26,7 @@ activation-legal-desc: Saya menerima kebijakan privasi dan ketentuan penggunaan 
 activation-notification: Notifikasi
 activation-notification-desc: Saya menerima untuk menerima pemberitahuan ketika versi aplikasi baru tersedia
 activation-validate: Mengesahkan
+active_users_by_version: Perangkat aktif berdasarkan paket
 add: Menambahkan
 add-another-app: Tambahkan aplikasi Anda
 add-api-key: Berhasil menambahkan kunci API baru

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -275,6 +275,7 @@ last-name: Cognome
 last-update: Ultimo aggiornamento
 last-upload: Ultimo caricamento
 last-version: Ultima versione
+latest_version: Ultimo pacchetto
 launch-bundle: Pacchetto di lancio
 leaving: In partenza
 limit-reached: Limite raggiunto

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -30,6 +30,7 @@ activation-notification-desc: >-
   Accetto di ricevere una notifica quando sarà disponibile una nuova versione
   dell'app
 activation-validate: Convalidare
+active_users_by_version: Dispositivo attivo per bundle
 add: Aggiungere
 add-another-app: Aggiungi la tua app
 add-api-key: Aggiunta con successo una nuova chiave API

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -26,6 +26,7 @@ activation-legal-desc: Capgo アプリのプライバシー ポリシーと利�
 activation-notification: 通知
 activation-notification-desc: アプリの新しいバージョンが利用可能になったときに通知を受け取ることに同意します
 activation-validate: 検証
+active_users_by_version: バンドルごとのアクティブなデバイス
 add: 追加
 add-another-app: アプリを追加する
 add-api-key: 新しい API キーが正常に追加されました

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -265,6 +265,7 @@ last-name: 苗字
 last-update: 最後の更新
 last-upload: 最後のアップロード
 last-version: 最後のバージョン
+latest_version: 最新バンドル
 launch-bundle: バンドルを起動
 leaving: 出発
 limit-reached: 制限に達しました

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -265,6 +265,7 @@ last-name: 성
 last-update: 마지막 업데이트
 last-upload: 마지막 업로드
 last-version: 마지막 버전
+latest_version: 최신 번들
 launch-bundle: 번들 실행
 leaving: 퇴거
 limit-reached: 한도 도달

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -26,6 +26,7 @@ activation-legal-desc: Capgo 앱 개인 정보 보호 정책 및 사용 약관�
 activation-notification: 알림
 activation-notification-desc: 새 앱 버전을 사용할 수 있을 때 알림 수신에 동의합니다.
 activation-validate: 확인
+active_users_by_version: 번들별 활성 기기
 add: 추가하다
 add-another-app: 앱 추가
 add-api-key: 새 API 키를 성공적으로 추가했습니다.

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -28,6 +28,7 @@ activation-notification-desc: >-
   Wyrażam zgodę na otrzymywanie powiadomień, gdy pojawi się nowa wersja
   aplikacji
 activation-validate: Uprawomocnić
+active_users_by_version: Aktywne urządzenie według pakietu
 add: Dodać
 add-another-app: Dodaj swoją aplikację
 add-api-key: Pomyślnie dodano nowy klucz API

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -271,6 +271,7 @@ last-name: Nazwisko
 last-update: Ostatnia aktualizacja
 last-upload: Ostatnie przesyłanie
 last-version: Ostatnia wersja
+latest_version: Najnowszy pakiet
 launch-bundle: Uruchom pakiet
 leaving: Odjazd
 limit-reached: Limit osiągnięty

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -269,6 +269,7 @@ last-name: Sobrenome
 last-update: Última atualização
 last-upload: último upload
 last-version: Última versão
+latest_version: Pacote mais recente
 launch-bundle: Lançar pacote
 leaving: Saindo
 limit-reached: Limite alcançado

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -28,6 +28,7 @@ activation-notification-desc: >-
   Aceito receber notificação quando uma nova versão do aplicativo estiver
   disponível
 activation-validate: Validar
+active_users_by_version: Dispositivo ativo por pacote
 add: Adicionar
 add-another-app: Adicione seu aplicativo
 add-api-key: Adicionada nova chave de API com sucesso

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -28,6 +28,7 @@ activation-legal-desc: >-
 activation-notification: Уведомления
 activation-notification-desc: Я согласен получать уведомления о появлении новой версии приложения
 activation-validate: Подтвердить
+active_users_by_version: Активное устройство по комплекту
 add: Добавлять
 add-another-app: Добавьте свое приложение
 add-api-key: Новый ключ API успешно добавлен

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -271,6 +271,7 @@ last-name: Фамилия
 last-update: Последнее обновление
 last-upload: Последняя загрузка
 last-version: Последняя версия
+latest_version: Последний пакет
 launch-bundle: Пакет запуска
 leaving: Уход
 limit-reached: Достигнут предел

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -269,6 +269,7 @@ last-name: Soy isim
 last-update: Son Güncelleme
 last-upload: Son yükleme
 last-version: Son sürüm
+latest_version: En son paket
 launch-bundle: Paketi başlat
 leaving: Ayrılıyorum
 limit-reached: Sınıra ulaşıldı

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -26,6 +26,7 @@ activation-legal-desc: Capgo uygulaması gizlilik politikasını ve kullanım ş
 activation-notification: Bildirimler
 activation-notification-desc: Yeni uygulama sürümü mevcut olduğunda bildirim almayı kabul ediyorum
 activation-validate: Doğrula
+active_users_by_version: Pakete göre etkin cihaz
 add: Eklemek
 add-another-app: uygulamanızı ekleyin
 add-api-key: Yeni API anahtarı başarıyla eklendi

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -271,6 +271,7 @@ last-name: Họ
 last-update: Cập nhật cuối cùng
 last-upload: Tải lên lần cuối
 last-version: Phiên bản cuối cùng
+latest_version: Gói mới nhất
 launch-bundle: Khởi chạy gói
 leaving: Rời đi
 limit-reached: Đạt tới giới hạn

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -28,6 +28,7 @@ activation-legal-desc: >-
 activation-notification: thông báo
 activation-notification-desc: Tôi chấp nhận nhận thông báo khi có phiên bản ứng dụng mới
 activation-validate: xác thực
+active_users_by_version: Thiết bị hoạt động theo gói
 add: Thêm vào
 add-another-app: Thêm ứng dụng của bạn
 add-api-key: Đã thêm khóa API mới thành công

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -26,6 +26,7 @@ activation-legal-desc: 我接受 Capgo 应用隐私政策和使用条款
 activation-notification: 通知
 activation-notification-desc: 我同意在新应用版本可用时收到通知
 activation-validate: 证实
+active_users_by_version: 按捆绑包列出的活动设备
 add: 添加
 add-another-app: 添加您的应用
 add-api-key: 成功添加新的 API 密钥

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -265,6 +265,7 @@ last-name: 姓
 last-update: 最后更新
 last-upload: 最后上传
 last-version: 最新版本
+latest_version: 最新捆绑包
 launch-bundle: 启动包
 leaving: 离开
 limit-reached: 达到限制

--- a/src/components/MobileStats.vue
+++ b/src/components/MobileStats.vue
@@ -96,7 +96,9 @@ const chartData = computed(() => {
       data: percentageData,
       borderColor: colors[color][400],
       backgroundColor: colors[color][200],
-      fill: false,
+      tension: 0.3,
+      pointRadius: 2,
+      pointBorderWidth: 0,
     }
   })
 
@@ -134,13 +136,15 @@ const chartData = computed(() => {
   }
 })
 
-const chartOptions = computed(() => ({
-  responsive: true,
+const chartOptions = ref({
   maintainAspectRatio: false,
   scales: {
     x: {
       grid: {
         display: false,
+      },
+      ticks: {
+        color: `${isDark.value ? 'white' : 'black'}`,
       },
     },
     y: {
@@ -148,10 +152,22 @@ const chartOptions = computed(() => ({
       max: 100,
       ticks: {
         callback: (value: number) => `${value}%`,
+        color: `${isDark.value ? 'white' : 'black'}`,
       },
     },
   },
-}))
+  plugins: {
+    // annotation: {
+    //   annotations: generateAnnotations.value,
+    // },
+    legend: {
+      display: false,
+    },
+    title: {
+      display: false,
+    },
+  },
+})
 
 watchEffect(async () => {
   if (route.path.includes('/package/')) {
@@ -171,24 +187,6 @@ watchEffect(async () => {
 })
 </script>
 
-<!-- <template>
-  <div
-    class="flex flex-col bg-white border rounded-lg shadow-lg col-span-full border-slate-200 sm:col-span-6 xl:col-span-4 dark:border-slate-900 dark:bg-gray-800"
-  >
-    <div class="px-5 pt-5">
-      <h2 class="mb-2 text-2xl font-semibold text-slate-800 dark:text-white">
-        {{ t('active_users_by_version') }}
-      </h2>
-    </div>
-
-    <div class="w-full p-6 h-96">
-      <Line v-if="!isLoading" :key="chartData.datasets.length" :data="chartData" :options="chartOptions" />
-      <div v-else class="flex items-center justify-center h-full">
-        <Spinner size="w-40 h-40" />
-      </div>
-    </div>
-  </div>
-</template> -->
 <template>
   <div class="flex flex-col bg-white border rounded-lg shadow-lg col-span-full border-slate-200 sm:col-span-6 xl:col-span-4 dark:border-slate-900 dark:bg-gray-800 h-[460px]">
     <div class="px-5 pt-3">
@@ -213,11 +211,8 @@ watchEffect(async () => {
         </div>
       </div>
     </div>
-    <!-- Chart built with Chart.js 3 -->
-
-    <!-- Change the height attribute to adjust the chart height -->
     <div class="w-full h-full p-6">
-      <Line v-if="!isLoading" :key="chartData.datasets.length" :data="chartData" :options="chartOptions" />
+      <Line v-if="!isLoading" :data="chartData" :options="chartOptions" />
       <div v-else class="flex items-center justify-center h-full">
         <Spinner size="w-40 h-40" />
       </div>

--- a/src/components/dashboard/Usage.vue
+++ b/src/components/dashboard/Usage.vue
@@ -155,7 +155,7 @@ if (main.dashboardFetched)
 </script>
 
 <template>
-  <div v-if="!noData || isLoading" class="grid grid-cols-12 gap-6 mb-6">
+  <div v-if="!noData || isLoading" class="grid grid-cols-12 gap-6 mb-6" :class="appId ? 'grid-cols-16' : ''">
     <!-- TODO: to reactivate when we do the new chart https://github.com/Cap-go/capgo/issues/645 <div v-if="!noData || isLoading" class="grid grid-cols-12 gap-6 mb-6" :class="appId ? 'grid-cols-16' : ''"> -->
     <UsageCard
       v-if="!isLoading" id="mau-stat" :limits="allLimits.mau" :colors="colors.emerald"
@@ -187,6 +187,6 @@ if (main.dashboardFetched)
     >
       <Spinner size="w-40 h-40" />
     </div>
-    <!-- <MobileStats v-if="appId" /> -->
+    <MobileStats v-if="appId" />
   </div>
 </template>

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -238,10 +238,10 @@ export async function getAllDashboard(orgId: string, startDate?: string, endDate
   }
 }
 
-export async function getVersionNames(appId: string, versionIds: string[]): Promise<{ id: string, name: string }[]> {
+export async function getVersionNames(appId: string, versionIds: string[]): Promise<{ id: string, name: string, created_at: string }[]> {
   const { data, error: vError } = await useSupabase()
     .from('app_versions')
-    .select('id, name')
+    .select('id, name, created_at')
     .eq('app_id', appId)
     .in('id', versionIds)
 

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -245,7 +245,6 @@ export async function getVersionNames(appId: string, versionIds: string[]): Prom
     .eq('app_id', appId)
     .in('id', versionIds)
 
-  console.log('getVersionNames', data)
   if (vError)
     return []
 

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -7,31 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          operationName?: string
-          query?: string
-          variables?: Json
-          extensions?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
       apikeys: {
@@ -540,7 +515,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
-          email: string
+          email?: string
           id?: string
         }
         Update: {
@@ -925,7 +900,6 @@ export type Database = {
           storage_unit: number | null
           stripe_id: string
           updated_at: string
-          version: number
         }
         Insert: {
           bandwidth: number
@@ -948,7 +922,6 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
-          version?: number
         }
         Update: {
           bandwidth?: number
@@ -971,7 +944,6 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
-          version?: number
         }
         Relationships: []
       }
@@ -1210,6 +1182,10 @@ export type Database = {
         }
         Returns: string
       }
+      calculate_daily_app_usage: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       check_min_rights:
         | {
             Args: {
@@ -1272,6 +1248,10 @@ export type Database = {
         Returns: number
       }
       count_all_onboarded: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
+      count_all_paying: {
         Args: Record<PropertyKey, never>
         Returns: number
       }
@@ -1460,6 +1440,18 @@ export type Database = {
         }
         Returns: string
       }
+      get_infos: {
+        Args: {
+          appid: string
+          deviceid: string
+          versionname: string
+        }
+        Returns: {
+          current_version_id: number
+          versiondata: Json
+          channel: Json
+        }[]
+      }
       get_metered_usage:
         | {
             Args: Record<PropertyKey, never>
@@ -1603,6 +1595,20 @@ export type Database = {
               uninstall: number
             }[]
           }
+      get_total_storage_size:
+        | {
+            Args: {
+              appid: string
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              userid: string
+              appid: string
+            }
+            Returns: number
+          }
       get_total_storage_size_org: {
         Args: {
           org_id: string
@@ -1634,6 +1640,27 @@ export type Database = {
           app_id: string
         }
         Returns: string
+      }
+      get_versions_with_no_metadata: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          app_id: string
+          bucket_id: string | null
+          checksum: string | null
+          created_at: string | null
+          deleted: boolean
+          external_url: string | null
+          id: number
+          minUpdateVersion: string | null
+          name: string
+          native_packages: Json[] | null
+          owner_org: string
+          r2_path: string | null
+          session_key: string | null
+          storage_provider: string
+          updated_at: string | null
+          user_id: string | null
+        }[]
       }
       get_weekly_stats: {
         Args: {
@@ -1811,6 +1838,10 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: number[]
       }
+      process_failed_uploads: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       process_free_trial_expired: {
         Args: Record<PropertyKey, never>
         Returns: undefined
@@ -1887,14 +1918,27 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      update_app_usage:
+        | {
+            Args: Record<PropertyKey, never>
+            Returns: undefined
+          }
+        | {
+            Args: {
+              minutes_interval: number
+            }
+            Returns: undefined
+          }
       verify_mfa: {
         Args: Record<PropertyKey, never>
         Returns: boolean
       }
     }
     Enums: {
+      app_mode: "prod" | "dev" | "livereload"
       disable_update: "major" | "minor" | "patch" | "version_number" | "none"
       key_mode: "read" | "write" | "all" | "upload"
+      pay_as_you_go_type: "base" | "units"
       platform_os: "ios" | "android"
       queue_job_status: "inserted" | "requested" | "failed"
       stats_action:
@@ -1923,6 +1967,7 @@ export type Database = {
         | "decrypt_fail"
         | "app_moved_to_foreground"
         | "app_moved_to_background"
+        | "uninstall"
       stripe_status:
         | "created"
         | "succeeded"
@@ -1930,7 +1975,7 @@ export type Database = {
         | "failed"
         | "deleted"
         | "canceled"
-      usage_mode: "last_saved" | "5min" | "day" | "cycle"
+      usage_mode: "5min" | "day" | "month" | "cycle" | "last_saved"
       user_min_right:
         | "invite_read"
         | "invite_upload"
@@ -1946,6 +1991,9 @@ export type Database = {
       version_action: "get" | "fail" | "install" | "uninstall"
     }
     CompositeTypes: {
+      match_plan: {
+        name: string | null
+      }
       orgs_table: {
         id: string | null
         created_by: string | null
@@ -1966,311 +2014,6 @@ export type Database = {
         bandwidth: number | null
         storage: number | null
       }
-    }
-  }
-  storage: {
-    Tables: {
-      buckets: {
-        Row: {
-          allowed_mime_types: string[] | null
-          avif_autodetection: boolean | null
-          created_at: string | null
-          file_size_limit: number | null
-          id: string
-          name: string
-          owner: string | null
-          owner_id: string | null
-          public: boolean | null
-          updated_at: string | null
-        }
-        Insert: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id: string
-          name: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Update: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id?: string
-          name?: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
-      migrations: {
-        Row: {
-          executed_at: string | null
-          hash: string
-          id: number
-          name: string
-        }
-        Insert: {
-          executed_at?: string | null
-          hash: string
-          id: number
-          name: string
-        }
-        Update: {
-          executed_at?: string | null
-          hash?: string
-          id?: number
-          name?: string
-        }
-        Relationships: []
-      }
-      objects: {
-        Row: {
-          bucket_id: string | null
-          created_at: string | null
-          id: string
-          last_accessed_at: string | null
-          metadata: Json | null
-          name: string | null
-          owner: string | null
-          owner_id: string | null
-          path_tokens: string[] | null
-          updated_at: string | null
-          version: string | null
-        }
-        Insert: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
-        Update: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "objects_bucketId_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      s3_multipart_uploads: {
-        Row: {
-          bucket_id: string
-          created_at: string
-          id: string
-          in_progress_size: number
-          key: string
-          owner_id: string | null
-          upload_signature: string
-          version: string
-        }
-        Insert: {
-          bucket_id: string
-          created_at?: string
-          id: string
-          in_progress_size?: number
-          key: string
-          owner_id?: string | null
-          upload_signature: string
-          version: string
-        }
-        Update: {
-          bucket_id?: string
-          created_at?: string
-          id?: string
-          in_progress_size?: number
-          key?: string
-          owner_id?: string | null
-          upload_signature?: string
-          version?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      s3_multipart_uploads_parts: {
-        Row: {
-          bucket_id: string
-          created_at: string
-          etag: string
-          id: string
-          key: string
-          owner_id: string | null
-          part_number: number
-          size: number
-          upload_id: string
-          version: string
-        }
-        Insert: {
-          bucket_id: string
-          created_at?: string
-          etag: string
-          id?: string
-          key: string
-          owner_id?: string | null
-          part_number: number
-          size?: number
-          upload_id: string
-          version: string
-        }
-        Update: {
-          bucket_id?: string
-          created_at?: string
-          etag?: string
-          id?: string
-          key?: string
-          owner_id?: string | null
-          part_number?: number
-          size?: number
-          upload_id?: string
-          version?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
-            columns: ["upload_id"]
-            isOneToOne: false
-            referencedRelation: "s3_multipart_uploads"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      can_insert_object: {
-        Args: {
-          bucketid: string
-          name: string
-          owner: string
-          metadata: Json
-        }
-        Returns: undefined
-      }
-      extension: {
-        Args: {
-          name: string
-        }
-        Returns: string
-      }
-      filename: {
-        Args: {
-          name: string
-        }
-        Returns: string
-      }
-      foldername: {
-        Args: {
-          name: string
-        }
-        Returns: string[]
-      }
-      get_size_by_bucket: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          size: number
-          bucket_id: string
-        }[]
-      }
-      list_multipart_uploads_with_delimiter: {
-        Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          next_key_token?: string
-          next_upload_token?: string
-        }
-        Returns: {
-          key: string
-          id: string
-          created_at: string
-        }[]
-      }
-      list_objects_with_delimiter: {
-        Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          start_after?: string
-          next_token?: string
-        }
-        Returns: {
-          name: string
-          id: string
-          metadata: Json
-          updated_at: string
-        }[]
-      }
-      search: {
-        Args: {
-          prefix: string
-          bucketname: string
-          limits?: number
-          levels?: number
-          offsets?: number
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
-        }
-        Returns: {
-          name: string
-          id: string
-          updated_at: string
-          created_at: string
-          last_accessed_at: string
-          metadata: Json
-        }[]
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
     }
   }
 }
@@ -2356,4 +2099,3 @@ export type Enums<
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
     : never
-

--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -6,7 +6,7 @@ import type { Database } from './supabase.types.ts'
 
 export type DeviceWithoutCreatedAt = Omit<Database['public']['Tables']['devices']['Insert'], 'created_at'>
 export interface StatsActions {
-  action: string
+  action: Database['public']['Enums']['stats_action']
   versionId?: number
 }
 
@@ -31,15 +31,10 @@ export function createStatsVersion(c: Context, version_id: number, app_id: strin
   return trackVersionUsageCF(c, version_id, app_id, action)
 }
 
-export function createStatsLogs(c: Context, app_id: string, device_id: string, action: string, version_id: number) {
+export function createStatsLogs(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], version_id: number) {
   if (!c.env.APP_LOG)
     return trackLogsSB(c, app_id, device_id, action, version_id)
   return trackLogsCF(c, app_id, device_id, action, version_id)
-}
-
-export interface StatsActions {
-  action: string
-  versionId?: number
 }
 
 export function createStatsDevices(c: Context, app_id: string, device_id: string, version: number, platform: Database['public']['Enums']['platform_os'], plugin_version: string, os_version: string, version_build: string, custom_id: string, is_prod: boolean, is_emulator: boolean) {

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -585,7 +585,7 @@ export function trackDevicesSB(c: Context, app_id: string, device_id: string, ve
     .eq('device_id', device_id)
 }
 
-export function trackLogsSB(c: Context, app_id: string, device_id: string, action: string, version_id: number) {
+export function trackLogsSB(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], version_id: number) {
   return supabaseAdmin(c)
     .from('stats')
     .insert(

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -7,31 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          operationName?: string
-          query?: string
-          variables?: Json
-          extensions?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
       apikeys: {
@@ -40,6 +15,7 @@ export type Database = {
           id: number
           key: string
           mode: Database["public"]["Enums"]["key_mode"]
+          name: string
           updated_at: string | null
           user_id: string
         }
@@ -48,6 +24,7 @@ export type Database = {
           id?: number
           key: string
           mode: Database["public"]["Enums"]["key_mode"]
+          name: string
           updated_at?: string | null
           user_id: string
         }
@@ -56,6 +33,7 @@ export type Database = {
           id?: number
           key?: string
           mode?: Database["public"]["Enums"]["key_mode"]
+          name?: string
           updated_at?: string | null
           user_id?: string
         }
@@ -537,7 +515,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
-          email: string
+          email?: string
           id?: string
         }
         Update: {
@@ -922,7 +900,6 @@ export type Database = {
           storage_unit: number | null
           stripe_id: string
           updated_at: string
-          version: number
         }
         Insert: {
           bandwidth: number
@@ -945,7 +922,6 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
-          version?: number
         }
         Update: {
           bandwidth?: number
@@ -968,7 +944,6 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
-          version?: number
         }
         Relationships: []
       }
@@ -1207,6 +1182,10 @@ export type Database = {
         }
         Returns: string
       }
+      calculate_daily_app_usage: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       check_min_rights:
         | {
             Args: {
@@ -1269,6 +1248,10 @@ export type Database = {
         Returns: number
       }
       count_all_onboarded: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
+      count_all_paying: {
         Args: Record<PropertyKey, never>
         Returns: number
       }
@@ -1457,6 +1440,18 @@ export type Database = {
         }
         Returns: string
       }
+      get_infos: {
+        Args: {
+          appid: string
+          deviceid: string
+          versionname: string
+        }
+        Returns: {
+          current_version_id: number
+          versiondata: Json
+          channel: Json
+        }[]
+      }
       get_metered_usage:
         | {
             Args: Record<PropertyKey, never>
@@ -1599,6 +1594,20 @@ export type Database = {
               install: number
               uninstall: number
             }[]
+          }
+      get_total_storage_size:
+        | {
+            Args: {
+              appid: string
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              userid: string
+              appid: string
+            }
+            Returns: number
           }
       get_total_storage_size_org: {
         Args: {
@@ -1829,6 +1838,10 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: number[]
       }
+      process_failed_uploads: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       process_free_trial_expired: {
         Args: Record<PropertyKey, never>
         Returns: undefined
@@ -1905,14 +1918,27 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      update_app_usage:
+        | {
+            Args: Record<PropertyKey, never>
+            Returns: undefined
+          }
+        | {
+            Args: {
+              minutes_interval: number
+            }
+            Returns: undefined
+          }
       verify_mfa: {
         Args: Record<PropertyKey, never>
         Returns: boolean
       }
     }
     Enums: {
+      app_mode: "prod" | "dev" | "livereload"
       disable_update: "major" | "minor" | "patch" | "version_number" | "none"
       key_mode: "read" | "write" | "all" | "upload"
+      pay_as_you_go_type: "base" | "units"
       platform_os: "ios" | "android"
       queue_job_status: "inserted" | "requested" | "failed"
       stats_action:
@@ -1941,6 +1967,7 @@ export type Database = {
         | "decrypt_fail"
         | "app_moved_to_foreground"
         | "app_moved_to_background"
+        | "uninstall"
       stripe_status:
         | "created"
         | "succeeded"
@@ -1948,7 +1975,7 @@ export type Database = {
         | "failed"
         | "deleted"
         | "canceled"
-      usage_mode: "last_saved" | "5min" | "day" | "cycle"
+      usage_mode: "5min" | "day" | "month" | "cycle" | "last_saved"
       user_min_right:
         | "invite_read"
         | "invite_upload"
@@ -1964,6 +1991,9 @@ export type Database = {
       version_action: "get" | "fail" | "install" | "uninstall"
     }
     CompositeTypes: {
+      match_plan: {
+        name: string | null
+      }
       orgs_table: {
         id: string | null
         created_by: string | null
@@ -1984,311 +2014,6 @@ export type Database = {
         bandwidth: number | null
         storage: number | null
       }
-    }
-  }
-  storage: {
-    Tables: {
-      buckets: {
-        Row: {
-          allowed_mime_types: string[] | null
-          avif_autodetection: boolean | null
-          created_at: string | null
-          file_size_limit: number | null
-          id: string
-          name: string
-          owner: string | null
-          owner_id: string | null
-          public: boolean | null
-          updated_at: string | null
-        }
-        Insert: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id: string
-          name: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Update: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id?: string
-          name?: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
-      migrations: {
-        Row: {
-          executed_at: string | null
-          hash: string
-          id: number
-          name: string
-        }
-        Insert: {
-          executed_at?: string | null
-          hash: string
-          id: number
-          name: string
-        }
-        Update: {
-          executed_at?: string | null
-          hash?: string
-          id?: number
-          name?: string
-        }
-        Relationships: []
-      }
-      objects: {
-        Row: {
-          bucket_id: string | null
-          created_at: string | null
-          id: string
-          last_accessed_at: string | null
-          metadata: Json | null
-          name: string | null
-          owner: string | null
-          owner_id: string | null
-          path_tokens: string[] | null
-          updated_at: string | null
-          version: string | null
-        }
-        Insert: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
-        Update: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "objects_bucketId_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      s3_multipart_uploads: {
-        Row: {
-          bucket_id: string
-          created_at: string
-          id: string
-          in_progress_size: number
-          key: string
-          owner_id: string | null
-          upload_signature: string
-          version: string
-        }
-        Insert: {
-          bucket_id: string
-          created_at?: string
-          id: string
-          in_progress_size?: number
-          key: string
-          owner_id?: string | null
-          upload_signature: string
-          version: string
-        }
-        Update: {
-          bucket_id?: string
-          created_at?: string
-          id?: string
-          in_progress_size?: number
-          key?: string
-          owner_id?: string | null
-          upload_signature?: string
-          version?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      s3_multipart_uploads_parts: {
-        Row: {
-          bucket_id: string
-          created_at: string
-          etag: string
-          id: string
-          key: string
-          owner_id: string | null
-          part_number: number
-          size: number
-          upload_id: string
-          version: string
-        }
-        Insert: {
-          bucket_id: string
-          created_at?: string
-          etag: string
-          id?: string
-          key: string
-          owner_id?: string | null
-          part_number: number
-          size?: number
-          upload_id: string
-          version: string
-        }
-        Update: {
-          bucket_id?: string
-          created_at?: string
-          etag?: string
-          id?: string
-          key?: string
-          owner_id?: string | null
-          part_number?: number
-          size?: number
-          upload_id?: string
-          version?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
-            columns: ["upload_id"]
-            isOneToOne: false
-            referencedRelation: "s3_multipart_uploads"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      can_insert_object: {
-        Args: {
-          bucketid: string
-          name: string
-          owner: string
-          metadata: Json
-        }
-        Returns: undefined
-      }
-      extension: {
-        Args: {
-          name: string
-        }
-        Returns: string
-      }
-      filename: {
-        Args: {
-          name: string
-        }
-        Returns: string
-      }
-      foldername: {
-        Args: {
-          name: string
-        }
-        Returns: string[]
-      }
-      get_size_by_bucket: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          size: number
-          bucket_id: string
-        }[]
-      }
-      list_multipart_uploads_with_delimiter: {
-        Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          next_key_token?: string
-          next_upload_token?: string
-        }
-        Returns: {
-          key: string
-          id: string
-          created_at: string
-        }[]
-      }
-      list_objects_with_delimiter: {
-        Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          start_after?: string
-          next_token?: string
-        }
-        Returns: {
-          name: string
-          id: string
-          metadata: Json
-          updated_at: string
-        }[]
-      }
-      search: {
-        Args: {
-          prefix: string
-          bucketname: string
-          limits?: number
-          levels?: number
-          offsets?: number
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
-        }
-        Returns: {
-          name: string
-          id: string
-          updated_at: string
-          created_at: string
-          last_accessed_at: string
-          metadata: Json
-        }[]
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
     }
   }
 }
@@ -2374,4 +2099,3 @@ export type Enums<
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
     : never
-

--- a/supabase/migrations/20240516164703_optimize_table_storage.sql
+++ b/supabase/migrations/20240516164703_optimize_table_storage.sql
@@ -54,7 +54,8 @@ CREATE TYPE "public"."stats_action" AS ENUM (
 'download_complete',
 'decrypt_fail',
 'app_moved_to_foreground',
-'app_moved_to_background'
+'app_moved_to_background',
+'uninstall'
 );
 
 DROP TABLE "public"."stats";

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,7 +1,7 @@
 select vault.create_secret('["c591b04e-cf29-4945-b9a0-776d0672061a"]', 'admin_users', 'admins user id');
 select vault.create_secret('http://172.17.0.1:54321', 'db_url', 'db url');
 select vault.create_secret('http://localhost:8881/.netlify/functions', 'netlify_function_url', 'Netlify function url'); -- Netlify backend for long runny functions
-select vault.create_secret('http://localhost:7777', 'cf_function_url', 'Cloudflare function url'); -- Cloudflare backend for specific functions using CF features
+select vault.create_secret('http://host.docker.internal:7777', 'cloudflare_function_url', 'Cloudflare function url'); -- Cloudflare backend for specific functions using CF features
 select vault.create_secret('testsecret', 'apikey', 'admin user id');
 
 -- Create cron jobs


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->
Add new chart to check the volume of user using one app version.
![CleanShot 2024-06-06 at 04 00 33@2x](https://github.com/Cap-go/capgo/assets/4084527/3b4fa05d-2692-44d5-8f28-77de32c3ba6d)
There are still some issue to fix before merging:
- the design ( chart it cropped)
- mouse over the chart makes it show many errors in the console
- if we have a day with missing data, the chart goes to zero where it should continue like normal


## Test plan

<!-- Include the steps to test your PR -->
<!-- Any PR that requires a complex setup to test MUST include this -->

## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->
<!-- Please include this if CLI/frontend behaviour has changed, can be skipped for backend changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `bun run lint-backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests 
