### PR TITLE
feat: allow 20-character public key in key_id with version check

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -44,7 +44,7 @@ export const jsonRequestSchema = z.looseObject({
   plugin_version: z.optional(z.string()),
   is_prod: z.boolean(),
   platform: devicePlatformScheme,
-  key_id: z.optional(z.string().check(z.maxLength(4))),
+  key_id: z.optional(z.string().check(z.maxLength(20))),
 })
 
 // TODO: delete when all mirgrated to jsonRequestSchema
@@ -55,7 +55,7 @@ export const jsonRequestSchemaGet = z.looseObject({
   is_emulator: z.boolean(),
   is_prod: z.boolean(),
   platform: devicePlatformScheme,
-  key_id: z.optional(z.string().check(z.maxLength(4))),
+  key_id: z.optional(z.string().check(z.maxLength(20))),
 })
 
 async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient>, body: DeviceLink): Promise<Response> {

--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -47,7 +47,7 @@ export const jsonRequestSchema = z.object({
   plugin_version: z.optional(z.string()),
   is_emulator: z.boolean(),
   is_prod: z.boolean(),
-  key_id: z.optional(z.string().check(z.maxLength(4))),
+  key_id: z.optional(z.string().check(z.maxLength(20))),
 })
 
 async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient>, body: AppStats) {

--- a/supabase/functions/_backend/plugins/updates.ts
+++ b/supabase/functions/_backend/plugins/updates.ts
@@ -52,7 +52,7 @@ const jsonRequestSchema = z.object({
   }).check(z.refine((version: string) => canParse(version), {
     message: INVALID_STRING_PLUGIN_VERSION,
   })),
-  key_id: z.optional(z.string().check(z.maxLength(4))),
+  key_id: z.optional(z.string().check(z.maxLength(20))),
 })
 
 export const app = new Hono<MiddlewareKeyVariables>()

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -189,7 +189,8 @@ export async function updateWithPG(
 
   // Check for encryption key mismatch between device and bundle
   // Only check if both device and bundle have key_id set (encrypted bundle)
-  if (body.key_id && version.key_id && body.key_id !== version.key_id) {
+  // Only enforce for plugin_version > 8.40.7 (transitional period for key_id format change from 4 to 20 chars)
+  if (body.key_id && version.key_id && body.key_id !== version.key_id && greaterThan(pluginVersion, parse('8.40.7'))) {
     cloudlog({ requestId: c.get('requestId'), message: 'Encryption key mismatch', device_id, deviceKeyId: body.key_id, bundleKeyId: version.key_id, versionName: version.name })
     await sendStatsAndDevice(c, device, [{ action: 'keyMismatch', versionName: version.name }])
     return simpleError200(c, 'key_id_mismatch', 'Device encryption key does not match bundle encryption key. The device may have a different public key than the one used to encrypt this bundle.', {


### PR DESCRIPTION
## Summary

Enable transition period for public key format change from 4 to 20 characters. The key_id validation now accepts up to 20 characters across all endpoints (updates, stats, channel_self), and the public key mismatch check is only enforced for plugin versions > 8.40.7. This allows older clients to update without errors during the migration period.

## Test plan

- Verify older plugin versions (≤8.40.7) can send 4-character key_id values without triggering mismatch errors
- Verify plugin versions >8.40.7 enforce the key_id mismatch check
- Test with new 20-character key_id format to ensure validation accepts the longer format

🤖 Generated with [Claude Code](https://claude.com/claude-code)