### PR TITLE
Add 60-second replication delay notification

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1339,5 +1339,5 @@
   "invalid-password": "Ungültiges Passwort",
   "password-does-not-meet-requirements": "Ihr Passwort erfüllt nicht die Anforderungen der Organisation. Bitte ändern Sie Ihr Passwort.",
   "verification-failed": "Überprüfung fehlgeschlagen",
-  "no-organization-selected": "Keine Organisation ausgewählt"
+  "cloud-replication-delay": "Änderungen werden innerhalb von 60 Sekunden weltweit übertragen"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1400,5 +1400,6 @@
   "allow-device": "Allow Device Updates",
   "channel-allow-device-self-set": "Allow Device Self-Assignment",
   "channel-disable-auto-update": "Disable Auto Update",
-  "channel-disable-auto-update-under-native": "Disable Auto Update Under Native"
+  "channel-disable-auto-update-under-native": "Disable Auto Update Under Native",
+  "cloud-replication-delay": "Changes will take up to 60 seconds to propagate globally"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1339,5 +1339,5 @@
   "invalid-password": "Contraseña inválida",
   "password-does-not-meet-requirements": "Tu contraseña no cumple con los requisitos de la organización. Por favor cambia tu contraseña.",
   "verification-failed": "Verificación fallida",
-  "no-organization-selected": "Ninguna organización seleccionada"
+  "cloud-replication-delay": "Los cambios tardarán hasta 60 segundos en propagarse globalmente"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1339,5 +1339,5 @@
   "invalid-password": "Mot de passe invalide",
   "password-does-not-meet-requirements": "Votre mot de passe ne répond pas aux exigences de l'organisation. Veuillez changer votre mot de passe.",
   "verification-failed": "Échec de la vérification",
-  "no-organization-selected": "Aucune organisation sélectionnée"
+  "cloud-replication-delay": "Les modifications prendront jusqu'à 60 secondes pour se propager globalement"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1330,5 +1330,5 @@
   "invalid-password": "अमान्य पासवर्ड",
   "password-does-not-meet-requirements": "आपका पासवर्ड संगठन की आवश्यकताओं को पूरा नहीं करता। कृपया अपना पासवर्ड बदलें।",
   "verification-failed": "सत्यापन विफल",
-  "no-organization-selected": "कोई संगठन चयनित नहीं"
+  "cloud-replication-delay": "परिवर्तनों को विश्व स्तर पर प्रसारित होने में 60 सेकंड तक का समय लगेगा"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -1330,5 +1330,5 @@
   "invalid-password": "Kata sandi tidak valid",
   "password-does-not-meet-requirements": "Kata sandi Anda tidak memenuhi persyaratan organisasi. Silakan ubah kata sandi Anda.",
   "verification-failed": "Verifikasi gagal",
-  "no-organization-selected": "Tidak ada organisasi yang dipilih"
+  "cloud-replication-delay": "Perubahan akan membutuhkan hingga 60 detik untuk menyebar secara global"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1331,5 +1331,5 @@
   "invalid-password": "Password non valida",
   "password-does-not-meet-requirements": "La tua password non soddisfa i requisiti dell'organizzazione. Per favore cambia la tua password.",
   "verification-failed": "Verifica fallita",
-  "no-organization-selected": "Nessuna organizzazione selezionata"
+  "cloud-replication-delay": "Le modifiche impiegheranno fino a 60 secondi per propagarsi globalmente"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1331,5 +1331,5 @@
   "invalid-password": "無効なパスワード",
   "password-does-not-meet-requirements": "パスワードが組織の要件を満たしていません。パスワードを変更してください。",
   "verification-failed": "確認に失敗しました",
-  "no-organization-selected": "組織が選択されていません"
+  "cloud-replication-delay": "変更がグローバルに反映されるまで最大60秒かかります"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -880,7 +880,7 @@
   "no-device-data": "사용 가능한 장치 데이터가 없습니다.",
   "no-error-message": "사용 가능한 오류 메시지가 없습니다",
   "no-manifest-bundle": "매니페스트 없음",
-  "no-organization-selected": "조직이 선택되지 않았습니다",
+  "no-organization-selected": "선택된 조직이 없습니다",
   "no-permission": "권한이 부족합니다",
   "no-permission-ask-super-admin": "권한이 부족하므로, 이 번들을 안전하지 않게 삭제하도록 슈퍼 관리자에게 요청하십시오.",
   "no-public-channel": "이 앱은 공개 채널이 없으므로, 이를 통하지 않고 배포를 계산할 수 없습니다.",
