### PR TITLE
fix: remove auto-open of demo onboarding modal

### DIFF
--- a/src/components/dashboard/DemoOnboardingGate.vue
+++ b/src/components/dashboard/DemoOnboardingGate.vue
@@ -54,10 +54,8 @@ const shouldShowDemoOnNoApps = computed(() => {
   if (path === '/login' || path === '/register' || path === '/forgot_password' || path === '/resend_email' || path === '/onboarding' || path === '/scan')
     return false
 
-  if (shouldForceShowDemoOnboarding.value)
-    return true
-
-  return shouldShowDemoOnboarding.value && !isDemoOnboardingClosed.value
+  // Only show when explicitly requested via query param
+  return shouldForceShowDemoOnboarding.value
 })
 
 function updateDemoOnboardingState() {


### PR DESCRIPTION
The demo modal no longer auto-opens when users have no apps. Users can still trigger it explicitly via `?show-onboarding-demo=1` query param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated demo onboarding display to only appear when explicitly triggered via query parameter, removing unintended automatic displays based on app count and other conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->