### PR TITLE
[codex] Show admin trial extension badges

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1687,6 +1687,7 @@
   "trial-banner-cta": "View plans",
   "trial-banner-message": "Enjoying your Capgo trial? Subscribe to a plan.",
   "trial-end-date": "Trial End Date",
+  "trial-extended-badge": "Extended {count}",
   "trial-left": "days left",
   "trial-organizations-list": "Trial Organizations List",
   "trial-plan-expired": "Trial Expired",

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -5,7 +5,7 @@ meta:
 
 <script setup lang="ts">
 import type { TableColumn } from '~/components/comp_def'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, h, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import AdminBarChart from '~/components/admin/AdminBarChart.vue'
@@ -114,6 +114,7 @@ interface TrialOrganization {
   management_email: string
   trial_end_date: string
   days_remaining: number
+  trial_extension_count: number
   created_at: string
   last_bundle_upload_at: string | null
 }
@@ -157,8 +158,26 @@ const cancelledOrganizationsCurrentPage = ref(1)
 const isLoadingCancelledOrganizations = ref(false)
 const CANCELLED_PAGE_SIZE = 20
 
+function getTrialExtensionBadgeLabel(extensionCount: number) {
+  return t('trial-extended-badge', { count: extensionCount })
+}
+
 const trialOrganizationsColumns = ref<TableColumn[]>([
-  { label: t('org-name'), key: 'org_name', mobile: true, head: true, sortable: false },
+  {
+    label: t('org-name'),
+    key: 'org_name',
+    mobile: true,
+    head: true,
+    sortable: false,
+    renderFunction: (item: TrialOrganization) => h('div', { class: 'flex flex-wrap items-center gap-2 text-slate-800 dark:text-white' }, [
+      h('span', { class: 'font-medium' }, item.org_name),
+      item.trial_extension_count > 0
+        ? h('span', {
+            class: 'inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-200',
+          }, getTrialExtensionBadgeLabel(item.trial_extension_count))
+        : null,
+    ]),
+  },
   { label: t('email'), key: 'management_email', mobile: false, sortable: false },
   {
     label: t('days-remaining'),

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1575,6 +1575,7 @@ export interface AdminTrialOrganization {
   management_email: string
   trial_end_date: string
   days_remaining: number
+  trial_extension_count: number
   created_at: string
   last_bundle_upload_at: string | null
 }
@@ -1623,6 +1624,11 @@ export async function getAdminTrialOrganizations(
         o.management_email,
         si.trial_at AS trial_end_date,
         GREATEST(0, (si.trial_at::date - CURRENT_DATE)) AS days_remaining,
+        CASE
+          WHEN si.trial_at::date - o.created_at::date > 15
+            THEN ((si.trial_at::date - o.created_at::date - 15) / 15)
+          ELSE 0
+        END AS trial_extension_count,
         o.created_at,
         lbu.last_bundle_upload_at
       FROM orgs o
@@ -1655,6 +1661,7 @@ export async function getAdminTrialOrganizations(
       management_email: row.management_email,
       trial_end_date: normalizeTimestamp(row.trial_end_date) ?? '',
       days_remaining: Number(row.days_remaining),
+      trial_extension_count: Number(row.trial_extension_count) || 0,
       created_at: normalizeTimestamp(row.created_at) ?? '',
       last_bundle_upload_at: normalizeTimestamp(row.last_bundle_upload_at),
     }))

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -8,6 +8,7 @@ const NOW = Date.now()
 const TRIAL_ORG_ID = randomUUID()
 const TRIAL_CUSTOMER_ID = `cus_admin_stats_trial_${TRIAL_ORG_ID.slice(0, 8)}`
 const TRIAL_APP_ID = `com.admin.stats.trial.${TRIAL_ORG_ID.slice(0, 8)}`
+const TRIAL_ORG_CREATED_AT = new Date(NOW).toISOString()
 const TRIAL_END_DATE = new Date(NOW + (45 * DAY_IN_MS)).toISOString()
 const TRIAL_LAST_UPLOAD_AT = new Date(NOW - DAY_IN_MS).toISOString()
 const TRIAL_BUILTIN_UPLOAD_AT = new Date(NOW - (12 * 60 * 60 * 1000)).toISOString()
@@ -163,6 +164,7 @@ beforeAll(async () => {
       created_by: USER_ID,
       management_email: TEST_EMAIL,
       customer_id: TRIAL_CUSTOMER_ID,
+      created_at: TRIAL_ORG_CREATED_AT,
     },
     {
       id: CANCELLED_YEARLY_ORG_ID,
@@ -333,6 +335,7 @@ describe('/private/admin_stats', () => {
         organizations: Array<{
           org_id: string
           last_bundle_upload_at: string | null
+          trial_extension_count: number
         }>
       }
     }
@@ -341,6 +344,7 @@ describe('/private/admin_stats', () => {
     const organization = payload.data.organizations.find(org => org.org_id === TRIAL_ORG_ID)
     expect(organization).toBeTruthy()
     expect(organization?.last_bundle_upload_at).toBe(TRIAL_LAST_UPLOAD_AT)
+    expect(organization?.trial_extension_count).toBe(2)
   })
 
   it.concurrent('returns cancellation billing metadata and subscription-or-signup dates', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- add `trial_extension_count` to the admin trial organizations query based on 15-day extensions beyond the initial trial window
- show an `Extended {count}` badge in the admin users trial table when a trial has been extended
- cover the new extension-count behavior in the admin stats test fixture and assertion

## Motivation (AI generated)

The admin users trial tab highlighted organizations that are close to expiry, but it did not show whether a trial had already been extended. That hid useful context for follow-up and made extended trials look the same as first-time trials.

## Business Impact (AI generated)

This gives the Capgo team clearer billing and follow-up context in the admin dashboard, which should reduce manual investigation and help support or sales understand whether a trial has already received extra time.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/admin-stats.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trial extension badge to the admin dashboard that displays the number of times an organization's trial has been extended.

* **Tests**
  * Added test coverage for the trial extension count feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->