### PR TITLE
Fix enterprise plan count in dashboard

### DIFF
--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -554,6 +554,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     plan_solo: plans.Solo,
     plan_maker: plans.Maker,
     plan_team: plans.Team,
+    plan_enterprise: plans.Enterprise || 0,
     // Revenue metrics
     mrr: revenue.mrr,
     total_revenue: revenue.total_revenue,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1115,6 +1115,7 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          plan_enterprise: number | null
           plan_enterprise_monthly: number
           plan_enterprise_yearly: number
           plan_maker: number | null
@@ -1169,6 +1170,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_enterprise?: number | null
           plan_enterprise_monthly?: number
           plan_enterprise_yearly?: number
           plan_maker?: number | null
@@ -1223,6 +1225,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_enterprise?: number | null
           plan_enterprise_monthly?: number
           plan_enterprise_yearly?: number
           plan_maker?: number | null


### PR DESCRIPTION
## Summary

Fixed the dashboard showing 0 pay-as-you-go (enterprise) users when there are actually 10. The issue was that the `plan_enterprise` field was never being populated in the global_stats table during the logsnag insights cron job.

## Test plan

After the next cron run, the dashboard should display the correct count of 10 enterprise plan users in the "Pay-as-you-go" card on the users tab.

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enterprise plan data tracking to the application's statistics system, enabling the collection and storage of enterprise plan metrics within analytics records. This enhancement provides improved visibility into enterprise plan performance and supports detailed reporting of enterprise-level usage patterns. The system is now better equipped to monitor and analyze enterprise plan activities across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->