### PR TITLE
Fix invite user error by using admin client for tmp_users

### DIFF
--- a/supabase/functions/_backend/private/invite_new_user_to_org.ts
+++ b/supabase/functions/_backend/private/invite_new_user_to_org.ts
@@ -7,7 +7,7 @@ import { z } from 'zod/mini'
 import { trackBentoEvent } from '../utils/bento.ts'
 import { middlewareAuth, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { supabaseClient } from '../utils/supabase.ts'
+import { supabaseAdmin, supabaseClient } from '../utils/supabase.ts'
 import { getEnv } from '../utils/utils.ts'
 
 // Validate name to prevent HTML/script injection
@@ -110,10 +110,10 @@ app.post('/', middlewareAuth, async (c) => {
   const inviteCreatorUser = res.inviteCreatorUser
   const org = res.org
 
-  // Use authenticated client for data queries - RLS will enforce access
-  const supabase = supabaseClient(c, res.authorization!)
+  // Use admin client for tmp_users operations since RLS blocks all access on that table
+  const supabaseAdminClient = supabaseAdmin(c)
 
-  const { data: existingInvitation } = await supabase
+  const { data: existingInvitation } = await supabaseAdminClient
     .from('tmp_users')
     .select('*')
     .eq('email', body.email)
@@ -127,7 +127,7 @@ app.post('/', middlewareAuth, async (c) => {
       return simpleError('user_already_invited', 'User already invited and it hasnt been 3 hours since the last invitation was cancelled')
     }
 
-    const { error: updateInvitationError, data: updatedInvitationData } = await supabase
+    const { error: updateInvitationError, data: updatedInvitationData } = await supabaseAdminClient
       .from('tmp_users')
       .update({
         cancelled_at: null,
@@ -146,7 +146,7 @@ app.post('/', middlewareAuth, async (c) => {
     newInvitation = updatedInvitationData
   }
   else {
-    const { error: createUserError, data: newInvitationData } = await supabase.from('tmp_users').insert({
+    const { error: createUserError, data: newInvitationData } = await supabaseAdminClient.from('tmp_users').insert({
       email: body.email,
       org_id: body.org_id,
       role: body.invite_type,


### PR DESCRIPTION
## Summary

Fixed the "Failed to invite user" error (400 status) that occurred when inviting users. The issue was that the `tmp_users` table has an RLS policy blocking all authenticated access, but the invite endpoint was using an authenticated Supabase client to perform SELECT, INSERT, and UPDATE operations on that table.

## Solution

Switched to using `supabaseAdmin` (service role client) for all `tmp_users` operations. Authorization is already enforced by the `validateInvite` function which checks user membership and org access, so using the service role client is safe and necessary to bypass the RLS policy.

## Test plan

- Invite a new user to an organization and verify the invitation is created
- Re-invite a previously cancelled user and verify the invitation is updated instead of creating a new one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend infrastructure for the organization user invitation process with enhanced access control mechanisms for temporary user data operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->