### PR TITLE
perf: add sendNotifToOrgMembersCached with smart TTL-based caching

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -11,7 +11,7 @@ import { isChannelSelfRateLimited, recordChannelSelfRequest } from '../utils/cha
 import { BRES, parseBody, simpleError200, simpleErrorWithStatus, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { sendNotifOrgCached } from '../utils/notifications.ts'
-import { sendNotifToOrgMembers } from '../utils/org_email_notifications.ts'
+import { sendNotifToOrgMembersCached } from '../utils/org_email_notifications.ts'
 import { closeClient, deleteChannelDevicePg, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getChannelDeviceOverridePg, getChannelsPg, getCompatibleChannelsPg, getDrizzleClient, getMainChannelsPg, getPgClient, setReplicationLagHeader, upsertChannelDevicePg } from '../utils/pg.ts'
 import { convertQueryToBody, makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
 import { sendStatsAndDevice } from '../utils/stats.ts'
@@ -107,7 +107,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   }
   if (dataChannelOverride && !dataChannelOverride.channel_id.allow_device_self_set) {
     // Send weekly notification to org about self-assignment rejection
-    backgroundTask(c, sendNotifToOrgMembers(
+    backgroundTask(c, sendNotifToOrgMembersCached(
       c,
       'device:channel_self_set_rejected',
       'channel_self_rejected',
@@ -133,7 +133,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
 
   if (!dataChannel.allow_device_self_set) {
     // Send weekly notification to org about self-assignment rejection
-    backgroundTask(c, sendNotifToOrgMembers(
+    backgroundTask(c, sendNotifToOrgMembersCached(
       c,
       'device:channel_self_set_rejected',
       'channel_self_rejected',
@@ -432,7 +432,7 @@ async function deleteOverride(c: Context, drizzleClient: ReturnType<typeof getDr
 
   if (!dataChannelOverride.channel_id.allow_device_self_set) {
     // Send weekly notification to org about self-assignment rejection
-    backgroundTask(c, sendNotifToOrgMembers(
+    backgroundTask(c, sendNotifToOrgMembersCached(
       c,
       'device:channel_self_set_rejected',
       'channel_self_rejected',


### PR DESCRIPTION
## Summary

Add cached wrapper for `sendNotifToOrgMembers` to reduce database hits in high-frequency plugin endpoints like channel_self. The cache uses a smart TTL calculation based on cron schedule, so cached results expire exactly when notifications become sendable again. This follows the same pattern as the existing `sendNotifOrgCached` implementation.

## Test plan

- Verify channel_self endpoint returns 200 responses for channel rejection notifications
- Check that cache hits occur for repeated calls within the throttle window (weekly for channel_self_rejected)
- Confirm that log messages show "cache hit - not sendable" when cache is effective

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] My change has adequate E2E test coverage
- [x] I have tested my code manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced organization member notification system with a caching mechanism that reduces database queries and improves delivery efficiency through better rate-limiting support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->