### PR TITLE
Restrict webhook RLS select to admin only

### DIFF
--- a/supabase/migrations/20260225120000_restrict_webhooks_select_for_admin_only.sql
+++ b/supabase/migrations/20260225120000_restrict_webhooks_select_for_admin_only.sql
@@ -1,0 +1,29 @@
+-- =============================================================================
+-- Migration: Restrict webhook secret exposure to admin readers
+--
+-- Reverts the org-reader regression introduced in
+-- 20260224153200_fix_webhook_rls_org_scoping.sql. Non-admin/API-key users
+-- with read-only rights were able to query `public.webhooks` directly and read
+-- signing `secret` values.
+-- =============================================================================
+
+-- Ensure only admin users can SELECT webhook rows.
+DROP POLICY IF EXISTS "Allow org members to select webhooks" ON public.webhooks;
+DROP POLICY IF EXISTS "Allow admin to select webhooks" ON public.webhooks;
+
+CREATE POLICY "Allow admin to select webhooks"
+ON public.webhooks
+FOR SELECT
+TO authenticated, anon
+USING (
+    public.check_min_rights(
+        'admin'::public.user_min_right,
+        public.get_identity_org_allowed(
+            '{read,upload,write,all}'::public.key_mode[],
+            org_id
+        ),
+        org_id,
+        null::character varying,
+        null::bigint
+    )
+);


### PR DESCRIPTION
## Summary (AI generated)
- Removed the read-only `webhooks` RLS policy and kept `SELECT` access restricted to admin-level identities only.
- Updated the webhook policy migration to close a direct REST path that exposed `secret` for org members with read rights.

## Test Plan (AI generated)
- [x] Ran `bun lint` and confirmed it completed successfully.
- [x] Reviewed `git diff origin/main...` to validate only the intended migration file is included.
- [ ] Run a regression check with a read-only API key against `public.webhooks` REST endpoint to confirm `secret` is no longer retrievable.

## Screenshots
- Not applicable (backend migration only).

## Checklist (AI generated)
- [x] My code follows the code style of this project and passes lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests.
