### PR TITLE
fix(database): enforce org-scoped webhook RLS

### DIFF
--- a/supabase/migrations/20260224100000_fix_webhook_rls_org_scoping.sql
+++ b/supabase/migrations/20260224100000_fix_webhook_rls_org_scoping.sql
@@ -1,0 +1,184 @@
+-- =============================================================================
+-- Migration: Fix webhook RLS policies for org-scoped API key isolation
+--
+-- The 20260107000000 migration introduced anon role support for webhook endpoints,
+-- but still resolves identity through get_identity(...), which does not enforce
+-- limited_to_orgs. This allows read-mode API keys scoped to a single org to read
+-- webhook secrets and delivery logs from other orgs.
+--
+-- This migration switches webhook and webhook_deliveries RLS checks to
+-- get_identity_org_allowed(..., org_id), so org restrictions from API keys are
+-- enforced per row.
+-- =============================================================================
+
+-- =====================================================
+-- Recreate webhooks policies with org-scoped API key identity
+-- =====================================================
+
+DROP POLICY IF EXISTS "Allow org members to select webhooks" ON public.webhooks;
+DROP POLICY IF EXISTS "Allow admin to insert webhooks" ON public.webhooks;
+DROP POLICY IF EXISTS "Allow admin to update webhooks" ON public.webhooks;
+DROP POLICY IF EXISTS "Allow admin to delete webhooks" ON public.webhooks;
+
+CREATE POLICY "Allow org members to select webhooks"
+ON public.webhooks
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'read'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);
+
+CREATE POLICY "Allow admin to insert webhooks"
+ON public.webhooks
+FOR INSERT
+TO authenticated, anon
+WITH CHECK (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);
+
+CREATE POLICY "Allow admin to update webhooks"
+ON public.webhooks
+FOR UPDATE
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+)
+WITH CHECK (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);
+
+CREATE POLICY "Allow admin to delete webhooks"
+ON public.webhooks
+FOR DELETE
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);
+
+-- =====================================================
+-- Recreate webhook_deliveries policies with org-scoped API key identity
+-- =====================================================
+
+DROP POLICY IF EXISTS "Allow org members to select webhook_deliveries" ON public.webhook_deliveries;
+DROP POLICY IF EXISTS "Allow admin to insert webhook_deliveries" ON public.webhook_deliveries;
+DROP POLICY IF EXISTS "Allow admin to update webhook_deliveries" ON public.webhook_deliveries;
+
+CREATE POLICY "Allow org members to select webhook_deliveries"
+ON public.webhook_deliveries
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'read'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);
+
+CREATE POLICY "Allow admin to insert webhook_deliveries"
+ON public.webhook_deliveries
+FOR INSERT
+TO authenticated, anon
+WITH CHECK (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);
+
+CREATE POLICY "Allow admin to update webhook_deliveries"
+ON public.webhook_deliveries
+FOR UPDATE
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity_org_allowed(
+                    '{read,upload,write,all}'::public.key_mode [],
+                    org_id
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);


### PR DESCRIPTION
## Summary (AI generated)

- Added `supabase/migrations/20260224100000_fix_webhook_rls_org_scoping.sql` to harden webhook table RLS.
- Updated `public.webhooks` SELECT/INSERT/UPDATE/DELETE policies to use `public.get_identity_org_allowed('{read,upload,write,all}'::public.key_mode [], org_id)` inside `public.check_min_rights(...)`.
- Updated `public.webhook_deliveries` SELECT/INSERT/UPDATE policies to use `public.get_identity_org_allowed('{read,upload,write,all}'::public.key_mode [], org_id)`.
- Maintained `TO authenticated, anon` role coverage to preserve API key and user-authenticated access paths.
- Prevents cross-tenant reads of webhook secrets and delivery payload/body when using org-scoped read keys.

## Motivation (AI generated)

Security review identified tenant isolation bypasses on webhook PostgREST access: org-scoped read API keys were able to query webhook rows outside their org because policies resolved identity via `get_identity(...)` instead of an org-aware helper. This migration enforces org-scoped identity checks in webhook RLS.

## Business Impact (AI generated)

- Removes exposure of another tenant’s webhook signing secrets and delivery data.
- Reduces risk of forged webhook events and downstream endpoint abuse.
- Restores correct tenant isolation for webhook operations, strengthening trust and compliance for multi-tenant users.

## Test Plan (AI generated)

- [x] Ran `bun lint`.
- [ ] Deploy/push migration to local Supabase test environment.
- [ ] Verify org-scoped read key can only query webhook rows for allowed `org_id` values.
- [ ] Verify attempts to read non-authorized webhook rows return no data.
- [ ] Spot-check existing webhook flows for expected behavior with admin credentials.

Generated with AI
