### PR TITLE
Fix CORS preflight for stats export

### DIFF
--- a/supabase/functions/_backend/private/stats.ts
+++ b/supabase/functions/_backend/private/stats.ts
@@ -73,7 +73,9 @@ const exportSchema = z.object({
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
-app.use('/', useCors)
+// Browser clients call this endpoint and require CORS preflight (OPTIONS).
+// Use '*' so it also applies to sub-routes like '/export'.
+app.use('*', useCors)
 
 app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   const body = await parseBody<DataStats>(c)

--- a/tests/stats-export-cors.test.ts
+++ b/tests/stats-export-cors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { app } from '../supabase/functions/_backend/private/stats.ts'
+
+describe('[OPTIONS] /private/stats/export', () => {
+  it('responds to CORS preflight', async () => {
+    const res = await app.request('http://local/export', {
+      method: 'OPTIONS',
+      headers: {
+        'origin': 'http://localhost:5173',
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type,authorization',
+      },
+    })
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+    expect(res.headers.get('access-control-allow-methods')).toContain('OPTIONS')
+    expect(res.headers.get('access-control-allow-headers')?.toLowerCase()).toContain('authorization')
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Enable CORS middleware for all `/private/stats/*` routes so `OPTIONS /private/stats/export` is handled.

## Motivation (AI generated)

Browser log export uses `fetch()` and requires an `OPTIONS` preflight; without it, the API returned 404 and the export failed.

## Business Impact (AI generated)

Fixes console log export for users in browser contexts and reduces support noise around failed exports.

## Test Plan (AI generated)

- `bun lint:backend`
- `bun lint`
- `bunx vitest run tests/stats-export-cors.test.ts`

## Screenshots (AI generated)

- N/A

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CORS handling for the stats export endpoint to ensure proper browser compatibility and successful cross-origin requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->