### PR TITLE
Add iOS and Android device platform tracking

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -684,6 +684,7 @@
   "device-pixel": "Pixel",
   "devices": "Geräte",
   "devices-trend": "Trend Aktiver Geräte",
+  "device-platform-trend": "Geräteplattform-Trend (iOS vs Android)",
   "dialog-with-custom-input": "Dialog mit benutzerdefinierter Eingabe",
   "did-not-recive-confirm-email": "Haben Sie keine Bestätigungs-E-Mail erhalten?",
   "disable": "Deaktivieren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -207,6 +207,7 @@
   "updates-and-success": "Updates & Success",
   "open-source-updates": "Open Source Updates",
   "devices-trend": "Active Devices Trend",
+  "device-platform-trend": "Device Platform Trend (iOS vs Android)",
   "github-stars-trend": "GitHub Stars Trend",
   "need-upgrade-trend": "Organizations Needing Upgrade",
   "revenue": "Revenue",

--- a/messages/es.json
+++ b/messages/es.json
@@ -684,6 +684,7 @@
   "device-pixel": "Píxel",
   "devices": "Dispositivos",
   "devices-trend": "Tendencia de Dispositivos Activos",
+  "device-platform-trend": "Tendencia de Plataforma de Dispositivos (iOS vs Android)",
   "dialog-with-custom-input": "Diálogo con Entrada Personalizada",
   "did-not-recive-confirm-email": "¿No recibiste el correo electrónico de confirmación?",
   "disable": "Deshabilitar",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -684,6 +684,7 @@
   "device-pixel": "Pixel",
   "devices": "Appareils",
   "devices-trend": "Tendance des Appareils Actifs",
+  "device-platform-trend": "Tendance des Plateformes d'Appareils (iOS vs Android)",
   "dialog-with-custom-input": "Dialogue avec entrée personnalisée",
   "did-not-recive-confirm-email": "Vous n'avez pas reçu l'email de confirmation?",
   "disable": "Désactiver",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -684,6 +684,7 @@
   "device-pixel": "पिक्सेल",
   "devices": "उपकरण",
   "devices-trend": "सक्रिय उपकरणों का ट्रेंड",
+  "device-platform-trend": "डिवाइस प्लेटफ़ॉर्म ट्रेंड (iOS vs Android)",
   "dialog-with-custom-input": "कस्टम इनपुट के साथ संवाद",
   "did-not-recive-confirm-email": "क्या आपको पुष्टिकरण ईमेल प्राप्त नहीं हुआ?",
   "disable": "निष्क्रिय करें",

--- a/messages/id.json
+++ b/messages/id.json
@@ -684,6 +684,7 @@
   "device-pixel": "Piksel",
   "devices": "Perangkat",
   "devices-trend": "Tren Perangkat Aktif",
+  "device-platform-trend": "Tren Platform Perangkat (iOS vs Android)",
   "dialog-with-custom-input": "Dialog dengan Input Kustom",
   "did-not-recive-confirm-email": "Tidak menerima email konfirmasi?",
   "disable": "Nonaktifkan",

--- a/messages/it.json
+++ b/messages/it.json
@@ -684,6 +684,7 @@
   "device-pixel": "Pixel",
   "devices": "Dispositivi",
   "devices-trend": "Tendenza dei Dispositivi Attivi",
+  "device-platform-trend": "Tendenza della Piattaforma dei Dispositivi (iOS vs Android)",
   "dialog-with-custom-input": "Dialogo con Input Personalizzato",
   "did-not-recive-confirm-email": "Non hai ricevuto l'email di conferma?",
   "disable": "Disabilita",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -684,6 +684,7 @@
   "device-pixel": "ピクセル",
   "devices": "デバイス",
   "devices-trend": "アクティブデバイスのトレンド",
+  "device-platform-trend": "デバイスプラットフォームトレンド（iOS vs Android）",
   "dialog-with-custom-input": "カスタム入力を使用したダイアログ",
   "did-not-recive-confirm-email": "確認メールが届きませんでしたか？",
   "disable": "無効にする",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -684,6 +684,7 @@
   "device-pixel": "픽셀",
   "devices": "장치들",
   "devices-trend": "활성 장치 추세",
+  "device-platform-trend": "기기 플랫폼 추세 (iOS vs Android)",
   "dialog-with-custom-input": "사용자 정의 입력 대화",
   "did-not-recive-confirm-email": "확인 이메일을 받지 못하셨나요?",
   "disable": "비활성화",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -684,6 +684,7 @@
   "device-pixel": "Piksel",
   "devices": "Urządzenia",
   "devices-trend": "Trend Urządzeń Aktywnych",
