### PR TITLE
Align snippet cache TTL with worker headers

### DIFF
--- a/cloudflare_workers/snippet/index.js
+++ b/cloudflare_workers/snippet/index.js
@@ -20,11 +20,11 @@ function getCircuitBreakerCacheKey(hostname, colo, workerUrl) {
 }
 
 function getOnPremCacheKey(hostname, appId, endpoint, method) {
-  return `https://${hostname}/__internal__/onprem-cache/${encodeURIComponent(appId)}/${endpoint}/${method}`
+  return `https://${hostname}/__internal__/onprem-cache-v2/${encodeURIComponent(appId)}/${endpoint}/${method}`
 }
 
 function getPlanUpgradeCacheKey(hostname, appId, endpoint, method) {
-  return `https://${hostname}/__internal__/plan-upgrade-cache/${encodeURIComponent(appId)}/${endpoint}/${method}`
+  return `https://${hostname}/__internal__/plan-upgrade-cache-v2/${encodeURIComponent(appId)}/${endpoint}/${method}`
 }
 
 // Endpoints that should be checked for on-prem caching
@@ -168,7 +168,7 @@ async function setOnPremCache(hostname, appId, endpoint, method, responseBody, s
     }
 
     const cache = caches.default
-    const cacheTags = `app-onprem:${appId}`
+    const cacheTags = `app-onprem-v2:${appId}`
     const headers = new Headers(responseHeaders)
     headers.set('Content-Type', 'application/json')
     headers.set('Cache-Tag', cacheTags)
@@ -213,7 +213,7 @@ async function setPlanUpgradeCache(hostname, appId, endpoint, method, responseBo
     }
 
     const cache = caches.default
-    const cacheTags = `app-plan:${appId}`
+    const cacheTags = `app-plan-v2:${appId}`
     const key = getPlanUpgradeCacheKey(hostname, appId, endpoint, method)
     const headers = new Headers(responseHeaders)
     headers.set('Content-Type', 'application/json')

--- a/supabase/functions/_backend/utils/appStatus.ts
+++ b/supabase/functions/_backend/utils/appStatus.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import { CacheHelper } from './cache.ts'
 import { backgroundTask } from './utils.ts'
 
-const APP_STATUS_CACHE_PATH = '/.app-status'
+const APP_STATUS_CACHE_PATH = '/.app-status-v2'
 const APP_STATUS_CACHE_TTL_SECONDS = 60
 
 export type AppStatus = 'cloud' | 'onprem' | 'cancelled'

--- a/supabase/functions/_backend/utils/cloudflare_cache_purge.ts
+++ b/supabase/functions/_backend/utils/cloudflare_cache_purge.ts
@@ -14,11 +14,11 @@ function parseZoneIds(raw: string): string[] {
 }
 
 export function buildOnPremCacheTag(appId: string) {
-  return `app-onprem:${appId}`
+  return `app-onprem-v2:${appId}`
 }
 
 export function buildPlanCacheTag(appId: string) {
-  return `app-plan:${appId}`
+  return `app-plan-v2:${appId}`
 }
 
 async function purgeByTags(c: Context, tags: string[]) {


### PR DESCRIPTION
## Summary (AI generated)

- Align on-prem/plan-upgrade cache TTLs in the Cloudflare snippet with worker Cache-Control headers.

## Test plan (AI generated)

- Not run (backend change only).

## Screenshots (AI generated)

- Not applicable.

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache behavior now dynamically respects upstream Cache-Control headers (s-maxage, max-age) for flexible TTL configuration
  * Improved cache management with automatic TTL calculation and enhanced handling of caching directives including no-store support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->