### PR TITLE
feat: add plugin version breakdown to global stats

### DIFF
--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1085,6 +1085,8 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          plugin_version_breakdown: Json
+          plugin_major_breakdown: Json
           plan_enterprise: number | null
           plan_enterprise_monthly: number
           plan_enterprise_yearly: number
@@ -1132,6 +1134,8 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plugin_version_breakdown?: Json
+          plugin_major_breakdown?: Json
           plan_enterprise?: number | null
           plan_enterprise_monthly?: number
           plan_enterprise_yearly?: number
@@ -1179,6 +1183,8 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plugin_version_breakdown?: Json
+          plugin_major_breakdown?: Json
           plan_enterprise?: number | null
           plan_enterprise_monthly?: number
           plan_enterprise_yearly?: number

--- a/supabase/migrations/20260113000000_add_plugin_breakdown_to_global_stats.sql
+++ b/supabase/migrations/20260113000000_add_plugin_breakdown_to_global_stats.sql
@@ -1,0 +1,13 @@
+-- Add plugin version breakdown columns to global_stats table
+-- This stores JSON breakdowns of plugin versions installed on devices
+
+-- Full plugin version breakdown (e.g., {"6.2.5": 45.2, "6.1.0": 30.1, ...})
+ALTER TABLE public.global_stats
+ADD COLUMN plugin_version_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+-- Major version breakdown (e.g., {"6": 75.3, "5": 20.5, ...})
+ALTER TABLE public.global_stats
+ADD COLUMN plugin_major_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+COMMENT ON COLUMN public.global_stats.plugin_version_breakdown IS 'JSON breakdown of plugin version percentages. Format: {"version": percentage, ...}';
+COMMENT ON COLUMN public.global_stats.plugin_major_breakdown IS 'JSON breakdown of plugin major version percentages. Format: {"major_version": percentage, ...}';


### PR DESCRIPTION
## Summary

Add daily plugin version distribution tracking to global stats. Captures percentage breakdown of plugin versions installed on devices, with both full version and major version aggregations.

## Test plan

- Verify migration creates two new JSONB columns: `plugin_version_breakdown` and `plugin_major_breakdown`
- Check that daily stats computation calculates correct percentages based on unique device plugin versions
- Validate JSON output format: `{"6.2.5": 45.2, "6.1.0": 30.1}` for full versions and `{"6": 75.3, "5": 20.5}` for major versions

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend`
- [ ] My change requires a change to the documentation
- [ ] My change has adequate E2E test coverage

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics now includes plugin version and major version breakdowns showing percentage distribution across the user base.
  * Plugin statistics are collected and aggregated over rolling 30-day periods for trend analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->