### PR TITLE
fix: add RLS policy for cron_tasks table

### DIFF
--- a/supabase/migrations/20251229030503_add_cron_tasks_rls_policy.sql
+++ b/supabase/migrations/20251229030503_add_cron_tasks_rls_policy.sql
@@ -1,0 +1,6 @@
+-- Add RLS policy for cron_tasks table
+-- This table has RLS enabled but was missing the policy
+-- Only service_role should access this table (service_role bypasses RLS)
+
+CREATE POLICY "Deny all access" ON public.cron_tasks FOR ALL USING (false)
+WITH CHECK (false);


### PR DESCRIPTION
## Summary

The `cron_tasks` table had RLS enabled but was missing the required policy. Added a deny-all policy to ensure only `service_role` can access this internal table, following the pattern used for other internal tables in the codebase.

## Test plan

This migration only adds an RLS policy. Run `supabase db reset` to verify the migration applies successfully without errors.

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] My change has adequate E2E test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security controls by restricting default access to cron tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->