### PR TITLE
refactor: restrict red and green colors to UpdateStats chart

### DIFF
--- a/src/components/dashboard/ChartCard.vue
+++ b/src/components/dashboard/ChartCard.vue
@@ -64,7 +64,7 @@ const displayNoDataMessage = computed(() => props.noDataMessage ?? t('no-data'))
         <div
           v-if="showEvolutionBadge"
           class="inline-flex justify-center items-center py-1 px-2 text-xs font-bold text-white whitespace-nowrap rounded-full shadow-lg"
-          :class="{ 'bg-emerald-500': (lastDayEvolution ?? 0) >= 0, 'bg-yellow-500': (lastDayEvolution ?? 0) < 0 }"
+          :class="{ 'bg-cyan-500': (lastDayEvolution ?? 0) >= 0, 'bg-yellow-500': (lastDayEvolution ?? 0) < 0 }"
         >
           {{ (lastDayEvolution ?? 0) < 0 ? '-' : '+' }}{{ Math.abs(lastDayEvolution ?? 0).toFixed(2) }}%
         </div>

--- a/src/components/dashboard/DeploymentStatsChart.vue
+++ b/src/components/dashboard/DeploymentStatsChart.vue
@@ -153,17 +153,43 @@ function monthdays() {
   return generateMonthDays(props.useBillingPeriod, cycleStart, cycleEnd)
 }
 
