### PR TITLE
fix: debounce breadcrumb computation in display store

### DIFF
--- a/src/stores/display.ts
+++ b/src/stores/display.ts
@@ -1,4 +1,5 @@
 import type { Database } from '~/types/supabase.types'
+import { useDebounceFn } from '@vueuse/core'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 import { useSupabase } from '~/services/supabase'
@@ -44,24 +45,6 @@ export const useDisplayStore = defineStore('display', () => {
       pendingFetches.clear()
       currentCacheOrgId.value = newOrgId
     }
-  }
-
-  function setChannelName(id: string, name: string) {
-    channelNameCache.value.set(id, name)
-    if (lastPath.value)
-      updatePathTitle(lastPath.value)
-  }
-
-  function setBundleName(id: string, name: string) {
-    bundleNameCache.value.set(id, name)
-    if (lastPath.value)
-      updatePathTitle(lastPath.value)
-  }
-
-  function setDeviceName(id: string, name: string) {
-    deviceNameCache.value.set(id, name)
-    if (lastPath.value)
-      updatePathTitle(lastPath.value)
   }
 
   function getPrettyName(segment: string, index: number, allSegments: string[]): string {
@@ -133,8 +116,33 @@ export const useDisplayStore = defineStore('display', () => {
     return false
   }
 
+  // Debounced breadcrumb computation to prevent recursive watch triggers
+  const debouncedComputeBreadcrumbs = useDebounceFn(() => {
+    if (lastPath.value)
+      computeBreadcrumbs(lastPath.value)
+  }, 50)
+
+  function setChannelName(id: string, name: string) {
+    channelNameCache.value.set(id, name)
+    debouncedComputeBreadcrumbs()
+  }
+
+  function setBundleName(id: string, name: string) {
+    bundleNameCache.value.set(id, name)
+    debouncedComputeBreadcrumbs()
+  }
+
+  function setDeviceName(id: string, name: string) {
+    deviceNameCache.value.set(id, name)
+    debouncedComputeBreadcrumbs()
+  }
+
   function updatePathTitle(path: string) {
     lastPath.value = path
+    debouncedComputeBreadcrumbs()
+  }
+
+  function computeBreadcrumbs(path: string) {
     const splitPath = path.split('/').filter(Boolean)
 
     const breadcrumbs: BreadcrumbItem[] = []
@@ -174,8 +182,7 @@ export const useDisplayStore = defineStore('display', () => {
           }
           finally {
             pendingFetches.delete(appId)
-            if (lastPath.value)
-              updatePathTitle(lastPath.value)
+            debouncedComputeBreadcrumbs()
           }
         })()
         pendingFetches.set(appId, fetchPromise)
@@ -294,13 +301,12 @@ export const useDisplayStore = defineStore('display', () => {
   }
 
   watch(NavTitle, () => {
-    if (lastPath.value)
-      updatePathTitle(lastPath.value)
+    debouncedComputeBreadcrumbs()
   })
 
   watch(resolverReady, (ready) => {
-    if (ready && lastPath.value)
-      updatePathTitle(lastPath.value)
+    if (ready)
+      debouncedComputeBreadcrumbs()
   })
 
   return {


### PR DESCRIPTION
## Summary (AI generated)

Fixed recursive watch triggers in the display store by implementing debounced breadcrumb computation with a 50ms delay. The updatePathTitle function now triggers a debounced breadcrumb computation instead of immediately recalculating, preventing cascading updates when cache values change rapidly.

## Test plan (AI generated)

- [ ] Navigate between pages rapidly and verify breadcrumbs display correctly
- [ ] Check Vue DevTools to ensure breadcrumb watchers aren't firing excessively
- [ ] Navigate to app pages with channels/bundles/devices and verify names load properly
- [ ] Test cache setters (setChannelName, setBundleName, setDeviceName) don't cause jank
- [ ] Verify router navigation doesn't cause multiple breadcrumb recalculations

## Checklist (AI generated)

- [x] Code passes linting and type checking
- [ ] Manual testing performed on rapid navigation scenarios

Generated with AI