### PR TITLE
feat(onboarding): add manual setup link to StepsApp

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -775,6 +775,8 @@
   "onboarding-invite-option-modal-title": "Laden Sie einen technischen Teamkollegen ein",
   "onboarding-invite-option-subtitle": "Laden Sie einen technischen Teamkollegen ein und wir werden ihm Anweisungen per E-Mail senden, um die App für diese Organisation zu erstellen.",
   "onboarding-invite-option-title": "Bevorzugen Sie es, wenn jemand anderes die Einrichtung übernimmt?",
+  "onboarding-manual-setup-link": "Anleitung zur manuellen Einrichtung",
+  "onboarding-manual-setup-prefix": "Oder folgen Sie unserer",
   "one-day-left": "Noch ein Tag übrig",
   "one-hour-short": "1h",
   "open": "Öffnen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Invite a technical teammate",
   "onboarding-invite-option-subtitle": "Invite a technical teammate and we will email them instructions to create the app for this organization.",
   "onboarding-invite-option-title": "Prefer someone else to handle the setup?",
+  "onboarding-manual-setup-link": "manual setup guide",
+  "onboarding-manual-setup-prefix": "Or follow our",
   "one-day-left": "One day left",
   "one-hour-short": "1h",
   "open": "Open",

--- a/messages/es.json
+++ b/messages/es.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Invita a un compañero de equipo técnico",
   "onboarding-invite-option-subtitle": "Invita a un compañero técnico y le enviaremos por correo electrónico las instrucciones para crear la aplicación para esta organización.",
   "onboarding-invite-option-title": "¿Prefieres que alguien más se encargue de la configuración?",
+  "onboarding-manual-setup-link": "guía de configuración manual",
+  "onboarding-manual-setup-prefix": "O sigue nuestra",
   "one-day-left": "Queda un día",
   "one-hour-short": "1h",
   "open": "Abierto",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Invitez un coéquipier technique",
   "onboarding-invite-option-subtitle": "Invitez un coéquipier technique et nous lui enverrons par email les instructions pour créer l'application pour cette organisation.",
   "onboarding-invite-option-title": "Préférez-vous que quelqu'un d'autre s'occupe de la configuration?",
+  "onboarding-manual-setup-link": "guide de configuration manuelle",
+  "onboarding-manual-setup-prefix": "Ou suivez notre",
   "one-day-left": "Un jour restant",
   "one-hour-short": "1h",
   "open": "Ouvrir",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "तकनीकी सहयोगी को आमंत्रित करें",
   "onboarding-invite-option-subtitle": "तकनीकी सहयोगी को आमंत्रित करें और हम उन्हें इस संगठन के लिए ऐप बनाने के निर्देशों का ईमेल करेंगे।",
   "onboarding-invite-option-title": "क्या आप चाहते हैं कि सेटअप का प्रबंधन कोई और करे?",
+  "onboarding-manual-setup-link": "मैन्युअल सेटअप गाइड",
+  "onboarding-manual-setup-prefix": "या हमारी",
   "one-day-left": "एक दिन बाकी है",
   "one-hour-short": "1h",
   "open": "खोलें",

--- a/messages/id.json
+++ b/messages/id.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Undang rekan kerja teknis",
   "onboarding-invite-option-subtitle": "Undang rekan kerja teknis dan kami akan mengirimkan email kepada mereka dengan instruksi untuk membuat aplikasi untuk organisasi ini.",
   "onboarding-invite-option-title": "Lebih suka orang lain yang menangani pengaturannya?",
+  "onboarding-manual-setup-link": "panduan pengaturan manual",
+  "onboarding-manual-setup-prefix": "Atau ikuti",
   "one-day-left": "Tinggal satu hari",
   "one-hour-short": "1h",
   "open": "Buka",

--- a/messages/it.json
+++ b/messages/it.json
@@ -775,6 +775,8 @@
   "onboarding-invite-option-modal-title": "Invita un compagno di squadra tecnico",
   "onboarding-invite-option-subtitle": "Invita un collega tecnico e gli invieremo via email le istruzioni per creare l'app per questa organizzazione.",
   "onboarding-invite-option-title": "Preferisci che qualcun altro gestisca l'installazione?",
+  "onboarding-manual-setup-link": "guida alla configurazione manuale",
+  "onboarding-manual-setup-prefix": "Oppure segui la nostra",
   "one-day-left": "Un giorno rimasto",
   "one-hour-short": "1h",
   "open": "Apri",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "技術的なチームメイトを招待する",
   "onboarding-invite-option-subtitle": "技術的なチームメイトを招待し、この組織のアプリを作成するための指示を彼らにメールで送ります。",
   "onboarding-invite-option-title": "設定は他の誰かに任せたいですか？",
+  "onboarding-manual-setup-link": "手動セットアップガイド",
+  "onboarding-manual-setup-prefix": "または",
   "one-day-left": "あと一日",
   "one-hour-short": "1h",
   "open": "開く",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -775,6 +775,8 @@
   "onboarding-invite-option-modal-title": "기술 팀원을 초대하십시오",
   "onboarding-invite-option-subtitle": "기술 팀원을 초대하면 이 조직을 위한 앱을 만드는 방법에 대한 지침을 이메일로 보내드립니다.",
   "onboarding-invite-option-title": "설정을 다른 사람에게 맡기는 것을 선호하시나요?",
