### PR TITLE
fix(frontend): don't show paywall for credits-only orgs

### DIFF
--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -189,7 +189,7 @@ export const useOrganizationStore = defineStore('organization', () => {
       currentOrganizationFailed.value = false
     }
     else {
-      currentOrganizationFailed.value = !(!!currentOrganizationRaw.paying || (currentOrganizationRaw.trial_left ?? 0) > 0)
+      currentOrganizationFailed.value = !(!!currentOrganizationRaw.paying || (currentOrganizationRaw.trial_left ?? 0) > 0 || !!currentOrganizationRaw.can_use_more)
     }
 
     // Clear caches when org changes to prevent showing stale data from other orgs
@@ -399,7 +399,7 @@ export const useOrganizationStore = defineStore('organization', () => {
       currentOrganizationFailed.value = false
     }
     else {
-      currentOrganizationFailed.value = !(!!currentOrganization.value?.paying || (currentOrganization.value?.trial_left ?? 0) > 0)
+      currentOrganizationFailed.value = !(!!currentOrganization.value?.paying || (currentOrganization.value?.trial_left ?? 0) > 0 || !!currentOrganization.value?.can_use_more)
     }
   }
 


### PR DESCRIPTION
## Summary (AI generated)

- Fixed `currentOrganizationFailed` check in the organization store to also consider `can_use_more` flag
- Two lines changed in `src/stores/organization.ts` — both places where the paywall state is computed

## Motivation (AI generated)

PR #1575 ("Allow credit usage without active plan") updated the backend so `get_orgs_v7()` returns `can_use_more: true` when an org has available credits, even without an active Stripe subscription. However, the frontend store still only checks `paying` and `trial_left` to decide whether to show the "subscription required" blocking modal. This means credits-only orgs (like with 5 credits, `paying: false`, `trial_left: 0`, `can_use_more: true`) get blocked by the paywall despite having valid credits.

## Business Impact (AI generated)

Credits-only / pay-as-you-go users are completely locked out of the dashboard by the paywall modal, even though the backend correctly allows them. This blocks the new use case that #1575 was designed to enable — users who buy credits without subscribing to a plan. Fixing this unblocks revenue from credit-only customers.

## Test Plan (AI generated)

- [x] Spoofed as Upfan org owner (`2e08b725-30cf-4098-8a9e-fe48a1c07306`) on localhost with production backend
- [x] Verified the "subscription required" PaymentRequiredModal no longer appears
- [x] Dashboard loads normally with all charts and data accessible
- [ ] Verify orgs with `paying: true` still work normally (no regression)
- [ ] Verify orgs with `trial_left > 0` still work normally (no regression)
- [ ] Verify orgs with `paying: false, trial_left: 0, can_use_more: false` still show the paywall

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where organizations could be incorrectly marked as failed, improving system reliability and reducing false failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->