### PR TITLE
Skip version usage tracking for internal builds

### DIFF
--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -8,7 +8,7 @@ import { simpleError200 } from './hono.ts'
 import { cloudlog } from './logging.ts'
 import { countDevicesSB, getAppsFromSB, getUpdateStatsSB, readBandwidthUsageSB, readDevicesSB, readDeviceUsageSB, readStatsSB, readStatsStorageSB, readStatsVersionSB, supabaseWithAuth, trackBandwidthUsageSB, trackDevicesSB, trackDeviceUsageSB, trackLogsSB, trackMetaSB, trackVersionUsageSB } from './supabase.ts'
 import { DEFAULT_LIMIT } from './types.ts'
-import { backgroundTask } from './utils.ts'
+import { backgroundTask, isInternalVersionName } from './utils.ts'
 
 export function createStatsMau(c: Context, device_id: string, app_id: string, org_id: string, platform: string) {
   const lowerDeviceId = device_id
@@ -53,6 +53,8 @@ export function createStatsBandwidth(c: Context, device_id: string, app_id: stri
 
 export type VersionAction = 'get' | 'fail' | 'install' | 'uninstall'
 export function createStatsVersion(c: Context, version_name: string, app_id: string, action: VersionAction) {
+  if (isInternalVersionName(version_name))
+    return Promise.resolve()
   if (!c.env.VERSION_USAGE)
     return backgroundTask(c, trackVersionUsageSB(c, version_name, app_id, action))
   return trackVersionUsageCF(c, version_name, app_id, action)


### PR DESCRIPTION
## Summary (AI generated)

- Skip version usage tracking for internal version names.

## Test plan (AI generated)

- Not run (not requested).

## Screenshots (AI generated)

- N/A

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes
      .
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal version names are no longer included in tracking metrics, ensuring cleaner analytics data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->