### PR TITLE
fix: fix cascade for account deletion

### DIFF
--- a/supabase/migrations/20251209052511_add_cascade_to_channel_devices_fkey.sql
+++ b/supabase/migrations/20251209052511_add_cascade_to_channel_devices_fkey.sql
@@ -1,0 +1,12 @@
+-- Drop the existing foreign key constraint without CASCADE
+ALTER TABLE public.channel_devices 
+DROP CONSTRAINT channel_devices_channel_id_fkey;
+
+-- Recreate the constraint with ON DELETE CASCADE
+-- This ensures that when a channel is deleted, all associated channel_devices are automatically deleted
+ALTER TABLE public.channel_devices
+ADD CONSTRAINT channel_devices_channel_id_fkey 
+FOREIGN KEY (channel_id) 
+REFERENCES public.channels (id) 
+ON DELETE CASCADE;
+


### PR DESCRIPTION
### The business issue

Currently, deleting the account doesn't work. After the 30 days period, the account deletion will enter an infinite loop of trying to revert and failing. This cause CPU usage and is not compliant with GDPR and other data regulations.


### Motivation

Capgo MUST follow proper data removal procedures, including the GDPR. Moreover, an excess number of failed deletions will cause high CPU usage, which might be burdensome to Capgo's infrastructure. Therefore, it is essential that we fix this problem as soon as possible, and as such, I have made this PR.

### The fix

1. Adding a `ON DELETE CASCADE` clause to the `channel_devices_channel_id_fkey` index. This should suffice to fix the issue.
  
 ### PR's checklist
 
 - [x] PR's passes lint - there is no SQL lint as far as I know. I think we have stopped doing SQL lint
 - [x] The PR has been tested. It has been, but another test in prod will happen after the merge of this PR to confirm that it is 100% working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency by ensuring related records are properly removed when channels are deleted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->