### PR TITLE
Reduce sensitive upload link logging

### DIFF
--- a/supabase/functions/_backend/private/upload_link.ts
+++ b/supabase/functions/_backend/private/upload_link.ts
@@ -22,8 +22,6 @@ app.post('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
   cloudlog({ requestId: c.get('requestId'), message: 'post upload link body', body })
   const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
   const capgkey = c.get('capgkey') as string
-  cloudlog({ requestId: c.get('requestId'), message: 'apikey', apikey })
-  cloudlog({ requestId: c.get('requestId'), message: 'capgkey', capgkey })
   const { data: _userId, error: _errorUserId } = await supabaseApikey(c, capgkey)
     .rpc('get_user_id', { apikey: capgkey, app_id: body.app_id })
   if (_errorUserId) {
@@ -72,7 +70,7 @@ app.post('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
 
   const url = await s3.getUploadUrl(c, filePath)
   if (!url) {
-    throw simpleError('cannot_get_upload_link', 'Cannot get upload link', { url })
+    throw simpleError('cannot_get_upload_link', 'Cannot get upload link')
   }
 
   const LogSnag = logsnag(c)
@@ -84,7 +82,7 @@ app.post('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
     notify: false,
   })
 
-  cloudlog({ requestId: c.get('requestId'), message: 'url', filePath, url })
+  cloudlog({ requestId: c.get('requestId'), message: 'upload link generated', filePath })
   const response = { url }
 
   const { error: changeError } = await supabaseApikey(c, capgkey)


### PR DESCRIPTION
## Summary (AI generated)

- Remove apikey/capgkey and URL logging from upload link handling while keeping a minimal audit log.

## Test plan (AI generated)

- Not run (not requested).

## Screenshots (AI generated)

- N/A.

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes
      
/Users/martindonadieu/conductor/workspaces/capgo/seattle-v2/src/pages/ApiKeys.vue
  16:8  error  'Table' is defined but never used  unused-imports/no-unused-imports

/Users/martindonadieu/conductor/workspaces/capgo/seattle-v2/src/pages/admin/dashboard/users.vue
  16:8  error  'Table' is defined but never used  unused-imports/no-unused-imports

/Users/martindonadieu/conductor/workspaces/capgo/seattle-v2/src/pages/settings/organization/Members.vue
  16:8  error  'Table' is defined but never used  unused-imports/no-unused-imports

✖ 3 problems (3 errors, 0 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option..
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI
