### PR TITLE
Fix: Disable prepared statements for Supabase pooler

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -122,8 +122,9 @@ export function getPgClient(c: Context, readOnly = false) {
   const dbName = c.res.headers.get('X-Database-Source') ?? 'unknown source'
   cloudlog({ requestId, message: 'SUPABASE_DB_URL', dbUrl, dbName, appName })
 
+  const prepare = !dbName.startsWith('sb_pooler')
   const options = {
-    prepare: true,
+    prepare,
     connectionString: dbUrl,
     max: 4,
     application_name: `${appName}-${dbName}`,


### PR DESCRIPTION
## Summary

Prepared statements are not supported by PgBouncer in transaction mode, which Supabase's pooler uses. This change disables prepared statements when connecting through the Supabase pooler while keeping them enabled for direct and Hyperdrive connections.

## Test plan

- Verify database connections through `sb_pooler` work without prepared statement errors
- Confirm direct and Hyperdrive connections still use prepared statements for performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection pool configuration for enhanced stability and reliability.
  * Optimized timeout and connection lifecycle settings.
  * Enhanced read-only transaction mode handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->