### PR TITLE
perf: add sendNotifOrgCached with smart TTL-based caching

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -10,7 +10,7 @@ import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
 import { isChannelSelfRateLimited, recordChannelSelfRequest } from '../utils/channelSelfRateLimit.ts'
 import { BRES, parseBody, simpleError200, simpleErrorWithStatus, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { sendNotifOrg } from '../utils/notifications.ts'
+import { sendNotifOrgCached } from '../utils/notifications.ts'
 import { sendNotifToOrgMembers } from '../utils/org_email_notifications.ts'
 import { closeClient, deleteChannelDevicePg, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getChannelDeviceOverridePg, getChannelsPg, getCompatibleChannelsPg, getDrizzleClient, getMainChannelsPg, getPgClient, setReplicationLagHeader, upsertChannelDevicePg } from '../utils/pg.ts'
 import { convertQueryToBody, makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
@@ -89,7 +89,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: app_id })
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
     // Send weekly notification about missing payment (not configurable - payment related)
-    backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+    backgroundTask(c, sendNotifOrgCached(c, 'org:missing_payment', {
       app_id,
       device_id,
       app_id_url: app_id,
@@ -275,7 +275,7 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: app_id })
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
     // Send weekly notification about missing payment (not configurable - payment related)
-    backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+    backgroundTask(c, sendNotifOrgCached(c, 'org:missing_payment', {
       app_id,
       device_id,
       app_id_url: app_id,
@@ -389,7 +389,7 @@ async function deleteOverride(c: Context, drizzleClient: ReturnType<typeof getDr
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: app_id })
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
     // Send weekly notification about missing payment (not configurable - payment related)
-    backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+    backgroundTask(c, sendNotifOrgCached(c, 'org:missing_payment', {
       app_id,
       device_id,
       app_id_url: app_id,
@@ -492,7 +492,7 @@ async function listCompatibleChannels(c: Context, drizzleClient: ReturnType<type
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
     // Send weekly notification about missing payment (not configurable - payment related)
     // Note: We don't have device_id in GET request for listing compatible channels
-    backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+    backgroundTask(c, sendNotifOrgCached(c, 'org:missing_payment', {
       app_id,
       app_id_url: app_id,
     }, appOwner.owner_org, app_id, '0 0 * * 1')) // Weekly on Monday

--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -8,7 +8,7 @@ import { z } from 'zod/mini'
 import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
 import { BRES, simpleError, simpleError200, simpleErrorWithStatus, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { sendNotifOrg } from '../utils/notifications.ts'
+import { sendNotifOrgCached } from '../utils/notifications.ts'
 import { closeClient, getAppOwnerPostgres, getAppVersionPostgres, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
 import { createStatsVersion, onPremStats, sendStatsAndDevice } from '../utils/stats.ts'
@@ -91,7 +91,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: app_id })
     await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
     // Send weekly notification about missing payment (not configurable - payment related)
-    backgroundTask(c, sendNotifOrg(c, 'org:missing_payment', {
+    backgroundTask(c, sendNotifOrgCached(c, 'org:missing_payment', {
       app_id,
       device_id: body.device_id,
       app_id_url: app_id,


### PR DESCRIPTION
## Summary (AI generated)

Adds `sendNotifOrgCached`, a caching wrapper for `sendNotifOrg` that dramatically reduces database queries in plugin endpoints (stats, updates, channel_self). The cache TTL is dynamically calculated based on the cron schedule and last send time, expiring exactly when the notification becomes sendable again.

## Motivation (AI generated)

`sendNotifOrg` is called multiple times in stats, updates, and channel_self endpoints and executes multiple database queries each time. Most of these calls result in "not sendable" because the notification was recently sent. By caching the "not sendable" result for the appropriate duration (until the next cron window), we eliminate redundant DB queries without risk of stale data.

## Business Impact (AI generated)

Reduces database load during high-traffic periods when the same orgs/events trigger notifications multiple times. This is especially valuable for the weekly `org:missing_payment` notifications which are checked during every stats/update/channel_self request.

## Test Plan (AI generated)

- [ ] Verify notifications still send on schedule (`'0 0 * * 1'` weekly on Monday)
- [ ] Verify cache expires at the correct time (when next cron window opens)
- [ ] Monitor database query metrics to confirm reduction in repeated sendNotifOrg checks
- [ ] Manual test: trigger stats/updates/channel_self endpoints and verify notification behavior unchanged

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized backend notification delivery system with caching layer to improve efficiency and reliability of scheduled notifications across organization and user events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->