-// Generate infinite distinct pastel colors starting with blue
+// Check if a hue is in the red or green range (reserved for UpdateStats)
+function isReservedHue(hue: number): boolean {
+  // Red range: 0-30 and 330-360
+  // Green range: 90-160
+  return (hue >= 0 && hue <= 30) || (hue >= 330 && hue <= 360) || (hue >= 90 && hue <= 160)
+}
+
+// Get the nth safe hue that skips red/green colors
+function getSafeHue(targetIndex: number): number {
+  let i = 0
+  let safeCount = 0
+
+  while (safeCount <= targetIndex && i < targetIndex * 3 + 10) {
+    const hue = (210 + i * 137.508) % 360
+    i++
+
+    if (!isReservedHue(hue)) {
+      if (safeCount === targetIndex)
+        return hue
+      safeCount++
+    }
+  }
+
+  // Fallback to blue if we somehow can't find enough safe hues
+  return 210
+}
+
+// Generate infinite distinct pastel colors starting with blue, skipping red/green
 function generateChannelColors(channelCount: number) {
   const colors = []
 
-  for (let i = 0; i < channelCount; i++) {
-    // Start with blue (210°) and use golden ratio for distribution
-    const hue = (210 + i * 137.508) % 360 // Start at blue, then golden angle
+  for (let colorIndex = 0; colorIndex < channelCount; colorIndex++) {
+    const hue = getSafeHue(colorIndex)
 
     // Use pastel-friendly saturation and lightness values
-    const saturation = 50 + (i % 3) * 8 // 50%, 58%, 66% - softer colors
-    const lightness = 60 + (i % 4) * 5 // 60%, 65%, 70%, 75% - lighter, more pastel
+    const saturation = 50 + (colorIndex % 3) * 8 // 50%, 58%, 66% - softer colors
+    const lightness = 60 + (colorIndex % 4) * 5 // 60%, 65%, 70%, 75% - lighter, more pastel
 
     const backgroundColor = `hsla(${hue}, ${saturation}%, ${lightness}%, 0.8)`
 
@@ -250,8 +276,8 @@ const chartData = computed<ChartData<any>>(() => {
     // Process data for cumulative mode
     if (props.accumulated) {
       processed = transformSeries(itemData, true, labelCount)
-      // Use LineChartStats color scheme for line mode
-      const hue = (210 + index * 137.508) % 360
+      // Use safe hue that skips red/green (reserved for UpdateStats)
+      const hue = getSafeHue(index)
       const saturation = 50 + (index % 3) * 8
       const lightness = 60 + (index % 4) * 5
       borderColor = `hsl(${hue}, ${saturation + 15}%, ${lightness - 15}%)`

--- a/src/components/dashboard/DevicesStats.vue
+++ b/src/components/dashboard/DevicesStats.vue
@@ -671,7 +671,7 @@ watch(
 
         <div class="flex flex-col items-end text-right shrink-0">
           <div
-            class="inline-flex items-center justify-center px-2 py-1 text-xs font-bold text-white rounded-full shadow-lg whitespace-nowrap bg-emerald-500"
+            class="inline-flex items-center justify-center px-2 py-1 text-xs font-bold text-white rounded-full shadow-lg whitespace-nowrap bg-cyan-500"
           >
             {{ latestVersionPercentageDisplay }}
           </div>

--- a/src/components/dashboard/LineChartStats.vue
+++ b/src/components/dashboard/LineChartStats.vue
@@ -211,17 +211,43 @@ const generateAnnotations = computed(() => {
   return annotations
 })
 
-// Generate infinite distinct pastel colors starting with blue
+// Check if a hue is in the red or green range (reserved for UpdateStats)
+function isReservedHue(hue: number): boolean {
+  // Red range: 0-30 and 330-360
+  // Green range: 90-160
+  return (hue >= 0 && hue <= 30) || (hue >= 330 && hue <= 360) || (hue >= 90 && hue <= 160)
+}
+
+// Get the nth safe hue that skips red/green colors
+function getSafeHue(targetIndex: number): number {
+  let i = 0
+  let safeCount = 0
+
+  while (safeCount <= targetIndex && i < targetIndex * 3 + 10) {
+    const hue = (210 + i * 137.508) % 360
+    i++
+
+    if (!isReservedHue(hue)) {
+      if (safeCount === targetIndex)
+        return hue
+      safeCount++
+    }
+  }
+
+  // Fallback to blue if we somehow can't find enough safe hues
+  return 210
+}
+
+// Generate infinite distinct pastel colors starting with blue, skipping red/green
 function generateAppColors(appCount: number) {
   const colors = []
 
-  for (let i = 0; i < appCount; i++) {
-    // Start with blue (210°) and use golden ratio for distribution
-    const hue = (210 + i * 137.508) % 360 // Start at blue, then golden angle
+  for (let colorIndex = 0; colorIndex < appCount; colorIndex++) {
+    const hue = getSafeHue(colorIndex)
 
     // Use pastel-friendly saturation and lightness values
-    const saturation = 50 + (i % 3) * 8 // 50%, 58%, 66% - softer colors
-    const lightness = 60 + (i % 4) * 5 // 60%, 65%, 70%, 75% - lighter, more pastel
+    const saturation = 50 + (colorIndex % 3) * 8 // 50%, 58%, 66% - softer colors
+    const lightness = 60 + (colorIndex % 4) * 5 // 60%, 65%, 70%, 75% - lighter, more pastel
 
     const borderColor = `hsl(${hue}, ${saturation + 15}%, ${lightness - 15}%)`
     const backgroundColor = `hsla(${hue}, ${saturation}%, ${lightness}%, 0.6)`
@@ -268,8 +294,8 @@ const chartData = computed<ChartData<'line' | 'bar'>>(() => {
           borderColor = appColors[index].border
         }
         else {
-          // Use existing bar chart colors for bar mode
-          const hue = (210 + index * 137.508) % 360
+          // Use safe hue that skips red/green (reserved for UpdateStats)
+          const hue = getSafeHue(index)
           const saturation = 50 + (index % 3) * 8
           const lightness = 60 + (index % 4) * 5
           backgroundColor = `hsla(${hue}, ${saturation}%, ${lightness}%, 0.8)`

--- a/src/components/dashboard/Usage.vue
+++ b/src/components/dashboard/Usage.vue
@@ -730,7 +730,7 @@ onMounted(() => {
     :class="appId ? 'xl:grid-cols-16' : 'xl:grid-cols-12'"
   >
     <UsageCard
-      id="mau-stat" :limits="allLimits.mau" :colors="colors.emerald" :accumulated="useBillingPeriod && showCumulative"
+      id="mau-stat" :limits="allLimits.mau" :colors="colors.cyan" :accumulated="useBillingPeriod && showCumulative"
       :data="mauData" :data-by-app="mauDataByApp" :app-names="appNames" :title="`${t('monthly-active')}`" :unit="t('units-users')"
       :use-billing-period="useBillingPeriod"
       :is-loading="isLoading"


### PR DESCRIPTION
## Summary (AI generated)

Charts for MAU, Storage, Bandwidth, Bundle Uploads, and Deployments now skip red and green colors, which are reserved for the UpdateStats chart where red indicates failures and green indicates successful updates. This prevents semantic color confusion across dashboard charts by using cyan for positive indicators and limiting red/green to failure/success semantics only.

## Test plan (AI generated)

- [ ] View the dashboard and verify MAU chart displays in cyan
- [ ] Verify app breakdown charts use blue, purple, orange, yellow colors
- [ ] Verify evolution badges show cyan for increases
- [ ] Verify UpdateStats chart retains red for failures and green for installs
- [ ] Verify charts render correctly in both light and dark modes

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes linting
- [ ] My change requires a change to the documentation

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved dashboard chart color generation with enhanced hue selection logic to optimize visual clarity, readability, and data representation consistency across bundle uploads, deployment statistics, device tracking, line charts, and all dashboard visualizations.

* **Style**
  * Updated progress indicator badge colors from emerald to cyan throughout all dashboard statistics cards, evolution indicators, device stats displays, and monthly active user metrics for improved visual consistency and platform appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->