### PR TITLE
fix(org): require admin 2FA before org-wide enforcement

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,6 +10,7 @@
   "2fa-enforcement-disabled": "2FA enforcement has been disabled.",
   "2fa-enforcement-enable-anyway": "Enable Anyway",
   "2fa-enforcement-enabled": "2FA enforcement has been enabled for this organization.",
+  "2fa-enforcement-self-2fa-required": "Enable two-factor authentication on your account before applying organization-wide 2FA enforcement.",
   "2fa-enforcement-title": "Require 2FA for All Members",
   "2fa-enforcement-warning-description": "Some organization members do not have 2FA enabled. Once you enable enforcement, they will be locked out of the organization until they enable 2FA.",
   "2fa-enforcement-warning-title": "Members Will Be Impacted",

--- a/src/pages/settings/organization/Security.vue
+++ b/src/pages/settings/organization/Security.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { FunctionsHttpError } from '@supabase/supabase-js'
 import { computedAsync } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, ref, watch } from 'vue'
@@ -384,12 +385,27 @@ async function save2faEnforcement(value: boolean) {
   isSaving.value = true
 
   try {
-    const { error } = await supabase
-      .from('orgs')
-      .update({ enforcing_2fa: value })
-      .eq('id', currentOrganization.value.gid)
+    const { error } = await supabase.functions.invoke('organization', {
+      method: 'PUT',
+      body: {
+        orgId: currentOrganization.value.gid,
+        enforcing_2fa: value,
+      },
+    })
 
     if (error) {
+      if (error instanceof FunctionsHttpError && error.context instanceof Response) {
+        try {
+          const payload = await error.context.clone().json<{ error?: string }>()
+          if (payload.error === 'requires_2fa_to_enforce_2fa') {
+            toast.error(t('2fa-enforcement-self-2fa-required'))
+            return
+          }
+        }
+        catch {
+          console.warn('Could not parse org security function error payload')
+        }
+      }
       console.error('Error updating 2FA enforcement:', error)
       toast.error(t('error-saving-settings'))
       return

--- a/supabase/functions/_backend/public/organization/put.ts
+++ b/supabase/functions/_backend/public/organization/put.ts
@@ -5,7 +5,7 @@ import { z } from 'zod/mini'
 import { quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { createSignedImageUrl, normalizeImagePath } from '../../utils/storage.ts'
-import { apikeyHasOrgRightWithPolicy, supabaseApikey } from '../../utils/supabase.ts'
+import { apikeyHasOrgRightWithPolicy, supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
 
 const bodySchema = z.object({
   orgId: z.string(),
@@ -15,6 +15,7 @@ const bodySchema = z.object({
   require_apikey_expiration: z.optional(z.boolean()),
   max_apikey_expiration_days: z.optional(z.nullable(z.number())),
   enforce_hashed_api_keys: z.optional(z.boolean()),
+  enforcing_2fa: z.optional(z.boolean()),
 })
 
 function parseBody(bodyRaw: unknown) {
@@ -68,7 +69,21 @@ function buildUpdateFields(body: z.infer<typeof bodySchema>) {
     updateFields.max_apikey_expiration_days = body.max_apikey_expiration_days
   if (body.enforce_hashed_api_keys !== undefined)
     updateFields.enforce_hashed_api_keys = body.enforce_hashed_api_keys
+  if (body.enforcing_2fa !== undefined)
+    updateFields.enforcing_2fa = body.enforcing_2fa
   return updateFields
+}
+
+async function enforceSelf2faRequirement(authUserId: string, c: Context<MiddlewareKeyVariables>) {
+  const { data: has2faEnabled, error } = await supabaseAdmin(c)
+    .rpc('has_2fa_enabled', { user_id: authUserId })
+
+  if (error) {
+    throw quickError(500, 'cannot_check_2fa', 'Cannot verify your 2FA status', { error: error.message })
+  }
+  if (!has2faEnabled) {
+    throw simpleError('requires_2fa_to_enforce_2fa', 'You must enable 2FA before enforcing it for your organization')
+  }
 }
 
 async function updateOrg(
@@ -93,9 +108,18 @@ async function updateOrg(
 export async function put(c: Context<MiddlewareKeyVariables>, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
   const body = parseBody(bodyRaw)
   const supabase = supabaseApikey(c, apikey.key)
+  const authUserId = c.get('auth')?.userId
 
   // Auth context is already set by middlewareKey
   await ensureOrgAccess(c, apikey, body.orgId, supabase)
+
+  if (body.enforcing_2fa && authUserId) {
+    await enforceSelf2faRequirement(authUserId, c)
+  }
+  else if (body.enforcing_2fa) {
+    throw simpleError('cannot_access_organization', 'You can\\'t access this organization', { orgId: body.orgId })
+  }
+
   validateMaxExpirationDays(body.max_apikey_expiration_days)
   const updateFields = buildUpdateFields(body)
   const dataOrg = await updateOrg(supabase, body.orgId, updateFields)


### PR DESCRIPTION
## Summary (AI generated)

- Added backend enforcement in \`supabase/functions/_backend/public/organization/put.ts\` to require admins to have 2FA enabled before enabling organization-wide 2FA via \`enforcing_2fa\`.
- Updated the organization security settings UI flow in \`src/pages/settings/organization/Security.vue\` to call the organization edge function for 2FA enforcement updates and surface a dedicated message when the new guard blocks the action.
- Added user-facing copy in \`messages/en.json\` for the new 2FA prerequisite error.

## Motivation (AI generated)

Allowing organization-wide 2FA enforcement without self-2FA can create inconsistent security policy application and potential admin misuse. This patch enforces hierarchical security by validating the actor's security posture before applying the org policy.

## Business Impact (AI generated)

- Prevents policy settings from being applied by admins who have not enabled 2FA, improving internal security posture.
- Reduces support risk from accidental lockouts and policy misuse.
- Improves trust in enforcement controls visible to organization members.

## Test Plan (AI generated)

- [x] Ran \`bun lint\` (passes after changes).
- [ ] Verify updating 2FA enforcement in org settings now fails with a clear error when actor 2FA is not enabled.
- [ ] Verify enabling/disabling 2FA enforcement succeeds once actor 2FA is enabled.

Generated with AI
