### PR TITLE
Improve file size display with smart unit formatting

### DIFF
--- a/src/components/tables/BundleTable.vue
+++ b/src/components/tables/BundleTable.vue
@@ -10,7 +10,7 @@ import { useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import IconSettings from '~icons/heroicons/cog-8-tooth'
 import IconTrash from '~icons/heroicons/trash'
-import { bytesToMbText } from '~/services/conversion'
+import { formatBytes } from '~/services/conversion'
 import { formatDate } from '~/services/date'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -440,7 +440,7 @@ columns.value = [
     sortable: true,
     displayFunction: (elem: Element) => {
       if (elem.size)
-        return bytesToMbText(elem.size)
+        return formatBytes(elem.size)
       else if (elem.external_url)
         return t('stored-externally')
       else if (elem.deleted)

--- a/src/pages/app/[package].bundle.[bundle].manifest.vue
+++ b/src/pages/app/[package].bundle.[bundle].manifest.vue
@@ -9,7 +9,7 @@ import { useRoute, useRouter } from 'vue-router'
 import IconDown from '~icons/ic/round-keyboard-arrow-down'
 import IconSearch from '~icons/ic/round-search?raw'
 import IconAlertCircle from '~icons/lucide/alert-circle'
-import { bytesToMbText } from '~/services/conversion'
+import { formatBytes } from '~/services/conversion'
 import { formatLocalDate } from '~/services/date'
 import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
@@ -69,7 +69,7 @@ const columns = ref<TableColumn[]>([
     mobile: false,
     displayFunction: (item: ManifestEntry) => {
       if (typeof item.file_size === 'number' && item.file_size > 0)
-        return bytesToMbText(item.file_size)
+        return formatBytes(item.file_size)
       return t('metadata-not-found')
     },
   },
@@ -123,7 +123,7 @@ const total = computed(() => displayEntries.value.length)
 
 const summarySizeLabel = computed(() => {
   if (summaryEntries.value.length === 0)
-    return bytesToMbText(0)
+    return formatBytes(0)
   let totalSize = 0
   let hasSize = false
   for (const entry of summaryEntries.value) {
@@ -132,7 +132,7 @@ const summarySizeLabel = computed(() => {
       hasSize = true
     }
   }
-  return hasSize ? bytesToMbText(totalSize) : t('metadata-not-found')
+  return hasSize ? formatBytes(totalSize) : t('metadata-not-found')
 })
 
 const compareStatusMessage = computed(() => {

--- a/src/pages/app/[package].bundle.[bundle].vue
+++ b/src/pages/app/[package].bundle.[bundle].vue
@@ -14,7 +14,7 @@ import IconDocumentDuplicate from '~icons/heroicons/document-duplicate'
 import IconTrash from '~icons/heroicons/trash'
 import IconSearch from '~icons/ic/round-search?raw'
 import IconAlertCircle from '~icons/lucide/alert-circle'
-import { bytesToMbText, getChecksumInfo } from '~/services/conversion'
+import { formatBytes, getChecksumInfo } from '~/services/conversion'
 import { formatDate, formatLocalDate } from '~/services/date'
 import { checkCompatibilityNativePackages, isCompatible, useSupabase } from '~/services/supabase'
 import { openVersion } from '~/services/versions'
@@ -144,7 +144,7 @@ const hasZip = computed(() => {
 
 const zipSizeLabel = computed(() => {
   if (version_meta.value?.size)
-    return bytesToMbText(version_meta.value.size)
+    return formatBytes(version_meta.value.size)
   if (version.value?.external_url)
     return t('stored-externally')
   return t('metadata-not-found')

--- a/src/services/conversion.ts
+++ b/src/services/conversion.ts
@@ -26,6 +26,26 @@ export function bytesToGBText(bytes: number) {
   return `${bytesToGb(bytes)} GB`
 }
 
+/**
+ * Formats bytes to a human-readable string with the appropriate unit (B, KB, MB, GB, TB).
+ * Automatically picks the right unit based on the size.
+ */
+export function formatBytes(bytes: number, decimals = 2): string {
+  if (bytes === 0)
+    return '0 B'
+  if (!Number.isFinite(bytes) || bytes < 0)
+    return '0 B'
+
+  const k = 1024
+  const dm = decimals < 0 ? 0 : decimals
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const index = Math.min(i, sizes.length - 1)
+
+  return `${Number.parseFloat((bytes / k ** index).toFixed(dm))} ${sizes[index]}`
+}
+
 export function getDaysBetweenDates(date1: string | Date, date2: string | Date) {
   const oneDay = 24 * 60 * 60 * 1000
   const firstDate = new Date(date1)


### PR DESCRIPTION
## Summary

Replace bytesToMbText with formatBytes to automatically display sizes in the appropriate unit (B, KB, MB, GB, TB) instead of always showing megabytes. Files smaller than 1 MB now display in KB or B, while larger files display in GB.

## Test plan

- Bundle list: verify sizes display correctly for bundles of different sizes
- Bundle manifest page: verify individual files and total size display with proper units
- Bundle detail page: verify zip file size displays with proper unit

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint`
- [ ] My change requires a change to the documentation
- [ ] My change has adequate E2E test coverage
- [x] I have tested my code manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and bundle size display throughout the app. Sizes now intelligently format to the most appropriate unit (B, KB, MB, GB, or TB) for better readability, replacing the previous formatting method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->