### PR TITLE
fix: use 'init' instead of 'i' alias in onboarding CLI commands

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -54,7 +54,7 @@ const appIdFeedback = ref('')
 const hasEditedAppId = ref(false)
 
 const localCommand = isLocal(config.supaHost) ? ` --supa-host ${config.supaHost} --supa-anon ${config.supaKey}` : ''
-const cliCommand = computed(() => `npx @capgo/cli@latest i ${apiKey.value ?? '[APIKEY]'}${localCommand}`)
+const cliCommand = computed(() => `npx @capgo/cli@latest init ${apiKey.value ?? '[APIKEY]'}${localCommand}`)
 const cliCommandArgs = computed(() => {
   const args: string[] = []
 
@@ -660,7 +660,7 @@ watch(suggestedAppId, (value) => {
                     <code class="block whitespace-pre-wrap break-all text-sm">
                       <span class="text-slate-500">npx</span>
                       <span class="text-sky-300"> @capgo/cli@latest</span>
-                      <span class="text-violet-300"> i</span>
+                      <span class="text-violet-300"> init</span>
                       <span class="text-emerald-300"> {{ apiKey ?? '[APIKEY]' }}</span>
                       <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                         <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
@@ -868,7 +868,7 @@ watch(suggestedAppId, (value) => {
             <code class="block whitespace-pre-wrap break-all text-sm">
               <span class="text-slate-500">npx</span>
               <span class="text-sky-300"> @capgo/cli@latest</span>
-              <span class="text-violet-300"> i</span>
+              <span class="text-violet-300"> init</span>
               <span class="text-emerald-300"> {{ apiKey ?? '[APIKEY]' }}</span>
               <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                 <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -660,7 +660,7 @@ watch(suggestedAppId, (value) => {
                     <code class="block whitespace-pre-wrap break-all text-sm">
                       <span class="text-slate-500">npx</span>
                       <span class="text-sky-300"> @capgo/cli@latest</span>
-                      <span class="text-violet-300"> i</span>
+                      <span class="text-violet-300 font-bold mr-1"> i</span>
                       <span class="text-emerald-300"> {{ apiKey ?? '[APIKEY]' }}</span>
                       <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                         <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
@@ -868,7 +868,7 @@ watch(suggestedAppId, (value) => {
             <code class="block whitespace-pre-wrap break-all text-sm">
               <span class="text-slate-500">npx</span>
               <span class="text-sky-300"> @capgo/cli@latest</span>
-              <span class="text-violet-300"> i</span>
+              <span class="text-violet-300 font-bold mr-1"> i</span>
               <span class="text-emerald-300"> {{ apiKey ?? '[APIKEY]' }}</span>
               <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                 <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -54,7 +54,7 @@ const appIdFeedback = ref('')
 const hasEditedAppId = ref(false)
 
 const localCommand = isLocal(config.supaHost) ? ` --supa-host ${config.supaHost} --supa-anon ${config.supaKey}` : ''
-const cliCommand = computed(() => `npx @capgo/cli@latest init ${apiKey.value ?? '[APIKEY]'}${localCommand}`)
+const cliCommand = computed(() => `npx @capgo/cli@latest i ${apiKey.value ?? '[APIKEY]'}${localCommand}`)
 const cliCommandArgs = computed(() => {
   const args: string[] = []
 
@@ -660,7 +660,7 @@ watch(suggestedAppId, (value) => {
                     <code class="block whitespace-pre-wrap break-all text-sm">
                       <span class="text-slate-500">npx</span>
                       <span class="text-sky-300"> @capgo/cli@latest</span>
-                      <span class="text-violet-300"> init</span>
+                      <span class="text-violet-300"> i</span>
                       <span class="text-emerald-300"> {{ apiKey ?? '[APIKEY]' }}</span>
                       <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                         <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
@@ -868,7 +868,7 @@ watch(suggestedAppId, (value) => {
             <code class="block whitespace-pre-wrap break-all text-sm">
               <span class="text-slate-500">npx</span>
               <span class="text-sky-300"> @capgo/cli@latest</span>
-              <span class="text-violet-300"> init</span>
+              <span class="text-violet-300"> i</span>
               <span class="text-emerald-300"> {{ apiKey ?? '[APIKEY]' }}</span>
               <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                 <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>

--- a/src/components/dashboard/StepsApp.vue
+++ b/src/components/dashboard/StepsApp.vue
@@ -46,7 +46,7 @@ const config = getLocalConfig()
 const localCommand = isLocal(config.supaHost) ? ` --supa-host ${config.supaHost} --supa-anon ${config.supaKey}` : ``
 const apiKey = ref<string | null>(null)
 // keep NPX for better support of our customers env, everyone has npx but not everyone has bunx, and bunx has some issues with pnpm
-const commandTemplate = `npx @capgo/cli@latest init [APIKEY]${localCommand}`
+const commandTemplate = `npx @capgo/cli@latest i [APIKEY]${localCommand}`
 const stepCommand = computed(() => commandTemplate.replace('[APIKEY]', apiKey.value ?? '[APIKEY]'))
 const steps = computed<Step[]>(() => [
   {

--- a/src/components/dashboard/StepsApp.vue
+++ b/src/components/dashboard/StepsApp.vue
@@ -46,7 +46,7 @@ const config = getLocalConfig()
 const localCommand = isLocal(config.supaHost) ? ` --supa-host ${config.supaHost} --supa-anon ${config.supaKey}` : ``
 const apiKey = ref<string | null>(null)
 // keep NPX for better support of our customers env, everyone has npx but not everyone has bunx, and bunx has some issues with pnpm
-const commandTemplate = `npx @capgo/cli@latest i [APIKEY]${localCommand}`
+const commandTemplate = `npx @capgo/cli@latest init [APIKEY]${localCommand}`
 const stepCommand = computed(() => commandTemplate.replace('[APIKEY]', apiKey.value ?? '[APIKEY]'))
 const steps = computed<Step[]>(() => [
   {


### PR DESCRIPTION
## Summary
- The `i` alias for `init` visually merged with API keys in the onboarding CLI command display (e.g. `if83efbda-...` instead of `init f83efbda-...`), making it look like the `init` subcommand was missing
- Changed to full `init` subcommand in `AppOnboardingFlow.vue` (both display and copy) and `StepsApp.vue`

## Test plan
- [ ] Open onboarding flow, verify command shows `npx @capgo/cli@latest init <apikey>`
- [ ] Copy the command and confirm it includes `init` with proper spacing
- [ ] Verify the command actually works with the CLI (`init` is the canonical name, `i` was just an alias)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced the visual formatting of CLI command snippets in the onboarding flow with improved styling for better clarity and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->