### PR TITLE
fix(security): escape org_id parameter in admin stats SQL queries

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1449,7 +1449,7 @@ export async function getAdminPlatformOverview(
   org_id?: string,
 ): Promise<AdminPlatformOverview | null> {
   try {
-    const orgFilter = org_id ? `AND blob2 = '${org_id}'` : ''
+    const orgFilter = org_id ? `AND blob2 = '${escapeSqlString(org_id)}'` : ''
 
     // Query 1: MAU from DEVICE_USAGE
     const mauQuery = `SELECT COUNT(DISTINCT blob1) AS mau
@@ -1631,7 +1631,7 @@ export async function getAdminMauTrend(
   if (!c.env.DEVICE_USAGE)
     return []
 
-  const orgFilter = org_id ? `AND blob2 = '${org_id}'` : ''
+  const orgFilter = org_id ? `AND blob2 = '${escapeSqlString(org_id)}'` : ''
 
   const query = `SELECT
     formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS date,


### PR DESCRIPTION
## Summary

Two locations in `cloudflare.ts` were interpolating `org_id` directly into SQL queries without using `escapeSqlString()`.

## Affected Functions

- `getAdminPlatformOverview()` (line 1452)
- `getAdminMauTrend()` (line 1634)

## Security Impact

While these are admin-only endpoints, defense-in-depth requires consistent escaping of all user-controllable parameters. A malicious admin or compromised admin session could potentially exploit this.

## Changes

- Use `escapeSqlString(org_id)` for consistent SQL injection prevention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in admin analytics queries by implementing proper string escaping for organization identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->