### PR TITLE
fix(frontend): sign out after account deletion

### DIFF
--- a/src/pages/settings/account/index.vue
+++ b/src/pages/settings/account/index.vue
@@ -319,8 +319,10 @@ async function performAccountDeletion(password: string) {
       return false
     }
 
-    // Reload the web page after successful account deletion
-    window.location.reload()
+    // Ensure the deleted account session is cleared to avoid being stuck on /accountDisabled
+    await main.logout()
+    toast.success(t('account-deleted-successfully'))
+    router.replace('/login')
     return true
   }
   catch (error) {


### PR DESCRIPTION
## Summary (AI generated)

- Replaced the post-`delete_user` hard reload in account settings with an explicit logout flow.
- After successful deletion request, the app now clears session state, shows a success toast, and redirects to `/login`.
- This prevents the stale deleted-account session from forcing users back to `/accountDisabled`.

## Motivation (AI generated)

The previous flow left the deleted account session active by reloading the page. Because auth guards check `is_account_disabled` for the current session user, users could appear locked to `/accountDisabled` until they manually cleared the session.

## Business Impact (AI generated)

- Reduces false lockout reports after account deletion.
- Improves account recovery UX on shared devices/browsers.
- Lowers support overhead related to perceived device-level bans.

## Test Plan (AI generated)

- [x] Run frontend lint on changed file: `bunx eslint src/pages/settings/account/index.vue`
- [ ] Manually verify flow:
- [ ] Delete account from Settings > Account
- [ ] Confirm redirect to `/login`
- [ ] Confirm logging in with a different account no longer loops to `/accountDisabled`

Generated with AI
