### PR TITLE
Remove database URL from log output

### DIFF
--- a/scripts/check_r2_big_files.ts
+++ b/scripts/check_r2_big_files.ts
@@ -633,7 +633,7 @@ export function getDatabaseURL(): string {
 
 export function getPgClient(c: Context) {
     const dbUrl = getDatabaseURL()
-    console.log({ message: 'getPgClient', dbUrl })
+    console.log({ message: 'getPgClient connected' })
     return new Pool({
         connectionString: dbUrl,
         max: 1,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -189,7 +189,7 @@ export function getPgClient(c: Context, readOnly = false) {
   const requestId = c.get('requestId')
   const appName = c.res.headers.get('X-Worker-Source') ?? 'unknown source'
   const dbName = c.res.headers.get('X-Database-Source') ?? 'unknown source'
-  cloudlog({ requestId, message: 'SUPABASE_DB_URL', dbUrl, dbName, appName })
+  cloudlog({ requestId, message: 'DB connection established', dbName, appName })
 
   const isPooler = dbName.startsWith('sb_pooler')
   const options = {


### PR DESCRIPTION
## Summary

Remove sensitive database connection strings from log output in two locations. The database URL is a sensitive credential and should never be exposed in logs.

## Test plan

- Code review to verify sensitive logging removed
- No behavioral changes as only log output is modified

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] My change has adequate E2E test coverage
- [x] No manual testing required (logging change only)