### PR TITLE
fix: update broken API keys doc links

### DIFF
--- a/src/pages/ApiKeys.vue
+++ b/src/pages/ApiKeys.vue
@@ -798,7 +798,7 @@ getKeys()
           <div class="mb-2 ml-4">
             <a
               class="inline-flex items-center text-blue-500 underline rounded-sm focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 focus:outline-none"
-              href="https://capgo.app/docs/tooling/cli/"
+              href="https://capgo.app/docs/cli/reference/key/"
               target="_blank"
               rel="noopener noreferrer"
               :aria-label="`${t('cli-doc')} (opens in new tab)`"
@@ -811,7 +811,7 @@ getKeys()
             </a>
             <a
               class="inline-flex items-center ml-1 text-blue-500 underline rounded-sm focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 focus:outline-none"
-              href="https://capgo.app/docs/tooling/api/"
+              href="https://capgo.app/docs/public-api/api-keys/"
               target="_blank"
               rel="noopener noreferrer"
               :aria-label="`${t('api-doc')} (opens in new tab)`"


### PR DESCRIPTION
## Summary (AI generated)

- Fix broken API key page documentation links in `src/pages/ApiKeys.vue`.
- Update `CLI doc` link to `https://capgo.app/docs/cli/reference/key/`.
- Update `API doc` link to `https://capgo.app/docs/public-api/api-keys/`.

## Motivation (AI generated)

- The old `/docs/tooling/*` links on the API keys screen route users to a generic page instead of the intended docs.

## Business Impact (AI generated)

- Reduces user friction when accessing API key documentation and lowers support load from broken navigation.

## Test plan (AI generated)

- [x] Run `bun run lint:backend && bun run lint`.
- [ ] Open `/apikeys` in the web app and verify both links open the intended docs pages.

## Screenshots (AI generated)

- N/A (link target update only).

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI
