### PR TITLE
fix(security): clean up role_bindings on member removal

### DIFF
--- a/supabase/functions/_backend/public/organization/members/delete.ts
+++ b/supabase/functions/_backend/public/organization/members/delete.ts
@@ -48,6 +48,19 @@ export async function deleteMember(c: Context<MiddlewareKeyVariables>, bodyRaw: 
   if (error) {
     throw simpleError('error_deleting_user_from_organization', 'Error deleting user from organization', { error })
   }
+
+  // Clean up RBAC role bindings for the removed user in this org (all scopes)
+  const { error: rbacError } = await supabaseAdmin(c)
+    .from('role_bindings')
+    .delete()
+    .eq('principal_type', 'user')
+    .eq('principal_id', userData.id)
+    .eq('org_id', body.orgId)
+
+  if (rbacError) {
+    throw simpleError('error_deleting_role_bindings', 'Error deleting role bindings for user', { error: rbacError })
+  }
+
   cloudlog({ requestId: c.get('requestId'), message: 'User deleted from organization', data: { user_id: userData.id, org_id: body.orgId } })
   return c.json(BRES)
 }

--- a/tests/organization-api.test.ts
+++ b/tests/organization-api.test.ts
@@ -325,6 +325,19 @@ describe('[DELETE] /organization/members', () => {
     })
     expect(error).toBeNull()
 
+    // Seed a role_binding to verify it gets cleaned up on member removal
+    const { data: roleData } = await getSupabaseClient().from('roles').select('id').eq('name', 'org_member').single()
+    expect(roleData).toBeTruthy()
+    const { error: rbacInsertError } = await getSupabaseClient().from('role_bindings').insert({
+      principal_type: 'user',
+      principal_id: userData!.id,
+      role_id: roleData!.id,
+      scope_type: 'org',
+      org_id: ORG_ID,
+      granted_by: USER_ID,
+    })
+    expect(rbacInsertError).toBeNull()
+
     const response = await fetch(`${BASE_URL}/organization/members?orgId=${ORG_ID}&email=${USER_ADMIN_EMAIL}`, {
       headers,
       method: 'DELETE',
@@ -340,6 +353,10 @@ describe('[DELETE] /organization/members', () => {
     const { data, error: orgUserError } = await getSupabaseClient().from('org_users').select().eq('org_id', ORG_ID).eq('user_id', userData!.id).single()
     expect(orgUserError).toBeTruthy()
     expect(data).toBeNull()
+
+    // Verify role_bindings were also cleaned up
+    const { data: rbacData } = await getSupabaseClient().from('role_bindings').select().eq('principal_type', 'user').eq('principal_id', userData!.id).eq('org_id', ORG_ID)
+    expect(rbacData).toHaveLength(0)
   })
 
   it('delete organization member with invalid body', async () => {


### PR DESCRIPTION
## Summary

- Fixes RBAC privilege persistence vulnerability where removed org members retained their role bindings (Cap-go/capgo#1667)
- `deleteMember` now deletes all `role_bindings` entries for the user within the org (all scopes: org, app, channel, bundle) after removing from `org_users`
- Uses `supabaseAdmin` — permission already validated via `checkPermission('org.update_user_roles')` before any mutations

## Test plan

- [ ] `'delete organization member'` test extended: seeds an `org_member` role_binding before deletion, asserts it is removed after
- [ ] All other member deletion error-case tests unchanged
- [ ] Run `bun test tests/organization-api.test.ts` to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization member removal to ensure all associated role bindings and access controls are properly cleaned up when a user is removed from an organization.

* **Tests**
  * Added test coverage to verify that role bindings are completely removed along with the user when organization members are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->