### PR TITLE
Use drizzle read replica for org_users in notifications

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "capgo-app",


### PR DESCRIPTION
## Summary

Refactor notification system to use drizzle with read replica for org_users queries. The `getEligibleOrgMemberEmails` function now accepts a drizzle client parameter instead of creating its own PG connection, ensuring queries use the read replica and reducing load on primary database.

## Test plan

- Notification system continues to fetch org_users correctly from read replica
- Email notifications to org members are sent without issues
- No changes to notification behavior or email delivery

## Checklist

- [x] Code follows project style
- [ ] No documentation changes needed
- [x] Changes are backend only