### PR TITLE
Fix audit_logs RLS timeout

### DIFF
--- a/supabase/migrations/20260205120000_fix_audit_logs_select_rls.sql
+++ b/supabase/migrations/20260205120000_fix_audit_logs_select_rls.sql
@@ -1,0 +1,155 @@
+-- Fix audit_logs unfiltered SELECT timeouts by avoiding per-row identity resolution.
+-- The previous policy called get_identity_org_allowed(keymode, org_id) per row, which:
+-- - parses request headers per row
+-- - queries apikeys per row
+-- - logs deny messages per row when no API key is provided
+-- On large tables this forces a slow scan and can saturate the DB under load.
+
+-- Compute the list of org_ids the current request can read audit logs for once per statement,
+-- then use a simple index-friendly predicate: org_id = ANY(...)
+CREATE OR REPLACE FUNCTION "public"."audit_logs_allowed_orgs"()
+RETURNS "uuid"[]
+LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_api_key_text text;
+  v_api_key public.apikeys%ROWTYPE;
+  v_allowed uuid[] := '{}'::uuid[];
+  v_org_id uuid;
+  v_use_rbac boolean;
+  v_perm text := public.rbac_permission_for_legacy(
+    public.rbac_right_super_admin(),
+    public.rbac_scope_org()
+  );
+  v_enforcing_2fa boolean;
+BEGIN
+  SELECT auth.uid() INTO v_user_id;
+
+  -- If no authenticated user, attempt Capgo API key auth (capgkey header).
+  IF v_user_id IS NULL THEN
+    SELECT public.get_apikey_header() INTO v_api_key_text;
+    IF v_api_key_text IS NULL THEN
+      RETURN v_allowed;
+    END IF;
+
+    SELECT * FROM public.find_apikey_by_value(v_api_key_text) INTO v_api_key;
+    IF v_api_key.id IS NULL THEN
+      RETURN v_allowed;
+    END IF;
+
+    IF NOT (v_api_key.mode = ANY('{read,upload,write,all}'::public.key_mode[])) THEN
+      RETURN v_allowed;
+    END IF;
+
+    IF public.is_apikey_expired(v_api_key.expires_at) THEN
+      RETURN v_allowed;
+    END IF;
+
+    v_user_id := v_api_key.user_id;
+  END IF;
+
+  -- Collect candidate orgs from legacy + RBAC bindings.
+  FOR v_org_id IN
+    SELECT DISTINCT org_id
+    FROM (
+      SELECT ou.org_id
+      FROM public.org_users ou
+      WHERE ou.user_id = v_user_id
+        AND ou.org_id IS NOT NULL
+        AND ou.app_id IS NULL
+        AND ou.channel_id IS NULL
+      UNION
+      SELECT rb.org_id
+      FROM public.role_bindings rb
+      WHERE rb.principal_type = public.rbac_principal_user()
+        AND rb.principal_id = v_user_id
+        AND rb.scope_type = public.rbac_scope_org()
+        AND rb.org_id IS NOT NULL
+      UNION
+      SELECT rb.org_id
+      FROM public.role_bindings rb
+      WHERE v_api_key.rbac_id IS NOT NULL
+        AND rb.principal_type = public.rbac_principal_apikey()
+        AND rb.principal_id = v_api_key.rbac_id
+        AND rb.scope_type = public.rbac_scope_org()
+        AND rb.org_id IS NOT NULL
+    ) candidates
+  LOOP
+    -- Enforce API key org restrictions (if present).
+    IF v_api_key.id IS NOT NULL
+      AND COALESCE(array_length(v_api_key.limited_to_orgs, 1), 0) > 0
+      AND NOT (v_org_id = ANY(v_api_key.limited_to_orgs))
+    THEN
+      CONTINUE;
+    END IF;
+
+    v_use_rbac := public.rbac_is_enabled_for_org(v_org_id);
+
+    IF NOT v_use_rbac THEN
+      -- Legacy rights (also enforces org 2FA + password policy).
+      IF public.check_min_rights_legacy(
+        'super_admin'::public.user_min_right,
+        v_user_id,
+        v_org_id,
+        NULL::character varying,
+        NULL::bigint
+      ) THEN
+        v_allowed := array_append(v_allowed, v_org_id);
+      END IF;
+    ELSE
+      -- Mirror check_min_rights() org gating for RBAC orgs (2FA + password policy).
+      SELECT o.enforcing_2fa INTO v_enforcing_2fa
+      FROM public.orgs o
+      WHERE o.id = v_org_id;
+
+      IF v_enforcing_2fa = true AND NOT public.has_2fa_enabled(v_user_id) THEN
+        CONTINUE;
+      END IF;
+
+      IF NOT public.user_meets_password_policy(v_user_id, v_org_id) THEN
+        CONTINUE;
+      END IF;
+
+      -- Allow if the user or the API key principal has the required RBAC permission.
+      IF public.rbac_has_permission(
+        public.rbac_principal_user(),
+        v_user_id,
+        v_perm,
+        v_org_id,
+        NULL::character varying,
+        NULL::bigint
+      ) THEN
+        v_allowed := array_append(v_allowed, v_org_id);
+      ELSIF v_api_key.id IS NOT NULL
+        AND v_api_key.rbac_id IS NOT NULL
+        AND public.rbac_has_permission(
+          public.rbac_principal_apikey(),
+          v_api_key.rbac_id,
+          v_perm,
+          v_org_id,
+          NULL::character varying,
+          NULL::bigint
+        )
+      THEN
+        v_allowed := array_append(v_allowed, v_org_id);
+      END IF;
+    END IF;
+  END LOOP;
+
+  RETURN v_allowed;
+END;
+$$;
+
+DROP POLICY IF EXISTS "Allow select for auth, api keys (super_admin+)" ON "public"."audit_logs";
+
+CREATE POLICY "Allow select for auth, api keys (super_admin+)" ON "public"."audit_logs"
+FOR SELECT TO "anon", "authenticated"
+USING (
+  "org_id" = ANY("public"."audit_logs_allowed_orgs"())
+);
+
+-- RLS policies execute functions as the caller; grant EXECUTE explicitly (default privileges were revoked).
+GRANT EXECUTE ON FUNCTION "public"."audit_logs_allowed_orgs"() TO "anon";
+GRANT EXECUTE ON FUNCTION "public"."audit_logs_allowed_orgs"() TO "authenticated";

