### PR TITLE
Add ARIA attributes for accessibility compliance

### DIFF
--- a/src/components/DialogV2.vue
+++ b/src/components/DialogV2.vue
@@ -45,6 +45,9 @@ onMounted(() => {
 
       <!-- Dialog -->
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dialog-title"
         class="overflow-y-auto relative mx-4 w-full bg-white rounded-lg shadow-xl max-h-[90vh] dark:bg-base-200"
         :class="[
           sizeClasses[dialogStore.dialogOptions?.size || 'md'],
@@ -53,6 +56,7 @@ onMounted(() => {
         <!-- Close button -->
         <button
           v-if="!dialogStore.dialogOptions?.preventAccidentalClose"
+          aria-label="Close dialog"
           class="absolute z-10 text-2xl text-black top-4 right-4 dark:text-white hover:text-white hover:bg-gray-500 d-btn d-btn-sm d-btn-circle d-btn-ghost dark:hover:bg-gray-500"
           @click="close()"
         >
@@ -61,7 +65,7 @@ onMounted(() => {
 
         <!-- Header -->
         <div v-if="dialogStore.dialogOptions?.title" class="px-6 pt-6 pb-2">
-          <h3 class="text-lg font-bold text-gray-900 dark:text-white">
+          <h3 id="dialog-title" class="text-lg font-bold text-gray-900 dark:text-white">
             {{ dialogStore.dialogOptions.title }}
           </h3>
         </div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -126,7 +126,7 @@ const tabs = computed<Tab[]>(() => {
       </div>
 
       <!-- Navigation -->
-      <div class="flex-1 px-3 py-4 space-y-4 overflow-y-auto lg:py-6 lg:px-6">
+      <nav role="navigation" aria-label="Main navigation" class="flex-1 px-3 py-4 space-y-4 overflow-y-auto lg:py-6 lg:px-6">
         <div>
           <h3 class="mb-3 text-xs font-semibold uppercase lg:mb-4 lg:tracking-wider text-slate-500 lg:text-slate-500">
             {{ t('pages') }}
@@ -156,7 +156,7 @@ const tabs = computed<Tab[]>(() => {
             </li>
           </ul>
         </div>
-      </div>
+      </nav>
 
       <!-- User menu -->
       <div class="pt-4 mt-auto lg:pt-6 lg:mt-0 lg:border-t shrink-0 lg:border-slate-700">

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -534,7 +534,9 @@ const isAdding = computed(() => props.isLoading || pendingAdd.value)
               v-for="(col, i) in columns" :key="i" scope="col" class="px-4 py-1 md:py-3 md:px-6" :class="{
                 'cursor-pointer': col.sortable,
                 'hidden md:table-cell': !col.mobile,
-              }" @click="sortClick(i)"
+              }"
+              :aria-sort="col.sortable === 'asc' ? 'ascending' : col.sortable === 'desc' ? 'descending' : col.sortable ? 'none' : undefined"
+              @click="sortClick(i)"
             >
               <div class="flex items-center first-letter:uppercase">
                 {{ col.label }}

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -13,6 +13,8 @@ const toastOptions = ref({
   <Toaster
     rich-colors close-button position="top-right"
     data-test="toast"
+    role="status"
+    aria-live="polite"
     :toast-options="toastOptions"
   />
 </template>


### PR DESCRIPTION
## Summary (AI generated)

Added missing ARIA attributes to four Vue components to improve accessibility compliance across the application. These attributes help screen readers and assistive technologies better understand component roles and states.

## Test plan (AI generated)

- Run `bun lint` and `bun typecheck` to verify no regressions
- Use browser accessibility tools (Lighthouse, axe DevTools) to verify improved a11y scores
- Test with screen readers:
  - Toast notifications should announce with `role="status"` and `aria-live="polite"`
  - Dialogs should be recognized as modal with proper labeling
  - Table column sorting state should be announced with `aria-sort` values

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint` and `bun typecheck`
- [ ] My change requires a change to the documentation
- [ ] I have tested my code manually with accessibility tools