### PR TITLE
fix: ensure manifest file_size is updated

### DIFF
--- a/supabase/functions/_backend/triggers/on_manifest_create.ts
+++ b/supabase/functions/_backend/triggers/on_manifest_create.ts
@@ -23,8 +23,10 @@ async function updateManifestSize(c: Context, record: Database['public']['Tables
     .from('manifest')
     .update({ file_size: size })
     .eq('id', record.id)
-  if (updateError)
+  if (updateError) {
     cloudlog({ requestId: c.get('requestId'), message: 'error update manifest size', error: updateError })
+    throw simpleError('manifest_update_failed', 'Failed to update manifest file_size', { record, updateError })
+  }
 
   return c.json(BRES)
 }


### PR DESCRIPTION
## Summary

Fixed on_manifest_create trigger to ensure file_size is always updated in the database. Previously, when getSize returned 0, the update was skipped, leaving file_size as 0 in production. Now it throws an error to trigger queue retry.

## Test plan

- Queue system will retry on size=0 until getSize returns valid size
- When size > 0, database update succeeds and function returns success
- Logs show file_size_zero errors when S3 returns 0 size

## Checklist

- [x] Change has adequate logging for debugging
- [x] Queue retry mechanism ensures reliability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest file-size handling improved: zero-size files now log record context (id and path) and raise a retryable error.
  * Non-zero sizes follow a single, consistent update path to set file size; failures during update now surface explicit errors and are logged for clearer failure diagnosis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->