--- a/supabase/tests/40_test_audit_log_apikey.sql
+++ b/supabase/tests/40_test_audit_log_apikey.sql
@@ -8,14 +8,51 @@ BEGIN;
 -- Org: 046a36ac-e03c-4590-9257-bd6c9dba9ee8
 -- App: com.demo.app
 
-SELECT plan(6);
+SELECT plan(9);
 
--- Test 1: Verify get_identity returns user_id when API key header is set
+-- Test 1: audit_logs_allowed_orgs should fail fast when no auth and no API key header is set
+DO $$
+BEGIN
+  PERFORM set_config('request.headers', '{}', true);
+END $$;
+
+SELECT
+  is(
+    public.audit_logs_allowed_orgs(),
+    '{}'::uuid[],
+    'audit_logs_allowed_orgs returns empty without auth or API key'
+  );
+
+-- Test 2: audit_logs_allowed_orgs should include the org for a valid API key
 DO $$
 BEGIN
   PERFORM set_config('request.headers', '{"capgkey": "ae6e7458-c46d-4c00-aa3b-153b0b8520ea"}', true);
 END $$;
 
+SELECT
+  ok(
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid = ANY(public.audit_logs_allowed_orgs()),
+    'audit_logs_allowed_orgs includes the org for API key requests'
+  );
+
+-- Test 3: policy should be implemented via audit_logs_allowed_orgs (avoid per-row identity resolution)
+SELECT
+  ok(
+    position(
+      'audit_logs_allowed_orgs' in (
+        SELECT pg_get_expr(p.polqual, p.polrelid)
+        FROM pg_policy p
+        JOIN pg_class c ON c.oid = p.polrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'audit_logs'
+          AND p.polname = 'Allow select for auth, api keys (super_admin+)'
+      )
+    ) > 0,
+    'audit_logs SELECT policy uses audit_logs_allowed_orgs()'
+  );
+
+-- Test 4: Verify get_identity returns user_id when API key header is set
 SELECT
     is(
         public.get_identity('{read,upload,write,all}'::public.key_mode []),
@@ -23,7 +60,7 @@ SELECT
         'get_identity with key_mode returns API key user_id'
     );
 
--- Test 2: Verify get_identity WITHOUT parameters returns NULL for API key (the old broken behavior)
+-- Test 5: Verify get_identity WITHOUT parameters returns NULL for API key (the old broken behavior)
 -- Note: This shows the original bug - parameterless get_identity doesn't check API keys
 SELECT
     is(
@@ -32,7 +69,7 @@ SELECT
         'get_identity without key_mode returns NULL for API key (original bug)'
     );
 
--- Test 3: Insert app_version with API key context and verify audit log is created
+-- Test 6: Insert app_version with API key context and verify audit log is created
 DO $$
 DECLARE
   v_version_id bigint;
@@ -63,7 +100,7 @@ END $$;
 
 SELECT ok(TRUE, 'app_version INSERT with API key creates audit log');
 
--- Test 4: Update app_version with API key context and verify audit log is created
+-- Test 7: Update app_version with API key context and verify audit log is created
 DO $$
 DECLARE
   v_audit_count int;
@@ -93,7 +130,7 @@ END $$;
 
 SELECT ok(TRUE, 'app_version UPDATE with API key creates audit log with changed_fields');
 
--- Test 5: Delete app_version with API key context and verify audit log is created
+-- Test 8: Delete app_version with API key context and verify audit log is created
 DO $$
 DECLARE
   v_version_id bigint;
@@ -128,7 +165,7 @@ END $$;
 
 SELECT ok(TRUE, 'app_version DELETE with API key creates audit log');
 
--- Test 6: Verify audit log contains correct old_record and new_record data
+-- Test 9: Verify audit log contains correct old_record and new_record data
 DO $$
 DECLARE
   v_version_id bigint;


### PR DESCRIPTION
## Summary (AI generated)
- Fix `audit_logs` unfiltered selects timing out by replacing per-row identity evaluation in RLS with statement-scoped `audit_logs_allowed_orgs()`.

## Motivation (AI generated)
- `/rest/v1/audit_logs?select=id&limit=1` timed out (57014) and parallel load caused other endpoints to time out.

## Business Impact (AI generated)
- Reduces DB load and prevents audit log queries from degrading unrelated API traffic.

## Test plan (AI generated)
- `bun lint:backend`
- `bun lint`
- `bun test:backend`

## Screenshots (AI generated)
- N/A

## Checklist (AI generated)
- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit log access control for API key authentication to properly restrict visibility based on organization permissions.

* **Tests**
  * Expanded test coverage for audit log access and API key-based audit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->