### PR TITLE
feat(backend): PostHog organization groups + $groupidentify

### DIFF
--- a/supabase/functions/_backend/private/delete_failed_version.ts
+++ b/supabase/functions/_backend/private/delete_failed_version.ts
@@ -91,6 +91,7 @@ app.delete('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
     channel: 'upload-failed',
     event: 'Failed to upload a bundle',
     user_id: version.owner_org,
+    groups: { organization: version.owner_org },
     icon: '💀',
   })
 

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -146,6 +146,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
     ...trackedBody,
     bento: onboardingBentoEvent,
     sentToBento: Boolean(onboardingBentoEvent),
+    groups: trackingUserId ? { organization: trackingUserId } : undefined,
   })
 
   return c.json(BRES)

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -15,17 +15,26 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
 
+interface ResolvedTrackingId {
+  trackingUserId: string
+  // Only set when we've verified the id refers to an organization the caller
+  // can access. Events for a bare authenticated user (no requestedUserId, or
+  // requestedUserId === authUserId) leave this undefined so we don't pollute
+  // the PostHog `organization` group with user UUIDs.
+  orgId?: string
+}
+
 async function resolveTrackingUserId(
   c: Context<MiddlewareKeyVariables>,
   requestedUserId: string | undefined,
   appId: string | undefined,
   notifyConsole = false,
-) {
+): Promise<ResolvedTrackingId> {
   const forbiddenError = notifyConsole ? 'Forbidden' : 'no_permission'
   const authUserId = c.get('auth')?.userId ?? ''
 
   if (!requestedUserId || requestedUserId === authUserId) {
-    return authUserId
+    return { trackingUserId: authUserId }
   }
 
   if (appId) {
@@ -44,11 +53,11 @@ async function resolveTrackingUserId(
       throw quickError(403, forbiddenError, 'You cannot send events for this organization')
     }
 
-    return requestedUserId
+    return { trackingUserId: requestedUserId, orgId: requestedUserId }
   }
 
   if (await checkPermission(c, 'org.read', { orgId: requestedUserId })) {
-    return requestedUserId
+    return { trackingUserId: requestedUserId, orgId: requestedUserId }
   }
 
   throw quickError(403, forbiddenError, 'You cannot send events for this organization')
@@ -83,7 +92,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
     : typeof body.tags?.app_id === 'string'
       ? body.tags.app_id
       : undefined
-  const trackingUserId = await resolveTrackingUserId(c, requestedUserId, appId, Boolean(body.notifyConsole))
+  const { trackingUserId, orgId: verifiedOrgId } = await resolveTrackingUserId(c, requestedUserId, appId, Boolean(body.notifyConsole))
   const trackedBody = requestedUserId ? { ...trackOptions, user_id: trackingUserId } : trackOptions
 
   // notifyConsole: broadcast to Supabase Realtime only, skip all tracking
@@ -99,7 +108,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
         description: trackedBody.description,
         icon: trackedBody.icon,
         app_id: appId,
-        org_id: trackingUserId,
+        org_id: requestedOrgId,
         channel_name: typeof trackedBody.tags?.channel === 'string' ? trackedBody.tags.channel : undefined,
         bundle_name: typeof trackedBody.tags?.bundle === 'string' ? trackedBody.tags.bundle : undefined,
         timestamp: new Date().toISOString(),
@@ -146,7 +155,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
     ...trackedBody,
     bento: onboardingBentoEvent,
     sentToBento: Boolean(onboardingBentoEvent),
-    groups: trackingUserId ? { organization: trackingUserId } : undefined,
+    groups: verifiedOrgId ? { organization: verifiedOrgId } : undefined,
   })
 
   return c.json(BRES)

--- a/supabase/functions/_backend/private/upload_link.ts
+++ b/supabase/functions/_backend/private/upload_link.ts
@@ -79,6 +79,7 @@ app.post('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
     event: 'Upload via single file',
     icon: '🏛️',
     user_id: app.owner_org,
+    groups: { organization: app.owner_org },
     notify: false,
   })
 

