### PR TITLE
[codex] Fix post-merge pricing CI and config hardening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,10 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v1.6.0
         with:
-          version: latest
+          # Supabase CLI 2.90.0 regressed our local test-db startup on GitHub
+          # Actions runners; pin to the last known-good version until upstream is
+          # stable again.
+          version: 2.84.2
       - name: Show Supabase CLI version
         run: supabase --version
       - name: Link Supabase templates

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -40,6 +40,15 @@ export function getLocalConfig() {
 let config: CapgoConfig = getLocalConfig()
 export const stripeEnabled = ref<boolean>(config.stripeEnabled ?? true)
 
+export function mergeRemoteConfig(localConfig: CapgoConfig, remoteConfig: Partial<CapgoConfig> | null | undefined): CapgoConfig {
+  return {
+    ...localConfig,
+    host: typeof remoteConfig?.host === 'string' ? remoteConfig.host : localConfig.host,
+    hostWeb: typeof remoteConfig?.hostWeb === 'string' ? remoteConfig.hostWeb : localConfig.hostWeb,
+    stripeEnabled: typeof remoteConfig?.stripeEnabled === 'boolean' ? remoteConfig.stripeEnabled : localConfig.stripeEnabled,
+  }
+}
+
 export async function getRemoteConfig() {
   const localConfig = getLocalConfig()
   if (import.meta.env.MODE === 'development')
@@ -52,8 +61,8 @@ export async function getRemoteConfig() {
       stripeEnabled.value = localConfig.stripeEnabled ?? stripeEnabled.value
       return localConfig as CapgoConfig
     }
-    const data = await response.json() as CapgoConfig
-    const merged = { ...localConfig, ...data } as CapgoConfig
+    const data = await response.json() as Partial<CapgoConfig>
+    const merged = mergeRemoteConfig(localConfig, data)
     config = merged
     stripeEnabled.value = merged.stripeEnabled ?? stripeEnabled.value
     return merged
@@ -83,7 +92,7 @@ export function useSupabase() {
   if (supaClient)
     return supaClient
 
-  supaClient = createClient<Database>(config.supaHost, config.supaKey, options)
+  supaClient = createClient<Database>(getSupabaseHost(), config.supaKey, options)
   return supaClient
 }
 

--- a/tests/supabase-config.unit.test.ts
+++ b/tests/supabase-config.unit.test.ts
@@ -1,0 +1,38 @@
+import type { CapgoConfig } from '../src/services/supabase'
+import { describe, expect, it } from 'vitest'
+import { mergeRemoteConfig } from '../src/services/supabase'
+
+describe('supabase config merging', () => {
+  const localConfig: CapgoConfig = {
+    supaHost: 'https://sb.capgo.app',
+    supaKey: 'local-anon-key',
+    supbaseId: 'sb',
+    host: 'https://capgo.app',
+    hostWeb: 'https://capgo.app',
+    stripeEnabled: true,
+  }
+
+  it('keeps Supabase connection parameters from the local build config', () => {
+    const merged = mergeRemoteConfig(localConfig, {
+      supaHost: 'https://evil.example.com',
+      supaKey: 'evil-key',
+      supbaseId: 'evil',
+      host: 'https://console.capgo.app',
+      hostWeb: 'https://www.capgo.app',
+      stripeEnabled: false,
+    })
+
+    expect(merged.supaHost).toBe(localConfig.supaHost)
+    expect(merged.supaKey).toBe(localConfig.supaKey)
+    expect(merged.supbaseId).toBe(localConfig.supbaseId)
+    expect(merged.host).toBe('https://console.capgo.app')
+    expect(merged.hostWeb).toBe('https://www.capgo.app')
+    expect(merged.stripeEnabled).toBe(false)
+  })
+
+  it('falls back to local values when remote config omits optional fields', () => {
+    const merged = mergeRemoteConfig(localConfig, {})
+
+    expect(merged).toEqual(localConfig)
+  })
+})

--- a/tests/supabase-config.unit.test.ts
+++ b/tests/supabase-config.unit.test.ts
@@ -1,6 +1,6 @@
-import type { CapgoConfig } from '../src/services/supabase'
+import type { CapgoConfig } from '~/services/supabase'
 import { describe, expect, it } from 'vitest'
-import { mergeRemoteConfig } from '../src/services/supabase'
+import { mergeRemoteConfig } from '~/services/supabase'
 
 describe('supabase config merging', () => {
   const localConfig: CapgoConfig = {
@@ -12,7 +12,7 @@ describe('supabase config merging', () => {
     stripeEnabled: true,
   }
 
-  it('keeps Supabase connection parameters from the local build config', () => {
+  it.concurrent('keeps Supabase connection parameters from the local build config', () => {
     const merged = mergeRemoteConfig(localConfig, {
       supaHost: 'https://evil.example.com',
       supaKey: 'evil-key',
@@ -30,7 +30,7 @@ describe('supabase config merging', () => {
     expect(merged.stripeEnabled).toBe(false)
   })
 
-  it('falls back to local values when remote config omits optional fields', () => {
+  it.concurrent('falls back to local values when remote config omits optional fields', () => {
     const merged = mergeRemoteConfig(localConfig, {})
 
     expect(merged).toEqual(localConfig)

--- a/vitest.config.cloudflare-plugin.ts
+++ b/vitest.config.cloudflare-plugin.ts
@@ -1,14 +1,20 @@
-import { cwd } from 'node:process'
+import path from 'node:path'
+import { cwd, env } from 'node:process'
 import { loadEnv } from 'vite'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig(({ mode }) => ({
+  resolve: {
+    alias: {
+      '~/': `${path.resolve(cwd(), 'src')}/`,
+    },
+  },
   test: {
     include: ['tests/*.test.ts'],
     environment: 'node',
     watch: false,
     bail: 0,
-    testTimeout: process.env.CI ? 60_000 : 30_000, // 60s in CI, 30s locally
+    testTimeout: env.CI ? 60_000 : 30_000, // 60s in CI, 30s locally
     hookTimeout: 10_000,
     retry: 2,
     // Very low concurrency for plugin tests that hit shared replica state

--- a/vitest.config.cloudflare.ts
+++ b/vitest.config.cloudflare.ts
@@ -1,8 +1,14 @@
+import path from 'node:path'
 import { cwd } from 'node:process'
 import { loadEnv } from 'vite'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig(({ mode }) => ({
+  resolve: {
+    alias: {
+      '~/': `${path.resolve(cwd(), 'src')}/`,
+    },
+  },
   test: {
     include: ['tests/*.test.ts'],
     environment: 'node',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
+import path from 'node:path'
 import { cwd } from 'node:process'
 import { loadEnv } from 'vite'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig(({ mode }) => ({
+  resolve: {
+    alias: {
+      '~/': `${path.resolve(cwd(), 'src')}/`,
+    },
+  },
   test: {
     include: ['tests/*.test.ts'],
     environment: 'node',


### PR DESCRIPTION
## Summary
- pin the Supabase CLI in CI to avoid the new runner regression
- keep remote pricing config from overriding Supabase connection settings
- add a regression test for the config merge behavior

## Verification
- bun typecheck
- bunx eslint src/services/supabase.ts tests/supabase-config.unit.test.ts
- bunx vitest run tests/supabase-config.unit.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned Supabase CLI version in CI for more stable runs.
  * Made test CI timeout detection more robust.

* **Bug Fixes**
  * Improved remote config merging so only valid remote fields override local settings.
  * Normalized Supabase host URL handling for more reliable connections.

* **Tests**
  * Added unit tests covering configuration merge behavior.
  * Added test resolver alias to simplify imports across test configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->