### PR TITLE
fix: clarify API key expiration requirement messaging

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Anforderungslast",
   "requested": "angefordert",
   "require-apikey-expiration": "API-Schlüssel müssen ein Ablaufdatum haben",
-  "require-apikey-expiration-description": "Wenn aktiviert, müssen alle API-Schlüssel für diese Organisation ein Ablaufdatum haben",
+  "require-apikey-expiration-description": "Wenn aktiviert, können nur API-Schlüssel mit Ablaufdatum auf diese Organisation zugreifen",
   "require-number": "Benötige Nummer",
   "require-special-character": "Benötigen Sie ein Sonderzeichen",
   "require-uppercase": "Benötigen Großbuchstaben",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1136,7 +1136,7 @@
   "reset-spoofed-user": "Stop spoofing",
   "reset-your-password": "Reset your password",
   "require-apikey-expiration": "Require API Key Expiration",
-  "require-apikey-expiration-description": "When enabled, all API keys for this organization must have an expiration date",
+  "require-apikey-expiration-description": "When enabled, only API keys with an expiration date can access this organization",
   "retention": "Auto delete bundles not used (after x seconds)",
   "retention-cannot-be-negative": "Retention cannot be a negative number",
   "retention-to-big": "Retention cannot be bigger than 63113903 (2 years)",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Carga de solicitud",
   "requested": "solicitado",
   "require-apikey-expiration": "Requerir que las claves API tengan una fecha de expiración",
-  "require-apikey-expiration-description": "Cuando está habilitado, todas las claves API de esta organización deben tener una fecha de expiración",
+  "require-apikey-expiration-description": "Cuando está habilitado, solo las claves API con fecha de expiración pueden acceder a esta organización",
   "require-number": "Requerir número",
   "require-special-character": "Requerir carácter especial",
   "require-uppercase": "Requerir mayúscula",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Contenu de la requête",
   "requested": "demandé",
   "require-apikey-expiration": "Exiger que les clés API aient une date d'expiration",
-  "require-apikey-expiration-description": "Lorsqu'activé, toutes les clés API de cette organisation doivent avoir une date d'expiration",
+  "require-apikey-expiration-description": "Lorsqu'activé, seules les clés API avec une date d'expiration peuvent accéder à cette organisation",
   "require-number": "Exiger un chiffre",
   "require-special-character": "Exiger un caractère spécial",
   "require-uppercase": "Exiger une majuscule",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1192,7 +1192,7 @@
   "request-payload": "अनुरोध पेलोड",
   "requested": "अनुरोध किया",
   "require-apikey-expiration": "API कुंजियों के लिए समाप्ति तिथि अनिवार्य करें",
-  "require-apikey-expiration-description": "जब सक्षम होता है, इस संगठन के सभी API कुंजियों में समाप्ति तिथि होनी चाहिए",
+  "require-apikey-expiration-description": "जब सक्षम होता है, केवल समाप्ति तिथि वाली API कुंजियां ही इस संगठन तक पहुंच सकती हैं",
   "require-number": "अंक आवश्यक",
   "require-special-character": "विशेष अक्षर आवश्यक",
   "require-uppercase": "बड़ा अक्षर आवश्यक",

--- a/messages/id.json
+++ b/messages/id.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Payload permintaan",
   "requested": "diminta",
   "require-apikey-expiration": "Wajibkan kunci API memiliki tanggal kedaluwarsa",
-  "require-apikey-expiration-description": "Jika diaktifkan, semua kunci API untuk organisasi ini harus memiliki tanggal kedaluwarsa",
+  "require-apikey-expiration-description": "Jika diaktifkan, hanya kunci API dengan tanggal kedaluwarsa yang dapat mengakses organisasi ini",
   "require-number": "Wajib angka",
   "require-special-character": "Wajib karakter khusus",
   "require-uppercase": "Wajib huruf kapital",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Payload richiesta",
   "requested": "richiesto",
   "require-apikey-expiration": "Richiedi che le chiavi API abbiano una data di scadenza",
-  "require-apikey-expiration-description": "Quando abilitato, tutte le chiavi API di questa organizzazione devono avere una data di scadenza",
+  "require-apikey-expiration-description": "Quando abilitato, solo le chiavi API con una data di scadenza possono accedere a questa organizzazione",
   "require-number": "Richiedi numero",
   "require-special-character": "Richiedi carattere speciale",
   "require-uppercase": "Richiedi maiuscola",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1192,7 +1192,7 @@
   "request-payload": "リクエストペイロード",
   "requested": "要求された",
   "require-apikey-expiration": "APIキーに有効期限を必須にする",
