### PR TITLE
Add rate limit reset headers to 429 responses

### DIFF
--- a/cloudflare_workers/snippet/index.js
+++ b/cloudflare_workers/snippet/index.js
@@ -167,6 +167,10 @@ async function setOnPremCache(hostname, appId, endpoint, method, responseBody, s
       ? Math.min(previousTtl * 2, ONPREM_CACHE_TTL_MAX_SECONDS)
       : ONPREM_CACHE_TTL_MIN_SECONDS
 
+    const resetAt = Date.now() + newTtl * 1000
+    const resetAtSeconds = Math.ceil(resetAt / 1000)
+    const retryAfter = new Date(resetAt).toUTCString()
+
     // Store the response cache
     const key = getOnPremCacheKey(hostname, appId, endpoint, method)
     const response = new Response(JSON.stringify(responseBody), {
@@ -177,6 +181,8 @@ async function setOnPremCache(hostname, appId, endpoint, method, responseBody, s
         'X-Onprem-Cached': 'true',
         'X-Onprem-App-Id': appId,
         'X-Onprem-Ttl': String(newTtl),
+        'X-RateLimit-Reset': String(resetAtSeconds),
+        'Retry-After': retryAfter,
       },
     })
     await cache.put(key, response)
@@ -218,6 +224,9 @@ async function setPlanUpgradeCache(hostname, appId, endpoint, method, responseBo
   try {
     const cache = caches.default
     const key = getPlanUpgradeCacheKey(hostname, appId, endpoint, method)
+    const resetAt = Date.now() + PLAN_UPGRADE_CACHE_TTL_SECONDS * 1000
+    const resetAtSeconds = Math.ceil(resetAt / 1000)
+    const retryAfter = new Date(resetAt).toUTCString()
     const response = new Response(JSON.stringify(responseBody), {
       status,
       headers: {
@@ -226,6 +235,8 @@ async function setPlanUpgradeCache(hostname, appId, endpoint, method, responseBo
         'X-Plan-Upgrade-Cached': 'true',
         'X-Plan-Upgrade-App-Id': appId,
         'X-Plan-Upgrade-Ttl': String(PLAN_UPGRADE_CACHE_TTL_SECONDS),
+        'X-RateLimit-Reset': String(resetAtSeconds),
+        'Retry-After': retryAfter,
       },
     })
     await cache.put(key, response)


### PR DESCRIPTION
## Summary (AI generated)

- Add rate limit reset metadata to 429 responses in worker and snippet
- Surface Retry-After and X-RateLimit-Reset headers from backend and cached 429s
- Include reset timestamps for API key/IP and channel/device rate limits

## Test plan (AI generated)

- bun lint

## Screenshots (AI generated)

- N/A

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes
      .
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced rate-limit responses with timing metadata, including X-RateLimit-Reset and Retry-After HTTP headers to inform clients when rate limits will reset.

* **Bug Fixes**
  * Improved rate-limit error handling by consistently including reset timing information across all endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->