### PR TITLE
fix: transfer org button not working

### DIFF
--- a/src/components/dashboard/AppSetting.vue
+++ b/src/components/dashboard/AppSetting.vue
@@ -781,9 +781,7 @@ function confirmTransferAppOwnership(org: Organization) {
 }
 
 async function transferAppOwnership() {
-  const transferHistory: { transferred_at: string }[] = (appRef.value as any) ?? []
-  if (!transferHistory || transferHistory.length === 0)
-    return
+  const transferHistory: { transferred_at: string }[] = ((appRef.value as any)?.transfer_history as any) ?? []
   const lastTransfer = transferHistory.length > 0
     ? transferHistory.sort((a, b) =>
       new Date(b.transferred_at).getTime() - new Date(a.transferred_at).getTime(),
@@ -829,7 +827,8 @@ async function transferAppOwnership() {
       ...superAdminOrganizations.map(org => ({
         text: org.name,
         role: 'secondary' as const,
-        handler: async () => {
+        preventClose: true,
+        handler: () => {
           confirmTransferAppOwnership(org)
         },
       })),


### PR DESCRIPTION
## Summary

- Fix dialog race condition when clicking org selection button during app transfer
- Fix incorrect `transferHistory` variable assignment that broke 32-day cooldown check

## Problem

The "Transfer App Ownership" button appeared to do nothing after selecting an organization. The confirmation dialog would never appear.

## Root Cause

**Bug 1 - Dialog Race Condition:**
When clicking an org button in the "Select destination organization" dialog, the handler called `confirmTransferAppOwnership(org)` which opens a NEW dialog. However, the dialog system then immediately closed the dialog because the handler returned `undefined` (not `false`), triggering `showDialog = false` which closed the newly opened confirmation dialog.

**Bug 2 - Incorrect transferHistory Assignment:**
```javascript
// Before (WRONG) - assigned entire app object:
const transferHistory = (appRef.value as any) ?? []

// After (CORRECT) - access transfer_history property:
const transferHistory = ((appRef.value as any)?.transfer_history as any) ?? []
```

## Fix

1. Added `preventClose: true` to org selection buttons so the dialog stays open while `confirmTransferAppOwnership` replaces the dialog content
2. Fixed `transferHistory` to correctly access `appRef.value.transfer_history`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the app ownership transfer process by adding safeguards for transfer history data retrieval.
  * Enhanced the destination organization selection dialog to prevent accidental closure during app transfer operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->