### PR TITLE
fix: improve credit page mobile layout for preset amount buttons

### DIFF
--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -681,10 +681,10 @@ watch(() => currentOrganization.value?.gid, async (newOrgId: string | undefined,
             {{ t('credits-cta-description') }}
           </p>
         </div>
-        <form class="flex w-full flex-row p-3 sm:h-full sm:flex-row sm:items-center sm:justify-between" @submit.prevent="handleBuyCredits">
+        <form class="flex w-full flex-col p-3 sm:flex-row sm:items-center sm:justify-between" @submit.prevent="handleBuyCredits">
           <div class="flex w-full flex-col gap-3 sm:max-w-md">
-            <div class="flex flex-row gap-2 sm:flex-row sm:items-end sm:gap-3">
-              <div class="relative w-full">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div class="relative w-full sm:flex-1">
                 <FormKit
                   v-model="topUpQuantityInput"
                   type="number"
@@ -706,12 +706,12 @@ watch(() => currentOrganization.value?.gid, async (newOrgId: string | undefined,
                   </template>
                 </FormKit>
               </div>
-              <div class="flex shrink-0 items-end gap-2">
+              <div class="grid grid-cols-3 gap-2 sm:flex sm:shrink-0 sm:items-end">
                 <button
                   v-for="amount in QUICK_TOP_UP_OPTIONS"
                   :key="amount"
                   type="button"
-                  class="d-btn d-btn-sm min-w-[4.25rem] h-11"
+                  class="d-btn d-btn-sm h-11 min-w-0 sm:min-w-[4.25rem]"
                   :class="topUpQuantity === amount
                     ? 'border border-blue-600 bg-blue-600 text-white hover:border-blue-700 hover:bg-blue-700 dark:border-blue-500 dark:bg-blue-500 dark:hover:border-blue-400 dark:hover:bg-blue-500/90'
                     : 'border border-blue-200 bg-white text-blue-700 hover:border-blue-400 hover:bg-blue-50 dark:border-blue-500/60 dark:bg-gray-900 dark:text-blue-200 dark:hover:border-blue-400 dark:hover:bg-blue-900/40'"
@@ -725,7 +725,7 @@ watch(() => currentOrganization.value?.gid, async (newOrgId: string | undefined,
               type="submit"
               :disabled="isProcessingCheckout || !isTopUpQuantityValid"
               :class="{ 'opacity-75 pointer-events-none': isProcessingCheckout || !isTopUpQuantityValid }"
-              class="inline-flex justify-center size-1/2 items-center py-2 px-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white text-sm font-semibold rounded-lg transition-all duration-200 shadow-md hover:shadow-lg transform hover:-translate-y-0.5 disabled:opacity-60 disabled:cursor-not-allowed"
+              class="inline-flex w-full justify-center items-center py-2 px-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white text-sm font-semibold rounded-lg transition-all duration-200 shadow-md hover:shadow-lg transform hover:-translate-y-0.5 disabled:opacity-60 disabled:cursor-not-allowed sm:w-auto"
             >
               <Spinner v-if="isProcessingCheckout" size="w-4 h-4" class="mr-2" color="white" />
               <span>{{ t('buy-credits') }}</span>


### PR DESCRIPTION
## Summary

Fixes mobile layout issues on the credits page where preset amount buttons were not displaying properly. The form now stacks vertically on mobile with a responsive 3-column grid layout for preset amounts, returning to horizontal layout on desktop.

## Test plan

1. Open the credits page on a mobile device or mobile viewport (< 640px width)
2. Verify the input field displays full-width
3. Verify the three preset amount buttons ($50, $500, $5000) display in a 3-column grid
4. Verify the "Buy Credits" button is full-width on mobile
5. Resize to desktop view and verify elements align horizontally as before

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually on mobile viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive design of the credits purchase form with enhanced layouts for various screen sizes.
  * Form elements now stack vertically on smaller screens for improved mobile usability.
  * Quick top-up options reorganized into a responsive grid layout.
  * Submit button now adapts its width based on screen size for better visual balance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->