### PR TITLE
fix: add CORS support to apikey endpoint

### DIFF
--- a/supabase/functions/_backend/public/apikey/index.ts
+++ b/supabase/functions/_backend/public/apikey/index.ts
@@ -1,10 +1,12 @@
-import { honoFactory } from '../../utils/hono.ts'
+import { honoFactory, useCors } from '../../utils/hono.ts'
 import deleteHandler from './delete.ts'
 import getHandler from './get.ts'
 import postHandler from './post.ts'
 import patchHandler from './put.ts'
 
 const app = honoFactory.createApp()
+
+app.use('*', useCors)
 
 app.route('/', getHandler)
 app.route('/', postHandler)

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -43,7 +43,7 @@ export interface MiddlewareKeyVariables {
 export const useCors = cors({
   origin: '*',
   allowHeaders: ['Content-Type', 'Authorization', 'capgkey', 'capgo_api', 'x-api-key', 'x-limited-key-id', 'apisecret', 'apikey', 'x-client-info'],
-  allowMethods: ['POST', 'GET', 'OPTIONS'],
+  allowMethods: ['POST', 'GET', 'PUT', 'DELETE', 'OPTIONS'],
 })
 
 export const honoFactory = createFactory<MiddlewareKeyVariables>()


### PR DESCRIPTION
## Summary

Enable CORS headers for the apikey endpoint to fix dashboard API key creation. Add PUT and DELETE to allowed HTTP methods in the shared CORS configuration to support all apikey operations (GET, POST, PUT, DELETE).

## Test plan

1. Open the dashboard and navigate to API key creation
2. Create a new API key - the CORS request should now succeed instead of being blocked
3. Test all apikey operations: create (POST), list (GET), update (PUT), and delete (DELETE)

- [ ] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional HTTP methods (PUT, DELETE, PATCH) on the API for expanded operation capabilities.
  * Enhanced cross-origin resource sharing (CORS) configuration for improved API accessibility across different domains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->