### PR TITLE
fix: delete_user properly call on_user_delete

### DIFF
--- a/supabase/migrations/20251208175306_fix_user_delete_old_record.sql
+++ b/supabase/migrations/20251208175306_fix_user_delete_old_record.sql
@@ -15,7 +15,7 @@ BEGIN
   SELECT row_to_json(u)::jsonb INTO old_record_json
   FROM (
     SELECT *
-    FROM users
+    FROM public.users
     WHERE id = user_id_fn
   ) AS u;
   
@@ -24,9 +24,12 @@ BEGIN
   PERFORM "pgmq"."send"(
     'on_user_delete'::text,
     "jsonb_build_object"(
-      'old_record', old_record_json,
-      "table": "users",
-      "type": "DELETE",
+      'payload', "jsonb_build_object"(
+        'old_record', old_record_json,
+        'table', 'users',
+        'type', 'DELETE'
+      ),
+      'function_name', 'on_user_delete'
     )
   );
   


### PR DESCRIPTION
### The business issue

Currently, deleting the account doesn't cancel the Capgo subscription. This has caused one user to get charged when he shouldn't have been. Furthermore, we had to issue a refund, which is a bad experience for the user and Martin had to waste his time on issuing the refund.

### Motivation

I strongly believe that if I have implemented a feature where deleting the account calls `on_user_delete` immediately, which consequently cancels the subscription, it should work. Therefore, I am making this PR

### The fix

The `on_user_delete` contains `triggerValidator('users', 'DELETE')`. I have missed that in the original PR #1191. As such, I have corrected the `on_user_delete` queue call
```diff
  PERFORM "pgmq"."send"(
    'on_user_delete'::text,
    "jsonb_build_object"(
+      'old_record', old_record_json,
-     'user_id', user_id_fn,
-     'email', user_email
+     "table": "users",
+     "type": "DELETE",
    )
  );
  ```
  
 ### PR's checklist
 
 - [x] PR's passes lint - there is no SQL lint as far as I know. I think we have stopped doing SQL lint
 - [x] The PR has been tested. It has been, but another test in prod will happen after the merge of this PR to confirm that it is 100% working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user account deletion: preserves a snapshot of the deleted account, emits a deletion event for downstream handling, and automatically schedules secure removal after a 30-day window.
  * Associated credentials (API keys) are now removed as part of the deletion workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->