### PR TITLE
feat: expand key_id column from varchar(4) to varchar(20)

### DIFF
--- a/supabase/functions/_backend/utils/postgres_schema.ts
+++ b/supabase/functions/_backend/utils/postgres_schema.ts
@@ -43,7 +43,7 @@ export const app_versions = pgTable('app_versions', {
   external_url: varchar('external_url'),
   checksum: varchar('checksum'),
   session_key: varchar('session_key'),
-  key_id: varchar('key_id', { length: 4 }),
+  key_id: varchar('key_id', { length: 20 }),
   storage_provider: text('storage_provider').default('r2').notNull(),
   min_update_version: varchar('min_update_version'),
   r2_path: varchar('r2_path'),

--- a/supabase/migrations/20251213140000_add_encryption_tracking_to_devices.sql
+++ b/supabase/migrations/20251213140000_add_encryption_tracking_to_devices.sql
@@ -1,19 +1,19 @@
 -- Add encryption key prefix column to devices table
 ALTER TABLE public.devices
-ADD COLUMN key_id character varying(4);
+ADD COLUMN key_id character varying(20);
 
 -- Add comment to explain the column
-COMMENT ON COLUMN public.devices.key_id IS 'First 4 characters of the base64-encoded public key (identifies which key is in use)';
+COMMENT ON COLUMN public.devices.key_id IS 'First 20 characters of the base64-encoded public key (identifies which key is in use)';
 
 -- Create index for better query performance on key_id
 CREATE INDEX IF NOT EXISTS idx_devices_key_id ON public.devices (key_id)
 WHERE key_id IS NOT NULL;
 
 ALTER TABLE public.app_versions
-ADD COLUMN key_id character varying(4);
+ADD COLUMN key_id character varying(20);
 
 -- Add comment to explain the column
-COMMENT ON COLUMN public.app_versions.key_id IS 'First 4 characters of the base64-encoded public key used to encrypt this bundle (identifies which key was used for encryption)';
+COMMENT ON COLUMN public.app_versions.key_id IS 'First 20 characters of the base64-encoded public key used to encrypt this bundle (identifies which key was used for encryption)';
 
 -- Create index for better query performance on key_id
 CREATE INDEX IF NOT EXISTS idx_app_versions_key_id ON public.app_versions (key_id)


### PR DESCRIPTION
## Summary

Updates the `key_id` column in both `devices` and `app_versions` tables from varchar(4) to varchar(20), aligning storage capacity with existing API validation limits that already support up to 20 characters.

## Test plan

- Run `supabase db reset` to apply the migration
- Verify the column schema changes with `\d public.devices` and `\d public.app_versions` in psql
- Run existing E2E tests to ensure no regressions with the expanded key_id format

## Checklist

- [x] Code follows project style (`bun run lint:backend && bun run lint`)
- [ ] Documentation update required
- [ ] E2E test coverage verified
- [x] Manual testing completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased identifier field storage capacity to support longer values (up to 20 characters).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->