### PR TITLE
fix(frontend): handle cancelled photo picker errors

### DIFF
--- a/src/services/photos.ts
+++ b/src/services/photos.ts
@@ -40,10 +40,9 @@ export function isPhotoSelectionCancelledError(error: unknown) {
   if (!message)
     return false
 
-  return message.includes('user cancelled photos app')
-    || message.includes('user canceled photos app')
-    || message.includes('cancelled')
-    || message.includes('canceled')
+  return message.includes('user')
+    && /cancel(?:led|ed)/.test(message)
+    && /photos?|images?|camera|picker|selection|picking|app/.test(message)
 }
 
 function base64ToArrayBuffer(base64: string) {

--- a/src/services/photos.ts
+++ b/src/services/photos.ts
@@ -25,6 +25,27 @@ function normalizeImageStoragePath(path?: string | null) {
   return pathWithoutQuery.replace(IMAGES_PREFIX_REGEX, '').replace(LEADING_SLASHES_REGEX, '')
 }
 
+function getPhotoErrorMessage(error: unknown) {
+  if (typeof error === 'string')
+    return error
+  if (error instanceof Error)
+    return error.message
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string')
+    return error.message
+  return ''
+}
+
+export function isPhotoSelectionCancelledError(error: unknown) {
+  const message = getPhotoErrorMessage(error).toLowerCase()
+  if (!message)
+    return false
+
+  return message.includes('user cancelled photos app')
+    || message.includes('user canceled photos app')
+    || message.includes('cancelled')
+    || message.includes('canceled')
+}
+
 function base64ToArrayBuffer(base64: string) {
   const binary = atob(base64)
   const bytes = new Uint8Array(binary.length)
@@ -212,15 +233,19 @@ function blobToData(blob: Blob) {
 
 export async function takePhoto(formId: string, isLoading: Ref<boolean>, type: 'org' | 'user', wentWrong: string) {
   const uploadPhoto = (type === 'user') ? uploadPhotoUser : uploadPhotoOrg
-  const cameraPhoto = await Camera.getPhoto({
-    resultType: CameraResultType.DataUrl,
-    source: CameraSource.Camera,
-    quality: 100,
-  })
-
-  isLoading.value = true
-
-  const fileName = `${Date.now()}.${cameraPhoto.format}`
+  let cameraPhoto
+  try {
+    cameraPhoto = await Camera.getPhoto({
+      resultType: CameraResultType.DataUrl,
+      source: CameraSource.Camera,
+      quality: 100,
+    })
+  }
+  catch (error) {
+    if (!isPhotoSelectionCancelledError(error))
+      console.error(error)
+    return
+  }
 
   if (!cameraPhoto.dataUrl)
     return
@@ -229,6 +254,9 @@ export async function takePhoto(formId: string, isLoading: Ref<boolean>, type: '
 
   if (!contentType)
     return
+
+  isLoading.value = true
+  const fileName = `${Date.now()}.${cameraPhoto.format}`
   try {
     await uploadPhoto(formId, cameraPhoto.dataUrl.split('base64,')[1], fileName, contentType, isLoading, wentWrong)
   }
@@ -240,11 +268,19 @@ export async function takePhoto(formId: string, isLoading: Ref<boolean>, type: '
 
 export async function pickPhoto(formId: string, isLoading: Ref<boolean>, type: 'org' | 'user', wentWrong: string) {
   const uploadPhoto = (type === 'user') ? uploadPhotoUser : uploadPhotoOrg
-  const { photos } = await Camera.pickImages({
-    limit: 1,
-    quality: 100,
-  })
-  isLoading.value = true
+  let pickedImages
+  try {
+    pickedImages = await Camera.pickImages({
+      limit: 1,
+      quality: 100,
+    })
+  }
+  catch (error) {
+    if (!isPhotoSelectionCancelledError(error))
+      console.error(error)
+    return
+  }
+  const { photos } = pickedImages
   if (photos.length === 0)
     return
   try {
@@ -261,6 +297,7 @@ export async function pickPhoto(formId: string, isLoading: Ref<boolean>, type: '
     const contentType = mime.getType(photos[0].format)
     if (!contentType)
       return
+    isLoading.value = true
     await uploadPhoto(
       formId,
       contents.data as any,

--- a/tests/photos.unit.test.ts
+++ b/tests/photos.unit.test.ts
@@ -62,7 +62,7 @@ describe('photo helpers', () => {
   })
 
   it('matches the PostHog photo cancellation errors', async () => {
-    const { isPhotoSelectionCancelledError } = await import('../src/services/photos.ts')
+    const { isPhotoSelectionCancelledError } = await import('~/services/photos.ts')
 
     expect(isPhotoSelectionCancelledError(new Error('User cancelled photos app'))).toBe(true)
     expect(isPhotoSelectionCancelledError({ message: 'User canceled image selection' })).toBe(true)
@@ -74,7 +74,7 @@ describe('photo helpers', () => {
     getPhotoMock.mockRejectedValueOnce(new Error('User cancelled photos app'))
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const isLoading = ref(false)
-    const { takePhoto } = await import('../src/services/photos.ts')
+    const { takePhoto } = await import('~/services/photos.ts')
 
     await expect(takePhoto('update-account', isLoading, 'user', 'went-wrong')).resolves.toBeUndefined()
 
@@ -86,7 +86,7 @@ describe('photo helpers', () => {
     pickImagesMock.mockRejectedValueOnce({ message: 'User canceled photos app' })
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const isLoading = ref(false)
-    const { pickPhoto } = await import('../src/services/photos.ts')
+    const { pickPhoto } = await import('~/services/photos.ts')
 
     await expect(pickPhoto('update-org', isLoading, 'org', 'went-wrong')).resolves.toBeUndefined()
 
@@ -94,11 +94,23 @@ describe('photo helpers', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
+  it('still logs unexpected camera capture errors', async () => {
+    getPhotoMock.mockRejectedValueOnce(new Error('Camera permission denied'))
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const isLoading = ref(false)
+    const { takePhoto } = await import('~/services/photos.ts')
+
+    await expect(takePhoto('update-org', isLoading, 'org', 'went-wrong')).resolves.toBeUndefined()
+
+    expect(isLoading.value).toBe(false)
+    expect(consoleErrorSpy).toHaveBeenCalledOnce()
+  })
+
   it('still logs unexpected image picker errors', async () => {
     pickImagesMock.mockRejectedValueOnce(new Error('Camera permission denied'))
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const isLoading = ref(false)
-    const { pickPhoto } = await import('../src/services/photos.ts')
+    const { pickPhoto } = await import('~/services/photos.ts')
 
     await expect(pickPhoto('update-org', isLoading, 'org', 'went-wrong')).resolves.toBeUndefined()
 

--- a/tests/photos.unit.test.ts
+++ b/tests/photos.unit.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const {
+  getPhotoMock,
+  pickImagesMock,
+} = vi.hoisted(() => ({
+  getPhotoMock: vi.fn(),
+  pickImagesMock: vi.fn(),
+}))
+
+vi.mock('@capacitor/camera', () => ({
+  Camera: {
+    getPhoto: getPhotoMock,
+    pickImages: pickImagesMock,
+  },
+  CameraResultType: {
+    DataUrl: 'DataUrl',
+  },
+  CameraSource: {
+    Camera: 'Camera',
+  },
+}))
+
+vi.mock('@capacitor/filesystem', () => ({
+  Filesystem: {
+    readFile: vi.fn(),
+  },
+}))
+
+vi.mock('~/services/supabase', () => ({
+  useSupabase: () => ({
+    from: vi.fn(),
+    storage: {
+      from: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('~/stores/main', () => ({
+  useMainStore: () => ({
+    user: null,
+  }),
+}))
+
+vi.mock('~/stores/organization', () => ({
+  useOrganizationStore: () => ({
+    currentOrganization: null,
+    fetchOrganizations: vi.fn(),
+    setCurrentOrganization: vi.fn(),
+  }),
+}))
+
+describe('photo helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('matches the PostHog photo cancellation errors', async () => {
+    const { isPhotoSelectionCancelledError } = await import('../src/services/photos.ts')
+
+    expect(isPhotoSelectionCancelledError(new Error('User cancelled photos app'))).toBe(true)
+    expect(isPhotoSelectionCancelledError({ message: 'User canceled image selection' })).toBe(true)
+    expect(isPhotoSelectionCancelledError('The user cancelled image picking')).toBe(true)
+    expect(isPhotoSelectionCancelledError(new Error('Camera permission denied'))).toBe(false)
+  })
+
+  it('swallows cancelled camera capture errors', async () => {
+    getPhotoMock.mockRejectedValueOnce(new Error('User cancelled photos app'))
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const isLoading = ref(false)
+    const { takePhoto } = await import('../src/services/photos.ts')
+
+    await expect(takePhoto('update-account', isLoading, 'user', 'went-wrong')).resolves.toBeUndefined()
+
+    expect(isLoading.value).toBe(false)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('swallows cancelled image picker errors', async () => {
+    pickImagesMock.mockRejectedValueOnce({ message: 'User canceled photos app' })
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const isLoading = ref(false)
+    const { pickPhoto } = await import('../src/services/photos.ts')
+
+    await expect(pickPhoto('update-org', isLoading, 'org', 'went-wrong')).resolves.toBeUndefined()
+
+    expect(isLoading.value).toBe(false)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('still logs unexpected image picker errors', async () => {
+    pickImagesMock.mockRejectedValueOnce(new Error('Camera permission denied'))
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const isLoading = ref(false)
+    const { pickPhoto } = await import('../src/services/photos.ts')
+
+    await expect(pickPhoto('update-org', isLoading, 'org', 'went-wrong')).resolves.toBeUndefined()
+
+    expect(isLoading.value).toBe(false)
+    expect(consoleErrorSpy).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- handle Capacitor camera/photo-picker cancellation rejections in the shared photo helpers
- avoid reporting expected user-cancel flows like PostHog issue `019da6f5-f886-7a32-be5f-381fa7ea5436` (`User cancelled photos app`) as runtime errors
- add unit coverage for cancelled and non-cancelled photo picker failures

## Motivation (AI generated)

Cancelling the native photo flow is expected user behavior, but the shared helpers in `src/services/photos.ts` let those rejections escape before local error handling started. That creates noisy PostHog errors and makes the photo flows less robust.

## Business Impact (AI generated)

This reduces error-tracking noise so the team can focus on real failures, and it prevents benign photo-flow cancellations from looking like broken account or organization settings flows.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/photos.unit.test.ts`
- [x] `bunx eslint src/services/photos.ts tests/photos.unit.test.ts`
- [x] `bun lint`
- [x] `bun typecheck`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Photo selection cancellations no longer surface error messages or logs.
  * Loading indicator reliably resets after cancelled or failed photo pick/capture.
  * Non-cancellation failures still log once and are handled gracefully.

* **Tests**
  * New unit tests cover cancellation detection and error-handling behavior for photo capture and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->