### PR TITLE
Fix LogSnag device platform stats not being reported

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -46,8 +46,9 @@ const TRACK_DEVICE_USAGE_CACHE_MAX_AGE_SECONDS = 29 * 24 * 60 * 60 // 29 days
  * @param device_id - Unique device identifier
  * @param app_id - Application identifier
  * @param org_id - Organization identifier (optional, defaults to empty string)
+ * @param platform - Device platform ('ios' or 'android')
  */
-export async function trackDeviceUsageCF(c: Context, device_id: string, app_id: string, org_id: string) {
+export async function trackDeviceUsageCF(c: Context, device_id: string, app_id: string, org_id: string, platform: string) {
   if (!c.env.DEVICE_USAGE)
     return
 
@@ -67,9 +68,13 @@ export async function trackDeviceUsageCF(c: Context, device_id: string, app_id: 
       }
     }
 
+    // Platform: 0 = android, 1 = ios
+    const platformValue = platform?.toLowerCase() === 'ios' ? 1 : 0
+
     // Write to Analytics Engine
     c.env.DEVICE_USAGE.writeDataPoint({
       blobs: [device_id, org_id],
+      doubles: [platformValue],
       indexes: [app_id],
     })
 
@@ -79,9 +84,12 @@ export async function trackDeviceUsageCF(c: Context, device_id: string, app_id: 
     }
   }
   catch {
+    // Platform: 0 = android, 1 = ios
+    const platformValue = platform?.toLowerCase() === 'ios' ? 1 : 0
     // On error, still try to write to Analytics Engine without caching
     c.env.DEVICE_USAGE.writeDataPoint({
       blobs: [device_id, org_id],
+      doubles: [platformValue],
       indexes: [app_id],
     })
   }
@@ -810,7 +818,7 @@ export interface DevicesByPlatform {
 }
 
 export async function readLastMonthDevicesByPlatformCF(c: Context): Promise<DevicesByPlatform> {
-  if (!c.env.DEVICE_INFO) {
+  if (!c.env.DEVICE_USAGE) {
     return { total: 0, ios: 0, android: 0 }
   }
 
@@ -820,7 +828,7 @@ export async function readLastMonthDevicesByPlatformCF(c: Context): Promise<Devi
     COUNT(DISTINCT blob1) AS total,
     COUNT(DISTINCT CASE WHEN double1 = 1 THEN blob1 END) AS ios,
     COUNT(DISTINCT CASE WHEN double1 = 0 THEN blob1 END) AS android
-  FROM device_info
+  FROM device_usage
   WHERE timestamp >= toDateTime('${formatDateCF(oneMonthAgo)}')
     AND timestamp < now()`
 

--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -9,11 +9,11 @@ import { countDevicesSB, getAppsFromSB, getUpdateStatsSB, readBandwidthUsageSB, 
 import { DEFAULT_LIMIT } from './types.ts'
 import { backgroundTask } from './utils.ts'
 
-export function createStatsMau(c: Context, device_id: string, app_id: string, org_id: string) {
+export function createStatsMau(c: Context, device_id: string, app_id: string, org_id: string, platform: string) {
   const lowerDeviceId = device_id
   if (!c.env.DEVICE_USAGE)
     return trackDeviceUsageSB(c, lowerDeviceId, app_id, org_id)
-  return trackDeviceUsageCF(c, lowerDeviceId, app_id, org_id)
+  return trackDeviceUsageCF(c, lowerDeviceId, app_id, org_id, platform)
 }
 
 export async function onPremStats(c: Context, app_id: string, action: string, device: DeviceWithoutCreatedAt) {

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -149,7 +149,7 @@ export async function updateWithPG(
     return simpleError200(c, 'missing_info', 'Cannot find device_id or app_id')
   }
 
-  await backgroundTask(c, createStatsMau(c, device_id, app_id, appOwner.owner_org))
+  await backgroundTask(c, createStatsMau(c, device_id, app_id, appOwner.owner_org, platform))
 
   cloudlog({ requestId: c.get('requestId'), message: 'vals', platform, device })
 


### PR DESCRIPTION
## Summary

Track device platform (iOS vs Android) in the device_usage Analytics Engine dataset instead of relying on device_info which has aggressive caching. This ensures platform breakdown stays fresh and matches the total device count in LogSnag insights.

## Test plan

- Deploy to production and verify iOS/Android device counts appear in LogSnag insights
- Check that device_usage dataset now includes platform data in the doubles field
- Verify counts continue to update in subsequent runs (29-day cache on device_usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced device usage analytics to track platform information alongside usage metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->