### PR TITLE
feat: reject_access_due_to_2fa_for_app

### DIFF
--- a/supabase/migrations/20251228150000_reject_access_due_to_2fa_for_app.sql
+++ b/supabase/migrations/20251228150000_reject_access_due_to_2fa_for_app.sql
@@ -63,7 +63,9 @@ $$;
 
 ALTER FUNCTION "public"."reject_access_due_to_2fa_for_app"("app_id" character varying) OWNER TO "postgres";
 
--- Grant permissions - accessible to authenticated users (CLI and frontend)
+-- Grant permissions - accessible to authenticated, anon (for API key usage), and service_role
+-- Note: anon is needed because API key requests come in as anon role with capgkey header
 GRANT EXECUTE ON FUNCTION "public"."reject_access_due_to_2fa_for_app"("app_id" character varying) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."reject_access_due_to_2fa_for_app"("app_id" character varying) TO "anon";
 GRANT EXECUTE ON FUNCTION "public"."reject_access_due_to_2fa_for_app"("app_id" character varying) TO "service_role";
 

--- a/supabase/tests/41_test_reject_access_due_to_2fa_for_app.sql
+++ b/supabase/tests/41_test_reject_access_due_to_2fa_for_app.sql
@@ -222,13 +222,13 @@ BEGIN
   PERFORM set_config('request.headers', '{}', true);
 END $$;
 
--- Test 9: Anonymous user (no auth) returns true (rejection)
+-- Test 9: Anonymous user (no auth, no API key) returns true (rejection - no user identity found)
 SELECT tests.clear_authentication();
 SELECT
     is(
         reject_access_due_to_2fa_for_app(current_setting('test.app_with_2fa')),
         true,
-        'reject_access_due_to_2fa_for_app test - anonymous user returns true'
+        'reject_access_due_to_2fa_for_app test - anonymous user returns true (no user identity)'
     );
 
 -- Test 10: Verify function exists


### PR DESCRIPTION
## Changes (AI Generated)

- Added new public database function `reject_access_due_to_2fa_for_app(app_id)`
  that allows CLI and frontend to check 2FA compliance for an app
- The function takes an app_id, finds its owner organization, gets the current
  user (via JWT or API key), and returns `true` if access should be denied due
  to 2FA enforcement
- Supports both regular authentication and API key authentication (important for
  CLI usage)
- Function is granted to `authenticated`, `anon` (needed for API key auth which
  comes as anon role with headers), and `service_role`
- Added 13 pgTAP tests covering: users with/without 2FA, orgs with/without 2FA
  enforcement, API key auth, anonymous users, non-existent apps, and service
  role access


### Motivation

Needed for part 2 of #1291 - the PR for the 2FA enforcement for the CLI.
Not really required for #1256, as the frontend can use `get_orgs_v7`, but it would be not performant and wasteful for the CLI to use `get_orgs_v7`. I have forgotten about this implementation detail in the implementation plan for 2FA enforcement, so I need to add it now

### Business impact

Low - if this PR were to be rejected, the CLI would use `get_orgs_v7`, which would be slow, and it would resolve in a bad user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces two-factor authentication (2FA) for app access when an organization requires it; access is denied for users without 2FA and allowed otherwise (including service/API access honoring the same rule).

* **Tests**
  * Added comprehensive test coverage validating 2FA enforcement across user, API key, anonymous, non-existent app, and repeated-call scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->