### PR TITLE
feat: Add missing payment Bento email notification

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -8,11 +8,12 @@ import { z } from 'zod/mini'
 import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
 import { BRES, parseBody, simpleError200, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { sendNotifOrg } from '../utils/notifications.ts'
 import { sendNotifToOrgMembers } from '../utils/org_email_notifications.ts'
 import { closeClient, getAppOwnerPostgres, getAppVersionPostgres, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
 import { createStatsVersion, onPremStats, sendStatsAndDevice } from '../utils/stats.ts'
-import { deviceIdRegex, INVALID_STRING_APP_ID, INVALID_STRING_DEVICE_ID, isLimited, MISSING_STRING_APP_ID, MISSING_STRING_DEVICE_ID, MISSING_STRING_PLATFORM, MISSING_STRING_VERSION_NAME, MISSING_STRING_VERSION_OS, NON_STRING_APP_ID, NON_STRING_DEVICE_ID, NON_STRING_PLATFORM, NON_STRING_VERSION_NAME, NON_STRING_VERSION_OS, reverseDomainRegex } from '../utils/utils.ts'
+import { backgroundTask, deviceIdRegex, INVALID_STRING_APP_ID, INVALID_STRING_DEVICE_ID, isLimited, MISSING_STRING_APP_ID, MISSING_STRING_DEVICE_ID, MISSING_STRING_PLATFORM, MISSING_STRING_VERSION_NAME, MISSING_STRING_VERSION_OS, NON_STRING_APP_ID, NON_STRING_DEVICE_ID, NON_STRING_PLATFORM, NON_STRING_VERSION_NAME, NON_STRING_VERSION_OS, reverseDomainRegex } from '../utils/utils.ts'
 import { ALLOWED_STATS_ACTIONS } from './stats_actions.ts'
 
 z.config(z.locales.en())
@@ -72,6 +73,12 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     await setAppStatus(c, app_id, 'cancelled')
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: app_id })
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
+    // Send weekly notification about missing payment (not configurable - payment related)
+    backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+      app_id,
+      device_id: body.device_id,
+      app_id_url: app_id,
+    }, appOwner.owner_org, app_id, '0 0 * * 1')) // Weekly on Monday
     return simpleError200(c, 'need_plan_upgrade', 'Cannot update, upgrade plan to continue to update')
   }
   await setAppStatus(c, app_id, 'cloud')

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -89,6 +89,12 @@ export async function updateWithPG(
     await setAppStatus(c, app_id, 'cancelled')
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: app_id })
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
+    // Send weekly notification about missing payment (not configurable - payment related)
+    await backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+      app_id,
+      device_id,
+      app_id_url: app_id,
+    }, appOwner.owner_org, app_id, '0 0 * * 1')) // Weekly on Monday
     return simpleError200(c, 'need_plan_upgrade', PLAN_ERROR)
   }
   await setAppStatus(c, app_id, 'cloud')


### PR DESCRIPTION
## Summary

Added Bento email notifications that send to organization owners when a device tries to connect to Capgo but the payment is missing. The email is sent once per week and includes app and device information.

## Test plan

- Manually set an organization's `stripe_subscription_valid` to false
- Trigger an update, stats, or channel_self request with an app from that org
- Verify that `org:missing_payment` event is sent to Bento for the org's management_email
- Verify it's rate limited to once per week (Monday at midnight)

## Notes

This notification is payment-related and does not respect email preferences - it always sends to the org owner's management_email. The Bento event name is `org:missing_payment` and should be configured in the Bento dashboard with an appropriate email template.