--- a/supabase/functions/_backend/triggers/credit_usage_alerts.ts
+++ b/supabase/functions/_backend/triggers/credit_usage_alerts.ts
@@ -77,6 +77,7 @@ app.post('/', middlewareAPISecret, async (c) => {
         event: `Credit usage ${threshold}%+`,
         icon: '⚡️',
         user_id: orgId,
+        groups: { organization: orgId },
         notify: threshold >= 100,
         tags: {
           alert_cycle: alertCycle.toString(),

--- a/supabase/functions/_backend/triggers/on_app_create.ts
+++ b/supabase/functions/_backend/triggers/on_app_create.ts
@@ -136,6 +136,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
     icon: isDemo ? '🎮' : isPendingOnboarding ? '🧭' : '🎉',
     sentToBento: Boolean(appCreatedBentoEvent),
     user_id: ownerOrg,
+    groups: { organization: ownerOrg },
     tags: {
       app_id: record.app_id,
       is_demo: isDemo ? 'true' : 'false',

--- a/supabase/functions/_backend/triggers/on_deploy_history_create.ts
+++ b/supabase/functions/_backend/triggers/on_deploy_history_create.ts
@@ -58,6 +58,7 @@ app.post('/', middlewareAPISecret, triggerValidator('deploy_history', 'INSERT'),
       event: 'Bundle Deployed',
       icon: '🚀',
       user_id: version.owner_org,
+      groups: { organization: version.owner_org },
       tags: {
         app_id: record.app_id,
         bundle_name: version.name,

--- a/supabase/functions/_backend/triggers/on_organization_create.ts
+++ b/supabase/functions/_backend/triggers/on_organization_create.ts
@@ -3,8 +3,10 @@ import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { groupIdentifyPosthog } from '../utils/posthog.ts'
 import { createStripeCustomer, finalizePendingStripeCustomer } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
+import { backgroundTask } from '../utils/utils.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -24,6 +26,19 @@ app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c)
     await finalizePendingStripeCustomer(c, record)
   }
 
+  await backgroundTask(c, groupIdentifyPosthog(c, {
+    groupType: 'organization',
+    groupKey: record.id,
+    properties: {
+      name: record.name,
+      management_email: record.management_email,
+      customer_id: record.customer_id,
+      created_by: record.created_by,
+      created_at: record.created_at,
+      website: record.website,
+    },
+  }))
+
   await sendEventToTracking(c, {
     bento: {
       cron: '* * * * *',
@@ -40,6 +55,7 @@ app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c)
     icon: '🎉',
     sentToBento: true,
     user_id: record.id,
+    groups: { organization: record.id },
     notify: false,
   })
 

--- a/supabase/functions/_backend/triggers/on_version_create.ts
+++ b/supabase/functions/_backend/triggers/on_version_create.ts
@@ -52,6 +52,7 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'INSERT'), a
       event: 'Bundle Created',
       icon: '🎉',
       user_id: record.owner_org,
+      groups: { organization: record.owner_org },
       tags: {
         app_id: record.app_id,
         bundle_name: record.name,

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -12,9 +12,11 @@ import { middlewareStripeWebhook } from '../utils/hono_middleware_stripe.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import * as schema from '../utils/postgres_schema.ts'
+import { groupIdentifyPosthog } from '../utils/posthog.ts'
 import { ensureCustomerMetadata, getCreditCheckoutDetails, syncStripeCustomerCountry } from '../utils/stripe.ts'
 import { customerToSegmentOrg, supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
+import { backgroundTask } from '../utils/utils.ts'
 
 export const app = new Hono<MiddlewareKeyVariablesStripe>()
 
@@ -276,6 +278,7 @@ async function customerSourceCreated(c: Context, org: Org, stripeEvent: Stripe.C
     icon: '💳',
     sentToBento: true,
     user_id: org.id,
+    groups: { organization: org.id },
     notify: false,
   })
   return c.json(BRES)
@@ -295,6 +298,7 @@ async function customerSourceExpiring(c: Context, org: Org) {
     icon: '⚠️',
     sentToBento: true,
     user_id: org.id,
+    groups: { organization: org.id },
     notify: false,
   })
   return c.json(BRES)
@@ -332,6 +336,7 @@ async function invoiceUpcoming(c: Context, org: Org, stripeEvent: Stripe.Invoice
     icon: '📄',
     sentToBento: true,
     user_id: org.id,
+    groups: { organization: org.id },
     notify: false,
   })
   return c.json(BRES)
@@ -384,6 +389,7 @@ async function createdOrUpdated(
         icon: '💰',
         sentToBento: true,
         user_id: org.id,
+        groups: { organization: org.id },
         notify: true,
         tags: {
           plan_name: plan.name,
@@ -418,11 +424,23 @@ async function createdOrUpdated(
       icon: '💰',
       sentToBento: true,
       user_id: org.id,
+      groups: { organization: org.id },
       notify: isNewSubscription,
       tags: {
         plan_name: plan.name,
       },
     })
+
+    await backgroundTask(c, groupIdentifyPosthog(c, {
+      groupType: 'organization',
+      groupKey: org.id,
+      properties: {
+        plan_name: plan.name,
+        plan_status: status,
+        plan_type: isMonthly ? 'monthly' : 'yearly',
+        subscription_status_name: statusName,
+      },
+    }))
   }
   else {
     const segment = await customerToSegmentOrg(c, org.id, stripeData.data.price_id)
@@ -458,8 +476,18 @@ async function didCancel(c: Context, org: Org) {
     icon: '⚠️',
     sentToBento: true,
     user_id: org.id,
+    groups: { organization: org.id },
     notify: true,
   })
+
+  await backgroundTask(c, groupIdentifyPosthog(c, {
+    groupType: 'organization',
+    groupKey: org.id,
+    properties: {
+      plan_status: 'canceled',
+      canceled_at: new Date().toISOString(),
+    },
+  }))
 }
 
 async function getOrg(c: Context, stripeData: StripeData) {

--- a/supabase/functions/_backend/utils/plans.ts
+++ b/supabase/functions/_backend/utils/plans.ts
@@ -320,6 +320,7 @@ async function userAbovePlan(c: Context, org: {
       event: `User need upgrade to ${bestPlanKey}`,
       icon: '⚠️',
       user_id: orgId,
+      groups: { organization: orgId },
       notify: false,
     }).catch()
   }
@@ -344,6 +345,7 @@ async function userIsAtPlanUsage(c: Context, orgId: string, customerId: string |
         event: 'User is at 90% of plan usage',
         icon: '⚠️',
         user_id: orgId,
+        groups: { organization: orgId },
         notify: false,
       }).catch()
     }
