### PR TITLE
fix: add watch cleanup and promise reset in Pinia stores

### DIFF
--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -42,7 +42,7 @@ export const useMainStore = defineStore('main', () => {
   const totalDevices = ref<number>(0)
   const totalStorage = ref<number>(0)
   const dashboardFetched = ref<boolean>(false)
-  const _initialLoadPromise = ref(Promise.withResolvers())
+  const _initialLoadPromise = ref(Promise.withResolvers<boolean>())
 
   const totalDownload = ref<number>(0)
 
@@ -115,6 +115,8 @@ export const useMainStore = defineStore('main', () => {
     }
     catch (error) {
       _initialLoadPromise.value.reject(error)
+      // Reset the promise so subsequent calls can succeed
+      _initialLoadPromise.value = Promise.withResolvers<boolean>()
       throw error
     }
   }


### PR DESCRIPTION
## Summary (AI generated)

- Store unwatch functions in organization.ts and dialogv2.ts to prevent watcher accumulation
- Clean up auth listener subscription on sign-out to prevent memory leaks  
- Reset _initialLoadPromise after rejection to allow subsequent awaits to succeed
- Add proper TypeScript types with WatchStopHandle and Subscription for cleanup functions

## Motivation (AI generated)

Pinia stores had multiple watch cleanup issues causing memory leaks and watcher accumulation. Watch functions without cleanup accumulate over time, especially on re-initialization. Auth listener subscriptions weren't being stored and cleaned up properly. Promise resolvers that reject become permanently failed, preventing retry logic from working.

## Business Impact (AI generated)

Fixes memory leaks in the application that could cause performance degradation and increased memory usage over time. Ensures proper cleanup on authentication state changes and store re-initialization. Enables robust retry logic for failed dashboard and organization data loads.

## Test Plan (AI generated)

- [ ] Run `bun typecheck` to verify TypeScript types
- [ ] Run `bun lint` to verify code style
- [ ] Test store initialization and sign-out flows manually to verify no watcher leaks
- [ ] Verify dashboard update retries succeed after failure

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal resource cleanup mechanisms across dialog and store management to improve app stability and prevent memory leaks.
  * Improved error recovery processes for initialization failures, enabling better retry behavior.
  * Strengthened lifecycle management during authentication state transitions to ensure proper cleanup and state resets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->