### PR TITLE
fix: change insert to upsert for app_versions in on_app_create trigger

### DIFF
--- a/supabase/functions/_backend/triggers/on_app_create.ts
+++ b/supabase/functions/_backend/triggers/on_app_create.ts
@@ -33,7 +33,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
   const supabase = supabaseAdmin(c)
   const { error: dbVersionError } = await supabase
     .from('app_versions')
-    .insert([
+    .upsert([
       {
         owner_org: record.owner_org,
         deleted: true,
@@ -46,7 +46,9 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
         name: 'builtin',
         app_id: record.app_id,
       },
-    ])
+    ], { onConflict: 'name,app_id', ignoreDuplicates: true })
+    .select()
+
   if (dbVersionError) {
     cloudlog({ requestId: c.get('requestId'), message: 'Error creating default versions', dbVersionError })
   }


### PR DESCRIPTION
## Changes (AI generated)

Updated the database operation in the on_app_create trigger to use upsert instead of insert for the app_versions table. This change includes handling conflicts on the 'name' and 'app_id' fields, ensuring that existing records are updated rather than duplicated. Additionally, the operation now selects the inserted or updated records for further processing.

## Motivation

This is a first, but an important step in fixing https://github.com/Cap-go/capgo/issues/1357. A CLI PR is to come, but said CLI PR cannot happen without this PR being merged

## Business impact

Lowly low - 1/9 - I was not able to reproduce the issue reported i n #1357, but I will assume it's possible to trigger it.

Since I don't reproduce - I don't believe it has much business impact, but this might be short-sighted and selfcentered, so I don't think it's a "none" business impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app creation process to gracefully handle duplicate scenarios, preventing errors and ensuring proper result tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->