### PR TITLE
fix: correct platform validation error message to include 'both'

### DIFF
--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -63,7 +63,7 @@ export async function requestBuild(
 
   if (!['ios', 'android', 'both'].includes(platform)) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Invalid platform', platform })
-    throw simpleError('invalid_parameter', 'platform must be ios or android')
+    throw simpleError('invalid_parameter', 'platform must be ios, android, or both')
   }
 
   if (build_mode && !['release', 'debug'].includes(build_mode)) {


### PR DESCRIPTION
## Summary (AI generated)
- Fixed error message for invalid platform parameter
- Changed from "must be ios or android" to "must be ios, android, or both"

## Motivation (AI generated)
The validation accepts `'both'` as a valid platform option (see references below), but the error message didn't reflect this. Users who tried `'both'` and got an error would see a confusing message suggesting it wasn't supported.

**Code references where `both` is valid:**
- Type definition: [request.ts:10](https://github.com/Cap-go/capgo/blob/main/supabase/functions/_backend/public/build/request.ts#L10) - `platform: 'ios' | 'android' | 'both'`
- Validation check: [request.ts:64](https://github.com/Cap-go/capgo/blob/main/supabase/functions/_backend/public/build/request.ts#L64) - `['ios', 'android', 'both'].includes(platform)`
- Database constraint: [migration:159](https://github.com/Cap-go/capgo/blob/main/supabase/migrations/20251119001847_add_native_build_system.sql#L159) - `platform IN ('ios', 'android', 'both')`

## Business Impact (AI generated)
Improves developer experience by providing accurate error messages. Reduces confusion and support requests when users are troubleshooting build API issues.

## Test Plan (AI generated)
- [ ] Send invalid platform value to `/build/request` endpoint
- [ ] Verify error message now says "platform must be ios, android, or both"

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for platform validation to explicitly indicate that "both" is a valid option alongside individual platform selections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->