@@ -1331,5 +1331,5 @@
   "invalid-password": "잘못된 비밀번호",
   "password-does-not-meet-requirements": "비밀번호가 조직의 요구 사항을 충족하지 않습니다. 비밀번호를 변경해주세요.",
   "verification-failed": "확인 실패",
-  "no-organization-selected": "선택된 조직이 없습니다"
+  "cloud-replication-delay": "변경 사항이 전 세계에 반영되는 데 최대 60초가 걸립니다"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1330,5 +1330,5 @@
   "invalid-password": "Nieprawidłowe hasło",
   "password-does-not-meet-requirements": "Twoje hasło nie spełnia wymagań organizacji. Proszę zmienić hasło.",
   "verification-failed": "Weryfikacja nie powiodła się",
-  "no-organization-selected": "Nie wybrano organizacji"
+  "cloud-replication-delay": "Zmiany zajmą do 60 sekund, aby rozprzestrzenić się globalnie"
 }

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -1331,5 +1331,5 @@
   "invalid-password": "Senha inválida",
   "password-does-not-meet-requirements": "Sua senha não atende aos requisitos da organização. Por favor, altere sua senha.",
   "verification-failed": "Verificação falhou",
-  "no-organization-selected": "Nenhuma organização selecionada"
+  "cloud-replication-delay": "As alterações levarão até 60 segundos para se propagar globalmente"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1330,5 +1330,5 @@
   "invalid-password": "Неверный пароль",
   "password-does-not-meet-requirements": "Ваш пароль не соответствует требованиям организации. Пожалуйста, измените пароль.",
   "verification-failed": "Ошибка подтверждения",
-  "no-organization-selected": "Организация не выбрана"
+  "cloud-replication-delay": "Изменения займут до 60 секунд для глобального распространения"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -879,7 +879,7 @@
   "no-device-data": "Cihaz verisi mevcut değil",
   "no-error-message": "Hata mesajı mevcut değil",
   "no-manifest-bundle": "Manifest yok",
-  "no-organization-selected": "Organizasyon seçilmedi",
+  "no-organization-selected": "Kuruluş seçilmedi",
   "no-permission": "Yetersiz izinler",
   "no-permission-ask-super-admin": "yetersiz izin, lütfen bu paketi güvensiz bir şekilde silmek için bir süper yöneticiye başvurun",
   "no-public-channel": "Uygulamanın herhangi bir halka açık kanalı yok, onun olmadan dağıtımı sayamayız.",
@@ -1330,5 +1330,5 @@
   "invalid-password": "Geçersiz şifre",
   "password-does-not-meet-requirements": "Şifreniz kuruluş gereksinimlerini karşılamıyor. Lütfen şifrenizi değiştirin.",
   "verification-failed": "Doğrulama başarısız",
-  "no-organization-selected": "Kuruluş seçilmedi"
+  "cloud-replication-delay": "Değişikliklerin küresel olarak yayılması 60 saniye kadar sürecektir"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -879,7 +879,7 @@
   "no-device-data": "Không có dữ liệu thiết bị nào",
   "no-error-message": "Không có thông báo lỗi nào sẵn có",
   "no-manifest-bundle": "Không có manifest",
-  "no-organization-selected": "Chưa chọn tổ chức",
+  "no-organization-selected": "Không có tổ chức nào được chọn",
   "no-permission": "Quyền hạn không đủ",
   "no-permission-ask-super-admin": "quyền không đủ, vui lòng yêu cầu quản trị viên cao cấp để xóa gói này một cách không an toàn",
   "no-public-channel": "Ứng dụng không có kênh công khai, chúng tôi không thể đếm số lần triển khai mà không có nó",
@@ -1330,5 +1330,5 @@
   "invalid-password": "Mật khẩu không hợp lệ",
   "password-does-not-meet-requirements": "Mật khẩu của bạn không đáp ứng yêu cầu của tổ chức. Vui lòng thay đổi mật khẩu.",
   "verification-failed": "Xác minh thất bại",
-  "no-organization-selected": "Không có tổ chức nào được chọn"
+  "cloud-replication-delay": "Các thay đổi sẽ mất đến 60 giây để lan truyền toàn cầu"
 }

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1331,5 +1331,5 @@
   "invalid-password": "无效密码",
   "password-does-not-meet-requirements": "您的密码不符合组织的要求。请更改您的密码。",
   "verification-failed": "验证失败",
