### PR TITLE
fix(frontend): Enforce correct order of organization settings tabs

### DIFF
--- a/src/constants/organizationTabs.ts
+++ b/src/constants/organizationTabs.ts
@@ -11,11 +11,10 @@ import IconUsers from '~icons/heroicons/users'
 export const organizationTabs: Tab[] = [
   { label: 'general', key: '/settings/organization', icon: IconInfo },
   { label: 'members', key: '/settings/organization/members', icon: IconUsers },
-  // Security tab is added dynamically in settings.vue for super_admins only
-  { label: 'security', key: '/settings/organization/security', icon: IconSecurity },
-  { label: 'audit-logs', key: '/settings/organization/auditlogs', icon: IconAudit },
   { label: 'plans', key: '/settings/organization/plans', icon: IconPlan },
-  { label: 'usage', key: '/settings/organization/usage', icon: IconChart },
   { label: 'credits', key: '/settings/organization/credits', icon: IconCredits },
+  { label: 'security', key: '/settings/organization/security', icon: IconSecurity },
+  { label: 'usage', key: '/settings/organization/usage', icon: IconChart },
+  { label: 'audit-logs', key: '/settings/organization/auditlogs', icon: IconAudit },
   { label: 'webhooks', key: '/settings/organization/webhooks', icon: IconWebhook },
 ]

--- a/src/layouts/settings.vue
+++ b/src/layouts/settings.vue
@@ -165,6 +165,19 @@ watchEffect(() => {
   if (!needsSecurity && hasSecurity)
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/security')
 
+  // Ensure tabs appear in the exact order defined by baseOrgTabs
+  organizationTabs.value.sort((a, b) => {
+    const idxA = baseOrgTabs.findIndex(t => t.key === a.key)
+    const idxB = baseOrgTabs.findIndex(t => t.key === b.key)
+    if (idxA === -1 && idxB === -1)
+      return 0
+    if (idxA === -1)
+      return 1
+    if (idxB === -1)
+      return -1
+    return idxA - idxB
+  })
+
   // Check billing access - users with org.read_billing permission can access billing
   if (!Capacitor.isNativePlatform()
     && billingEnabled


### PR DESCRIPTION
## Summary (AI generated)

- Reordered base organization tabs to match the requested hierarchy (General, Members, Plans, Credits, Security, Usage, Audit Logs, Webhooks)
- Added array sorting logic in the settings layout so dynamically appended tabs always respect the base order regardless of when permissions finish loading

## Motivation (AI generated)

Tabs like Plans, Credits, Security, and Usage were previously loaded asynchronously based on permissions and appended to the end of the array, resulting in an unpredictable display order.

## Business Impact (AI generated)

This ensures a consistent, predictable UX for organization settings, which improves user navigation efficiency.

## Test Plan (AI generated)

- [ ] Verify organization settings tabs display in the correct requested order: General, Members, Plans, Credits, Security, Usage, Audit Logs, Webhooks, Billing
- [ ] Verify tabs maintain their order even when permission checks return with latency

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Reorganized organization settings tabs order, with security, audit logs, and usage tabs now positioned differently for improved workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->