### PR TITLE
fix: resolve Supabase database test failures

### DIFF
--- a/supabase/tests/40_test_email_preferences.sql
+++ b/supabase/tests/40_test_email_preferences.sql
@@ -218,9 +218,15 @@ SELECT
   );
 
 -- Test 13: New user gets default preferences
+DO $$
+BEGIN
+  PERFORM tests.create_supabase_user('new_email_pref_user', 'new-email-pref-user@example.com', '555-001-0002');
+END;
+$$ LANGUAGE plpgsql;
+
 INSERT INTO public.users (id, email, created_at, updated_at)
 VALUES (
-  gen_random_uuid(),
+  tests.get_supabase_uid('new_email_pref_user'),
   'new-email-pref-user@example.com',
   now(),
   now()


### PR DESCRIPTION
## Summary

Fixed two failing Supabase database tests that were preventing the test suite from passing.

## Test plan

Run `bun test:all` or `npx supabase test db` to verify all 790 tests pass.

## Changes

- **40_test_email_preferences.sql**: Create user in auth.users before inserting into public.users to satisfy foreign key constraint
- **40_test_password_policy_enforcement.sql**: Resolve ambiguous column reference and use proper existence check instead of invalid ON CONFLICT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved email preferences test setup with deterministic user identities for enhanced test reproducibility and reliability.
  * Refined password policy enforcement tests with more robust duplicate prevention logic to ensure data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->