### PR TITLE
fix(db): harden transfer_app against app id enumeration

### DIFF
--- a/supabase/migrations/20260224120000_fix_transfer_app_security.sql
+++ b/supabase/migrations/20260224120000_fix_transfer_app_security.sql
@@ -1,0 +1,126 @@
+-- Restrict transfer_app execution to authenticated contexts and avoid app
+-- enumeration through distinct error payloads.
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM anon;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM public;
+
+CREATE OR REPLACE FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+    v_old_org_id uuid;
+    v_user_id uuid;
+    v_last_transfer jsonb;
+    v_last_transfer_date timestamp;
+BEGIN
+  SELECT owner_org, transfer_history[array_length(transfer_history, 1)]
+  INTO v_old_org_id, v_last_transfer
+  FROM public.apps
+  WHERE app_id = p_app_id;
+
+  IF v_old_org_id IS NULL THEN
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  v_user_id := (SELECT auth.uid());
+
+  IF v_user_id IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NO_AUTH',
+      jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      v_old_org_id,
+      p_app_id,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_OLD_ORG_RIGHTS',
+      jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      p_new_org_id,
+      NULL::character varying,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NEW_ORG_RIGHTS',
+      jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF v_last_transfer IS NOT NULL THEN
+    v_last_transfer_date := (v_last_transfer->>'transferred_at')::timestamp;
+    IF v_last_transfer_date + interval '32 days' > now() THEN
+      RAISE EXCEPTION
+          'Cannot transfer app. Must wait at least 32 days '
+          'between transfers. Last transfer was on %',
+          v_last_transfer_date;
+    END IF;
+  END IF;
+
+  UPDATE public.apps
+  SET
+      owner_org = p_new_org_id,
+      updated_at = now(),
+      transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
+          'transferred_at', now(),
+          'transferred_from', v_old_org_id,
+          'transferred_to', p_new_org_id,
+          'initiated_by', v_user_id
+      )::jsonb
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions_meta
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channel_devices
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channels
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+END;
+$$;
+
+COMMENT ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) IS 'Transfers an app and all its related data to a new '
+'organization. Requires app.transfer permission on both '
+'source and destination organizations.';


### PR DESCRIPTION
## Summary (AI generated)

- Removed anonymous access to `public.transfer_app` via `REVOKE ALL ... FROM anon` in a new migration.
- Updated `transfer_app` to return a uniform error message for non-existent apps and unauthorized requests when called without valid user context.
- Kept transfer permission checks and cooldown logic intact while adding explicit unauthenticated call logging.
- Ran SQL lint on the updated migration file to satisfy repo formatting and SQL style checks.

## Motivation (AI generated)

`transfer_app` was previously callable by the anonymous/publiable role, allowing unauthenticated callers to infer valid `app_id` values from distinct error payloads. This is a confidentiality/tenant-enumeration risk.

## Business Impact (AI generated)

- Prevents anonymous app-identifier enumeration that can aid targeted abuse or reconnaissance.
- Preserves existing transfer safeguards while reducing information disclosure risk.
- Keeps behavior for authenticated workflows unchanged where applicable.

## Test Plan (AI generated)

- [x] `bunx sqlfluff lint --dialect postgres supabase/migrations/20260224120000_fix_transfer_app_security.sql`
- [ ] Deploy migration to a staging Supabase instance and confirm anon `rest/v1/rpc/transfer_app` requests cannot transfer or enumerate app IDs.
- [ ] Confirm authenticated transfer path still functions for authorized users with valid app/org permissions.

Generated with AI
