### PR TITLE
fix: cascade delete org_metrics_cache when org is deleted

### DIFF
--- a/supabase/migrations/20260408135649_cascade_org_metrics_cache_fk.sql
+++ b/supabase/migrations/20260408135649_cascade_org_metrics_cache_fk.sql
@@ -1,0 +1,11 @@
+-- Fix organization deletion failing due to FK constraint from org_metrics_cache.
+-- The org_metrics_cache table holds derived/cached metrics keyed by org_id.
+-- When an org is deleted, its cached metrics should be removed automatically,
+-- matching the ON DELETE CASCADE behavior used by every other FK into public.orgs.
+
+ALTER TABLE "public"."org_metrics_cache"
+    DROP CONSTRAINT IF EXISTS "org_metrics_cache_org_id_fkey";
+
+ALTER TABLE "public"."org_metrics_cache"
+    ADD CONSTRAINT "org_metrics_cache_org_id_fkey"
+    FOREIGN KEY ("org_id") REFERENCES "public"."orgs"("id") ON DELETE CASCADE;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -15295,7 +15295,7 @@ ALTER TABLE ONLY "public"."manifest"
 
 
 ALTER TABLE ONLY "public"."org_metrics_cache"
-    ADD CONSTRAINT "org_metrics_cache_org_id_fkey" FOREIGN KEY ("org_id") REFERENCES "public"."orgs"("id");
+    ADD CONSTRAINT "org_metrics_cache_org_id_fkey" FOREIGN KEY ("org_id") REFERENCES "public"."orgs"("id") ON DELETE CASCADE;
 
 
 


### PR DESCRIPTION
## Summary
- Org deletion was failing with: `update or delete on table "orgs" violates foreign key constraint "org_metrics_cache_org_id_fkey" on table "org_metrics_cache"`.
- `org_metrics_cache` stores derived metrics keyed by `org_id` and was the only FK into `public.orgs` without `ON DELETE CASCADE`.
- Migration drops and recreates the constraint with `ON DELETE CASCADE` so cached rows are cleaned up with the org.
- `supabase/schemas/prod.sql` snapshot updated to match.

## Test plan
- [ ] Apply migration on preprod
- [ ] Delete an org that has a row in `org_metrics_cache` and confirm it succeeds
- [ ] Confirm the cached row is gone after the delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to automatically remove cached organization metrics when an organization is deleted, improving data consistency and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->