### PR TITLE
Fix demo chart data consistency

### DIFF
--- a/src/components/dashboard/BundleUploadsCard.vue
+++ b/src/components/dashboard/BundleUploadsCard.vue
@@ -2,7 +2,14 @@
 import colors from 'tailwindcss/colors'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { calculateDemoEvolution, calculateDemoTotal, DEMO_APP_NAMES, generateDemoBundleUploadsData } from '~/services/demoChartData'
+import {
+  calculateDemoEvolution,
+  calculateDemoTotal,
+  DEMO_APP_NAMES,
+  generateConsistentDemoData,
+  generateDemoBundleUploadsData,
+  getDemoDayCount,
+} from '~/services/demoChartData'
 import { useSupabase } from '~/services/supabase'
 import { useDashboardAppsStore } from '~/stores/dashboardApps'
 import { useOrganizationStore } from '~/stores/organization'
@@ -86,12 +93,14 @@ const singleAppNameCache = new Map<string, string>()
 // Check if we have real data
 const hasRealData = computed(() => total.value > 0)
 
-// Generate demo data
-const demoBundleData = computed(() => generateDemoBundleUploadsData(30))
-const demoDataByApp = computed(() => ({
-  'demo-app-1': generateDemoBundleUploadsData(30),
-  'demo-app-2': generateDemoBundleUploadsData(30),
-}))
+// Generate consistent demo data where total is derived from per-app breakdown
+const consistentDemoData = computed(() => {
+  const days = getDemoDayCount(props.useBillingPeriod, bundleData.value.length)
+  return generateConsistentDemoData(days, generateDemoBundleUploadsData)
+})
+
+const demoBundleData = computed(() => consistentDemoData.value.total)
+const demoDataByApp = computed(() => consistentDemoData.value.byApp)
 
 // Demo mode detection
 const isDemoMode = computed(() => !hasRealData.value && !isLoading.value)

--- a/src/components/dashboard/DeploymentStatsCard.vue
+++ b/src/components/dashboard/DeploymentStatsCard.vue
@@ -2,7 +2,14 @@
 import colors from 'tailwindcss/colors'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { calculateDemoEvolution, calculateDemoTotal, DEMO_APP_NAMES, generateDemoDeploymentData } from '~/services/demoChartData'
+import {
+  calculateDemoEvolution,
+  calculateDemoTotal,
+  DEMO_APP_NAMES,
+  generateConsistentDemoData,
+  generateDemoDeploymentData,
+  getDemoDayCount,
+} from '~/services/demoChartData'
 import { useSupabase } from '~/services/supabase'
 import { useDashboardAppsStore } from '~/stores/dashboardApps'
 import { useOrganizationStore } from '~/stores/organization'
@@ -87,12 +94,14 @@ const isLoading = ref(true)
 // Check if we have real data
 const hasRealData = computed(() => totalDeployments.value > 0)
 
-// Generate demo data
-const demoDeploymentData = computed(() => generateDemoDeploymentData(30))
-const demoDataByApp = computed(() => ({
-  'demo-app-1': generateDemoDeploymentData(30),
-  'demo-app-2': generateDemoDeploymentData(30),
-}))
+// Generate consistent demo data where total is derived from per-app breakdown
+const consistentDemoData = computed(() => {
+  const days = getDemoDayCount(props.useBillingPeriod, deploymentData.value.length)
+  return generateConsistentDemoData(days, generateDemoDeploymentData)
+})
+
+const demoDeploymentData = computed(() => consistentDemoData.value.total)
+const demoDataByApp = computed(() => consistentDemoData.value.byApp)
 
 // Demo mode detection
 const isDemoMode = computed(() => !hasRealData.value && !isLoading.value)

--- a/src/services/demoChartData.ts
+++ b/src/services/demoChartData.ts
@@ -171,10 +171,53 @@ export const DEMO_APP_NAMES: { [key: string]: string } = {
 
 /**
  * Generate demo data broken down by fake apps
+ * @deprecated Use generateConsistentDemoData instead for consistent total/byApp data
  */
 export function generateDemoDataByApp(days: number = 30, dataGenerator: (days: number) => number[]): { [appId: string]: number[] } {
   return {
     'demo-app-1': dataGenerator(days),
     'demo-app-2': dataGenerator(days),
   }
+}
+
+/**
+ * Generate consistent demo data where the total is derived from the per-app breakdown.
+ * This ensures the chart totals match when displaying stacked per-app data.
+ */
+export function generateConsistentDemoData(
+  days: number,
+  dataGenerator: (days: number) => number[],
+): {
+  total: number[]
+  byApp: { [appId: string]: number[] }
+} {
+  // Generate per-app data first
+  const app1Data = dataGenerator(days)
+  const app2Data = dataGenerator(days)
+
+  // Derive total from per-app data (sum each day)
+  const total = app1Data.map((val, idx) => val + app2Data[idx])
+
+  return {
+    total,
+    byApp: {
+      'demo-app-1': app1Data,
+      'demo-app-2': app2Data,
+    },
+  }
+}
+
+/**
+ * Get the number of days for demo data based on chart mode.
+ * In billing period mode, use the data array length if available.
+ * In last-30-days mode, always use 30.
+ */
+export function getDemoDayCount(useBillingPeriod: boolean, existingDataLength?: number): number {
+  if (!useBillingPeriod) {
+    // Last 30 days mode always uses 30 data points
+    return 30
+  }
+
+  // In billing period mode, use existing data length if provided, otherwise default to 30
+  return existingDataLength && existingDataLength > 0 ? existingDataLength : 30
 }


### PR DESCRIPTION
## Summary

Addresses PR review feedback from #1389 about demo data inconsistency:

- **Fix totals not matching stacked chart**: Demo totals are now derived from per-app breakdown by generating per-app data first, then summing to create the total series. This ensures the card stats always match the stacked chart data.

- **Fix array length mismatch with chart labels**: Added `getDemoDayCount()` to determine correct demo data length based on chart mode (30 for last-30-days, or billing period length otherwise).

## Test plan

- [ ] View dashboard with no apps or data - demo charts should display
- [ ] Toggle between "Last 30 days" and "Billing period" modes
- [ ] Verify the total value in card header matches the sum of stacked chart segments
- [ ] Check that chart labels align with data points (no truncation/padding)

## Checklist

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency of demo data generation across dashboard cards to better align with billing periods and actual data lengths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->