### PR TITLE
fix(frontend): reduce noisy PostHog client errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import { routes } from 'vue-router/auto-routes'
 import { posthogLoader } from '~/services/posthog'
-import { getErrorMessage, isStaleAssetErrorMessage } from '~/services/staleAssetErrors'
+import { getErrorMessage, isKnownCrawlerNoiseErrorMessage, isStaleAssetErrorMessage } from '~/services/staleAssetErrors'
 import { getLocalConfig } from '~/services/supabase'
 import App from './App.vue'
 import { getRemoteConfig } from './services/supabase'
@@ -87,6 +87,12 @@ window.addEventListener('error', (event) => {
     event.preventDefault()
     event.stopImmediatePropagation()
     handleChunkError(event.message)
+    return
+  }
+
+  if (isKnownCrawlerNoiseErrorMessage(event.message)) {
+    event.preventDefault()
+    event.stopImmediatePropagation()
   }
 }, true)
 
@@ -97,6 +103,12 @@ window.addEventListener('unhandledrejection', (event) => {
     event.preventDefault()
     event.stopImmediatePropagation()
     handleChunkError(message)
+    return
+  }
+
+  if (isKnownCrawlerNoiseErrorMessage(message)) {
+    event.preventDefault()
+    event.stopImmediatePropagation()
   }
 })
 

--- a/src/services/chartAnnotations.ts
+++ b/src/services/chartAnnotations.ts
@@ -18,10 +18,21 @@ export interface AnnotationOptions {
   }
 }
 
