### PR TITLE
Improve usage credit RLS policies with get_identity_org_allowed

### DIFF
--- a/supabase/migrations/20260110044840_improve_usage_credit_rls.sql
+++ b/supabase/migrations/20260110044840_improve_usage_credit_rls.sql
@@ -1,0 +1,117 @@
+-- =============================================================================
+-- Migration: Improve usage credit RLS policies
+--
+-- This migration updates the RLS policies for usage credit tables to use the
+-- consistent pattern used across the codebase:
+-- 1. Use check_min_rights() function with get_identity_org_allowed()
+-- 2. Support both authenticated and anon roles (for API key support)
+--
+-- These tables only have org_id (no app_id) as credits are organization-level
+-- resources, so we use get_identity_org_allowed() per AGENTS.md guidelines.
+--
+-- Tables affected:
+-- - usage_credit_grants
+-- - usage_credit_transactions
+-- - usage_overage_events
+-- - usage_credit_consumptions
+-- =============================================================================
+
+-- =====================================================
+-- Update usage_credit_grants table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Allow read for org admin" ON public.usage_credit_grants;
+
+-- Recreate with consistent pattern using get_identity_org_allowed (no app_id on table)
+CREATE POLICY "Allow org members to select usage_credit_grants"
+ON public.usage_credit_grants
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        public.get_identity_org_allowed(
+            '{read,upload,write,all}'::public.key_mode[],
+            org_id
+        ),
+        org_id,
+        NULL::CHARACTER VARYING,
+        NULL::BIGINT
+    )
+);
+
+-- =====================================================
+-- Update usage_credit_transactions table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Allow read for org admin" ON public.usage_credit_transactions;
+
+-- Recreate with consistent pattern using get_identity_org_allowed (no app_id on table)
+CREATE POLICY "Allow org members to select usage_credit_transactions"
+ON public.usage_credit_transactions
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        public.get_identity_org_allowed(
+            '{read,upload,write,all}'::public.key_mode[],
+            org_id
+        ),
+        org_id,
+        NULL::CHARACTER VARYING,
+        NULL::BIGINT
+    )
+);
+
+-- =====================================================
+-- Update usage_overage_events table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Allow read for org admin" ON public.usage_overage_events;
+
+-- Recreate with consistent pattern using get_identity_org_allowed (no app_id on table)
+CREATE POLICY "Allow org members to select usage_overage_events"
+ON public.usage_overage_events
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        public.get_identity_org_allowed(
+            '{read,upload,write,all}'::public.key_mode[],
+            org_id
+        ),
+        org_id,
+        NULL::CHARACTER VARYING,
+        NULL::BIGINT
+    )
+);
+
+-- =====================================================
+-- Update usage_credit_consumptions table policies
+-- =====================================================
+
+-- Drop existing policy
+DROP POLICY IF EXISTS "Allow read for org admin" ON public.usage_credit_consumptions;
+
+-- Recreate with consistent pattern using get_identity_org_allowed (no app_id on table)
+CREATE POLICY "Allow org members to select usage_credit_consumptions"
+ON public.usage_credit_consumptions
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        public.get_identity_org_allowed(
+            '{read,upload,write,all}'::public.key_mode[],
+            org_id
+        ),
+        org_id,
+        NULL::CHARACTER VARYING,
+        NULL::BIGINT
+    )
+);


### PR DESCRIPTION
## Summary (AI generated)

Updated RLS policies on usage_credit_grants, usage_credit_transactions, usage_overage_events, and usage_credit_consumptions tables to use get_identity_org_allowed() instead of get_identity() for granular API key permission control, following the pattern established in AGENTS.md.

## Motivation (AI generated)

The usage credit tables were using get_identity() for RLS checks, providing less granular permission control for API keys. By switching to get_identity_org_allowed(), we gain better API key scope verification while maintaining organization-level access control. This aligns with the broader codebase pattern used in similar org-level resources.

## Business Impact (AI generated)

Improves security by ensuring API keys can only access usage credit data for their permitted organizations, preventing unauthorized access to billing and credit information.

## Test Plan (AI generated)

- [ ] Run `supabase db reset` to apply the migration
- [ ] Run `bun test:backend` to verify all tests pass
- [ ] Verify authenticated users can access their org's usage credit data
- [ ] Verify API key authentication respects organization boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced access control for usage credit data to better align with organizational membership and user roles. Updated the underlying permission system to use a unified approach, ensuring consistent access patterns across related features while supporting both authenticated and anonymous users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->