### PR TITLE
Replace extensions.uuid_generate_v4() with gen_random_uuid()

### DIFF
--- a/planetscale/schema_replicate.sql
+++ b/planetscale/schema_replicate.sql
@@ -67,7 +67,7 @@ CREATE TABLE public.apps (
     name character varying,
     last_version character varying,
     updated_at timestamp with time zone,
-    id uuid DEFAULT extensions.uuid_generate_v4(),
+    id uuid DEFAULT gen_random_uuid(),
     retention bigint DEFAULT '2592000'::bigint NOT NULL,
     owner_org uuid NOT NULL,
     default_upload_channel character varying DEFAULT 'production'::character varying NOT NULL,

--- a/supabase/migrations/20251229233706_replace_uuid_generate_v4_with_gen_random_uuid.sql
+++ b/supabase/migrations/20251229233706_replace_uuid_generate_v4_with_gen_random_uuid.sql
@@ -1,0 +1,35 @@
+-- Migration: Replace extensions.uuid_generate_v4() with gen_random_uuid()
+--
+-- gen_random_uuid() is:
+-- - Built-in since PostgreSQL 13 (no extension needed)
+-- - ~3.5x faster than uuid_generate_v4()
+-- - Functionally equivalent (both generate UUID v4)
+-- - Recommended by PostgreSQL documentation
+
+-- Update apps table
+ALTER TABLE "public"."apps"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- Update build_logs table
+ALTER TABLE "public"."build_logs"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- Update build_requests table
+ALTER TABLE "public"."build_requests"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- Update deleted_account table
+ALTER TABLE "public"."deleted_account"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- Update plans table
+ALTER TABLE "public"."plans"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- Update usage_credit_grants table
+ALTER TABLE "public"."usage_credit_grants"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- Update usage_overage_events table
+ALTER TABLE "public"."usage_overage_events"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();

--- a/supabase/tests/00-supabase_test_helpers.sql
+++ b/supabase/tests/00-supabase_test_helpers.sql
@@ -67,7 +67,7 @@ DECLARE
 BEGIN
 
     -- create the user
-    user_id := extensions.uuid_generate_v4();
+    user_id := gen_random_uuid();
     INSERT INTO auth.users (id, email, phone, raw_user_meta_data, raw_app_meta_data, created_at, updated_at)
     VALUES (user_id, coalesce(email, concat(user_id, '@test.com')), phone, jsonb_build_object('test_identifier', identifier) || coalesce(metadata, '{}'::jsonb), '{}'::jsonb, now(), now())
     RETURNING id INTO user_id;

--- a/supabase/tests/35_test_has_2fa_enabled.sql
+++ b/supabase/tests/35_test_has_2fa_enabled.sql
@@ -21,7 +21,7 @@ BEGIN
     -- Insert verified MFA factor for test_user_with_2fa
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         user_with_2fa_id,
         'Test TOTP',
         'totp'::auth.factor_type,
@@ -33,7 +33,7 @@ BEGIN
     -- Insert unverified MFA factor for test_user_with_unverified_2fa
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         user_unverified_2fa_id,
         'Test TOTP Unverified',
         'totp'::auth.factor_type,

--- a/supabase/tests/36_test_check_org_members_2fa_enabled.sql
+++ b/supabase/tests/36_test_check_org_members_2fa_enabled.sql
@@ -30,7 +30,7 @@ DECLARE
     member3_id uuid;
     member4_id uuid;
 BEGIN
-    test_org_id := extensions.uuid_generate_v4();
+    test_org_id := gen_random_uuid();
     super_admin_id := tests.get_supabase_uid('test_admin');
     member1_id := tests.get_supabase_uid('test_org_member_1');
     member2_id := tests.get_supabase_uid('test_org_member_2');
@@ -71,7 +71,7 @@ BEGIN
     -- Insert verified MFA factor for member1
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         member1_id,
         'Test TOTP',
         'totp'::auth.factor_type,
@@ -83,7 +83,7 @@ BEGIN
     -- Insert verified MFA factor for member4 (to test multiple members with 2FA)
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         member4_id,
         'Test TOTP Member4',
         'totp'::auth.factor_type,
@@ -95,7 +95,7 @@ BEGIN
     -- Insert unverified MFA factor for member2 (should not count)
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         member2_id,
         'Test TOTP Unverified',
         'totp'::auth.factor_type,
@@ -265,7 +265,7 @@ SELECT
     throws_ok(
         format(
             'SELECT * FROM check_org_members_2fa_enabled(''%s'')',
-            extensions.uuid_generate_v4()
+            gen_random_uuid()
         ),
         'Organization does not exist',
         'check_org_members_2fa_enabled test - non-existent org raises exception'

--- a/supabase/tests/37_test_check_min_rights_2fa_enforcement.sql
+++ b/supabase/tests/37_test_check_min_rights_2fa_enforcement.sql
@@ -33,8 +33,8 @@ DECLARE
     test_unverified_2fa_user_id uuid;
     test_admin_id uuid;
 BEGIN
-    org_with_2fa_enforcement_id := extensions.uuid_generate_v4();
-    org_without_2fa_enforcement_id := extensions.uuid_generate_v4();
+    org_with_2fa_enforcement_id := gen_random_uuid();
+    org_without_2fa_enforcement_id := gen_random_uuid();
     test_2fa_user_id := tests.get_supabase_uid('test_2fa_user');
     test_no_2fa_user_id := tests.get_supabase_uid('test_no_2fa_user');
     test_unverified_2fa_user_id := tests.get_supabase_uid('test_unverified_2fa_user');
@@ -80,7 +80,7 @@ BEGIN
     -- Insert verified MFA factor for test_2fa_user
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         test_2fa_user_id,
         'Test TOTP',
         'totp'::auth.factor_type,
@@ -92,7 +92,7 @@ BEGIN
     -- Insert unverified MFA factor for test_unverified_2fa_user
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         test_unverified_2fa_user_id,
         'Test TOTP Unverified',
         'totp'::auth.factor_type,
@@ -361,7 +361,7 @@ SELECT
         check_min_rights(
             'read'::public.user_min_right,
             tests.get_supabase_uid('test_2fa_user'),
-            extensions.uuid_generate_v4(),
+            gen_random_uuid(),
             NULL::character varying,
             NULL::bigint
         ),

--- a/supabase/tests/38_test_get_orgs_v7_2fa_enforcement.sql
+++ b/supabase/tests/38_test_get_orgs_v7_2fa_enforcement.sql
@@ -25,8 +25,8 @@ DECLARE
     test_no_2fa_user_id uuid;
     test_admin_id uuid;
 BEGIN
-    org_with_2fa_enforcement_id := extensions.uuid_generate_v4();
-    org_without_2fa_enforcement_id := extensions.uuid_generate_v4();
+    org_with_2fa_enforcement_id := gen_random_uuid();
+    org_without_2fa_enforcement_id := gen_random_uuid();
     test_2fa_user_id := tests.get_supabase_uid('test_2fa_user_v7');
     test_no_2fa_user_id := tests.get_supabase_uid('test_no_2fa_user_v7');
     test_admin_id := tests.get_supabase_uid('test_admin');
@@ -66,7 +66,7 @@ BEGIN
     -- Insert verified MFA factor for test_2fa_user_v7
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         test_2fa_user_id,
         'Test TOTP V7',
         'totp'::auth.factor_type,

--- a/supabase/tests/39_test_reject_access_due_to_2fa.sql
+++ b/supabase/tests/39_test_reject_access_due_to_2fa.sql
@@ -35,8 +35,8 @@ DECLARE
     test_no_2fa_user_id uuid;
     test_admin_id uuid;
 BEGIN
-    org_with_2fa_enforcement_id := extensions.uuid_generate_v4();
-    org_without_2fa_enforcement_id := extensions.uuid_generate_v4();
+    org_with_2fa_enforcement_id := gen_random_uuid();
+    org_without_2fa_enforcement_id := gen_random_uuid();
     test_2fa_user_id := tests.get_supabase_uid('test_2fa_user_reject');
     test_no_2fa_user_id := tests.get_supabase_uid('test_no_2fa_user_reject');
     test_admin_id := tests.get_supabase_uid('test_admin');
@@ -76,7 +76,7 @@ BEGIN
     -- Insert verified MFA factor for test_2fa_user_reject
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         test_2fa_user_id,
         'Test TOTP Reject',
         'totp'::auth.factor_type,
@@ -147,7 +147,7 @@ SELECT tests.authenticate_as_service_role();
 SELECT
     is(
         reject_access_due_to_2fa(
-            extensions.uuid_generate_v4(),
+            gen_random_uuid(),
             tests.get_supabase_uid('test_2fa_user_reject')
         ),
         false,

--- a/supabase/tests/40_test_password_policy_enforcement.sql
+++ b/supabase/tests/40_test_password_policy_enforcement.sql
@@ -37,8 +37,8 @@ DECLARE
     policy_config jsonb;
     policy_hash text;
 BEGIN
-    org_with_pwd_policy_id := extensions.uuid_generate_v4();
-    org_without_pwd_policy_id := extensions.uuid_generate_v4();
+    org_with_pwd_policy_id := gen_random_uuid();
+    org_without_pwd_policy_id := gen_random_uuid();
     compliant_user_id := tests.get_supabase_uid('test_pwd_compliant_user');
     noncompliant_user_id := tests.get_supabase_uid('test_pwd_noncompliant_user');
     test_admin_id := tests.get_supabase_uid('test_admin');
@@ -245,7 +245,7 @@ SELECT
 SELECT
     is(
         reject_access_due_to_password_policy(
-            extensions.uuid_generate_v4(),
+            gen_random_uuid(),
             tests.get_supabase_uid('test_pwd_noncompliant_user')
         ),
         FALSE,
@@ -263,7 +263,7 @@ DECLARE
     test_admin_id uuid;
     noncompliant_user_id uuid;
 BEGIN
-    org_disabled_policy_id := extensions.uuid_generate_v4();
+    org_disabled_policy_id := gen_random_uuid();
     test_admin_id := tests.get_supabase_uid('test_admin');
     noncompliant_user_id := tests.get_supabase_uid('test_pwd_noncompliant_user');
 
@@ -391,7 +391,7 @@ DECLARE
     policy_config jsonb;
     policy_hash text;
 BEGIN
-    org_both_policies_id := extensions.uuid_generate_v4();
+    org_both_policies_id := gen_random_uuid();
     test_admin_id := tests.get_supabase_uid('test_admin');
     compliant_user_id := tests.get_supabase_uid('test_pwd_compliant_user');
     noncompliant_user_id := tests.get_supabase_uid('test_pwd_noncompliant_user');

--- a/supabase/tests/41_test_get_orgs_v7_password_policy.sql
+++ b/supabase/tests/41_test_get_orgs_v7_password_policy.sql
@@ -38,9 +38,9 @@ DECLARE
     policy_config jsonb;
     policy_hash text;
 BEGIN
-    org_with_pwd_policy_id := extensions.uuid_generate_v4();
-    org_without_pwd_policy_id := extensions.uuid_generate_v4();
-    org_with_both_policies_id := extensions.uuid_generate_v4();
+    org_with_pwd_policy_id := gen_random_uuid();
+    org_without_pwd_policy_id := gen_random_uuid();
+    org_with_both_policies_id := gen_random_uuid();
     compliant_user_id := tests.get_supabase_uid('test_pwd_compliant_v7');
     noncompliant_user_id := tests.get_supabase_uid('test_pwd_noncompliant_v7');
     test_admin_id := tests.get_supabase_uid('test_admin');
@@ -554,7 +554,7 @@ DECLARE
     test_admin_id uuid;
     noncompliant_user_id uuid;
 BEGIN
-    org_disabled_policy_id := extensions.uuid_generate_v4();
+    org_disabled_policy_id := gen_random_uuid();
     test_admin_id := tests.get_supabase_uid('test_admin');
     noncompliant_user_id := tests.get_supabase_uid('test_pwd_noncompliant_v7');
 

--- a/supabase/tests/41_test_reject_access_due_to_2fa_for_app.sql
+++ b/supabase/tests/41_test_reject_access_due_to_2fa_for_app.sql
@@ -36,8 +36,8 @@ DECLARE
     test_2fa_user_id uuid;
     test_no_2fa_user_id uuid;
 BEGIN
-    org_with_2fa_enforcement_id := extensions.uuid_generate_v4();
-    org_without_2fa_enforcement_id := extensions.uuid_generate_v4();
+    org_with_2fa_enforcement_id := gen_random_uuid();
+    org_without_2fa_enforcement_id := gen_random_uuid();
     test_2fa_user_id := tests.get_supabase_uid('test_2fa_user_app');
     test_no_2fa_user_id := tests.get_supabase_uid('test_no_2fa_user_app');
 
@@ -104,7 +104,7 @@ BEGIN
     -- Insert verified MFA factor for test_2fa_user_app
     INSERT INTO auth.mfa_factors (id, user_id, friendly_name, factor_type, status, created_at, updated_at)
     VALUES (
-        extensions.uuid_generate_v4(),
+        gen_random_uuid(),
         test_2fa_user_id,
         'Test TOTP App',
         'totp'::auth.factor_type,


### PR DESCRIPTION
## Summary

Replace `extensions.uuid_generate_v4()` with the built-in `gen_random_uuid()` function across the codebase. Both functions generate UUID v4, but `gen_random_uuid()` is ~3.5x faster, requires no extension, and is recommended by PostgreSQL documentation.

## Test plan

- Run the Supabase migration: `supabase db reset` (includes the new migration)
- Verify test files still pass: `bun test:all`
- Confirm UUID generation still works as expected in tables

## Screenshots

No UI changes for this backend migration.

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [x] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal identifier generation mechanisms across database schemas and test environments to enhance system consistency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->