### PR TITLE
fix(backend): revert argMaxIf to argMax in readDevicesCF query

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -599,9 +599,7 @@ export async function readDevicesCF(c: Context, params: ReadDevicesParams, custo
   argMax(blob2, timestamp) AS version_name,
   argMax(blob3, timestamp) AS plugin_version,
   argMax(blob4, timestamp) AS os_version,
-  -- Preserve the last non-empty custom_id so events that don't include it
-  -- (or blocked /stats traffic) don't clear owner-visible device metadata.
-  argMaxIf(blob5, timestamp, blob5 != '') AS custom_id,
+  argMax(blob5, timestamp) AS custom_id,
   argMax(blob6, timestamp) AS version_build,
   argMax(blob7, timestamp) AS default_channel,
   argMax(blob8, timestamp) AS key_id,


### PR DESCRIPTION
## Summary (AI generated)

- Reverted `argMaxIf(blob5, timestamp, blob5 != '')` back to `argMax(blob5, timestamp)` in the `readDevicesCF` query (`cloudflare.ts:602`)

## Motivation (AI generated)

Commit `5a4828b97` ("Gate device custom_id from /stats", #1615) introduced `argMaxIf` in the device list query to preserve the last non-empty `custom_id` when newer `/stats` pings write `''` to blob5. However, **`argMaxIf` is not a supported function in Cloudflare Analytics Engine SQL API**. The query fails with `"unknown function call: ARGMAXIF"`, the error is silently caught, and an empty `[]` is returned to the client.

This broke `POST /private/devices` for **all apps, all users** — the console device list has been returning empty since #1615 was merged.

Beyond the missing function, the `argMaxIf` approach was also logically flawed:
- It made it **impossible to unset** a device's `custom_id` — empty values were always ignored in favor of older non-empty ones, regardless of the `allow_device_custom_id` setting.
- It **contradicted the write side**, which intentionally strips `custom_id` to `''` when `allow_device_custom_id` is `false`.

`argMax(blob5, timestamp)` is correct: last write wins. If the write side clears `custom_id`, the read side should reflect that.

## Business Impact (AI generated)

**Critical / P0.** The device list in the Capgo console has been completely broken for all customers since #1615 was merged. No user can see their devices. This is a core feature of the dashboard and directly impacts customer experience and trust.

## Test Plan (AI generated)

- [x] Verified `argMaxIf` fails in CF Analytics Engine SQL Studio: `"Error: Input was invalid: unknown function call: ARGMAXIF"`
- [x] Verified `argMax` query returns correct results in CF Analytics Engine SQL Studio (11 rows for `com.shelf.app`)
- [x] Verified `device_info` dataset has 338M+ records with active writes (latest: 2026-02-11 14:32:15)
- [x] Deployed to preprod (`bun run deploy:cloudflare:api:preprod`) and tested `POST https://api.preprod.capgo.app/private/devices` — returns non-empty results
- [ ] Deploy to production and verify console device list works

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device custom ID now consistently reflects the most recent value, including when the ID has been cleared, so dashboards and exports match the current device state.
  * Reduces cases where an outdated non-empty custom ID persisted after removal, improving data accuracy in device views and reports.
  * No UI changes; users may notice corrected custom ID values appearing as blank when recently cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->