+  "device-platform-trend": "Trend Platform Urządzeń (iOS vs Android)",
   "dialog-with-custom-input": "Dialog z niestandardowym wprowadzaniem danych",
   "did-not-recive-confirm-email": "Nie otrzymałeś e-maila z potwierdzeniem?",
   "disable": "Wyłącz",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -684,6 +684,7 @@
   "device-pixel": "Pixel",
   "devices": "Dispositivos",
   "devices-trend": "Tendência de Dispositivos Ativos",
+  "device-platform-trend": "Tendência de Plataforma de Dispositivos (iOS vs Android)",
   "dialog-with-custom-input": "Diálogo com Entrada Personalizada",
   "did-not-recive-confirm-email": "Não recebeu o email de confirmação?",
   "disable": "Desativar",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -684,6 +684,7 @@
   "device-pixel": "Пиксель",
   "devices": "Устройства",
   "devices-trend": "Тенденции активных устройств",
+  "device-platform-trend": "Тренд платформ устройств (iOS vs Android)",
   "dialog-with-custom-input": "Диалог с пользовательским вводом",
   "did-not-recive-confirm-email": "Не получили письмо с подтверждением?",
   "disable": "Отключить",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -684,6 +684,7 @@
   "device-pixel": "Piksel",
   "devices": "Cihazlar",
   "devices-trend": "Aktif Cihazlar Trendi",
+  "device-platform-trend": "Cihaz Platform Trendi (iOS vs Android)",
   "dialog-with-custom-input": "Özel Girişli Diyalog",
   "did-not-recive-confirm-email": "Onay e-postası almadınız mı?",
   "disable": "Devre dışı bırak",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -685,6 +685,7 @@
   "device-pixel": "Pixel",
   "devices": "Thiết bị",
   "devices-trend": "Xu hướng Thiết bị Hoạt động",
+  "device-platform-trend": "Xu hướng Nền tảng Thiết bị (iOS vs Android)",
   "dialog-with-custom-input": "Hội thoại với Đầu vào Tùy chỉnh",
   "did-not-recive-confirm-email": "Không nhận được email xác nhận?",
   "disable": "Vô hiệu hóa",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -684,6 +684,7 @@
   "device-pixel": "像素",
   "devices": "设备",
   "devices-trend": "活动设备趋势",
+  "device-platform-trend": "设备平台趋势（iOS vs Android）",
   "dialog-with-custom-input": "自定义输入的对话",
   "did-not-recive-confirm-email": "没有收到确认邮件吗？",
   "disable": "禁用",

--- a/src/pages/admin/dashboard/index.vue
+++ b/src/pages/admin/dashboard/index.vue
@@ -42,6 +42,8 @@ const globalStatsTrendData = ref<Array<{
   plan_enterprise: number
   registers_today: number
   devices_last_month: number
+  devices_last_month_ios: number
+  devices_last_month_android: number
   stars: number
   need_upgrade: number
 }>>([])
@@ -157,6 +159,30 @@ const needUpgradeTrendSeries = computed(() => {
         value: item.need_upgrade,
       })),
       color: '#ef4444', // red
+    },
+  ]
+})
+
+const devicePlatformTrendSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: 'iOS Devices',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.devices_last_month_ios || 0,
+      })),
+      color: '#000000', // black (Apple)
+    },
+    {
+      label: 'Android Devices',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.devices_last_month_android || 0,
+      })),
+      color: '#3ddc84', // Android green
     },
   ]
 })
@@ -355,6 +381,79 @@ displayStore.defaultBack = '/dashboard'
             >
               <AdminMultiLineChart
                 :series="bundleStorageTrendSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
