### PR TITLE
Fix mobile app list spacing on mobile

### DIFF
--- a/src/components/tables/AppTable.vue
+++ b/src/components/tables/AppTable.vue
@@ -244,8 +244,10 @@ const filteredApps = computed(() => {
 </script>
 
 <template>
-  <div class="pb-14 md:pb-0 w-full block">
-    <div class="bg-white border rounded-lg shadow-lg col-span-full border-slate-300 xl:col-span-16 dark:border-slate-800 dark:bg-gray-800">
+  <div class="w-full block pb-14 md:pb-0">
+    <div
+      class="w-full col-span-full xl:col-span-16 border-none rounded-none bg-transparent shadow-none dark:bg-transparent md:rounded-lg md:border md:bg-white md:shadow-lg md:dark:border-slate-800 md:dark:bg-gray-800"
+    >
       <Table
         v-model:filters="filters"
         v-model:columns="columns"

--- a/src/pages/app/index.vue
+++ b/src/pages/app/index.vue
@@ -70,7 +70,7 @@ displayStore.defaultBack = '/app'
     <div v-if="!isLoading">
       <StepsApp v-if="stepsOpen" :onboarding="!apps.length" @done="NextStep" @close-step="stepsOpen = !stepsOpen" />
       <div v-else class="h-full pb-4 overflow-hidden">
-        <div class="w-full h-full px-4 pt-2 md:pt-8 mx-auto mb-8 overflow-y-auto max-w-9xl max-h-fit lg:px-8 sm:px-6">
+        <div class="w-full h-full px-0 pt-0 md:pt-8 mx-auto mb-8 overflow-y-auto max-w-9xl max-h-fit sm:px-6 lg:px-8">
           <AppTable :apps="apps" :delete-button="true" @add-app="stepsOpen = !stepsOpen" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove mobile-only padding and top margin from the apps list container so it spans edge-to-edge like other lists

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68cedef966b883268034b69abf017b9c