+function getCanvasContext(ctx: unknown): CanvasRenderingContext2D | null {
+  if (ctx && typeof (ctx as CanvasRenderingContext2D).save === 'function')
+    return ctx as CanvasRenderingContext2D
+
+  return null
+}
+
 export const inlineAnnotationPlugin = {
   id: 'inlineAnnotationPlugin',
   afterDatasetsDraw: (chart: any, args: any, options: AnnotationOptions) => {
-    const { ctx, chartArea } = chart
+    const ctx = getCanvasContext(chart?.ctx)
+    if (!ctx)
+      return
+
+    const { chartArea } = chart
     const { left, right } = chartArea
 
     Object.entries(options).forEach(([key, val]) => {

--- a/src/services/chartTooltip.ts
+++ b/src/services/chartTooltip.ts
@@ -21,6 +21,25 @@ export interface TooltipClickHandler {
   appIdByLabel?: Record<string, string> // Maps app label/name to app ID
 }
 
+function getCanvasContext(ctx: unknown): CanvasRenderingContext2D | null {
+  if (ctx && typeof (ctx as CanvasRenderingContext2D).save === 'function')
+    return ctx as CanvasRenderingContext2D
+
+  return null
+}
+
+function canSafelyUpdateChart(chart: Chart): boolean {
+  return !!getCanvasContext(chart.ctx) && !!chart.canvas?.isConnected
+}
+
+function clearTooltipSelection(chart: Chart) {
+  if (!canSafelyUpdateChart(chart))
+    return
+
+  chart.setActiveElements([])
+  chart.update('none')
+}
+
 function formatTooltipValue(value: unknown) {
   if (typeof value !== 'number' || Number.isNaN(value))
     return '0'
@@ -138,8 +157,7 @@ export function createCustomTooltip(context: TooltipContext, isAccumulated: bool
         // Check if the touch is not on the chart canvas
         if (!canvas.contains(e.target as Node)) {
           tooltipEl!.style.opacity = '0'
-          chart.setActiveElements([])
-          chart.update('none')
+          clearTooltipSelection(chart)
         }
       }
 
@@ -169,8 +187,7 @@ export function createCustomTooltip(context: TooltipContext, isAccumulated: bool
     (tooltipEl as any).hideTimer = setTimeout(() => {
       tooltipEl.style.opacity = '0'
       // Trigger chart update to clear tooltip
-      chart.setActiveElements([])
-      chart.update('none')
+      clearTooltipSelection(chart)
     }, 3000)
   }
 
@@ -391,8 +408,7 @@ export function createCustomTooltip(context: TooltipContext, isAccumulated: bool
       ;(tooltipEl as any).hideTimer = setTimeout(() => {
         if (!(tooltipEl as any).isHovered) {
           tooltipEl!.style.opacity = '0'
-          chart.setActiveElements([])
-          chart.update('none')
+          clearTooltipSelection(chart)
         }
       }, 100)
     })
@@ -494,7 +510,9 @@ export const verticalLinePlugin = {
     const active = chart.tooltip?.getActiveElements()
     if (chart.tooltip && active && active.length > 0) {
       const activePoint = active[0]
-      const ctx = chart.ctx
+      const ctx = getCanvasContext(chart.ctx)
+      if (!ctx)
+        return
       const x = activePoint.element.x
       const topY = chart.scales.y.top
       const bottomY = chart.scales.y.bottom
@@ -599,7 +617,9 @@ export const todayLinePlugin = {
     if (typeof x !== 'number' || Number.isNaN(x))
       return
 
-    const ctx = chart.ctx
+    const ctx = getCanvasContext(chart.ctx)
+    if (!ctx)
+      return
     const topY = yScale.top ?? chart.chartArea?.top
     const bottomY = yScale.bottom ?? chart.chartArea?.bottom
     if (typeof topY !== 'number' || typeof bottomY !== 'number')

--- a/src/services/staleAssetErrors.ts
+++ b/src/services/staleAssetErrors.ts
@@ -8,11 +8,22 @@ const STALE_ASSET_ERROR_PATTERNS = [
   /Loading CSS chunk [\w-]+ failed/i,
 ]
 
+const KNOWN_CRAWLER_ERROR_PATTERNS = [
+  /Object Not Found Matching Id:\d+(?:,\s*MethodName:[^,]+,\s*ParamCount:\d+)?/i,
+]
+
 export function isStaleAssetErrorMessage(message: string | undefined): boolean {
   if (!message)
     return false
 
   return STALE_ASSET_ERROR_PATTERNS.some(pattern => pattern.test(message))
+}
+
+export function isKnownCrawlerNoiseErrorMessage(message: string | undefined): boolean {
+  if (!message)
+    return false
+
+  return KNOWN_CRAWLER_ERROR_PATTERNS.some(pattern => pattern.test(message))
 }
 
 export function getErrorMessage(value: unknown): string | undefined {
@@ -50,9 +61,9 @@ export function shouldSuppressPostHogExceptionEvent(event: PostHogEventLike): bo
 
   const exception = event.properties?.$exception_list?.[0]
   const exceptionValue = getErrorMessage(exception?.value) ?? getErrorMessage(exception?.$exception_value)
-  if (isStaleAssetErrorMessage(exceptionValue))
+  if (isStaleAssetErrorMessage(exceptionValue) || isKnownCrawlerNoiseErrorMessage(exceptionValue))
     return true
 
   const fallbackValue = getErrorMessage(event.properties?.$exception_values?.[0])
-  return isStaleAssetErrorMessage(fallbackValue)
+  return isStaleAssetErrorMessage(fallbackValue) || isKnownCrawlerNoiseErrorMessage(fallbackValue)
 }

--- a/tests/chart-plugins.unit.test.ts
+++ b/tests/chart-plugins.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { inlineAnnotationPlugin } from '../src/services/chartAnnotations'
+import { todayLinePlugin, verticalLinePlugin } from '../src/services/chartTooltip'
+
+describe('chart plugins', () => {
+  it('skips drawing the vertical hover line when the chart context is gone', () => {
+    expect(() => verticalLinePlugin.afterDatasetsDraw({
+      ctx: null,
+      tooltip: {
+        getActiveElements: () => [{ element: { x: 12 } }],
+      },
+      scales: {
+        y: {
+          top: 10,
+          bottom: 90,
+        },
+      },
+      options: {
+        plugins: {},
+      },
+    } as any)).not.toThrow()
+  })
+
+  it('skips drawing the today line when the chart context is gone', () => {
+    expect(() => todayLinePlugin.afterDatasetsDraw({
+      ctx: null,
+      chartArea: {
+        top: 10,
+        bottom: 90,
+      },
+      scales: {
+        x: {
+          getPixelForValue: () => 24,
+        },
+        y: {
+          top: 10,
+          bottom: 90,
+        },
+      },
+    } as any, undefined, {
+      enabled: true,
+      xIndex: 2,
+      label: 'Today',
+    })).not.toThrow()
+  })
+
+  it('skips inline annotations when the chart context is gone', () => {
+    expect(() => inlineAnnotationPlugin.afterDatasetsDraw({
+      ctx: null,
+      chartArea: {
+        left: 0,
+        right: 100,
+      },
+      scales: {
+        x: {
+          getPixelForValue: () => 10,
+        },
+        y: {
+          getPixelForValue: () => 20,
+        },
+      },
+    }, undefined, {
+      line_limit: {
+        yMin: 3,
+        yMax: 3,
+        borderColor: '#fff',
+        borderWidth: 1,
+      },
+      label_limit: {
+        xValue: 1,
+        yValue: 3,
+        backgroundColor: '#000',
+        content: ['Limit'],
+        borderWidth: 1,
+        font: {
+          size: 12,
+        },
+      },
+    } as any)).not.toThrow()
+  })
+})

--- a/tests/stale-asset-errors.unit.test.ts
+++ b/tests/stale-asset-errors.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getErrorMessage, isStaleAssetErrorMessage, shouldSuppressPostHogExceptionEvent } from '../src/services/staleAssetErrors'
+import { getErrorMessage, isKnownCrawlerNoiseErrorMessage, isStaleAssetErrorMessage, shouldSuppressPostHogExceptionEvent } from '../src/services/staleAssetErrors'
 
 describe('stale asset error helpers', () => {
   it('matches the stale asset errors currently seen in PostHog', () => {
@@ -17,6 +17,12 @@ describe('stale asset error helpers', () => {
     expect(isStaleAssetErrorMessage('Cannot read properties of undefined (reading \'digest\')')).toBe(false)
     expect(isStaleAssetErrorMessage('\'application/json\' is not a valid JavaScript MIME type.')).toBe(false)
     expect(isStaleAssetErrorMessage('\'text/plain\' is not a valid JavaScript MIME type.')).toBe(false)
+  })
+
+  it('matches the known crawler-only Object Not Found noise seen in PostHog', () => {
+    expect(isKnownCrawlerNoiseErrorMessage('Object Not Found Matching Id:2, MethodName:update, ParamCount:4')).toBe(true)
+    expect(isKnownCrawlerNoiseErrorMessage('Non-Error promise rejection captured with value: Object Not Found Matching Id:5')).toBe(true)
+    expect(isKnownCrawlerNoiseErrorMessage('Cannot read properties of null (reading \'save\')')).toBe(false)
   })
 
   it('extracts useful messages from arbitrary rejection values', () => {
@@ -46,5 +52,12 @@ describe('stale asset error helpers', () => {
         $exception_list: [{ value: 'ResizeObserver loop completed with undelivered notifications.' }],
       },
     })).toBe(false)
+
+    expect(shouldSuppressPostHogExceptionEvent({
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'Object Not Found Matching Id:3, MethodName:update, ParamCount:4' }],
+      },
+    })).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- suppress known crawler-only `Object Not Found Matching Id:*` client errors before they reach PostHog
- keep the PostHog `before_send` suppression aligned with the same crawler-noise matcher
- guard chart drawing plugins when Chart.js no longer has a live canvas context, which stops repeated `null.save` crashes
- add unit coverage for the new error filtering and chart plugin guard paths

## Motivation (AI generated)

PostHog error tracking is currently dominated by two frontend-only problems: crawler-generated noise from email link scanning, and chart plugin redraws that run after the canvas context is gone. Those issues hide real regressions and waste time during triage.

## Business Impact (AI generated)

This reduces false-positive production noise in PostHog so real customer-facing errors stay visible, and it removes a real chart crash affecting mobile users on stats and bundles views. Cleaner monitoring improves support response and lowers the risk of missing genuine regressions.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/stale-asset-errors.unit.test.ts tests/chart-plugins.unit.test.ts`
- [x] `bun run typecheck`
- [ ] GitHub Actions CI passes

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for crawler-related and stale-asset errors to reduce noise in error reporting
  * Enhanced chart rendering stability when the rendering context is unavailable
  * Optimized tooltip state management during user interactions

* **Tests**
  * Added tests for chart plugin robustness and error suppression logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->