### PR TITLE
fix(security): block SSRF bypass vectors in webhook URL validation

### DIFF
--- a/supabase/functions/_backend/utils/webhook.ts
+++ b/supabase/functions/_backend/utils/webhook.ts
@@ -48,6 +48,31 @@ export type WebhookEventType = typeof WEBHOOK_EVENT_TYPES[number]
 const LOCALHOST_SUFFIX = '.localhost'
 const IPV4_REGEX = /^\d{1,3}(?:\.\d{1,3}){3}$/
 
+// Known domains that resolve to localhost (SSRF bypass vectors)
+const BLOCKED_LOCALHOST_DOMAINS = new Set([
+  'localtest.me',
+  'vcap.me',
+  'lvh.me',
+  'lacolhost.com',
+  'yoogle.com',
+])
+
+// DNS rebinding service suffixes (SSRF bypass vectors)
+const BLOCKED_DNS_REBINDING_SUFFIXES = [
+  '.nip.io',
+  '.xip.io',
+  '.sslip.io',
+  '.traefik.me',
+]
+
+// Cloud metadata hostnames (SSRF targets)
+const BLOCKED_METADATA_HOSTNAMES = new Set([
+  'metadata.google.internal',
+  'metadata.goog',
+  'metadata',
+  'instance-data',
+])
+
 function allowLocalWebhookUrls(c: Context): boolean {
   return getEnv(c, 'CAPGO_ALLOW_LOCAL_WEBHOOK_URLS') === 'true'
 }
@@ -64,6 +89,28 @@ function isIpLiteral(hostname: string): boolean {
   return IPV4_REGEX.test(hostname) || hostname.includes(':')
 }
 
+function isBlockedLocalhostDomain(hostname: string): boolean {
+  if (BLOCKED_LOCALHOST_DOMAINS.has(hostname))
+    return true
+  for (const domain of BLOCKED_LOCALHOST_DOMAINS) {
+    if (hostname.endsWith(`.${domain}`))
+      return true
+  }
+  return false
+}
+
+function isDnsRebindingService(hostname: string): boolean {
+  for (const suffix of BLOCKED_DNS_REBINDING_SUFFIXES) {
+    if (hostname.endsWith(suffix))
+      return true
+  }
+  return false
+}
+
+function isCloudMetadataHostname(hostname: string): boolean {
+  return BLOCKED_METADATA_HOSTNAMES.has(hostname)
+}
+
 export function getWebhookUrlValidationError(c: Context, urlString: string): string | null {
   let url: URL
   try {
@@ -77,11 +124,24 @@ export function getWebhookUrlValidationError(c: Context, urlString: string): str
     return null
 
   const hostname = normalizeHostname(url.hostname)
+
   if (isLocalhostHostname(hostname))
     return 'Webhook URL must point to a public host'
 
   if (isIpLiteral(hostname))
     return 'Webhook URL must use a hostname, not an IP address'
+
+  // Block known localhost domains (SSRF bypass prevention)
+  if (isBlockedLocalhostDomain(hostname))
+    return 'Webhook URL must point to a public host'
+
+  // Block DNS rebinding services (SSRF bypass prevention)
+  if (isDnsRebindingService(hostname))
+    return 'Webhook URL must not use DNS rebinding services'
+
+  // Block cloud metadata endpoints (SSRF target prevention)
+  if (isCloudMetadataHostname(hostname))
+    return 'Webhook URL must point to a public host'
 
   if (url.protocol !== 'https:')
     return 'Webhook URL must use HTTPS'


### PR DESCRIPTION
## Summary

This PR fixes SSRF (Server-Side Request Forgery) bypass vulnerabilities in the webhook URL validation.

## Security Issue

The existing validation in `getWebhookUrlValidationError()` could be bypassed using:

1. **DNS rebinding services**: `169.254.169.254.nip.io` resolves to AWS/GCP metadata endpoint
2. **Known localhost domains**: `localtest.me`, `vcap.me` resolve to `127.0.0.1`
3. **Cloud metadata hostnames**: `metadata.google.internal`

## Impact

- Access to cloud metadata endpoints (AWS/GCP credentials)
- Access to internal services
- Data exfiltration

## Changes

Added blocklists for:
- Known localhost domains (`localtest.me`, `vcap.me`, `lvh.me`, etc.)
- DNS rebinding service suffixes (`.nip.io`, `.xip.io`, `.sslip.io`, etc.)
- Cloud metadata hostnames (`metadata.google.internal`, etc.)

## Testing

The following URLs are now correctly blocked:
- `https://169.254.169.254.nip.io/` - DNS rebinding to metadata
- `https://localtest.me/` - Resolves to 127.0.0.1
- `https://metadata.google.internal/` - GCP metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook URL validation has been strengthened with additional endpoint checks. Some webhook URLs that previously worked may no longer be accepted during validation. If your webhooks fail validation, review and update your webhook URLs accordingly. Additional endpoint patterns are now blocked. Contact support if you need assistance with your webhook configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->