### PR TITLE
feat: schedule cron_plan from cron_stats

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "13.0.5"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -182,6 +202,7 @@ export type Database = {
           app_id: string
           checksum: string
           created_at: string | null
+          devices: number | null
           id: number
           owner_org: string
           size: number
@@ -191,6 +212,7 @@ export type Database = {
           app_id: string
           checksum: string
           created_at?: string | null
+          devices?: number | null
           id?: number
           owner_org: string
           size: number
@@ -200,6 +222,7 @@ export type Database = {
           app_id?: string
           checksum?: string
           created_at?: string | null
+          devices?: number | null
           id?: number
           owner_org?: string
           size?: number
@@ -581,7 +604,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
-          email?: string
+          email: string
           id?: string
         }
         Update: {
@@ -706,7 +729,6 @@ export type Database = {
           app_id: string
           custom_id: string
           device_id: string
-          id: number
           is_emulator: boolean | null
           is_prod: boolean | null
           os_version: string | null
@@ -721,7 +743,6 @@ export type Database = {
           app_id: string
           custom_id?: string
           device_id: string
-          id?: never
           is_emulator?: boolean | null
           is_prod?: boolean | null
           os_version?: string | null
@@ -736,7 +757,6 @@ export type Database = {
           app_id?: string
           custom_id?: string
           device_id?: string
-          id?: never
           is_emulator?: boolean | null
           is_prod?: boolean | null
           os_version?: string | null
@@ -1035,6 +1055,7 @@ export type Database = {
           storage_unit: number | null
           stripe_id: string
           updated_at: string
+          version: number
         }
         Insert: {
           bandwidth: number
@@ -1057,6 +1078,7 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
+          version?: number
         }
         Update: {
           bandwidth?: number
@@ -1079,6 +1101,7 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
+          version?: number
         }
         Relationships: []
       }
@@ -1142,6 +1165,7 @@ export type Database = {
           id: number
           is_good_plan: boolean | null
           mau_exceeded: boolean | null
+          plan_calculated_at: string | null
           plan_usage: number | null
           price_id: string | null
           product_id: string
@@ -1162,6 +1186,7 @@ export type Database = {
           id?: number
           is_good_plan?: boolean | null
           mau_exceeded?: boolean | null
+          plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
           product_id: string
@@ -1182,6 +1207,7 @@ export type Database = {
           id?: number
           is_good_plan?: boolean | null
           mau_exceeded?: boolean | null
+          plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
           product_id?: string
@@ -1872,10 +1898,6 @@ export type Database = {
         Args: { orgid: string }
         Returns: boolean
       }
-      is_owner_of_org: {
-        Args: { org_id: string; user_id: string }
-        Returns: boolean
-      }
       is_paying_and_good_plan_org: {
         Args: { orgid: string }
         Returns: boolean
@@ -1965,6 +1987,10 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      queue_cron_plan_for_org: {
+        Args: { customer_id: string; org_id: string }
+        Returns: undefined
+      }
       read_bandwidth_usage: {
         Args: { p_app_id: string; p_period_end: string; p_period_start: string }
         Returns: {
@@ -2008,6 +2034,30 @@ export type Database = {
       rescind_invitation: {
         Args: { email: string; org_id: string }
         Returns: string
+      }
+      reset_and_seed_app_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
+      }
+      reset_and_seed_app_stats_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
+      }
+      reset_and_seed_data: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      reset_and_seed_stats_data: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      reset_app_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
+      }
+      reset_app_stats_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
       }
       seed_get_app_metrics_caches: {
         Args: { p_end_date: string; p_org_id: string; p_start_date: string }
@@ -2059,10 +2109,8 @@ export type Database = {
     }
     Enums: {
       action_type: "mau" | "storage" | "bandwidth"
-      app_mode: "prod" | "dev" | "livereload"
       disable_update: "major" | "minor" | "patch" | "version_number" | "none"
       key_mode: "read" | "write" | "all" | "upload"
-      pay_as_you_go_type: "base" | "units"
       platform_os: "ios" | "android"
       stats_action:
         | "delete"
@@ -2112,8 +2160,8 @@ export type Database = {
         | "getChannel"
         | "rateLimited"
         | "disableAutoUpdate"
-        | "ping"
         | "InvalidIp"
+        | "ping"
       stripe_status:
         | "created"
         | "succeeded"
@@ -2121,7 +2169,7 @@ export type Database = {
         | "failed"
         | "deleted"
         | "canceled"
-      usage_mode: "5min" | "day" | "month" | "cycle" | "last_saved"
+      usage_mode: "last_saved" | "5min" | "day" | "cycle"
       user_min_right:
         | "invite_read"
         | "invite_upload"
@@ -2141,9 +2189,6 @@ export type Database = {
         file_name: string | null
         s3_path: string | null
         file_hash: string | null
-      }
-      match_plan: {
-        name: string | null
       }
       message_update: {
         msg_id: number | null
@@ -2292,13 +2337,14 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       action_type: ["mau", "storage", "bandwidth"],
-      app_mode: ["prod", "dev", "livereload"],
       disable_update: ["major", "minor", "patch", "version_number", "none"],
       key_mode: ["read", "write", "all", "upload"],
-      pay_as_you_go_type: ["base", "units"],
       platform_os: ["ios", "android"],
       stats_action: [
         "delete",
@@ -2348,8 +2394,8 @@ export const Constants = {
         "getChannel",
         "rateLimited",
         "disableAutoUpdate",
-        "ping",
         "InvalidIp",
+        "ping",
       ],
       stripe_status: [
         "created",
@@ -2359,7 +2405,7 @@ export const Constants = {
         "deleted",
         "canceled",
       ],
-      usage_mode: ["5min", "day", "month", "cycle", "last_saved"],
+      usage_mode: ["last_saved", "5min", "day", "cycle"],
       user_min_right: [
         "invite_read",
         "invite_upload",
@@ -2377,3 +2423,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/functions/_backend/triggers/cron_plan.ts
+++ b/supabase/functions/_backend/triggers/cron_plan.ts
@@ -3,9 +3,11 @@ import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, parseBody, simpleError } from '../utils/hono.ts'
 import { cloudlog } from '../utils/loggin.ts'
 import { checkPlanOrg } from '../utils/plans.ts'
+import { supabaseAdmin } from '../utils/supabase.ts'
 
 interface OrgToGet {
   orgId?: string
+  customerId?: string
 }
 
 export const app = new Hono<MiddlewareKeyVariables>()
@@ -17,5 +19,18 @@ app.post('/', middlewareAPISecret, async (c) => {
     throw simpleError('no_orgId', 'No orgId', { body })
 
   await checkPlanOrg(c, body.orgId)
+
+  // Update plan_calculated_at timestamp if we have customerId
+  if (body.customerId) {
+    const supabase = supabaseAdmin(c)
+    await supabase
+      .from('stripe_info')
+      .update({ plan_calculated_at: new Date().toISOString() })
+      .eq('customer_id', body.customerId)
+      .throwOnError()
+
+    cloudlog({ requestId: c.get('requestId'), message: 'plan calculated timestamp updated', customerId: body.customerId })
+  }
+
   return c.json(BRES)
 })

--- a/supabase/functions/_backend/triggers/cron_stats.ts
+++ b/supabase/functions/_backend/triggers/cron_stats.ts
@@ -103,7 +103,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     // Queue plan processing for this organization
     await supabase.rpc('queue_cron_plan_for_org', {
       org_id: body.orgId,
-      customer_id: orgData.customer_id
+      customer_id: orgData.customer_id,
     }).throwOnError()
 
     cloudlog({ requestId: c.get('requestId'), message: 'plan processing queued for org', orgId: body.orgId, customerId: orgData.customer_id })

--- a/supabase/functions/_backend/triggers/cron_stats.ts
+++ b/supabase/functions/_backend/triggers/cron_stats.ts
@@ -92,5 +92,22 @@ app.post('/', middlewareAPISecret, async (c) => {
     .eq('id', body.orgId)
     .throwOnError()
 
+  // Get customer_id for the organization to queue plan processing
+  const { data: orgData, error: orgError } = await supabase
+    .from('orgs')
+    .select('customer_id')
+    .eq('id', body.orgId)
+    .single()
+
+  if (!orgError && orgData?.customer_id) {
+    // Queue plan processing for this organization
+    await supabase.rpc('queue_cron_plan_for_org', {
+      org_id: body.orgId,
+      customer_id: orgData.customer_id
+    }).throwOnError()
+
+    cloudlog({ requestId: c.get('requestId'), message: 'plan processing queued for org', orgId: body.orgId, customerId: orgData.customer_id })
+  }
+
   return c.json({ status: 'Stats saved', mau, bandwidth, storage, versionUsage })
 })

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "13.0.5"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -182,6 +202,7 @@ export type Database = {
           app_id: string
           checksum: string
           created_at: string | null
+          devices: number | null
           id: number
           owner_org: string
           size: number
@@ -191,6 +212,7 @@ export type Database = {
           app_id: string
           checksum: string
           created_at?: string | null
+          devices?: number | null
           id?: number
           owner_org: string
           size: number
@@ -200,6 +222,7 @@ export type Database = {
           app_id?: string
           checksum?: string
           created_at?: string | null
+          devices?: number | null
           id?: number
           owner_org?: string
           size?: number
@@ -581,7 +604,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
-          email?: string
+          email: string
           id?: string
         }
         Update: {
@@ -706,7 +729,6 @@ export type Database = {
           app_id: string
           custom_id: string
           device_id: string
-          id: number
           is_emulator: boolean | null
           is_prod: boolean | null
           os_version: string | null
@@ -721,7 +743,6 @@ export type Database = {
           app_id: string
           custom_id?: string
           device_id: string
-          id?: never
           is_emulator?: boolean | null
           is_prod?: boolean | null
           os_version?: string | null
@@ -736,7 +757,6 @@ export type Database = {
           app_id?: string
           custom_id?: string
           device_id?: string
-          id?: never
           is_emulator?: boolean | null
           is_prod?: boolean | null
           os_version?: string | null
@@ -1035,6 +1055,7 @@ export type Database = {
           storage_unit: number | null
           stripe_id: string
           updated_at: string
+          version: number
         }
         Insert: {
           bandwidth: number
@@ -1057,6 +1078,7 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
+          version?: number
         }
         Update: {
           bandwidth?: number
@@ -1079,6 +1101,7 @@ export type Database = {
           storage_unit?: number | null
           stripe_id?: string
           updated_at?: string
+          version?: number
         }
         Relationships: []
       }
@@ -1142,6 +1165,7 @@ export type Database = {
           id: number
           is_good_plan: boolean | null
           mau_exceeded: boolean | null
+          plan_calculated_at: string | null
           plan_usage: number | null
           price_id: string | null
           product_id: string
@@ -1162,6 +1186,7 @@ export type Database = {
           id?: number
           is_good_plan?: boolean | null
           mau_exceeded?: boolean | null
+          plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
           product_id: string
@@ -1182,6 +1207,7 @@ export type Database = {
           id?: number
           is_good_plan?: boolean | null
           mau_exceeded?: boolean | null
+          plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
           product_id?: string
@@ -1872,10 +1898,6 @@ export type Database = {
         Args: { orgid: string }
         Returns: boolean
       }
-      is_owner_of_org: {
-        Args: { org_id: string; user_id: string }
-        Returns: boolean
-      }
       is_paying_and_good_plan_org: {
         Args: { orgid: string }
         Returns: boolean
@@ -1965,6 +1987,10 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      queue_cron_plan_for_org: {
+        Args: { customer_id: string; org_id: string }
+        Returns: undefined
+      }
       read_bandwidth_usage: {
         Args: { p_app_id: string; p_period_end: string; p_period_start: string }
         Returns: {
@@ -2008,6 +2034,30 @@ export type Database = {
       rescind_invitation: {
         Args: { email: string; org_id: string }
         Returns: string
+      }
+      reset_and_seed_app_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
+      }
+      reset_and_seed_app_stats_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
+      }
+      reset_and_seed_data: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      reset_and_seed_stats_data: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      reset_app_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
+      }
+      reset_app_stats_data: {
+        Args: { p_app_id: string }
+        Returns: undefined
       }
       seed_get_app_metrics_caches: {
         Args: { p_end_date: string; p_org_id: string; p_start_date: string }
@@ -2059,10 +2109,8 @@ export type Database = {
     }
     Enums: {
       action_type: "mau" | "storage" | "bandwidth"
-      app_mode: "prod" | "dev" | "livereload"
       disable_update: "major" | "minor" | "patch" | "version_number" | "none"
       key_mode: "read" | "write" | "all" | "upload"
-      pay_as_you_go_type: "base" | "units"
       platform_os: "ios" | "android"
       stats_action:
         | "delete"
@@ -2112,8 +2160,8 @@ export type Database = {
         | "getChannel"
         | "rateLimited"
         | "disableAutoUpdate"
-        | "ping"
         | "InvalidIp"
+        | "ping"
       stripe_status:
         | "created"
         | "succeeded"
@@ -2121,7 +2169,7 @@ export type Database = {
         | "failed"
         | "deleted"
         | "canceled"
-      usage_mode: "5min" | "day" | "month" | "cycle" | "last_saved"
+      usage_mode: "last_saved" | "5min" | "day" | "cycle"
       user_min_right:
         | "invite_read"
         | "invite_upload"
@@ -2141,9 +2189,6 @@ export type Database = {
         file_name: string | null
         s3_path: string | null
         file_hash: string | null
-      }
-      match_plan: {
-        name: string | null
       }
       message_update: {
         msg_id: number | null
@@ -2292,13 +2337,14 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       action_type: ["mau", "storage", "bandwidth"],
-      app_mode: ["prod", "dev", "livereload"],
       disable_update: ["major", "minor", "patch", "version_number", "none"],
       key_mode: ["read", "write", "all", "upload"],
-      pay_as_you_go_type: ["base", "units"],
       platform_os: ["ios", "android"],
       stats_action: [
         "delete",
@@ -2348,8 +2394,8 @@ export const Constants = {
         "getChannel",
         "rateLimited",
         "disableAutoUpdate",
-        "ping",
         "InvalidIp",
+        "ping",
       ],
       stripe_status: [
         "created",
@@ -2359,7 +2405,7 @@ export const Constants = {
         "deleted",
         "canceled",
       ],
-      usage_mode: ["5min", "day", "month", "cycle", "last_saved"],
+      usage_mode: ["last_saved", "5min", "day", "cycle"],
       user_min_right: [
         "invite_read",
         "invite_upload",
@@ -2377,3 +2423,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/migrations/20251007034349_cron_plan_from_stats_backend.sql
+++ b/supabase/migrations/20251007034349_cron_plan_from_stats_backend.sql
@@ -1,0 +1,74 @@
+-- Remove the daily process_subscribed_orgs cron job
+SELECT cron.unschedule('process_subscribed_orgs');
+
+-- Remove the current process_cron_plan_queue job
+SELECT cron.unschedule('process_cron_plan_queue');
+
+-- Reschedule process_cron_plan_queue to run every minute instead of every 2 hours
+SELECT cron.schedule(
+  'process_cron_plan_queue',
+  '* * * * *',
+  'SELECT public.process_function_queue(''cron_plan'')'
+);
+
+-- Create a function to queue plan processing for a specific organization
+CREATE OR REPLACE FUNCTION public.queue_cron_plan_for_org(org_id uuid, customer_id text)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM pgmq.send('cron_plan',
+    jsonb_build_object(
+      'function_name', 'cron_plan',
+      'function_type', 'cloudflare',
+      'payload', jsonb_build_object(
+        'orgId', org_id,
+        'customerId', customer_id
+      )
+    )
+  );
+END;
+$$;
+
+ALTER FUNCTION public.queue_cron_plan_for_org(uuid, text) OWNER TO postgres;
+
+-- Revoke all permissions first, then grant only to service_role
+REVOKE ALL ON FUNCTION public.queue_cron_plan_for_org(uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.queue_cron_plan_for_org(uuid, text) FROM anon;
+REVOKE ALL ON FUNCTION public.queue_cron_plan_for_org(uuid, text) FROM authenticated;
+GRANT ALL ON FUNCTION public.queue_cron_plan_for_org(uuid, text) TO service_role;
+
+-- Add column to track when plan was last calculated
+ALTER TABLE public.stripe_info ADD COLUMN IF NOT EXISTS plan_calculated_at timestamp with time zone;
+
+-- Update the queue function to check if plan was calculated in the last hour
+CREATE OR REPLACE FUNCTION public.queue_cron_plan_for_org(org_id uuid, customer_id text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  last_calculated timestamptz;
+BEGIN
+  -- Check when plan was last calculated for this customer
+  SELECT plan_calculated_at INTO last_calculated
+  FROM public.stripe_info
+  WHERE stripe_info.customer_id = queue_cron_plan_for_org.customer_id;
+  
+  -- Only queue if plan wasn't calculated in the last hour
+  IF last_calculated IS NULL OR last_calculated < NOW() - INTERVAL '1 hour' THEN
+    PERFORM pgmq.send('cron_plan',
+      jsonb_build_object(
+        'function_name', 'cron_plan',
+        'function_type', 'cloudflare',
+        'payload', jsonb_build_object(
+          'orgId', org_id,
+          'customerId', customer_id
+        )
+      )
+    );
+  END IF;
+END;
+$$;

--- a/tests/cron_plan_integration.test.ts
+++ b/tests/cron_plan_integration.test.ts
@@ -1,0 +1,297 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { BASE_URL, ORG_ID, USER_ID, getSupabaseClient, resetAndSeedAppData, resetAndSeedAppDataStats, resetAppData, resetAppDataStats } from './test-utils.ts'
+
+const appId = `com.cron.plan.integration.${randomUUID()}`
+
+const triggerHeaders = {
+    'Content-Type': 'application/json',
+    'apisecret': 'testsecret',
+}
+
+describe('[Integration] cron_stats -> cron_plan flow', () => {
+    beforeAll(async () => {
+        await resetAndSeedAppData(appId)
+        await resetAndSeedAppDataStats(appId)
+
+        const supabase = getSupabaseClient()
+
+        // Reset timestamps
+        await supabase
+            .from('orgs')
+            .update({ stats_updated_at: null })
+            .eq('id', ORG_ID)
+            .throwOnError()
+
+        // Reset plan calculated timestamp
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: null })
+            .eq('customer_id', 'cus_Pa0k8TO6HVln6A') // From seed data
+            .throwOnError()
+    })
+
+    afterAll(async () => {
+        await resetAppData(appId)
+        await resetAppDataStats(appId)
+    })
+
+    it('cron_stats triggers plan processing and updates plan_calculated_at', async () => {
+        const supabase = getSupabaseClient()
+
+        // First, get the actual customer_id for our test org
+        const { data: orgData } = await supabase
+            .from('orgs')
+            .select('customer_id')
+            .eq('id', ORG_ID)
+            .single()
+            .throwOnError()
+
+        console.log('Test org customer_id:', orgData?.customer_id)
+
+        // Skip test if no customer_id (this org doesn't have stripe setup)
+        if (!orgData?.customer_id) {
+            console.log('Skipping test - org has no customer_id')
+            return
+        }
+
+        // Reset plan_calculated_at to null for this customer
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: null })
+            .eq('customer_id', orgData.customer_id)
+            .throwOnError()
+
+        // Verify initial state - no plan_calculated_at
+        const { data: initialStripeInfo } = await supabase
+            .from('stripe_info')
+            .select('plan_calculated_at')
+            .eq('customer_id', orgData.customer_id)
+            .single()
+            .throwOnError()
+
+        expect(initialStripeInfo?.plan_calculated_at).toBeNull()
+
+        // Trigger cron_stats which should queue plan processing
+        const statsResponse = await fetch(`${BASE_URL}/triggers/cron_stats`, {
+            method: 'POST',
+            headers: triggerHeaders,
+            body: JSON.stringify({
+                appId,
+                orgId: ORG_ID,
+            }),
+        })
+
+        expect(statsResponse.status).toBe(200)
+        const statsJson = await statsResponse.json() as { status?: string }
+        expect(statsJson.status).toBe('Stats saved')
+
+        // Verify stats_updated_at was set
+        const { data: org } = await supabase
+            .from('orgs')
+            .select('stats_updated_at')
+            .eq('id', ORG_ID)
+            .single()
+            .throwOnError()
+
+        expect(org?.stats_updated_at).toBeTruthy()
+
+        // Check that a plan job was queued (we can't easily test queue contents, but we can verify the function doesn't error)
+        // The plan processing would normally be triggered by the queue processor
+
+        // Manually trigger cron_plan to simulate queue processing
+        const planResponse = await fetch(`${BASE_URL}/triggers/cron_plan`, {
+            method: 'POST',
+            headers: triggerHeaders,
+            body: JSON.stringify({
+                orgId: ORG_ID,
+                customerId: orgData.customer_id,
+            }),
+        })
+
+        expect(planResponse.status).toBe(200)
+
+        // Verify plan_calculated_at was updated
+        const { data: updatedStripeInfo } = await supabase
+            .from('stripe_info')
+            .select('plan_calculated_at')
+            .eq('customer_id', orgData.customer_id)
+            .single()
+            .throwOnError()
+
+        expect(updatedStripeInfo?.plan_calculated_at).toBeTruthy()
+
+        const timestamp = updatedStripeInfo?.plan_calculated_at
+        const updatedAtMs = new Date(timestamp!).getTime()
+        expect(Number.isNaN(updatedAtMs)).toBe(false)
+
+        const diffMs = Math.abs(Date.now() - updatedAtMs)
+        expect(diffMs).toBeLessThan(60_000) // Within last minute
+    })
+
+    it('rate limiting prevents duplicate plan processing within 1 hour', async () => {
+        const supabase = getSupabaseClient()
+
+        // Get the actual customer_id for our test org
+        const { data: orgData } = await supabase
+            .from('orgs')
+            .select('customer_id')
+            .eq('id', ORG_ID)
+            .single()
+            .throwOnError()
+
+        // Skip test if no customer_id
+        if (!orgData?.customer_id) {
+            console.log('Skipping test - org has no customer_id')
+            return
+        }
+
+        // Set plan_calculated_at to 30 minutes ago (within 1 hour)
+        const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000)
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: thirtyMinutesAgo.toISOString() })
+            .eq('customer_id', orgData.customer_id)
+            .throwOnError()
+
+        // Call the queue function directly (simulating what cron_stats does)
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: orgData.customer_id
+        })
+
+        // Should not error (rate limiting should silently skip)
+        expect(error).toBeNull()
+
+        // The timestamp should remain unchanged (not updated)
+        const { data: stripeInfo } = await supabase
+            .from('stripe_info')
+            .select('plan_calculated_at')
+            .eq('customer_id', orgData.customer_id)
+            .single()
+            .throwOnError()
+
+        const actualTimestamp = new Date(stripeInfo?.plan_calculated_at!).getTime()
+        const expectedTimestamp = thirtyMinutesAgo.getTime()
+
+        // Should be within 1 second of the original timestamp (accounting for precision)
+        expect(Math.abs(actualTimestamp - expectedTimestamp)).toBeLessThan(1000)
+    })
+
+    it('allows plan processing after 1 hour has passed', async () => {
+        const supabase = getSupabaseClient()
+
+        // Get the actual customer_id for our test org
+        const { data: orgData } = await supabase
+            .from('orgs')
+            .select('customer_id')
+            .eq('id', ORG_ID)
+            .single()
+            .throwOnError()
+
+        // Skip test if no customer_id
+        if (!orgData?.customer_id) {
+            console.log('Skipping test - org has no customer_id')
+            return
+        }
+
+        // Set plan_calculated_at to 2 hours ago (outside 1 hour window)
+        const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: twoHoursAgo.toISOString() })
+            .eq('customer_id', orgData.customer_id)
+            .throwOnError()
+
+        // Call the queue function directly
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: orgData.customer_id
+        })
+
+        expect(error).toBeNull()
+
+        // Now manually trigger plan processing to simulate queue processing
+        const planResponse = await fetch(`${BASE_URL}/triggers/cron_plan`, {
+            method: 'POST',
+            headers: triggerHeaders,
+            body: JSON.stringify({
+                orgId: ORG_ID,
+                customerId: orgData.customer_id,
+            }),
+        })
+
+        expect(planResponse.status).toBe(200)
+
+        // Verify plan_calculated_at was updated to recent time
+        const { data: stripeInfo } = await supabase
+            .from('stripe_info')
+            .select('plan_calculated_at')
+            .eq('customer_id', orgData.customer_id)
+            .single()
+            .throwOnError()
+
+        const timestamp = stripeInfo?.plan_calculated_at
+        const updatedAtMs = new Date(timestamp!).getTime()
+        const diffMs = Math.abs(Date.now() - updatedAtMs)
+
+        // Should be updated to within the last minute
+        expect(diffMs).toBeLessThan(60_000)
+    })
+
+    it('handles missing customer_id gracefully', async () => {
+        // Trigger cron_stats for an org without customer_id
+        const supabase = getSupabaseClient()
+
+        // Create a temporary org without customer_id
+        const tempOrgId = randomUUID()
+        await supabase
+            .from('orgs')
+            .insert({
+                id: tempOrgId,
+                name: 'Test Org No Customer',
+                management_email: 'test@example.com',
+                created_by: USER_ID,
+            })
+            .throwOnError()
+
+        // Create app for this org
+        const tempAppId = `com.test.nocustomer.${randomUUID()}`
+        await supabase
+            .from('apps')
+            .insert({
+                app_id: tempAppId,
+                owner_org: tempOrgId,
+                name: 'Test App No Customer',
+                icon_url: 'https://example.com/icon.png',
+            })
+            .throwOnError()
+
+        // Create app version
+        await supabase
+            .from('app_versions')
+            .insert({
+                app_id: tempAppId,
+                name: '1.0.0',
+                owner_org: tempOrgId,
+            })
+            .throwOnError()
+
+        // Trigger cron_stats - should not error even without customer_id
+        const statsResponse = await fetch(`${BASE_URL}/triggers/cron_stats`, {
+            method: 'POST',
+            headers: triggerHeaders,
+            body: JSON.stringify({
+                appId: tempAppId,
+                orgId: tempOrgId,
+            }),
+        })
+
+        expect(statsResponse.status).toBe(200)
+
+        // Clean up
+        await supabase.from('app_versions').delete().eq('app_id', tempAppId).throwOnError()
+        await supabase.from('apps').delete().eq('app_id', tempAppId).throwOnError()
+        await supabase.from('orgs').delete().eq('id', tempOrgId).throwOnError()
+    })
+})

--- a/tests/queue_cron_plan_function.test.ts
+++ b/tests/queue_cron_plan_function.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { ORG_ID, getSupabaseClient } from './test-utils.ts'
+
+describe('[Function] queue_cron_plan_for_org', () => {
+    let testCustomerId: string | null = null
+
+    beforeAll(async () => {
+        const supabase = getSupabaseClient()
+
+        // Get an existing customer_id from the test org or any existing stripe_info
+        const { data: orgData } = await supabase
+            .from('orgs')
+            .select('customer_id')
+            .eq('id', ORG_ID)
+            .single()
+
+        if (orgData?.customer_id) {
+            testCustomerId = orgData.customer_id
+        } else {
+            // Fallback: get any existing stripe_info record
+            const { data: stripeData } = await supabase
+                .from('stripe_info')
+                .select('customer_id')
+                .limit(1)
+                .single()
+
+            testCustomerId = stripeData?.customer_id || null
+        }
+    })
+
+    afterAll(async () => {
+        // No cleanup needed since we're using existing data
+    })
+
+    it('queues plan processing when plan_calculated_at is null', async () => {
+        if (!testCustomerId) {
+            console.log('Skipping test - no customer_id available')
+            return
+        }
+
+        const supabase = getSupabaseClient()
+
+        // Ensure plan_calculated_at is null
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: null })
+            .eq('customer_id', testCustomerId)
+            .throwOnError()
+
+        // Call the function
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: testCustomerId
+        })
+
+        expect(error).toBeNull()
+        // Note: We can't easily verify the queue was populated, but no error means it worked
+    })
+
+    it('skips queuing when plan was calculated within last hour', async () => {
+        if (!testCustomerId) {
+            console.log('Skipping test - no customer_id available')
+            return
+        }
+
+        const supabase = getSupabaseClient()
+
+        // Set plan_calculated_at to 30 minutes ago
+        const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000)
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: thirtyMinutesAgo.toISOString() })
+            .eq('customer_id', testCustomerId)
+            .throwOnError()
+
+        // Call the function
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: testCustomerId
+        })
+
+        expect(error).toBeNull()
+        // Function should succeed but skip queuing (no way to verify this directly)
+    })
+
+    it('queues plan processing when plan was calculated over 1 hour ago', async () => {
+        if (!testCustomerId) {
+            console.log('Skipping test - no customer_id available')
+            return
+        }
+
+        const supabase = getSupabaseClient()
+
+        // Set plan_calculated_at to 2 hours ago
+        const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+        await supabase
+            .from('stripe_info')
+            .update({ plan_calculated_at: twoHoursAgo.toISOString() })
+            .eq('customer_id', testCustomerId)
+            .throwOnError()
+
+        // Call the function
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: testCustomerId
+        })
+
+        expect(error).toBeNull()
+    })
+
+    it('handles non-existent customer_id gracefully', async () => {
+        const supabase = getSupabaseClient()
+
+        // Call with non-existent customer_id
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: 'non_existent_customer'
+        })
+
+        expect(error).toBeNull()
+        // Should not error even if customer doesn't exist
+    })
+
+    it('has correct permissions - only service_role can call', async () => {
+        if (!testCustomerId) {
+            console.log('Skipping test - no customer_id available')
+            return
+        }
+
+        // This test verifies the function exists and can be called
+        // The actual permission restriction is tested at the database level
+        const supabase = getSupabaseClient()
+
+        const { error } = await supabase.rpc('queue_cron_plan_for_org', {
+            org_id: ORG_ID,
+            customer_id: testCustomerId
+        })
+
+        expect(error).toBeNull()
+    })
+})

--- a/tests/queue_cron_plan_function.test.ts
+++ b/tests/queue_cron_plan_function.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { ORG_ID, getSupabaseClient } from './test-utils.ts'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically queues plan recalculation after usage stats are saved; adds plan_calculated_at timestamp and one-hour throttle to prevent duplicates.
  - Adds device count and plan version fields for more accurate usage/billing.
  - Cron rescheduled to check plan queue more frequently.

- Bug Fixes
  - Improves reliability of plan processing and reduces duplicate work.

- Chores
  - Email now required when requesting account deletion.

- Tests
  - Added end-to-end, RPC/function, and integration tests plus DB helpers for cron/queue verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->