-  "no-organization-selected": "未选择组织"
+  "cloud-replication-delay": "更改将需要最多60秒才能在全球范围内生效"
 }

--- a/src/pages/app/[package].bundle.[bundle].vue
+++ b/src/pages/app/[package].bundle.[bundle].vue
@@ -261,6 +261,7 @@ async function handleChannelLink(chan: Database['public']['Tables']['channels'][
     await setChannel(chan, version.value.id)
     await getChannels()
     toast.success(t('linked-bundle'))
+    toast.info(t('cloud-replication-delay'))
   }
   catch (error) {
     console.error(error)
@@ -323,6 +324,7 @@ async function handleChannelAction(action: 'set' | 'open' | 'unlink') {
       await setChannel(channel.value, id)
       await getChannels()
       toast.success(t('channels-unlinked-successfully'))
+      toast.info(t('cloud-replication-delay'))
     }
     catch (error) {
       console.error(error)

--- a/src/pages/app/[package].channel.[channel].devices.vue
+++ b/src/pages/app/[package].channel.[channel].devices.vue
@@ -150,8 +150,10 @@ async function customDeviceOverwritePart5(
   if (overwriteError) {
     console.error('overwriteError', overwriteError)
     toast.error(t('cannot-create-overwrite'))
+    return
   }
 
+  toast.info(t('cloud-replication-delay'))
   reload()
 }
 

--- a/src/pages/app/[package].channel.[channel].vue
+++ b/src/pages/app/[package].channel.[channel].vue
@@ -150,6 +150,9 @@ async function saveChannelChange(key: string, val: any) {
       toast.error(t('error-update-channel'))
       console.error('no channel update', error)
     }
+    else {
+      toast.info(t('cloud-replication-delay'))
+    }
   }
   catch (error) {
     console.error(error)
@@ -320,6 +323,7 @@ async function handleRevert() {
           }
 
           await getChannel(true)
+          toast.info(t('cloud-replication-delay'))
         },
       },
     ],
@@ -447,8 +451,12 @@ async function onSelectAutoUpdate(value: Database['public']['Enums']['disable_up
     .update({ disable_auto_update: value })
     .eq('id', id.value)
 
-  if (error)
+  if (error) {
     console.error(error)
+  }
+  else {
+    toast.info(t('cloud-replication-delay'))
+  }
 
   if (channel.value?.disable_auto_update)
     channel.value.disable_auto_update = value

--- a/src/pages/app/[package].device.[device].vue
+++ b/src/pages/app/[package].device.[device].vue
@@ -292,6 +292,7 @@ async function onSelectChannel(value: string) {
     if (device.value?.device_id)
       await delDevChannel(device.value?.device_id)
     toast.success(t('unlink-channel'))
+    toast.info(t('cloud-replication-delay'))
     await loadData()
   }
   else if (value !== 'none') {
@@ -304,6 +305,7 @@ async function onSelectChannel(value: string) {
       await upsertDevChannel(device.value?.device_id, Number(value))
         .then(async () => {
           toast.success(t('channel-linked'))
+          toast.info(t('cloud-replication-delay'))
           return loadData()
         })
         .catch(async (error) => {


### PR DESCRIPTION
## Summary

Users are now informed via toast notifications that cloud changes (channel settings, bundle assignments, device overrides) take up to 60 seconds to propagate globally due to heavy read replication infrastructure.

## Test plan

- Update a channel setting (e.g., toggle iOS or Android) and verify the "Changes will take up to 60 seconds..." toast appears
- Assign a bundle to a channel and verify the replication delay toast appears
- Override a device to a specific channel and verify the toast appears
- Test in multiple languages to ensure translations display correctly

## Checklist

- [x] Code follows project style and passes linting
- [ ] Change requires documentation update
- [ ] E2E test coverage added
- [x] Changes tested manually across multiple pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud replication delay notifications across various channel and device operations, informing users that changes may take up to 60 seconds to propagate globally.
  * Updated localization with new messaging for cloud replication delays across multiple languages including German, English, Spanish, French, Hindi, Indonesian, Italian, Japanese, Korean, Polish, Portuguese, Russian, Turkish, Vietnamese, and Simplified Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->