### PR TITLE
fix: set channel when setting new override

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -270,7 +270,7 @@ export function requestInfosPostgres(
           eq(channelAlias.app_id, app_id),
           eq(platformQuery, true),
         )
-      : and (
+      : and(
           eq(channelAlias.app_id, app_id),
           eq(channelAlias.name, defaultChannel),
         ),
@@ -518,6 +518,7 @@ export async function upsertChannelDevicePg(
         device_id: data.device_id,
         channel_id: data.channel_id,
         app_id: data.app_id,
+        owner_org: data.owner_org,
       })
       .onConflictDoUpdate({
         target: [schema.channel_devices.device_id, schema.channel_devices.app_id],

--- a/supabase/functions/_backend/utils/postgress_schema.ts
+++ b/supabase/functions/_backend/utils/postgress_schema.ts
@@ -6,7 +6,7 @@ import { bigint, boolean, customType, pgEnum, pgTable, serial, text, timestamp, 
 export const disableUpdatePgEnum = pgEnum('disable_update', ['major', 'minor', 'patch', 'version_number', 'none'])
 
 // Keeping this for backward compatibility but marking as deprecated
-const manfiestType = customType <{ data: Database['public']['CompositeTypes']['manifest_entry'][] }>({
+const manfiestType = customType<{ data: Database['public']['CompositeTypes']['manifest_entry'][] }>({
   dataType() {
     return 'manifest_entry[]'
   },
@@ -102,7 +102,7 @@ export const channel_devices = pgTable('channel_devices', {
   device_id: text('device_id').notNull(),
   channel_id: bigint('channel_id', { mode: 'number' }).notNull().references(() => channels.id),
   app_id: varchar('app_id').notNull().references(() => apps.name),
-  owner_org: uuid('owner_org'),
+  owner_org: uuid('owner_org').notNull(),
 })
 
 export const orgs = pgTable('orgs', {


### PR DESCRIPTION
This PR fixes set_channel by:

- Adding an org_id field
- Adding a test for this case
- Fixing an existing test case (finding if app doesn't exist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to verify app existence before processing channel operations, ensuring proper error handling with clearer feedback when an app is not found.

* **Tests**
  * Added test coverage for channel-device creation with organization ownership tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->