### PR TITLE
Normalize plugin on-prem responses

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -6,7 +6,7 @@ import { greaterOrEqual, parse } from '@std/semver'
 import { Hono } from 'hono/tiny'
 import { z } from 'zod/mini'
 import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
-import { BRES, simpleError, simpleError200, simpleErrorWithStatus, simpleRateLimit } from '../utils/hono.ts'
+import { BRES, simpleError, simpleError200, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { sendNotifOrgCached } from '../utils/notifications.ts'
 import { closeClient, getAppOwnerPostgres, getAppVersionPostgres, getDrizzleClient, getPgClient } from '../utils/pg.ts'
@@ -240,7 +240,7 @@ app.post('/', async (c) => {
         return c.json(BRES)
       }
       if (result.error === 'need_plan_upgrade') {
-        return simpleErrorWithStatus(c, 429, result.error, result.message!, result.moreInfo)
+        return c.json({ error: 'on_premise_app', message: 'On-premise app detected' }, 429)
       }
       return simpleError200(c, result.error!, result.message!, result.moreInfo)
     }
@@ -266,7 +266,7 @@ app.post('/', async (c) => {
           results.push({ status: 'ok', index: i })
         }
         else if (result.error === 'need_plan_upgrade') {
-          return simpleErrorWithStatus(c, 429, result.error, result.message!, result.moreInfo)
+          return c.json({ error: 'on_premise_app', message: 'On-premise app detected' }, 429)
         }
         else {
           results.push({

--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -302,9 +302,9 @@ describe('[GET] /channel_self tests', () => {
     data.app_id = 'com.nonexistent.app'
     const response = await fetchGetChannels(data as any)
 
-    expect(response.status).toBe(200)
+    expect(response.status).toBe(429)
     const error = await getResponseErrorCode(response)
-    expect(error).toBe('app_not_found')
+    expect(error).toBe('on_premise_app')
   })
 
   it('[GET] should return compatible channels for iOS', async () => {

--- a/tests/cron_stat_org.test.ts
+++ b/tests/cron_stat_org.test.ts
@@ -210,7 +210,7 @@ describe('[POST] /triggers/cron_stat_org', () => {
     const updateResponse = await postUpdate(baseData)
 
     expect(updateResponse.status).toBe(429)
-    expect(await updateResponse.json<{ error: string }>().then(data => data.error)).toEqual('need_plan_upgrade')
+    expect(await updateResponse.json<{ error: string }>().then(data => data.error)).toEqual('on_premise_app')
   })
 
   it('should handle too big storage correctly', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Normalize plugin plan/cancelled responses to 429 on_premise_app for cache consistency.
- Keep /channel_self app-not-found aligned with on-prem semantics.
- Document cache behavior expectations in AGENTS.md.
- Update affected tests to match the new error response.

## Test plan (AI generated)

- bun lint

## Screenshots (AI generated)

- N/A (backend change)

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes
      .
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added HTTP response caching documentation describing the layered cache strategy, including edge-level and application-level caches for handling on-premise and plan-upgrade scenarios.

* **Bug Fixes**
  * Standardized error responses across API operations when on-premise applications are detected, ensuring consistent error messaging across channels, statistics, and update endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->