### PR TITLE
fix: correct trial_at date in test database seed

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -748,7 +748,7 @@ BEGIN
     plan_product_id,
     'sub_seeded_demo',
     'succeeded',
-    now() - interval '15 days',
+    now() + interval '15 days',
     true,
     2,
     '{}'::json,


### PR DESCRIPTION
## Summary

Fixed the reset_and_seed_app_data function which was setting trial_at to 15 days in the past, causing trial expiration and plan check failures in tests. Changed trial_at from `now() - interval '15 days'` to `now() + interval '15 days'` to align with the original reset_and_seed_data function.

## Test plan

- Run `bun test:all` - all 50 test files pass with 843 tests passing

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] My change has adequate test coverage (database seeding fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo subscription trial period data to extend the trial window forward.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->