### PR TITLE
fix: remove 'both' as valid platform option for builds

### DIFF
--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -7,7 +7,7 @@ import { getEnv } from '../../utils/utils.ts'
 
 export interface RequestBuildBody {
   app_id: string
-  platform: 'ios' | 'android' | 'both'
+  platform: 'ios' | 'android'
   build_mode?: 'release' | 'debug'
   build_config?: Record<string, any>
   credentials?: Record<string, string>
@@ -61,7 +61,7 @@ export async function requestBuild(
     throw simpleError('missing_parameter', 'platform is required')
   }
 
-  if (!['ios', 'android', 'both'].includes(platform)) {
+  if (!['ios', 'android'].includes(platform)) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Invalid platform', platform })
     throw simpleError('invalid_parameter', 'platform must be ios or android')
   }

--- a/supabase/migrations/20260109000000_remove_both_platform_option.sql
+++ b/supabase/migrations/20260109000000_remove_both_platform_option.sql
@@ -1,0 +1,16 @@
+-- Remove 'both' as a valid platform option from build_requests
+-- Platform should only be 'ios' or 'android'
+
+-- First, update any existing records that have 'both' to a default value
+-- (there shouldn't be any in production, but just in case)
+UPDATE public.build_requests
+SET platform = 'ios'
+WHERE platform = 'both';
+
+-- Drop the old constraint and add the new one
+ALTER TABLE public.build_requests
+DROP CONSTRAINT IF EXISTS build_requests_platform_check;
+
+ALTER TABLE public.build_requests
+ADD CONSTRAINT build_requests_platform_check
+CHECK (platform IN ('ios', 'android'));


### PR DESCRIPTION
## Summary (AI generated)
- Removed `'both'` from platform type definition
- Removed `'both'` from validation check
- Added migration to update database constraint to only allow `'ios'` or `'android'`

## Motivation (AI generated)
The `'both'` platform option was a mistake. Builds should target either iOS or Android, not both simultaneously. This option was never intended to be used and could cause undefined behavior.

## Business Impact (AI generated)
Prevents potential confusion and errors from users trying to use an unsupported `'both'` option. Simplifies the build system by enforcing a clear contract: one build = one platform.

## Test Plan (AI generated)
- [ ] Verify builds work with `platform: 'ios'`
- [ ] Verify builds work with `platform: 'android'`
- [ ] Verify error message when invalid platform is provided
- [ ] Run migration on local database

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform selection has been streamlined. The 'both' option for simultaneous iOS and Android builds has been removed. Users must now select either iOS or Android individually. Existing builds previously configured with 'both' have been automatically migrated to iOS.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->