-  "require-apikey-expiration-description": "有効にすると、この組織のすべてのAPIキーに有効期限が必要になります",
+  "require-apikey-expiration-description": "有効にすると、有効期限が設定されたAPIキーのみがこの組織にアクセスできます",
   "require-number": "数字を必須にする",
   "require-special-character": "特殊文字を必須にする",
   "require-uppercase": "大文字を必須にする",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1192,7 +1192,7 @@
   "request-payload": "요청 페이로드",
   "requested": "요청된",
   "require-apikey-expiration": "API 키에 만료일 필수 설정",
-  "require-apikey-expiration-description": "활성화하면 이 조직의 모든 API 키에 만료일이 있어야 합니다",
+  "require-apikey-expiration-description": "활성화하면 만료일이 있는 API 키만 이 조직에 접근할 수 있습니다",
   "require-number": "숫자 필수",
   "require-special-character": "특수문자 필수",
   "require-uppercase": "대문자 필수",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Ładunek żądania",
   "requested": "żądany",
   "require-apikey-expiration": "Wymagaj daty wygaśnięcia dla kluczy API",
-  "require-apikey-expiration-description": "Po włączeniu wszystkie klucze API dla tej organizacji muszą mieć datę wygaśnięcia",
+  "require-apikey-expiration-description": "Po włączeniu tylko klucze API z datą wygaśnięcia mogą uzyskać dostęp do tej organizacji",
   "require-number": "Wymagaj cyfry",
   "require-special-character": "Wymagaj znaku specjalnego",
   "require-uppercase": "Wymagaj wielkiej litery",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Payload da requisição",
   "requested": "solicitado",
   "require-apikey-expiration": "Exigir que as chaves API tenham uma data de expiração",
-  "require-apikey-expiration-description": "Quando habilitado, todas as chaves API desta organização devem ter uma data de expiração",
+  "require-apikey-expiration-description": "Quando habilitado, apenas chaves API com data de expiração podem acessar esta organização",
   "require-number": "Exigir número",
   "require-special-character": "Exigir caractere especial",
   "require-uppercase": "Exigir maiúscula",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Тело запроса",
   "requested": "запрошенный",
   "require-apikey-expiration": "Требовать дату истечения для API-ключей",
-  "require-apikey-expiration-description": "При включении все API-ключи для этой организации должны иметь дату истечения",
+  "require-apikey-expiration-description": "При включении только API-ключи с датой истечения могут получить доступ к этой организации",
   "require-number": "Требовать цифру",
   "require-special-character": "Требовать специальный символ",
   "require-uppercase": "Требовать заглавную букву",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1192,7 +1192,7 @@
   "request-payload": "İstek yükü",
   "requested": "talep edilen",
   "require-apikey-expiration": "API anahtarlarının son kullanma tarihi olmasını zorunlu kıl",
-  "require-apikey-expiration-description": "Etkinleştirildiğinde, bu kuruluşun tüm API anahtarlarının bir son kullanma tarihi olması gerekir",
+  "require-apikey-expiration-description": "Etkinleştirildiğinde, yalnızca son kullanma tarihi olan API anahtarları bu kuruluşa erişebilir",
   "require-number": "Rakam gerekli",
   "require-special-character": "Özel karakter gerekli",
   "require-uppercase": "Büyük harf gerekli",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1192,7 +1192,7 @@
   "request-payload": "Payload yêu cầu",
   "requested": "đã yêu cầu",
   "require-apikey-expiration": "Yêu cầu khóa API phải có ngày hết hạn",
-  "require-apikey-expiration-description": "Khi được bật, tất cả các khóa API của tổ chức này phải có ngày hết hạn",
+  "require-apikey-expiration-description": "Khi được bật, chỉ những khóa API có ngày hết hạn mới có thể truy cập tổ chức này",
   "require-number": "Yêu cầu số",
   "require-special-character": "Yêu cầu ký tự đặc biệt",
   "require-uppercase": "Yêu cầu chữ hoa",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1192,7 +1192,7 @@
   "request-payload": "请求载荷",
   "requested": "请求的",
   "require-apikey-expiration": "要求API密钥必须设置过期日期",
-  "require-apikey-expiration-description": "启用后，此组织的所有API密钥必须设置过期日期",
+  "require-apikey-expiration-description": "启用后，只有设置了过期日期的API密钥才能访问此组织",
   "require-number": "要求数字",
   "require-special-character": "要求特殊字符",
   "require-uppercase": "要求大写字母",


### PR DESCRIPTION
## Summary

Corrects misleading i18n text in the API key expiration feature. The strings now accurately describe that only API keys without expiration dates are blocked from accessing the organization, not all user API keys globally.

## Test plan

Review the changed message in the organization security settings. Verify that the wording now correctly reflects the feature behavior across all 15 language files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)