### PR TITLE
[codex] fix replication toast hover gap

### DIFF
--- a/src/services/updateReplicationToast.ts
+++ b/src/services/updateReplicationToast.ts
@@ -36,6 +36,9 @@ const REPLICATION_TOAST_CLASSES = {
   content: 'w-full min-w-0',
   toast: 'replication-toast',
 }
+const REPLICATION_DONE_TOAST_STYLE = {
+  '--initial-height': 'auto',
+}
 
 function getCurrentTimeZone(): string | null {
   if (typeof Intl === 'undefined')
@@ -263,6 +266,7 @@ export function showUploadReplicationToast({
       id: toastId,
       descriptionClass: 'w-full',
       classes: REPLICATION_TOAST_CLASSES,
+      style: REPLICATION_DONE_TOAST_STYLE,
       description: buildDoneDescription(
         regions,
         hasAction ? actionLabel : undefined,

--- a/src/services/updateReplicationToast.ts
+++ b/src/services/updateReplicationToast.ts
@@ -32,6 +32,10 @@ const DEPLOYMENT_REGIONS: DeploymentRegion[] = [
 
 const TOTAL_REPLICATION_MS = 60_000
 const UPDATE_INTERVAL_MS = 500
+const REPLICATION_TOAST_CLASSES = {
+  content: 'w-full min-w-0',
+  toast: 'replication-toast',
+}
 
 function getCurrentTimeZone(): string | null {
   if (typeof Intl === 'undefined')
@@ -229,7 +233,7 @@ export function showUploadReplicationToast({
     toast(getToastTitle(), {
       id: toastId,
       descriptionClass: 'w-full',
-      classes: { content: 'w-full min-w-0' },
+      classes: REPLICATION_TOAST_CLASSES,
       description: buildDescription(
         regions,
         completed,
@@ -258,7 +262,7 @@ export function showUploadReplicationToast({
     toast(i18n.global.t('replication-toast-globally-available'), {
       id: toastId,
       descriptionClass: 'w-full',
-      classes: { content: 'w-full min-w-0' },
+      classes: REPLICATION_TOAST_CLASSES,
       description: buildDoneDescription(
         regions,
         hasAction ? actionLabel : undefined,
@@ -271,7 +275,7 @@ export function showUploadReplicationToast({
   const toastTitle = getToastTitle()
   toastId = toast(toastTitle, {
     descriptionClass: 'w-full',
-    classes: { content: 'w-full min-w-0' },
+    classes: REPLICATION_TOAST_CLASSES,
     description: buildDescription(
       regions,
       0,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -20,6 +20,11 @@ layer(base);
   padding-top: max(var(--safe-area-top), 0px);
 }
 
+/* Sonner adds a hover spacer above expanded toasts; it reads as a broken top margin on this single status toast. */
+[data-sonner-toast].replication-toast[data-front='true'][data-expanded='true']::after {
+  content: none;
+}
+
 @plugin "daisyui" {
   themes: capgolight --default, capgodark --prefersdark;
   logs: true;


### PR DESCRIPTION
## Summary (AI generated)

- scope the replication status toast with a dedicated class
- remove the extra hover spacer above the completed replication toast
- keep the Sonner override limited to this toast so other notifications keep default behavior

## Motivation (AI generated)

The global replication toast showed a broken top margin once it reached the fully replicated state and the toast expanded on hover. The underlying issue was Sonner's expanded-toast spacer pseudo-element, which looked correct for stacked toasts but produced a visual glitch for this single replication status toast.

## Business Impact (AI generated)

This removes a visible UI defect in a core deployment feedback flow. It makes the replication status feel stable and polished when users monitor bundle rollout, reducing confusion during release operations.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Reproduced the completed replication toast in a headless browser and verified the hover spacer no longer appears

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved replication toast appearance and expanded-toast spacing for a cleaner, more polished user experience across interaction states.

* **Refactor**
  * Centralized replication toast styling and behavior into shared configuration to ensure consistent presentation and simplify future adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->