### PR TITLE
Allow unpaid orgs to see app list and info tab

### DIFF
--- a/src/pages/app/index.vue
+++ b/src/pages/app/index.vue
@@ -33,47 +33,6 @@ const lacksSecurityAccess = computed(() => {
   return lacks2FA || lacksPassword
 })
 
-// Payment failed state (subscription required)
-const paymentFailed = computed(() => {
-  return organizationStore.currentOrganizationFailed && !lacksSecurityAccess.value
-})
-
-// Demo apps for showing behind blur when payment fails
-// Using any[] to avoid type instantiation depth issues with Database types
-const demoApps = [
-  {
-    app_id: 'com.demo.production',
-    name: 'Production App',
-    icon_url: '',
-    last_version: '2.1.0',
-    updated_at: new Date().toISOString(),
-    created_at: new Date().toISOString(),
-    owner_org: '',
-  },
-  {
-    app_id: 'com.demo.staging',
-    name: 'Staging App',
-    icon_url: '',
-    last_version: '2.2.0-beta',
-    updated_at: new Date(Date.now() - 86400000).toISOString(),
-    created_at: new Date().toISOString(),
-    owner_org: '',
-  },
-  {
-    app_id: 'com.demo.beta',
-    name: 'Beta App',
-    icon_url: '',
-    last_version: '3.0.0-alpha',
-    updated_at: new Date(Date.now() - 172800000).toISOString(),
-    created_at: new Date().toISOString(),
-    owner_org: '',
-  },
-] as any[]
-
-// Apps to display - use demo apps when payment failed
-const displayApps = computed(() => (paymentFailed.value ? demoApps : apps.value) as Database['public']['Tables']['apps']['Row'][])
-const displayTotal = computed(() => paymentFailed.value ? demoApps.length : totalApps.value)
-
 async function NextStep(appId: string) {
   console.log('Navigating to app with ID:', appId)
   router.push(`/app/${appId}`)
@@ -168,32 +127,26 @@ displayStore.defaultBack = '/app'
       <FailedCard />
     </div>
     <div v-else-if="!isLoading">
-      <!-- Show onboarding steps when no apps and no payment issue -->
-      <StepsApp v-if="stepsOpen && !paymentFailed" :onboarding="!apps.length" @done="NextStep" @close-step="stepsOpen = !stepsOpen" />
+      <!-- Show onboarding steps when no apps -->
+      <StepsApp v-if="stepsOpen" :onboarding="!apps.length" @done="NextStep" @close-step="stepsOpen = !stepsOpen" />
       <div v-else class="relative overflow-hidden pb-4 h-full">
         <div class="overflow-y-auto px-0 pt-0 mx-auto mb-8 w-full h-full sm:px-6 md:pt-8 lg:px-8 max-w-9xl max-h-fit">
-          <!-- App table - blurred when payment failed -->
-          <div
-            :class="{ 'blur-sm pointer-events-none select-none': paymentFailed }"
-            class="flex overflow-hidden overflow-y-auto flex-col bg-white border shadow-lg md:rounded-lg dark:bg-gray-800 border-slate-300 dark:border-slate-900"
-          >
+          <!-- App table - always visible even when payment failed -->
+          <div class="flex overflow-hidden overflow-y-auto flex-col bg-white border shadow-lg md:rounded-lg dark:bg-gray-800 border-slate-300 dark:border-slate-900">
             <AppTable
               v-model:current-page="currentPage"
               v-model:search="searchQuery"
-              :apps="displayApps"
-              :total="displayTotal"
-              :delete-button="!paymentFailed"
-              :server-side-pagination="!paymentFailed"
-              :is-loading="isTableLoading && !paymentFailed"
+              :apps="apps"
+              :total="totalApps"
+              :delete-button="!organizationStore.currentOrganizationFailed"
+              :server-side-pagination="true"
+              :is-loading="isTableLoading"
               @add-app="stepsOpen = !stepsOpen"
               @reload="getMyApps()"
               @reset="getMyApps()"
             />
           </div>
         </div>
-
-        <!-- Payment required overlay -->
-        <PaymentRequiredModal v-if="paymentFailed" />
       </div>
     </div>
     <div v-else class="flex flex-col justify-center items-center h-full">


### PR DESCRIPTION
## Summary (AI generated)

Allow customers with unpaid organizations to still view their app list and access the app info/settings tab, while restricting access to other feature tabs (dashboard, bundles, channels, devices, logs, builds).

## Motivation (AI generated)

When an organization's payment fails, customers should still have visibility into their apps and be able to view/manage app settings, but not access advanced features that require an active subscription.

## Business Impact (AI generated)

Improves customer experience for unpaid accounts by maintaining transparency and allowing users to manage their app information and prepare for reactivation. Prevents complete lockout of app management.

## Test Plan (AI generated)

- [ ] With a paid org: verify all tabs (dashboard, info, bundles, etc.) are visible
- [ ] With an unpaid org: verify only the info tab is visible
- [ ] With an unpaid org: attempt to access bundles/channels directly and verify redirect to info
- [ ] With an unpaid org: verify app list is fully visible without blur or demo apps
- [ ] Verify delete button is disabled for unpaid orgs in app list

Generated with AI