@@ -357,6 +359,7 @@ async function userIsAtPlanUsage(c: Context, orgId: string, customerId: string |
         event: 'User is at 70% of plan usage',
         icon: '⚠️',
         user_id: orgId,
+        groups: { organization: orgId },
         notify: false,
       }).catch()
     }
@@ -369,6 +372,7 @@ async function userIsAtPlanUsage(c: Context, orgId: string, customerId: string |
         event: 'User is at 50% of plan usage',
         icon: '⚠️',
         user_id: orgId,
+        groups: { organization: orgId },
         notify: false,
       }).catch()
     }
@@ -455,6 +459,7 @@ export async function handleOrgNotificationsAndEvents(c: Context, org: any, orgI
         event: 'User need onboarding',
         icon: '🥲',
         user_id: orgId,
+        groups: { organization: orgId },
         notify: false,
       }).catch()
     }

--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -6,8 +6,11 @@ import { existInEnv, getEnv } from './utils.ts'
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
 const POSTHOG_EXCEPTION_URL = 'https://eu.i.posthog.com/i/v0/e/'
 
+export type PostHogGroups = Record<string, string>
+
 interface PostHogCapturePayload extends Pick<TrackOptions, 'event'>, Pick<TrackOptions, 'channel' | 'description'> {
   distinct_id?: string
+  groups?: PostHogGroups
   ip?: string
   setPersonProperties?: boolean
   tags?: Record<string, any>
@@ -28,11 +31,14 @@ export async function trackPosthogEvent(c: Context, payload: PostHogCapturePaylo
 
   const distinctId = payload.user_id || payload.distinct_id || 'anonymous'
 
+  const hasGroups = payload.groups && Object.keys(payload.groups).length > 0
+
   const properties = {
     ...(payload.tags || {}),
     channel: payload.channel,
     description: payload.description,
     ...(payload.setPersonProperties === false ? {} : { $set: payload.tags }),
+    ...(hasGroups ? { $groups: payload.groups } : {}),
   }
 
   const body = {
@@ -225,6 +231,76 @@ export async function capturePosthogException(c: Context, payload: {
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'PostHog exception fetch failed', error: serializeError(e), event: '$exception', distinctId })
+    return false
+  }
+}
+
+export interface PostHogGroupIdentifyPayload {
+  groupType: string
+  groupKey: string
+  properties?: Record<string, unknown>
+}
+
+export async function groupIdentifyPosthog(c: Context, payload: PostHogGroupIdentifyPayload) {
+  const apiKey = getEnv(c, 'POSTHOG_API_KEY')
+  if (!apiKey || !existInEnv(c, 'POSTHOG_API_KEY')) {
+    cloudlog({ requestId: c.get('requestId'), message: 'PostHog not configured' })
+    return false
+  }
+
+  const host = getEnv(c, 'POSTHOG_API_HOST') || POSTHOG_CAPTURE_URL
+  const posthogUrl = host.endsWith('/capture/')
+    ? host
+    : new URL('capture/', host.endsWith('/') ? host : `${host}/`).toString()
+
+  const body = {
+    api_key: apiKey,
+    event: '$groupidentify',
+    distinct_id: `$${payload.groupType}_${payload.groupKey}`,
+    properties: {
+      $group_type: payload.groupType,
+      $group_key: payload.groupKey,
+      $group_set: payload.properties ?? {},
+    },
+    timestamp: new Date().toISOString(),
+  }
+
+  try {
+    const res = await fetch(posthogUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    if (!res.ok) {
+      const error = await res.text()
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'PostHog $groupidentify error',
+        status: res.status,
+        error,
+        groupType: payload.groupType,
+        groupKey: payload.groupKey,
+      })
+      return false
+    }
+
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'PostHog $groupidentify sent',
+      groupType: payload.groupType,
+      groupKey: payload.groupKey,
+    })
+    return true
+  }
+  catch (e) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'PostHog $groupidentify fetch failed',
+      error: serializeError(e),
+      groupType: payload.groupType,
+      groupKey: payload.groupKey,
+    })
     return false
   }
 }

