### PR TITLE
Use shared locale date formatting in admin dashboard

### DIFF
--- a/src/pages/admin/dashboard/credits.vue
+++ b/src/pages/admin/dashboard/credits.vue
@@ -13,6 +13,7 @@ import { toast } from 'vue-sonner'
 import MagnifyingGlassIcon from '~icons/heroicons/magnifying-glass'
 import XMarkIcon from '~icons/heroicons/x-mark'
 import Spinner from '~/components/Spinner.vue'
+import { formatLocalDateTime } from '~/services/date'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
@@ -90,10 +91,6 @@ function getExpiresAt() {
 
 function formatCredits(value: number) {
   return new Intl.NumberFormat(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value)
-}
-
-function formatDate(date: string) {
-  return dayjs(date).format('MMM D, YYYY HH:mm')
 }
 
 async function searchOrgs(query: string) {
@@ -385,7 +382,7 @@ onMounted(async () => {
                   <span class="text-sm font-normal text-gray-500">/ {{ formatCredits(orgBalance.total_credits) }}</span>
                 </div>
                 <div v-if="orgBalance.next_expiration" class="text-sm text-gray-500 dark:text-gray-400">
-                  {{ t('admin-credits-expires') }}: {{ formatDate(orgBalance.next_expiration) }}
+                  {{ t('admin-credits-expires') }}: {{ formatLocalDateTime(orgBalance.next_expiration) }}
                 </div>
               </div>
               <div v-else class="mt-2 text-gray-500 dark:text-gray-400">
@@ -495,10 +492,10 @@ onMounted(async () => {
                     {{ grant.notes || '-' }}
                   </td>
                   <td class="px-4 py-3 text-gray-700 dark:text-gray-300">
-                    {{ formatDate(grant.granted_at) }}
+                    {{ formatLocalDateTime(grant.granted_at) }}
                   </td>
                   <td class="px-4 py-3 text-gray-700 dark:text-gray-300">
-                    {{ formatDate(grant.expires_at) }}
+                    {{ formatLocalDateTime(grant.expires_at) }}
                   </td>
                 </tr>
               </tbody>

--- a/src/pages/admin/dashboard/replication.vue
+++ b/src/pages/admin/dashboard/replication.vue
@@ -9,6 +9,7 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import AdminStatsCard from '~/components/admin/AdminStatsCard.vue'
 import Spinner from '~/components/Spinner.vue'
+import { formatLocalDateTime } from '~/services/date'
 import { defaultApiHost } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
@@ -93,7 +94,7 @@ const maxLagMinutes = computed(() => {
 const checkedAt = computed(() => {
   if (!data.value?.checked_at)
     return '-'
-  return new Date(data.value.checked_at).toLocaleString()
+  return formatLocalDateTime(data.value.checked_at)
 })
 
 async function loadReplicationStatus() {

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -14,6 +14,7 @@ import AdminMultiLineChart from '~/components/admin/AdminMultiLineChart.vue'
 import ChartCard from '~/components/dashboard/ChartCard.vue'
 import Spinner from '~/components/Spinner.vue'
 import Table from '~/components/Table.vue'
+import { formatLocalDate } from '~/services/date'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useAdminDashboardStore } from '~/stores/adminDashboard'
 import { useDisplayStore } from '~/stores/display'
@@ -139,8 +140,7 @@ const trialOrganizationsColumns = ref<TableColumn[]>([
     mobile: false,
     sortable: false,
     displayFunction: (item: TrialOrganization) => {
-      const date = new Date(item.trial_end_date)
-      return date.toLocaleDateString()
+      return formatLocalDate(item.trial_end_date)
     },
   },
 ])
@@ -156,8 +156,7 @@ const cancelledOrganizationsColumns = ref<TableColumn[]>([
     displayFunction: (item: CancelledOrganization) => {
       if (!item.canceled_at)
         return t('unknown')
-      const date = new Date(item.canceled_at)
-      return date.toLocaleDateString()
+      return formatLocalDate(item.canceled_at)
     },
   },
   {

--- a/src/services/date.ts
+++ b/src/services/date.ts
@@ -15,6 +15,8 @@ export function formatLocalDate(date: Date | string | undefined | null): string 
   if (!date)
     return ''
   const d = typeof date === 'string' ? new Date(date) : date
+  if (Number.isNaN(d.getTime()))
+    return ''
   return d.toLocaleDateString(getAppLocale())
 }
 
@@ -25,7 +27,21 @@ export function formatLocalDateLong(date: Date | string | undefined | null): str
   if (!date)
     return ''
   const d = typeof date === 'string' ? new Date(date) : date
+  if (Number.isNaN(d.getTime()))
+    return ''
   return d.toLocaleDateString(getAppLocale(), { month: 'long', day: 'numeric' })
+}
+
+/**
+ * Format a date/time using the app's locale (e.g., "Dec 15, 2025, 3:45 PM" in English)
+ */
+export function formatLocalDateTime(date: Date | string | undefined | null): string {
+  if (!date)
+    return ''
+  const d = typeof date === 'string' ? new Date(date) : date
+  if (Number.isNaN(d.getTime()))
+    return ''
+  return d.toLocaleString(getAppLocale(), { dateStyle: 'medium', timeStyle: 'short' })
 }
 
 export function formatDate(date: string | undefined) {


### PR DESCRIPTION
## Summary (AI generated)

- Use shared locale-aware date/time formatting in admin dashboard views.

## Test plan (AI generated)

- Not run (UI-only date formatting change).

## Screenshots (AI generated)

- Not applicable.

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated date formatting across admin dashboard pages for consistency and improved reliability.
  * Date displays for balances, grants, replication status, and organization information now use standardized formatting with proper validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->