+              />
+            </ChartCard>
+          </div>
+
+          <!-- Device Platform Distribution -->
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <!-- iOS Devices Card -->
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div class="flex items-start justify-between mb-4">
+                <div class="p-3 rounded-lg bg-gray-900/10 dark:bg-gray-100/10">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-gray-900 dark:text-gray-100">
+                    <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+                  </svg>
+                </div>
+              </div>
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  iOS Devices (30d)
+                </p>
+                <div v-if="isLoadingGlobalStatsTrend" class="my-2">
+                  <span class="loading loading-spinner loading-lg text-gray-900 dark:text-gray-100" />
+                </div>
+                <p v-else-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+                  {{ (latestGlobalStats.devices_last_month_ios || 0).toLocaleString() }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+                  0
+                </p>
+                <p v-if="latestGlobalStats && latestGlobalStats.devices_last_month" class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  {{ ((latestGlobalStats.devices_last_month_ios || 0) / latestGlobalStats.devices_last_month * 100).toFixed(1) }}% of total
+                </p>
+              </div>
+            </div>
+
+            <!-- Android Devices Card -->
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div class="flex items-start justify-between mb-4">
+                <div class="p-3 rounded-lg bg-green-500/10">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-green-500">
+                    <path d="M17.523 2.477a.75.75 0 0 0-1.06 1.06l1.47 1.47A6.472 6.472 0 0 0 12 3.5a6.472 6.472 0 0 0-5.933 1.507l1.47-1.47a.75.75 0 0 0-1.06-1.06L4.537 4.417a.75.75 0 0 0 0 1.06l1.94 1.94A6.5 6.5 0 0 0 5.5 11v5.5a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V11a6.5 6.5 0 0 0-.977-3.583l1.94-1.94a.75.75 0 0 0 0-1.06l-1.94-1.94zM9 10a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm6 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2z" />
+                  </svg>
+                </div>
+              </div>
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Android Devices (30d)
+                </p>
+                <div v-if="isLoadingGlobalStatsTrend" class="my-2">
+                  <span class="loading loading-spinner loading-lg text-green-500" />
+                </div>
+                <p v-else-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-green-500">
+                  {{ (latestGlobalStats.devices_last_month_android || 0).toLocaleString() }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-green-500">
+                  0
+                </p>
+                <p v-if="latestGlobalStats && latestGlobalStats.devices_last_month" class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  {{ ((latestGlobalStats.devices_last_month_android || 0) / latestGlobalStats.devices_last_month * 100).toFixed(1) }}% of total
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Device Platform Trend Chart -->
+          <div class="grid grid-cols-1 gap-6">
+            <ChartCard
+              :title="t('device-platform-trend')"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="devicePlatformTrendSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="devicePlatformTrendSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
               />
             </ChartCard>

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1072,6 +1072,8 @@ export type Database = {
           credits_consumed: number
           date_id: string
           devices_last_month: number | null
+          devices_last_month_android: number | null
+          devices_last_month_ios: number | null
           mrr: number
           need_upgrade: number | null
           new_paying_orgs: number
@@ -1117,6 +1119,8 @@ export type Database = {
           credits_consumed?: number
           date_id: string
           devices_last_month?: number | null
+          devices_last_month_android?: number | null
+          devices_last_month_ios?: number | null
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number
@@ -1162,6 +1166,8 @@ export type Database = {
           credits_consumed?: number
           date_id?: string
           devices_last_month?: number | null
+          devices_last_month_android?: number | null
+          devices_last_month_ios?: number | null
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -1,8 +1,9 @@
 import type { Context } from 'hono'
+import type { DevicesByPlatform } from '../utils/cloudflare.ts'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
-import { readActiveAppsCF, readLastMonthDevicesCF, readLastMonthUpdatesCF } from '../utils/cloudflare.ts'
+import { readActiveAppsCF, readLastMonthDevicesByPlatformCF, readLastMonthDevicesCF, readLastMonthUpdatesCF } from '../utils/cloudflare.ts'
 import { BRES, middlewareAPISecret } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { logsnag, logsnagInsights } from '../utils/logsnag.ts'
@@ -43,6 +44,7 @@ interface GlobalStats {
   plans: PromiseLike<PlanTotal>
   actives: Promise<Actives>
   devices_last_month: PromiseLike<number>
+  devices_by_platform: PromiseLike<DevicesByPlatform>
   registers_today: PromiseLike<number>
   bundle_storage_gb: PromiseLike<number>
   revenue: PromiseLike<PlanRevenue>
@@ -305,6 +307,7 @@ function getStats(c: Context): GlobalStats {
     }),
     updates_last_month: readLastMonthUpdatesCF(c),
     devices_last_month: readLastMonthDevicesCF(c),
+    devices_by_platform: readLastMonthDevicesByPlatformCF(c),
     registers_today: supabase
       .from('users')
       .select('id', { count: 'exact', head: true })
@@ -398,6 +401,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     actives,
     updates_last_month,
     devices_last_month,
+    devices_by_platform,
     registers_today,
     bundle_storage_gb,
     success_rate,
@@ -420,6 +424,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     res.actives,
     res.updates_last_month,
     res.devices_last_month,
+    res.devices_by_platform,
     res.registers_today,
     res.bundle_storage_gb,
     res.success_rate,
@@ -468,6 +473,8 @@ app.post('/', middlewareAPISecret, async (c) => {
     not_paying,
     updates_last_month,
     devices_last_month,
+    devices_last_month_ios: devices_by_platform.ios,
+    devices_last_month_android: devices_by_platform.android,
     registers_today,
     bundle_storage_gb,
     success_rate,
@@ -622,6 +629,16 @@ app.post('/', middlewareAPISecret, async (c) => {
       title: 'Orgs Enterprise Plan',
       value: `${((plans.Enterprise || 0) * 100 / customers.total).toFixed(0)}% - ${plans.Enterprise || 0}`,
       icon: '📈',
+    },
+    {
+      title: 'Devices iOS (30d)',
+      value: devices_by_platform.ios,
+      icon: '🍎',
+    },
+    {
+      title: 'Devices Android (30d)',
+      value: devices_by_platform.android,
+      icon: '🤖',
     },
   ]).catch((e) => {
     cloudlogErr({ requestId: c.get('requestId'), message: 'insights error', e })

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -803,6 +803,8 @@ export interface AdminGlobalStatsTrend {
   plan_enterprise: number
   registers_today: number
   devices_last_month: number
+  devices_last_month_ios: number
+  devices_last_month_android: number
   stars: number
   need_upgrade: number
   paying_yearly: number
@@ -852,6 +854,8 @@ export async function getAdminGlobalStatsTrend(
         plan_enterprise::int,
         registers_today::int,
         devices_last_month::int,
+        COALESCE(devices_last_month_ios, 0)::int AS devices_last_month_ios,
+        COALESCE(devices_last_month_android, 0)::int AS devices_last_month_android,
         stars::int,
         need_upgrade::int,
         paying_yearly::int,
@@ -891,6 +895,8 @@ export async function getAdminGlobalStatsTrend(
       plan_enterprise: Number(row.plan_enterprise) || 0,
       registers_today: Number(row.registers_today) || 0,
       devices_last_month: Number(row.devices_last_month) || 0,
+      devices_last_month_ios: Number(row.devices_last_month_ios) || 0,
+      devices_last_month_android: Number(row.devices_last_month_android) || 0,
       stars: Number(row.stars) || 0,
       need_upgrade: Number(row.need_upgrade) || 0,
       paying_yearly: Number(row.paying_yearly) || 0,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1072,6 +1072,8 @@ export type Database = {
           credits_consumed: number
           date_id: string
           devices_last_month: number | null
+          devices_last_month_android: number | null
+          devices_last_month_ios: number | null
           mrr: number
           need_upgrade: number | null
           new_paying_orgs: number
@@ -1117,6 +1119,8 @@ export type Database = {
           credits_consumed?: number
           date_id: string
           devices_last_month?: number | null
+          devices_last_month_android?: number | null
+          devices_last_month_ios?: number | null
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number
@@ -1162,6 +1166,8 @@ export type Database = {
           credits_consumed?: number
           date_id?: string
           devices_last_month?: number | null
+          devices_last_month_android?: number | null
+          devices_last_month_ios?: number | null
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number

--- a/supabase/migrations/20260108024031_add_devices_platform_columns.sql
+++ b/supabase/migrations/20260108024031_add_devices_platform_columns.sql
@@ -1,0 +1,4 @@
+-- Add columns for tracking devices by platform (iOS and Android)
+ALTER TABLE global_stats
+ADD COLUMN IF NOT EXISTS devices_last_month_ios bigint DEFAULT 0,
+ADD COLUMN IF NOT EXISTS devices_last_month_android bigint DEFAULT 0;


### PR DESCRIPTION
## Summary

Add tracking for iOS and Android device registrations separately in GlobalStat and LogSnag. This provides visibility into platform breakdown for device account functionality with both current counts and 30-day trends.

## Test plan

- [ ] Run `supabase db reset` to apply migration
- [ ] Verify GlobalStat cron job includes new platform-specific counts
- [ ] Check admin dashboard shows iOS/Android device cards and trend chart
- [ ] Confirm LogSnag receives platform-specific device insights (🍎 iOS, 🤖 Android)

## Changes

- Backend: Added `readLastMonthDevicesByPlatformCF()` to query Cloudflare Analytics for platform breakdown
- Database: New migration adding `devices_last_month_ios` and `devices_last_month_android` columns
- Admin UI: Device platform cards with percentage breakdown + trend chart
- Translations: Added translation key to all 14 language files
- Types: Updated Supabase types and admin stats types for new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)