### PR TITLE
Fix org member RPC access controls

### DIFF
--- a/supabase/migrations/20260224000000_fix_org_member_rpc_access.sql
+++ b/supabase/migrations/20260224000000_fix_org_member_rpc_access.sql
@@ -19,7 +19,7 @@ BEGIN
   v_user_id := public.get_identity('{read,upload,write,all}'::public.key_mode[]);
   v_is_service_role := (
     ((SELECT auth.jwt() ->> 'role') = 'service_role')
-    OR ((SELECT current_user) IS NOT DISTINCT FROM 'postgres')
+    OR ((SELECT session_user) IS NOT DISTINCT FROM 'postgres')
   );
 
   IF NOT v_is_service_role THEN
@@ -58,7 +58,7 @@ DECLARE
 BEGIN
   v_is_service_role := (
     ((SELECT auth.jwt() ->> 'role') = 'service_role')
-    OR ((SELECT current_user) IS NOT DISTINCT FROM 'postgres')
+    OR ((SELECT session_user) IS NOT DISTINCT FROM 'postgres')
   );
 
   IF NOT v_is_service_role THEN
@@ -86,11 +86,10 @@ BEGIN
     FROM public.org_users o
     JOIN public.users ON users.id = o.user_id
     WHERE o.org_id = get_org_members.guild_id
-    AND public.is_member_of_org(users.id, o.org_id)
   UNION
     -- Get pending invitations from tmp_users
     SELECT
-      ((SELECT COALESCE(MAX(id), 0) FROM public.org_users) + tmp.id)::bigint AS aid,
+      (-tmp.id)::bigint AS aid,
       tmp.future_uuid AS uid,
       tmp.email::varchar,
       ''::varchar AS image_url,
@@ -108,7 +107,6 @@ ALTER FUNCTION "public"."get_org_members" ("guild_id" "uuid") OWNER TO "postgres
 
 GRANT EXECUTE ON FUNCTION "public"."get_org_members" ("guild_id" "uuid") TO "authenticated";
 GRANT EXECUTE ON FUNCTION "public"."get_org_members" ("guild_id" "uuid") TO "service_role";
-GRANT EXECUTE ON FUNCTION "public"."get_org_members" ("user_id" uuid, "guild_id" uuid) TO "authenticated";
 GRANT EXECUTE ON FUNCTION "public"."get_org_members" ("user_id" uuid, "guild_id" uuid) TO "service_role";
 REVOKE ALL ON FUNCTION "public"."get_org_members" ("guild_id" "uuid") FROM PUBLIC;
 REVOKE ALL ON FUNCTION "public"."get_org_members" ("user_id" uuid, "guild_id" uuid) FROM PUBLIC;
@@ -128,11 +126,11 @@ DECLARE
     v_user_id uuid;
     v_is_service_role boolean;
 BEGIN
-    v_user_id := public.get_identity('{read,upload,write,all}'::public.key_mode[]);
-    v_is_service_role := (
-      ((SELECT auth.jwt() ->> 'role') = 'service_role')
-      OR ((SELECT current_user) IS NOT DISTINCT FROM 'postgres')
-    );
+  v_user_id := public.get_identity('{read,upload,write,all}'::public.key_mode[]);
+  v_is_service_role := (
+    ((SELECT auth.jwt() ->> 'role') = 'service_role')
+    OR ((SELECT session_user) IS NOT DISTINCT FROM 'postgres')
+  );
 
     IF NOT v_is_service_role THEN
       IF v_user_id IS NULL OR NOT (
@@ -144,6 +142,7 @@ BEGIN
           NULL::bigint
         )
       ) THEN
+        PERFORM public.pg_log('deny: NO_RIGHTS', jsonb_build_object('org_id', check_org_members_password_policy.org_id, 'uid', v_user_id));
         RAISE EXCEPTION 'NO_RIGHTS';
       END IF;
     END IF;


### PR DESCRIPTION
## Summary (AI generated)

- Fixed privilege bypass in the org RPC migration by replacing `current_user` checks with `session_user`-based service-role/admin bypass logic in all affected SECURITY DEFINER functions.
- Removed redundant member validation in `get_org_members(user_id, guild_id)` and made temporary invitation `aid` values stable.
- Removed execute grant to `authenticated` for the two-argument inner `get_org_members` overload.
- Added missing `NO_RIGHTS` audit logging in `check_org_members_password_policy` before denial.

## Motivation (AI generated)

- The previous migration allowed potential authorization bypass and exposed sensitive organization member and password-policy data.
- The inner overload was callable by authenticated roles and included an ineffective authorization branch due `current_user` semantics under SECURITY DEFINER.
- This PR restores defense-in-depth and aligns behavior with other hardened RPC access patterns.

## Business Impact (AI generated)

- Prevents cross-organization member enumeration and sensitive org-data leakage.
- Restores audit visibility for denied password-policy checks.
- Reduces exposed attack surface by keeping inner RPC implementation functions non-public.

## Test Plan (AI generated)

- [x] Run `bun lint:backend`.
- [x] Run `sqlfluff lint --dialect postgres supabase/migrations/20260224000000_fix_org_member_rpc_access.sql` (tooling run; reports repository-wide SQL style constraints for context).
- [ ] Confirm an authenticated caller with no access to a target org cannot call `get_org_members` or `check_org_members_password_policy` without `NO_RIGHTS`.
- [ ] Confirm `service_role`/`postgres` paths still function for internal jobs/administrative callers as intended.
- [ ] Confirm invite rows return stable negative `aid` values and non-stable collision-prone arithmetic is removed.
- [ ] Verify `authenticated` can only execute the one-argument wrapper `get_org_members` path, and not the inner `(user_id, guild_id)` overload.

Generated with AI
