### PR TITLE
test: add CLI tests for encrypted/hashed API key support

### DIFF
--- a/tests/cli-hashed-apikey.test.ts
+++ b/tests/cli-hashed-apikey.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for CLI operations using hashed (encrypted) API keys
+ *
+ * These tests verify that CLI operations work correctly when using hashed API keys
+ * instead of plain-text API keys. The hashed key is stored as SHA-256 hash in the
+ * database, but the client sends the plain key value which gets hashed server-side
+ * for comparison.
+ *
+ * Uses the pre-seeded hashed API key: 'test-hashed-apikey-for-auth-test' (id=100)
+ */
+import type { UploadOptions } from '@capgo/cli/sdk'
+import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
+import { env } from 'node:process'
+import { CapgoSDK } from '@capgo/cli/sdk'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { cleanupCli, getSemver, prepareCli, tempFileFolder } from './cli-utils'
+import { APIKEY_TEST_HASHED, resetAndSeedAppData, resetAppData, resetAppDataStats } from './test-utils'
+
+// Supabase base URL (not including /functions/v1)
+const SUPABASE_URL = env.SUPABASE_URL || 'http://localhost:54321'
+const SUPABASE_ANON_KEY = env.SUPABASE_ANON_KEY || 'sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH'
+
+/**
+ * Create an SDK instance with the hashed API key (same pattern as createTestSDK)
+ */
+function createHashedKeySDK() {
+  return new CapgoSDK({
+    apikey: APIKEY_TEST_HASHED,
+    supaHost: SUPABASE_URL,
+    supaAnon: SUPABASE_ANON_KEY,
+  })
+}
+
+/**
+ * Upload a bundle using the hashed API key
+ */
+async function uploadBundleWithHashedKey(
+  appId: string,
+  version: string,
+  channel?: string,
+  additionalOptions?: Partial<UploadOptions>,
+) {
+  const sdk = createHashedKeySDK()
+
+  const options: UploadOptions = {
+    appId,
+    path: join(tempFileFolder(appId), 'dist'),
+    bundle: version,
+    channel,
+    disableCodeCheck: true,
+    useZip: true,
+    ...additionalOptions,
+  }
+
+  return sdk.uploadBundle(options)
+}
+
+// Helper to retry SDK operations that may fail due to transient network issues
+async function retryUpload<T extends { success: boolean, error?: string }>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+): Promise<T> {
+  let lastResult: T | null = null
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    lastResult = await fn()
+    if (lastResult.success || !lastResult.error?.includes('fetch failed')) {
+      return lastResult
+    }
+    await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)))
+  }
+  return lastResult!
+}
+
+describe('CLI operations with hashed API key', () => {
+  const id = randomUUID()
+  const APPNAME = `com.cli_hashed_${id}`
+
+  beforeAll(async () => {
+    await Promise.all([
+      resetAndSeedAppData(APPNAME),
+      prepareCli(APPNAME),
+    ])
+  })
+
+  afterAll(async () => {
+    await Promise.all([
+      cleanupCli(APPNAME),
+      resetAppData(APPNAME),
+      resetAppDataStats(APPNAME),
+    ])
+  })
+
+  it('should upload bundle successfully with hashed API key', async () => {
+    const semver = getSemver()
+    const result = await retryUpload(() => uploadBundleWithHashedKey(APPNAME, semver, 'production', {
+      ignoreCompatibilityCheck: true,
+    }))
+
+    expect(result.success).toBe(true)
+  }, 30000)
+
+  it('should list bundles with hashed API key', async () => {
+    const sdk = createHashedKeySDK()
+    const result = await sdk.listBundles(APPNAME)
+
+    expect(result.success).toBe(true)
+    expect(Array.isArray(result.data)).toBe(true)
+  }, 30000)
+
+  it('should list channels with hashed API key', async () => {
+    const sdk = createHashedKeySDK()
+    const result = await sdk.listChannels(APPNAME)
+
+    expect(result.success).toBe(true)
+    expect(Array.isArray(result.data)).toBe(true)
+  }, 30000)
+
+  it('should list apps with hashed API key', async () => {
+    const sdk = createHashedKeySDK()
+    const result = await sdk.listApps()
+
+    expect(result.success).toBe(true)
+    expect(Array.isArray(result.data)).toBe(true)
+    // Verify our test app is in the list
+    const hasTestApp = result.data?.some((app: any) => app.appId === APPNAME)
+    expect(hasTestApp).toBe(true)
+  }, 30000)
+
+  it('should create and delete channel with hashed API key', async () => {
+    const sdk = createHashedKeySDK()
+    const channelName = `test-hashed-channel-${Date.now()}`
+
+    // Create channel
+    const createResult = await sdk.addChannel({
+      appId: APPNAME,
+      channelId: channelName,
+    })
+    expect(createResult.success).toBe(true)
+
+    // Verify channel exists
+    const listResult = await sdk.listChannels(APPNAME)
+    expect(listResult.success).toBe(true)
+    const channelExists = listResult.data?.some((ch: any) => ch.name === channelName)
+    expect(channelExists).toBe(true)
+
+    // Delete channel
+    const deleteResult = await sdk.deleteChannel(channelName, APPNAME)
+    expect(deleteResult.success).toBe(true)
+  }, 30000)
+
+  it('should get current bundle with hashed API key', async () => {
+    const sdk = createHashedKeySDK()
+
+    // Just verify we can get the current bundle for the production channel
+    // The bundle should have been set by the first upload test
+    const bundleResult = await sdk.getCurrentBundle(APPNAME, 'production')
+    expect(bundleResult.success).toBe(true)
+    // The result should be a version string
+    expect(typeof bundleResult.data).toBe('string')
+  }, 30000)
+
+  it('should update channel with hashed API key', async () => {
+    const sdk = createHashedKeySDK()
+
+    // Update channel settings
+    const updateResult = await sdk.updateChannel({
+      appId: APPNAME,
+      channelId: 'production',
+      ios: true,
+      android: true,
+    })
+    expect(updateResult.success).toBe(true)
+  }, 30000)
+})

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -39,6 +39,7 @@ export function getEndpointUrl(path: string): string {
 export const APIKEY_TEST_ALL = 'ae6e7458-c46d-4c00-aa3b-153b0b8520ea' // all key
 export const APIKEY_TEST_UPLOAD = 'c591b04e-cf29-4945-b9a0-776d0672061b' // upload key
 export const APIKEY_TEST2_ALL = 'ac4d9a98-ec25-4af8-933c-2aae4aa52b85' // test2 all key (dedicated for statistics)
+export const APIKEY_TEST_HASHED = 'test-hashed-apikey-for-auth-test' // hashed key (plain value, stored as SHA-256 hash in DB)
 export const ORG_ID = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
 export const STRIPE_INFO_CUSTOMER_ID = 'cus_Q38uE91NP8Ufqc' // Customer ID for ORG_ID
 export const NON_OWNER_ORG_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for CLI operations using hashed API keys. Tests verify that all core SDK operations (upload, list, channel management) work correctly with hashed API keys stored as SHA-256 hashes in the database.

## Test plan

- Run `bun test:cli` to execute the new hashed API key tests
- All 7 tests in `cli-hashed-apikey.test.ts` pass, covering:
  - Bundle uploads with hashed keys
  - Listing bundles, channels, and apps
  - Creating and deleting channels
  - Getting current bundle version
  - Updating channel settings

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for CLI authentication and operations using hashed keys, including upload, listing, channel management, and settings configuration tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->