### PR TITLE
fix: query replica lag from pg_stat_subscription

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -563,8 +563,8 @@ app.post('/', async (c) => {
   // POST has writes, so always create PG client (even if using D1 for reads)
   const pgClient = getPgClient(c)
 
-  // Set replication lag header (uses cached status, non-blocking)
-  await setReplicationLagHeader(c)
+  // Set replication lag header using the existing pool
+  await setReplicationLagHeader(c, pgClient)
 
   const bodyParsed = parsePluginBody<DeviceLink>(c, body, jsonRequestSchema)
   if (!bodyParsed.channel) {
@@ -591,8 +591,8 @@ app.put('/', async (c) => {
 
   const pgClient = getPgClient(c)
 
-  // Set replication lag header (uses cached status, non-blocking)
-  await setReplicationLagHeader(c)
+  // Set replication lag header using the existing pool
+  await setReplicationLagHeader(c, pgClient)
 
   const bodyParsed = parsePluginBody<DeviceLink>(c, body, jsonRequestSchema)
   let res
@@ -617,8 +617,8 @@ app.delete('/', async (c) => {
   // DELETE has writes, so always create PG client (even if using D1 for reads)
   const pgClient = getPgClient(c)
 
-  // Set replication lag header (uses cached status, non-blocking)
-  await setReplicationLagHeader(c)
+  // Set replication lag header using the existing pool
+  await setReplicationLagHeader(c, pgClient)
 
   const bodyParsed = parsePluginBody<DeviceLink>(c, body, jsonRequestSchema)
   let res
@@ -641,8 +641,8 @@ app.get('/', async (c) => {
 
   const pgClient = getPgClient(c, true)
 
-  // Set replication lag header (uses cached status, non-blocking)
-  await setReplicationLagHeader(c)
+  // Set replication lag header using the existing pool
+  await setReplicationLagHeader(c, pgClient)
 
   const bodyParsed = parsePluginBody<DeviceLink>(c, body, jsonRequestSchemaGet, false)
   let res


### PR DESCRIPTION
## Summary

Stop creating unnecessary connections to the primary database for replication lag checks. Replicas now query their own pg_stat_subscription locally using the existing pool, eliminating wasteful round-trips to primary and reducing database load.

## Test plan

Deploy to staging and verify:
1. Channel endpoints (POST, PUT, DELETE, GET) set X-Replication-Lag header
2. No additional connections to primary DB for lag checking
3. Response latency is unaffected or improved

## Checklist

- [x] Code follows project style
- [ ] Documentation updated (not required for backend fix)
- [ ] Manual testing completed on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized backend replication lag monitoring by streamlining the query mechanism for improved system efficiency and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->