### PR TITLE
fix: update build system RLS policies for consistency

### DIFF
--- a/supabase/migrations/20260109000000_fix_build_system_rls_consistency.sql
+++ b/supabase/migrations/20260109000000_fix_build_system_rls_consistency.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- Migration: Fix build system RLS policies for consistency
+--
+-- This migration updates the RLS policies for build_requests, build_logs, and
+-- daily_build_time tables to use the consistent pattern used across the codebase:
+-- 1. Use check_min_rights() function instead of direct EXISTS queries
+-- 2. Use get_identity_org_appid() when app_id is available (preferred)
+-- 3. Use get_identity_org_allowed() only when app_id is not available (fallback)
+-- 4. Support both authenticated and anon roles (for API key support)
+--
+-- This matches the pattern used in apps, channels, app_versions, etc.
+-- =============================================================================
+
+-- =====================================================
+-- Update build_requests table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Users read own org build requests" ON public.build_requests;
+
+-- Recreate with consistent pattern using get_identity_org_appid (has app_id)
+CREATE POLICY "Allow org members to select build_requests"
+ON public.build_requests
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'read'::public.user_min_right,
+        public.get_identity_org_appid(
+            '{read,upload,write,all}'::public.key_mode[],
+            owner_org,
+            app_id
+        ),
+        owner_org,
+        app_id,
+        NULL::BIGINT
+    )
+);
+
+-- =====================================================
+-- Update build_logs table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Users read own or org admin builds" ON public.build_logs;
+
+-- Recreate with consistent pattern using get_identity_org_allowed (no app_id available)
+CREATE POLICY "Allow org members to select build_logs"
+ON public.build_logs
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'read'::public.user_min_right,
+        public.get_identity_org_allowed(
+            '{read,upload,write,all}'::public.key_mode[],
+            org_id
+        ),
+        org_id,
+        NULL::CHARACTER VARYING,
+        NULL::BIGINT
+    )
+);
+
+-- =====================================================
+-- Update daily_build_time table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Users read own org build time" ON public.daily_build_time;
+
+-- Recreate with consistent pattern using get_identity_org_appid (has app_id)
+-- Joins through apps table to get owner_org
+CREATE POLICY "Allow org members to select daily_build_time"
+ON public.daily_build_time
+FOR SELECT
+TO authenticated, anon
+USING (
+    EXISTS (
+        SELECT 1
+        FROM public.apps
+        WHERE apps.app_id = daily_build_time.app_id
+        AND public.check_min_rights(
+            'read'::public.user_min_right,
+            public.get_identity_org_appid(
+                '{read,upload,write,all}'::public.key_mode[],
+                apps.owner_org,
+                apps.app_id
+            ),
+            apps.owner_org,
+            apps.app_id,
+            NULL::BIGINT
+        )
+    )
+);


### PR DESCRIPTION
## Summary

- Update RLS policies for `build_requests`, `build_logs`, and `daily_build_time` tables to use consistent patterns
- Use `get_identity_org_appid()` when app_id is available (preferred)
- Use `get_identity_org_allowed()` only when app_id is unavailable (fallback)
- Add support for both `authenticated` and `anon` roles to enable API key authentication

## Motivation

The native build system RLS policies were inconsistent with the rest of the codebase. They used direct `EXISTS` queries with `auth.uid()` instead of the standard `check_min_rights()` and `get_identity_org_appid()` functions used across other tables like apps, channels, and webhooks.

This inconsistency caused issues with:
- API key authentication not working for build system endpoints
- Missing org/app-level API key restriction validation
- Harder maintenance due to non-standard patterns

## Business Impact

**Revenue Generation**: A working native build system is essential for Capgo's growth. By fixing the RLS policies:

- Users can now properly access build requests and build logs through both JWT and API key authentication
- The build system becomes reliable and consistent, improving user experience
- A smooth build experience reduces churn and increases customer satisfaction
- Enables Capgo to offer native builds as a premium feature that drives subscriptions

## Test Plan

- [ ] Verify authenticated users can read their org's build requests
- [ ] Verify API key authentication works for build_requests endpoint
- [ ] Verify build_logs are accessible with proper org membership
- [ ] Verify daily_build_time data is accessible for apps the user has access to
- [ ] Run `supabase db reset` to apply migration locally

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized database access control policies to improve consistency and reliability across backend systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->