+  "onboarding-manual-setup-link": "수동 설정 가이드",
+  "onboarding-manual-setup-prefix": "또는",
   "one-day-left": "하루 남았습니다",
   "one-hour-short": "1h",
   "open": "열다",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -775,6 +775,8 @@
   "onboarding-invite-option-modal-title": "Zaproś technicznego kolegę z zespołu",
   "onboarding-invite-option-subtitle": "Zaproś kolegę z zespołu technicznego, a my wyślemy mu na e-mail instrukcje dotyczące stworzenia aplikacji dla tej organizacji.",
   "onboarding-invite-option-title": "Wolisz, aby ktoś inny zajął się konfiguracją?",
+  "onboarding-manual-setup-link": "przewodnik ręcznej konfiguracji",
+  "onboarding-manual-setup-prefix": "Lub skorzystaj z naszego",
   "one-day-left": "Pozostał jeden dzień",
   "one-hour-short": "1h",
   "open": "Otwórz",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Convide um colega de equipe técnica",
   "onboarding-invite-option-subtitle": "Convide um colega de equipe técnico e nós enviaremos a ele instruções por email para criar o aplicativo para esta organização.",
   "onboarding-invite-option-title": "Prefere que outra pessoa cuide da configuração?",
+  "onboarding-manual-setup-link": "guia de configuração manual",
+  "onboarding-manual-setup-prefix": "Ou siga nosso",
   "one-day-left": "Falta um dia",
   "one-hour-short": "1h",
   "open": "Aberto",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Пригласите технического коллегу",
   "onboarding-invite-option-subtitle": "Пригласите технического сотрудника, и мы отправим ему на электронную почту инструкции по созданию приложения для этой организации.",
   "onboarding-invite-option-title": "Предпочитаете, чтобы кто-то другой занимался настройкой?",
+  "onboarding-manual-setup-link": "руководство по ручной настройке",
+  "onboarding-manual-setup-prefix": "Или следуйте нашему",
   "one-day-left": "Остался один день",
   "one-hour-short": "1h",
   "open": "Открыть",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -775,6 +775,8 @@
   "onboarding-invite-option-modal-title": "Teknik bir takım arkadaşını davet et",
   "onboarding-invite-option-subtitle": "Bir teknik takım arkadaşını davet edin ve bu organizasyon için uygulamayı oluşturmak üzere onlara talimatları e-posta ile göndereceğiz.",
   "onboarding-invite-option-title": "Kurulumu başkasının yapmasını tercih eder misiniz?",
+  "onboarding-manual-setup-link": "manuel kurulum kılavuzuna",
+  "onboarding-manual-setup-prefix": "Ya da",
   "one-day-left": "Bir gün kaldı",
   "one-hour-short": "1h",
   "open": "Açık",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -776,6 +776,8 @@
   "onboarding-invite-option-modal-title": "Mời một đồng đội kỹ thuật",
   "onboarding-invite-option-subtitle": "Mời một đồng đội kỹ thuật và chúng tôi sẽ gửi email cho họ hướng dẫn để tạo ứng dụng cho tổ chức này.",
   "onboarding-invite-option-title": "Bạn muốn người khác đảm nhận việc thiết lập?",
+  "onboarding-manual-setup-link": "hướng dẫn thiết lập thủ công",
+  "onboarding-manual-setup-prefix": "Hoặc làm theo",
   "one-day-left": "Còn một ngày nữa",
   "one-hour-short": "1h",
   "open": "Mở",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -775,6 +775,8 @@
   "onboarding-invite-option-modal-title": "邀请一位技术团队成员",
   "onboarding-invite-option-subtitle": "邀请一名技术团队成员，我们将向他们发送电子邮件指导如何为这个组织创建应用程序。",
   "onboarding-invite-option-title": "更喜欢让别人来处理设置吗？",
+  "onboarding-manual-setup-link": "手动设置指南",
+  "onboarding-manual-setup-prefix": "或者查看我们的",
   "one-day-left": "还剩一天",
   "one-hour-short": "1h",
   "open": "打开",

--- a/src/components/dashboard/StepsApp.vue
+++ b/src/components/dashboard/StepsApp.vue
@@ -342,6 +342,15 @@ onUnmounted(() => {
               >
                 {{ t('onboarding-invite-option-cta') }}
               </button>
+              <p class="mt-4 text-xs text-gray-400">
+                {{ t('onboarding-manual-setup-prefix') }}
+                <a
+                  href="https://capgo.app/docs/getting-started/add-an-app/#manual-setup"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="underline hover:text-gray-600"
+                >{{ t('onboarding-manual-setup-link') }}</a>
+              </p>
             </div>
           </div>
         </template>


### PR DESCRIPTION
## Summary
- Add a subtle "manual setup guide" link in the onboarding flow for users who prefer not to use the CLI wizard
- Link points to https://capgo.app/docs/getting-started/add-an-app/#manual-setup
- Added translations for all 14 supported languages

## Test plan
- [ ] Verify the manual setup link appears below the "Invite a teammate" button
- [ ] Confirm the link opens in a new tab
- [ ] Check translations display correctly for different locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added a manual setup guide option to the onboarding flow, providing users with an alternative method to complete their initial configuration without requiring an invitation from an existing user
- Comprehensive multilingual support implemented across all available languages, ensuring global accessibility
- Manual setup option displayed alongside the existing invitation-based onboarding method, offering users greater flexibility in how they begin

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->