### PR TITLE
fix(build): use supabaseAdmin for build status updates

### DIFF
--- a/supabase/migrations/20260215184121_fix_build_status_update_mark_stale_builds.sql
+++ b/supabase/migrations/20260215184121_fix_build_status_update_mark_stale_builds.sql
@@ -1,8 +1,0 @@
-UPDATE public.build_requests
-SET
-    status = 'failed',
-    last_error = 'Build timed out (stale for over 1 hour)',
-    updated_at = NOW()
-WHERE
-    status IN ('pending', 'running', 'in_progress')
-    AND updated_at < NOW() - INTERVAL '1 hour';


### PR DESCRIPTION
## Summary (AI generated)

- Switch `/build/status` endpoint from `supabaseApikey` (anon client) to `supabaseAdmin` for the `build_requests` UPDATE call

## Motivation (AI generated)

The `/build/status` endpoint correctly fetches real status from the builder API and returns it to the caller, but the corresponding `build_requests` row in the database was never actually updated. The root cause: only SELECT RLS policies exist for `anon`/`authenticated` on `build_requests` — no UPDATE policy.

Rather than adding an UPDATE RLS policy (which would let any API-key holder forge build status, error messages, and build times via direct PostgREST calls), the fix uses `supabaseAdmin` for this specific server-side write. Access control is already enforced upstream via RLS SELECT + `checkPermission()`, and the data written comes from the trusted builder API — not from user input.

Companion CLI PR: [Cap-go/CLI#496](https://github.com/Cap-go/CLI/pull/496) — ensures the CLI calls `/build/status` after the WebSocket delivers a terminal status.

## Business Impact (AI generated)

- **Dashboard now shows correct build state**: `status` and `last_error` columns are actually persisted, so BuildTable.vue can display real error details instead of perpetual "pending"
- **No security regression**: Avoids opening an UPDATE RLS policy that would be exploitable

## Test Plan (AI generated)

- [ ] Trigger a build via API, wait for it to complete/fail, verify `build_requests` row has updated `status` and `last_error`
- [ ] Verify the dashboard BuildTable shows the correct status and error details
- [ ] Confirm no UPDATE RLS policy was added — direct PostgREST update from anon/authenticated should still be denied

Generated with AI