### PR TITLE
fix(backend): prevent org existence oracle

### DIFF
--- a/tests/password-policy.test.ts
+++ b/tests/password-policy.test.ts
@@ -243,6 +243,24 @@ describe('[POST] /private/validate_password_compliance', () => {
     expect(responseData.error).toBe('not_member')
   })
 
+  it('returns policy errors for non-compliant member', async () => {
+    const response = await fetch(`${BASE_URL}/private/validate_password_compliance`, {
+      headers,
+      method: 'POST',
+      body: JSON.stringify({
+        email: USER_EMAIL,
+        password: USER_PASSWORD,
+        org_id: ORG_ID,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    const responseData = await response.json() as { error: string, moreInfo?: { errors?: string[] } }
+    expect(responseData.error).toBe('password_does_not_meet_policy')
+    expect(Array.isArray(responseData.moreInfo?.errors)).toBe(true)
+    expect(responseData.moreInfo!.errors!.length).toBeGreaterThan(0)
+  })
+
   it('reject request for org without password policy', async () => {
     const policyConfig = {
       enabled: true,


### PR DESCRIPTION
## Summary (AI generated)

- Prevent org existence probing via `/private/validate_password_compliance` by authenticating first and returning a stable `not_member` for non-members/non-existent orgs.
- Keep remediation working for password-policy non-compliant users by fetching org policy with service-role after membership verification (avoids `check_min_rights` password-policy enforcement loop).

## Motivation (AI generated)

`/private/validate_password_compliance` leaked org existence via status/error differences and must remain usable as the password-policy remediation path.

## Business Impact (AI generated)

Reduces org enumeration risk without breaking the password-policy compliance flow for legitimate users.

## Test Plan (AI generated)

- `bun lint:backend && bun lint`
- `bunx supabase db reset`
- `SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_ANON_KEY=<from bunx supabase status --output env> bun run test:backend -- tests/password-policy.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Password policy validation now enforces user authentication before verifying organization membership and retrieving policies.
  * Error responses improved to provide more specific feedback and prevent disclosing organization existence information.

* **Tests**
  * Updated test cases to validate new authentication flow and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->