--- a/supabase/functions/_backend/utils/tracking.ts
+++ b/supabase/functions/_backend/utils/tracking.ts
@@ -1,5 +1,6 @@
 import type { TrackOptions } from '@logsnag/node'
 import type { Context } from 'hono'
+import type { PostHogGroups } from './posthog.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { logsnag } from './logsnag.ts'
 import { sendNotifToOrgMembers } from './org_email_notifications.ts'
@@ -17,6 +18,7 @@ export interface BentoTrackingPayload {
 
 export interface SendEventToTrackingPayload extends TrackOptions {
   bento?: BentoTrackingPayload
+  groups?: PostHogGroups
   sentToBento?: boolean
 }
 
@@ -46,7 +48,7 @@ function getTrackingIp(c: Context, ip?: string) {
   return c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for')?.split(',')[0]?.trim()
 }
 
-async function executeTracking(c: Context, payload: TrackOptions, options: SendEventToTrackingOptions) {
+async function executeTracking(c: Context, payload: SendEventToTrackingPayload, options: SendEventToTrackingOptions) {
   const tasks: Array<Promise<void>> = [
     runTrackedCall(c, 'logsnag', () => logsnag(c).track(payload)),
     runTrackedCall(c, 'posthog', () => trackPosthogEvent(c, {
@@ -55,6 +57,7 @@ async function executeTracking(c: Context, payload: TrackOptions, options: SendE
       tags: payload.tags,
       channel: payload.channel,
       description: payload.description,
+      groups: payload.groups,
       ip: getTrackingIp(c, options.ip),
     })),
   ]


### PR DESCRIPTION
## Summary

Server-side events carry `groups: { organization: orgId }` to PostHog so dashboards can break down by org/plan. Adds a new `groupIdentifyPosthog` helper and calls it on org creation + Stripe lifecycle changes to keep org properties (plan, status, etc.) fresh.

## Why

The LogSnag → PostHog KPI port we just did showed that backend events land on PostHog with `distinct_id = record.id` (the org/app UUID), creating anonymous person records with no way to correlate to users or aggregate by org. PostHog's Groups feature is the canonical B2B fix — events attributed to a group type can be broken down, cohorted, and flagged by group properties without changing the distinct_id scheme.

## What changed

### Plumbing
- `utils/posthog.ts`: `trackPosthogEvent` now adds `$groups` to the capture body when a `groups` map is supplied. New exported `groupIdentifyPosthog(c, { groupType, groupKey, properties })` posts `$groupidentify` events.
- `utils/tracking.ts`: `SendEventToTrackingPayload` gains an optional `groups?: PostHogGroups` field; `executeTracking` forwards it to PostHog. LogSnag's `.track()` ignores the extra field (same pattern as the existing `bento` / `sentToBento` fields).

### Org $groupidentify
- **`on_organization_create`** — identifies the new org with `{ name, management_email, customer_id, created_by, created_at, website }`.
- **`stripe_event`** — on subscription created/updated, refreshes `{ plan_name, plan_status, plan_type, subscription_status_name }`; on cancel, sets `{ plan_status: 'canceled', canceled_at }`.

Both calls run inside `backgroundTask` so they don't block the webhook response.

### `groups` propagated
Every existing `sendEventToTracking` call that has an `orgId` in scope now passes `groups: { organization: orgId }`:
- Triggers: `on_organization_create`, `on_app_create`, `on_version_create`, `on_deploy_history_create`, `credit_usage_alerts`, all 6 `stripe_event` paths.
- Private endpoints: `upload_link`, `delete_failed_version`, `events` (when `trackingUserId` is known).
- `utils/plans.ts`: all 5 plan/usage alert events.

`on_user_create` intentionally does **not** pass `groups` (user-scope event, no org context at signup time).

## Out of scope (separate PR)
- App groups (`groups: { app: appId }`) — straightforward follow-up once this lands.
- Fixing the broader "distinct_id should be the user UUID, not the org/app UUID" identity issue — that's the next PR on the list.

## Test plan

- [x] `bun lint:backend` — clean
- [x] `bun typecheck` — clean
- [x] `bunx vitest run tests/tracking.unit.test.ts tests/plans-onboarding-reminder.unit.test.ts` — 3 tests pass
- [ ] After merge, verify in PostHog that new events show `$groups.organization` on the event properties (filter by `$groups.organization is set`).
- [ ] Verify Groups → Organizations tab in PostHog starts populating with properties from `groupIdentifyPosthog` calls.
- [ ] Rebuild one insight on the [Capgo KPIs dashboard](https://eu.posthog.com/project/22029/dashboard/634570) with breakdown by `organization` to confirm org-level aggregation works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tracking events now include organization-level grouping and group identification across backend functions, triggers, and utilities.
  * Analytics payloads consistently carry organization context to improve organization-level metrics, alerting, and subscription/event tracking.
  * Added support for sending group-identify calls to the analytics provider for richer org-level insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->