### PR TITLE
Fix memory leak in DialogV2 from missing event listener cleanup

### DIFF
--- a/src/components/DialogV2.vue
+++ b/src/components/DialogV2.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, watch } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { useDialogV2Store } from '~/stores/dialogv2'
 
 const dialogStore = useDialogV2Store()
@@ -16,20 +16,30 @@ function close(button?: any) {
   dialogStore.closeDialog(button)
 }
 
+// Named handler for cleanup
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && dialogStore.showDialog && !dialogStore.dialogOptions?.preventAccidentalClose) {
+    dialogStore.closeDialog()
+  }
+}
+
+let unwatchRoute: (() => void) | undefined
+
 onMounted(() => {
   // Close dialog on route change
-  watch(route, () => {
+  unwatchRoute = watch(route, () => {
     if (dialogStore.showDialog) {
       dialogStore.closeDialog()
     }
   })
 
   // Close dialog on Escape key
-  addEventListener('keydown', (event: KeyboardEvent) => {
-    if (event.key === 'Escape' && dialogStore.showDialog && !dialogStore.dialogOptions?.preventAccidentalClose) {
-      dialogStore.closeDialog()
-    }
-  })
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+  unwatchRoute?.()
 })
 </script>
 


### PR DESCRIPTION
## Summary

Fix memory leak in DialogV2.vue by properly cleaning up event listeners and route watchers in the onUnmounted hook. Event listeners and watchers were being registered repeatedly without cleanup.

## Test plan

1. Open the dialog multiple times in a page
2. Close it each time
3. Use Vue DevTools to verify that component instances are properly garbage collected and listeners are removed

## Checklist

- [x] Code follows project style and passes linting
- [ ] My change requires documentation updates
- [ ] Documentation has been updated
- [ ] E2E test coverage is adequate
- [x] Tested manually - dialog opens/closes without memory leaks