### PR TITLE
fix: restrict webhook secret access to admin-only

### DIFF
--- a/supabase/migrations/20260224000000_fix_webhooks_select_permission.sql
+++ b/supabase/migrations/20260224000000_fix_webhooks_select_permission.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- Migration: Restrict webhooks read access to admin keys only
+--
+-- Previously, org members with read permissions could query the webhooks table
+-- through Supabase REST and retrieve the signing `secret`, which allows spoofed
+-- webhook events. This keeps non-admin clients from reading secrets while still
+-- allowing admin-managed access through existing authenticated flows.
+-- =============================================================================
+
+-- Ensure previous webhook SELECT policies are replaced with admin-only access.
+DROP POLICY IF EXISTS "Allow org members to select webhooks" ON public.webhooks;
+DROP POLICY IF EXISTS "Allow admin to select webhooks" ON public.webhooks;
+
+CREATE POLICY "Allow admin to select webhooks"
+ON public.webhooks
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        (
+            SELECT
+                public.get_identity(
+                    '{read,upload,write,all}'::public.key_mode []
+                )
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);


### PR DESCRIPTION
## Summary (AI generated)

- Added migration `20260224000000_fix_webhooks_select_permission.sql` to restrict `SELECT` access on `public.webhooks` to admin-level API credentials.
- Replaced the prior org member read policy with an admin-only policy to prevent non-admin/read keys from retrieving webhook signing secrets.
- Kept webhook write/update/delete policies unchanged so admin-managed create/update/delete workflows remain unaffected.

## Motivation (AI generated)

A security report shows non-admin/read API keys could query `/rest/v1/webhooks` and read `secret` values. That secret enables forging signed webhook payloads. This change closes that data leak at the RLS layer.

## Business Impact (AI generated)

This restores webhook integrity by preventing signed request forgery from keys with read-only permission, protecting downstream automation, billing/workflow triggers, and customer event pipelines from unauthorized event injection.

## Test Plan (AI generated)

- [x] Ran `bun lint`.
- [x] Ran `bun lint:backend`.
- [ ] Apply migration in a non-production environment and verify non-admin/read API keys can no longer select webhook rows or `secret`.
- [ ] Verify admin API keys can still read webhook configuration as expected.
- [ ] Validate existing webhook delivery/test flows using admin keys remain functional.

Generated with AI
