### PR TITLE
fix: return 503 for service_unavailable build errors

### DIFF
--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
-import { simpleError } from '../../utils/hono.ts'
+import { quickError, simpleError } from '../../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
@@ -129,7 +129,7 @@ export async function requestBuild(
       builder_url_configured: !!builderUrl,
       builder_api_key_configured: !!builderApiKey,
     })
-    throw simpleError('service_unavailable', 'Build service unavailable (builder not configured)')
+    throw quickError(503, 'service_unavailable', 'Build service unavailable (builder not configured)')
   }
 
   try {
@@ -186,7 +186,7 @@ export async function requestBuild(
         app_id,
         platform,
       })
-      throw simpleError('service_unavailable', 'Build service unavailable (builder error)')
+      throw quickError(503, 'service_unavailable', 'Build service unavailable (builder error)')
     }
   }
   catch (error) {
@@ -201,7 +201,7 @@ export async function requestBuild(
       app_id,
       platform,
     })
-    throw simpleError('service_unavailable', 'Build service unavailable (builder call failed)')
+    throw quickError(503, 'service_unavailable', 'Build service unavailable (builder call failed)')
   }
 
   const upload_expires_at = new Date(Date.now() + 60 * 60 * 1000)
@@ -214,7 +214,7 @@ export async function requestBuild(
       builder_url: builderUrl,
       builder_api_key_present: !!builderApiKey,
     })
-    throw simpleError('service_unavailable', 'Build service unavailable (upload URL missing)')
+    throw quickError(503, 'service_unavailable', 'Build service unavailable (upload URL missing)')
   }
 
   const upload_url = `${getEnv(c, 'PUBLIC_URL') || 'https://api.capgo.app'}/build/upload/${builderJob.jobId}`

--- a/supabase/functions/_backend/public/build/upload.ts
+++ b/supabase/functions/_backend/public/build/upload.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
-import { simpleError } from '../../utils/hono.ts'
+import { quickError, simpleError } from '../../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
@@ -33,7 +33,7 @@ export async function tusProxy(
       message: 'Builder not configured for TUS proxy',
       job_id: jobId,
     })
-    throw simpleError('service_unavailable', 'Builder service not configured')
+    throw quickError(503, 'service_unavailable', 'Builder service not configured')
   }
 
   // Use authenticated client for data queries - RLS will enforce access


### PR DESCRIPTION
## Summary
- Replace `simpleError('service_unavailable', ...)` (HTTP 400) with `quickError(503, ...)` at 5 call sites in the build request/upload flow
- Builder availability errors are transient server-side failures, not client errors — 503 is the semantically correct status
- This enables the CLI's existing retry logic (3 attempts with 1s/3s/5s backoff) to automatically retry these failures

## Test plan
- [ ] Verify builder unavailable errors now return HTTP 503
- [ ] Verify CLI retries on 503 responses
- [ ] Verify non-service_unavailable errors (missing_parameter, unauthorized, etc.) still return 400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved error handling consistency in backend service requests. Error responses are now standardized for certain failure scenarios, enhancing system reliability monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->