### PR TITLE
Ensure placeholder versions and mute Discord noise

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -9,7 +9,7 @@ import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
 import { BRES, simpleError, simpleError200, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { sendNotifOrgCached } from '../utils/notifications.ts'
-import { closeClient, getAppOwnerPostgres, getAppVersionPostgres, getDrizzleClient, getPgClient } from '../utils/pg.ts'
+import { closeClient, ensurePlaceholderVersions, getAppOwnerPostgres, getAppVersionPostgres, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
 import { createStatsMau, createStatsVersion, onPremStats, sendStatsAndDevice } from '../utils/stats.ts'
 import { backgroundTask, deviceIdRegex, INVALID_STRING_APP_ID, INVALID_STRING_DEVICE_ID, isLimited, MISSING_STRING_APP_ID, MISSING_STRING_DEVICE_ID, MISSING_STRING_PLATFORM, MISSING_STRING_VERSION_NAME, MISSING_STRING_VERSION_OS, NON_STRING_APP_ID, NON_STRING_DEVICE_ID, NON_STRING_PLATFORM, NON_STRING_VERSION_NAME, NON_STRING_VERSION_OS, reverseDomainRegex } from '../utils/utils.ts'
@@ -118,6 +118,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
       cloudlog({ requestId: c.get('requestId'), message: `Version name ${version_name} not found, using unknown instead`, app_id, version_name })
     }
     else {
+      backgroundTask(c, ensurePlaceholderVersions(c, app_id))
       return { success: false, error: 'version_not_found', message: 'Version not found', moreInfo: { app_id, version_name } }
     }
   }


### PR DESCRIPTION
## Summary (AI generated)
- Ensure builtin/unknown placeholders are created on stats version_not_found
- Suppress Discord alerts for expected version_not_found and no_channel queue failures

## Test plan (AI generated)
- bun lint

## Screenshots (AI generated)
- Not applicable

## Checklist (AI generated)
- [ ] My code follows the code style of this project and passes
      .
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system resilience by automatically creating placeholder app versions when unavailable, preventing potential downstream operation failures
  * Reduced monitoring false alerts by intelligently filtering non-critical error codes to improve incident visibility and response prioritization
  * Enhanced error tracking capabilities with detailed error code extraction, analysis, and categorization for background queue operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->