### PR TITLE
fix: devices upsert

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -85,7 +85,7 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
   INSERT INTO devices (
     updated_at, device_id, version_name, app_id, platform, 
     plugin_version, os_version, version_build, custom_id, 
-    is_prod, is_emulator
+    is_prod, is_emulator, version
   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT (device_id, app_id) DO UPDATE SET
     updated_at = excluded.updated_at,
@@ -96,7 +96,8 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
     version_build = excluded.version_build,
     custom_id = excluded.custom_id,
     is_prod = excluded.is_prod,
-    is_emulator = excluded.is_emulator
+    is_emulator = excluded.is_emulator,
+    version = 0
 `
   try {
     const updated_at = new Date().toISOString()
@@ -124,6 +125,7 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
           comparableDevice.custom_id ?? '',
           comparableDevice.is_prod ? 1 : 0,
           comparableDevice.is_emulator ? 1 : 0,
+          device.version ?? 0,
         )
         .run()
       cloudlog({ requestId: c.get('requestId'), message: 'Upsert result:', res })


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

## Test plan

<!-- Include the steps to test your PR -->
<!-- Any PR that requires a complex setup to test MUST include this -->

## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->
<!-- Please include this if CLI/frontend behaviour has changed, can be skipped for backend changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `bun run lint-backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures device records always include a version, defaulting to 0 when not provided. This prevents upsert errors, improves data consistency, and stabilizes device updates.
  * Improves reliability of device synchronization by standardizing version handling across insert and update operations, reducing edge cases where missing version data could cause failures or inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->