### PR TITLE
feat: show bundle disconnection events in history

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1342,5 +1342,10 @@
   "invalid-password": "Invalid password",
   "password-does-not-meet-requirements": "Your password does not meet the organization's requirements. Please change your password.",
   "verification-failed": "Verification failed",
-  "no-organization-selected": "No organization selected"
+  "no-organization-selected": "No organization selected",
+  "assigned": "Assigned",
+  "removed": "Removed",
+  "event": "Event",
+  "by": "By",
+  "date": "Date"
 }


### PR DESCRIPTION
## Summary

Display when bundles are removed from channels in the bundle history page. The implementation uses audit_logs data to show disconnection events alongside assignment events, giving users full visibility into the bundle's lifecycle across channels.

## Test plan

1. Navigate to a bundle's history page at `/app/{appId}/bundle/{bundleId}/history`
2. The table now shows an "Event" column indicating whether each row is "Assigned" or "Removed"
3. Try disconnecting a bundle from a channel (by assigning a different bundle to that channel)
4. Verify the disconnection appears in the history as a "Removed" event with the timestamp and user who performed the action

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually (verified typecheck and lint pass)