### PR TITLE
Hard-delete old deleted app versions

### DIFF
--- a/supabase/migrations/20260113160650_delete_old_deleted_versions.sql
+++ b/supabase/migrations/20260113160650_delete_old_deleted_versions.sql
@@ -1,6 +1,33 @@
+-- Fix: update_app_versions_retention should set updated_at when marking versions as deleted
+-- This ensures we can track when a version was soft-deleted
+CREATE OR REPLACE FUNCTION "public"."update_app_versions_retention" () RETURNS void LANGUAGE "plpgsql"
+SET
+  search_path = '' AS $$
+BEGIN
+    -- Use a more efficient approach with direct timestamp comparison
+    -- Also set updated_at to track when the version was marked as deleted
+    UPDATE public.app_versions
+    SET deleted = true, updated_at = NOW()
+    WHERE app_versions.deleted = false
+      AND (SELECT retention FROM public.apps WHERE apps.app_id = app_versions.app_id) >= 0
+      AND (SELECT retention FROM public.apps WHERE apps.app_id = app_versions.app_id) < 63113904
+      AND app_versions.created_at < (
+          SELECT NOW() - make_interval(secs => apps.retention)
+          FROM public.apps
+          WHERE apps.app_id = app_versions.app_id
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM public.channels
+          WHERE channels.app_id = app_versions.app_id
+            AND channels.version = app_versions.id
+      );
+END;
+$$;
+
 -- Create a function to permanently delete app versions that are:
 -- 1. Already marked as deleted (soft deleted)
--- 2. Older than one year
+-- 2. Soft-deleted more than one year ago (using updated_at, not created_at)
 -- This helps with database cleanup and compliance with data retention policies.
 -- Note: Foreign keys have ON DELETE CASCADE, so related records in
 -- app_versions_meta, channels, deploy_history, and manifest will be automatically cleaned up.
@@ -13,11 +40,11 @@ DECLARE
 BEGIN
     -- Delete versions that are:
     -- 1. Marked as deleted (soft deleted)
-    -- 2. Created more than 1 year ago
+    -- 2. Soft-deleted more than 1 year ago (based on updated_at, which is set when deleted=true)
     -- 3. NOT currently linked to any channel (safety check, though should not happen for deleted versions)
     DELETE FROM "public"."app_versions"
     WHERE deleted = true
-      AND created_at < NOW() - INTERVAL '1 year'
+      AND updated_at < NOW() - INTERVAL '1 year'
       AND NOT EXISTS (
         SELECT 1 FROM "public"."channels"
         WHERE channels.version = app_versions.id
@@ -37,11 +64,11 @@ ALTER FUNCTION "public"."delete_old_deleted_versions" () OWNER TO "postgres";
 REVOKE EXECUTE ON FUNCTION "public"."delete_old_deleted_versions" () FROM public;
 GRANT EXECUTE ON FUNCTION "public"."delete_old_deleted_versions" () TO service_role;
 
--- Add to cron_tasks table to run daily at 02:00:00
+-- Add to cron_tasks table to run daily at 03:00:00
 -- Runs AFTER:
 --   - 00:40 update_app_versions_retention() marks versions as deleted
 --   - 02:00 cron_clear_versions queue processes S3 cleanup
--- This ensures all soft-delete and S3 cleanup operations are complete
+-- Scheduled at 03:00 to ensure S3 cleanup is complete before hard deletion
 INSERT INTO public.cron_tasks (
     name,
     description,
@@ -65,7 +92,7 @@ INSERT INTO public.cron_tasks (
     null,   -- second_interval
     null,   -- minute_interval
     null,   -- hour_interval
-    2,      -- run_at_hour: 02:00
+    3,      -- run_at_hour: 03:00 (after S3 cleanup at 02:00)
     0,      -- run_at_minute
     0,      -- run_at_second
     null,   -- run_on_dow (no day-of-week restriction)


### PR DESCRIPTION
## Summary (AI generated)

Add automatic cleanup to permanently delete app versions that have been soft-deleted for over a year. Runs daily at 02:00 UTC after retention marking and S3 cleanup are complete.

## Motivation (AI generated)

The system currently soft-deletes old app versions based on retention policy, but they remain in the database forever. This cleanup task hard-deletes versions older than 1 year, reducing database size and ensuring compliance with data retention policies.

## Business Impact (AI generated)

Reduces database storage costs and ensures old user data is properly cleaned up per retention policies. Related records in app_versions_meta, channels, deploy_history, and manifest are automatically removed via ON DELETE CASCADE.

## Test Plan (AI generated)

- [ ] Verify the migration applies successfully to local database
- [ ] Check that `delete_old_deleted_versions()` function exists and is callable
- [ ] Confirm cron_tasks entry was added with correct schedule (02:00 UTC daily)
- [ ] Verify task runs after retention marking at 00:40 and S3 cleanup at 02:00

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated daily cleanup that permanently removes app versions that were soft-deleted and remain unlinked to any channels after one year.
  * Added a background retention update step to mark older versions for deletion so cleanup runs can safely and efficiently remove them.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->