### PR TITLE
Enable RLS on security_settings table

### DIFF
--- a/supabase/migrations/20260204051137_enable_security_settings_rls.sql
+++ b/supabase/migrations/20260204051137_enable_security_settings_rls.sql
@@ -1,5 +1,5 @@
 -- Enable RLS on singleton security settings table
-ALTER TABLE "public"."security_settings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS "public"."security_settings" ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Deny access to security settings"
 ON "public"."security_settings"


### PR DESCRIPTION
## Summary (AI generated)

- Enable RLS on public.security_settings.

## Test plan (AI generated)

- `bun lint:backend`

## Screenshots (AI generated)

- N/A (backend-only change).

## Checklist (AI generated)

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented access restrictions at the database level for security settings to enforce protection against unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->