### PR TITLE
fix: create stripe_info synchronously on org creation to fix trial delay

### DIFF
--- a/supabase/migrations/20260115051444_sync_stripe_info_on_org_create.sql
+++ b/supabase/migrations/20260115051444_sync_stripe_info_on_org_create.sql
@@ -1,0 +1,62 @@
+-- Fix race condition: create stripe_info synchronously on org creation
+-- Pending customer_id (pending_{org_id}) is replaced with real Stripe customer_id by async handler
+
+CREATE OR REPLACE FUNCTION "public"."generate_org_user_stripe_info_on_org_create"() 
+    RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+AS $$
+DECLARE
+    solo_plan_stripe_id VARCHAR;
+    pending_customer_id VARCHAR;
+    trial_at_date TIMESTAMPTZ;
+BEGIN
+    INSERT INTO public.org_users (user_id, org_id, user_right) 
+    VALUES (NEW.created_by, NEW.id, 'super_admin'::"public"."user_min_right");
+    
+    IF NEW.customer_id IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+    
+    SELECT stripe_id INTO solo_plan_stripe_id 
+    FROM public.plans 
+    WHERE name = 'Solo' 
+    LIMIT 1;
+    
+    IF solo_plan_stripe_id IS NULL THEN
+        RAISE WARNING 'Solo plan not found, skipping sync stripe_info creation for org %', NEW.id;
+        RETURN NEW;
+    END IF;
+    
+    pending_customer_id := 'pending_' || NEW.id::text;
+    trial_at_date := NOW() + INTERVAL '15 days';
+    
+    INSERT INTO public.stripe_info (
+        customer_id,
+        product_id,
+        trial_at,
+        status,
+        is_good_plan
+    ) VALUES (
+        pending_customer_id,
+        solo_plan_stripe_id,
+        trial_at_date,
+        NULL,
+        true
+    );
+    
+    UPDATE public.orgs 
+    SET customer_id = pending_customer_id 
+    WHERE id = NEW.id;
+    
+    RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS "generate_org_user_on_org_create" ON "public"."orgs";
+
+CREATE TRIGGER "generate_org_user_stripe_info_on_org_create"
+    AFTER INSERT ON "public"."orgs"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."generate_org_user_stripe_info_on_org_create"();
+
+DROP FUNCTION IF EXISTS "public"."generate_org_user_on_org_create"();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -249,7 +249,7 @@ BEGIN
     ('2022-06-03 05:54:15+00', '', 'encrypted', 'Capgo', NULL, 'encrypted@capgo.app', 'f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f708193', NOW(), 't', 't');
     ALTER TABLE public.users ENABLE TRIGGER generate_org_on_user_create;
 
-    ALTER TABLE public.orgs DISABLE TRIGGER generate_org_user_on_org_create;
+    ALTER TABLE public.orgs DISABLE TRIGGER generate_org_user_stripe_info_on_org_create;
     INSERT INTO "public"."orgs" ("id", "created_by", "created_at", "updated_at", "logo", "name", "management_email", "customer_id") VALUES
     ('22dbad8a-b885-4309-9b3b-a09f8460fb6d', 'c591b04e-cf29-4945-b9a0-776d0672061a', NOW(), NOW(), '', 'Admin org', 'admin@capgo.app', 'cus_Pa0k8TO6HVln6A'),
     ('046a36ac-e03c-4590-9257-bd6c9dba9ee8', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Demo org', 'test@capgo.app', 'cus_Q38uE91NP8Ufqc'),
@@ -260,7 +260,7 @@ BEGIN
     ('f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f7a8b92', 'e5f6a7b8-c9d0-4e1f-8a2b-3c4d5e6f7a81', NOW(), NOW(), '', 'CLI Hashed Test Org', 'cli_hashed@capgo.app', 'cus_cli_hashed_test_123'),
     ('a7b8c9d0-e1f2-4a3b-9c4d-5e6f7a8b9ca4', 'f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f708193', NOW(), NOW(), '', 'Encrypted Test Org', 'encrypted@capgo.app', 'cus_encrypted_test_123'),
     ('e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a82', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Private Error Test Org', 'test@capgo.app', NULL);
-    ALTER TABLE public.orgs ENABLE TRIGGER generate_org_user_on_org_create;
+    ALTER TABLE public.orgs ENABLE TRIGGER generate_org_user_stripe_info_on_org_create;
 
     INSERT INTO public.usage_credit_grants (
       org_id,


### PR DESCRIPTION
## Summary (AI generated)

- Create `stripe_info` synchronously in the database trigger when a new org is created
- Use a temporary `pending_{org_id}` customer_id that is later replaced with the real Stripe customer_id
- Add `finalizePendingStripeCustomer()` function to safely swap pending → real customer_id
- Rename trigger function from `generate_org_user_on_org_create` to `generate_org_user_stripe_info_on_org_create`

## Motivation (AI generated)

When a user creates a new organization, they immediately see "subscription required" instead of their trial. This happens because:

1. Org creation inserts into `orgs` table (synchronous)
2. Trigger queues `on_organization_create` job to pgmq (async)
3. Frontend fetches orgs via `get_orgs_v7()` - but `stripe_info` doesn't exist yet
4. Since `stripe_info` is missing, `trial_left = 0` and user sees "subscription required"
5. ~10-60 seconds later, queue processes and creates `stripe_info` with trial

This fix creates `stripe_info` synchronously with a pending customer_id, so the trial is visible immediately.

## Business Impact (AI generated)

- **User Experience**: New users no longer see a confusing "subscription required" message for up to a minute after creating their account
- **Conversion**: Reduces friction during onboarding - users immediately see their 15-day trial instead of a payment wall
- **Support**: Eliminates potential support tickets from confused new users who think the trial isn't working

## Test Plan (AI generated)

- [ ] Create a new organization and verify trial shows immediately (no "subscription required" flash)
- [ ] Verify after ~10 seconds the pending customer_id is replaced with real Stripe customer_id
- [ ] Verify existing organizations are unaffected
- [ ] Run `bun test:backend` to ensure no regressions

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations now automatically initialize Stripe billing with a 15-day trial when created.
  * Added support for transitioning pending Stripe customers to finalized billing status.

* **Bug Fixes**
  * Ensures pending billing records are finalized and related temporary entries are cleaned up during onboarding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->