### PR TITLE
fix: correct typo 'getm' to 'get' in MFA error messages

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -50,7 +50,7 @@ async function checkMfa() {
   const { data: mfaFactors, error: mfaError } = await supabase.auth.mfa.listFactors()
   if (mfaError) {
     setErrors('login-account', ['See browser console'], {})
-    console.error('Cannot getm MFA factors', mfaError)
+    console.error('Cannot get MFA factors', mfaError)
     return
   }
 
@@ -188,7 +188,7 @@ async function checkAuthUser() {
     const { data: mfaFactors, error } = await supabase.auth.mfa.listFactors()
     if (error) {
       setErrors('login-account', ['See browser console'], {})
-      console.error('Cannot getm MFA factors', error)
+      console.error('Cannot get MFA factors', error)
       return
     }
 

--- a/src/pages/settings/account/index.vue
+++ b/src/pages/settings/account/index.vue
@@ -527,7 +527,7 @@ async function handleMfa() {
 onMounted(async () => {
   const { data: mfaFactors, error } = await supabase.auth.mfa.listFactors()
   if (error) {
-    console.error('Cannot getm MFA factors', error)
+    console.error('Cannot get MFA factors', error)
     return
   }
 


### PR DESCRIPTION
## Summary

Fix typo in console error messages where "getm" was used instead of "get" in MFA error handling.

## Test plan

No functional changes, only console error messages corrected.

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] My change has adequate E2E test coverage