### PR TITLE
Fix MFA code space handling

### DIFF
--- a/src/pages/forgot_password.vue
+++ b/src/pages/forgot_password.vue
@@ -89,7 +89,7 @@ async function step2(form: { password: string, password_confirm: string }) {
             const { data: _verify, error: errorVerify } = await supabase.auth.mfa.verify({
               factorId: factor.id,
               challengeId: challenge.id,
-              code: mfaCode.value.replace(' ', ''),
+              code: mfaCode.value.replaceAll(' ', ''),
             })
             if (errorVerify) {
               toast.error(t('invalid-mfa-code'))

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -162,7 +162,7 @@ async function submit(form: { email: string, password: string, code: string }) {
     const verify = await supabase.auth.mfa.verify({
       factorId: mfaLoginFactor.value!.id!,
       challengeId: mfaChallengeId.value!,
-      code: form.code.replace(' ', ''),
+      code: form.code.replaceAll(' ', ''),
     })
 
     if (verify.error) {

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -177,7 +177,7 @@ async function submit(form: { password: string, password_confirm: string }) {
             const { data: _verify, error: errorVerify } = await supabase.auth.mfa.verify({
               factorId: factor.id,
               challengeId: challenge.id,
-              code: mfaCode.value.replace(' ', ''),
+              code: mfaCode.value.replaceAll(' ', ''),
             })
             if (errorVerify) {
               toast.error(t('invalid-mfa-code'))

--- a/src/pages/settings/account/index.vue
+++ b/src/pages/settings/account/index.vue
@@ -490,7 +490,7 @@ async function handleMfa() {
         id: 'verify',
         handler: async () => {
           // User has clicked the "verify button - let's check"
-          const verifyCode = mfaVerificationCode.value.replace(' ', '')
+          const verifyCode = mfaVerificationCode.value.replaceAll(' ', '')
 
           const { data: challenge, error: challengeError } = await supabase.auth.mfa.challenge({ factorId: data.id })
 


### PR DESCRIPTION
## Summary

Fixed MFA code input validation to correctly remove all spaces instead of just the first one. Changed `.replace(' ', '')` to `.replaceAll(' ', '')` in all four MFA code input handlers.

## Test Plan

- Test entering MFA codes with spaces: `123 456` → should become `123456`
- Test entering MFA codes with multiple spaces: `12 34 56` → should become `123456`
- Verify codes still work in all four locations: login, forgot password, change password, and account settings

## Checklist

- [x] Code follows project style and passes linting
- [ ] No documentation changes needed
- [ ] No E2E tests needed (input transformation fix)

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced MFA code input handling to remove all spaces from user-provided codes, improving verification reliability across login and account management pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->