### PR TITLE
fix(backend): avoid header mutation after body stream

### DIFF
--- a/tests/pg-header-safety.test.ts
+++ b/tests/pg-header-safety.test.ts
@@ -10,7 +10,12 @@ describe('getDatabaseURL header safety', () => {
     let headerCalls = 0
     const ctx = {
       res,
-      env: {},
+      env: {
+        // Provide a deterministic code path that doesn't depend on host env vars.
+        HYPERDRIVE_CAPGO_DIRECT_EU: { connectionString: 'postgres://postgres:postgres@localhost:5432/postgres' },
+        // Included to satisfy environments where `getEnv()` might read from `c.env`.
+        SUPABASE_DB_URL: 'postgres://postgres:postgres@localhost:5432/postgres',
+      },
       header: () => {
         headerCalls++
         throw new TypeError('This ReadableStream is disturbed (has already been read from), and cannot be used as a body.')
@@ -37,7 +42,12 @@ describe('getDatabaseURL header safety', () => {
     let headerCalls = 0
     const ctx = {
       res,
-      env: {},
+      env: {
+        // Provide a deterministic code path that doesn't depend on host env vars.
+        HYPERDRIVE_CAPGO_DIRECT_EU: { connectionString: 'postgres://postgres:postgres@localhost:5432/postgres' },
+        // Included to satisfy environments where `getEnv()` might read from `c.env`.
+        SUPABASE_DB_URL: 'postgres://postgres:postgres@localhost:5432/postgres',
+      },
       header: () => {
         headerCalls++
         throw new TypeError('This ReadableStream is disturbed (has already been read from), and cannot be used as a body.')


### PR DESCRIPTION
## Summary (AI generated)

Prevent `TypeError: This ReadableStream is disturbed...` by making response header writes best-effort when the response body is already streaming (background `waitUntil()` tasks).

## Test plan (AI generated)

- `bun lint:backend`
- `bunx eslint tests/pg-header-safety.test.ts`
- `bunx vitest run tests/pg-header-safety.test.ts`

## Screenshots (AI generated)

N/A

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made header handling more robust so background tasks and streaming responses no longer crash.
  * Ensured consistent propagation of the selected database source across routing paths.

* **Tests**
  * Added tests verifying header safety when response bodies are consumed or streams are locked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->