### PR TITLE
fix(frontend): guard dashboard date range parsing

### DIFF
--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -217,10 +217,36 @@ export interface AppUsageGlobalByApp {
   byApp: AppUsageByApp[]
 }
 
+function parseDashboardRangeDate(value?: string) {
+  if (!value)
+    return null
+
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export function normalizeDashboardDateRange(startDate?: string, endDate?: string, now: Date = new Date()) {
+  const fallbackEnd = new Date(now)
+  fallbackEnd.setHours(0, 0, 0, 0)
+  fallbackEnd.setDate(fallbackEnd.getDate() + 1)
+
+  const fallbackStart = new Date(fallbackEnd)
+  fallbackStart.setDate(fallbackStart.getDate() - 30)
+
+  const resolvedStart = parseDashboardRangeDate(startDate) ?? fallbackStart
+  const resolvedEnd = parseDashboardRangeDate(endDate) ?? fallbackEnd
+
+  return {
+    start: resolvedStart.toISOString(),
+    end: resolvedEnd.toISOString(),
+  }
+}
+
 export async function getAllDashboard(orgId: string, startDate?: string, endDate?: string): Promise<AppUsageGlobalByApp> {
   try {
     const supabase = useSupabase()
-    const dateRange = `?from=${new Date(startDate!).toISOString()}&to=${new Date(endDate!).toISOString()}&breakdown=true&noAccumulate=true`
+    const { start, end } = normalizeDashboardDateRange(startDate, endDate)
+    const dateRange = `?from=${start}&to=${end}&breakdown=true&noAccumulate=true`
 
     // 🚀 SUPER OPTIMIZED: Single API call returns both aggregated AND per-app breakdown (with daily values, not accumulated)
     const response = await supabase.functions.invoke(`statistics/org/${orgId}/${dateRange}`, {

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -236,6 +236,13 @@ export function normalizeDashboardDateRange(startDate?: string, endDate?: string
   const resolvedStart = parseDashboardRangeDate(startDate) ?? fallbackStart
   const resolvedEnd = parseDashboardRangeDate(endDate) ?? fallbackEnd
 
+  if (resolvedStart.getTime() > resolvedEnd.getTime()) {
+    return {
+      start: fallbackStart.toISOString(),
+      end: fallbackEnd.toISOString(),
+    }
+  }
+
   return {
     start: resolvedStart.toISOString(),
     end: resolvedEnd.toISOString(),

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -233,8 +233,10 @@ export function normalizeDashboardDateRange(startDate?: string, endDate?: string
   const fallbackStart = new Date(fallbackEnd)
   fallbackStart.setDate(fallbackStart.getDate() - 30)
 
-  const resolvedStart = parseDashboardRangeDate(startDate) ?? fallbackStart
-  const resolvedEnd = parseDashboardRangeDate(endDate) ?? fallbackEnd
+  const parsedStart = parseDashboardRangeDate(startDate)
+  const parsedEnd = parseDashboardRangeDate(endDate)
+  const resolvedStart = parsedStart && parsedEnd ? parsedStart : fallbackStart
+  const resolvedEnd = parsedStart && parsedEnd ? parsedEnd : fallbackEnd
 
   if (resolvedStart.getTime() > resolvedEnd.getTime()) {
     return {

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -221,8 +221,24 @@ function parseDashboardRangeDate(value?: string) {
   if (!value)
     return null
 
+  const dateParts = value.match(/^(\d{4})-(\d{2})-(\d{2})(?:$|T)/)
+  if (!dateParts)
+    return null
+
+  const [year, month, day] = dateParts.slice(1).map(Number)
   const parsed = new Date(value)
-  return Number.isNaN(parsed.getTime()) ? null : parsed
+  if (Number.isNaN(parsed.getTime()))
+    return null
+
+  if (
+    parsed.getUTCFullYear() !== year
+    || parsed.getUTCMonth() + 1 !== month
+    || parsed.getUTCDate() !== day
+  ) {
+    return null
+  }
+
+  return parsed
 }
 
 export function normalizeDashboardDateRange(startDate?: string, endDate?: string, now: Date = new Date()) {

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -5,15 +5,16 @@ import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref } from 'vue'
 import { getDaysBetweenDates } from '~/services/conversion'
 import { reset } from '~/services/posthog'
-import { getLocalConfig, useSupabase } from '~/services/supabase'
-import { createDeferredPromise } from '../utils/promise'
 import {
   findBestPlan,
   getAllDashboard,
+  getLocalConfig,
   getTotalStorage,
   normalizeDashboardDateRange,
   unspoofUser,
-} from './../services/supabase'
+  useSupabase,
+} from '~/services/supabase'
+import { createDeferredPromise } from '../utils/promise'
 
 interface TotalStats {
   mau: number

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -11,6 +11,7 @@ import {
   findBestPlan,
   getAllDashboard,
   getTotalStorage,
+  normalizeDashboardDateRange,
   unspoofUser,
 } from './../services/supabase'
 
@@ -101,11 +102,12 @@ export const useMainStore = defineStore('main', () => {
 
   const updateDashboard = async (currentOrgId: string, rangeStart?: string, rangeEnd?: string) => {
     try {
-      const dashboardRes = await getAllDashboard(currentOrgId, rangeStart, rangeEnd)
+      const { start, end } = normalizeDashboardDateRange(rangeStart, rangeEnd)
+      const dashboardRes = await getAllDashboard(currentOrgId, start, end)
       dashboard.value = dashboardRes.global
       dashboardByapp.value = dashboardRes.byApp
 
-      const monthDay = calculateMonthDay(rangeStart)
+      const monthDay = calculateMonthDay(start)
 
       totalDevices.value = dashboard.value[monthDay]?.mau ?? 0
       totalDownload.value = dashboard.value[monthDay]?.get ?? 0

--- a/tests/dashboard-date-range.unit.test.ts
+++ b/tests/dashboard-date-range.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDashboardDateRange } from '~/services/supabase'
+
+function createFallbackWindow(now: Date) {
+  const end = new Date(now)
+  end.setHours(0, 0, 0, 0)
+  end.setDate(end.getDate() + 1)
+
+  const start = new Date(end)
+  start.setDate(start.getDate() - 30)
+
+  return {
+    start: start.toISOString(),
+    end: end.toISOString(),
+  }
+}
+
+describe('dashboard date range normalization', () => {
+  it.concurrent('keeps valid explicit dates unchanged', () => {
+    const normalized = normalizeDashboardDateRange(
+      '2026-04-01T00:00:00.000Z',
+      '2026-05-01T00:00:00.000Z',
+      new Date('2026-04-21T12:00:00.000Z'),
+    )
+
+    expect(normalized).toEqual({
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+    })
+  })
+
+  it.concurrent('falls back to the last 30-day window when dates are omitted', () => {
+    const now = new Date('2026-04-21T15:45:00.000Z')
+
+    expect(normalizeDashboardDateRange(undefined, undefined, now)).toEqual(createFallbackWindow(now))
+  })
+
+  it.concurrent('falls back only the invalid side of the range', () => {
+    const now = new Date('2026-04-21T15:45:00.000Z')
+    const fallback = createFallbackWindow(now)
+
+    expect(normalizeDashboardDateRange('not-a-date', '2026-04-30T00:00:00.000Z', now)).toEqual({
+      start: fallback.start,
+      end: '2026-04-30T00:00:00.000Z',
+    })
+
+    expect(normalizeDashboardDateRange('2026-04-01T00:00:00.000Z', 'still-not-a-date', now)).toEqual({
+      start: '2026-04-01T00:00:00.000Z',
+      end: fallback.end,
+    })
+  })
+})

--- a/tests/dashboard-date-range.unit.test.ts
+++ b/tests/dashboard-date-range.unit.test.ts
@@ -39,6 +39,7 @@ describe('dashboard date range normalization', () => {
     const now = new Date('2026-04-21T15:45:00.000Z')
     expect(normalizeDashboardDateRange('not-a-date', '2026-04-30T00:00:00.000Z', now)).toEqual(createFallbackWindow(now))
     expect(normalizeDashboardDateRange('2026-04-01T00:00:00.000Z', 'still-not-a-date', now)).toEqual(createFallbackWindow(now))
+    expect(normalizeDashboardDateRange('2026-02-31T00:00:00.000Z', '2026-04-30T00:00:00.000Z', now)).toEqual(createFallbackWindow(now))
   })
 
   it.concurrent('falls back to the default window when the resolved range is inverted', () => {

--- a/tests/dashboard-date-range.unit.test.ts
+++ b/tests/dashboard-date-range.unit.test.ts
@@ -35,19 +35,10 @@ describe('dashboard date range normalization', () => {
     expect(normalizeDashboardDateRange(undefined, undefined, now)).toEqual(createFallbackWindow(now))
   })
 
-  it.concurrent('falls back only the invalid side of the range', () => {
+  it.concurrent('falls back to the default window when either bound is invalid', () => {
     const now = new Date('2026-04-21T15:45:00.000Z')
-    const fallback = createFallbackWindow(now)
-
-    expect(normalizeDashboardDateRange('not-a-date', '2026-04-30T00:00:00.000Z', now)).toEqual({
-      start: fallback.start,
-      end: '2026-04-30T00:00:00.000Z',
-    })
-
-    expect(normalizeDashboardDateRange('2026-04-01T00:00:00.000Z', 'still-not-a-date', now)).toEqual({
-      start: '2026-04-01T00:00:00.000Z',
-      end: fallback.end,
-    })
+    expect(normalizeDashboardDateRange('not-a-date', '2026-04-30T00:00:00.000Z', now)).toEqual(createFallbackWindow(now))
+    expect(normalizeDashboardDateRange('2026-04-01T00:00:00.000Z', 'still-not-a-date', now)).toEqual(createFallbackWindow(now))
   })
 
   it.concurrent('falls back to the default window when the resolved range is inverted', () => {

--- a/tests/dashboard-date-range.unit.test.ts
+++ b/tests/dashboard-date-range.unit.test.ts
@@ -49,4 +49,10 @@ describe('dashboard date range normalization', () => {
       end: fallback.end,
     })
   })
+
+  it.concurrent('falls back to the default window when the resolved range is inverted', () => {
+    const now = new Date('2026-04-21T15:45:00.000Z')
+
+    expect(normalizeDashboardDateRange('2026-05-01T00:00:00.000Z', '2026-04-01T00:00:00.000Z', now)).toEqual(createFallbackWindow(now))
+  })
 })

--- a/tests/main-dashboard-range.unit.test.ts
+++ b/tests/main-dashboard-range.unit.test.ts
@@ -10,7 +10,7 @@ vi.mock('../src/services/posthog.ts', () => ({
   reset: vi.fn(),
 }))
 
-vi.mock('../src/services/supabase.ts', () => ({
+vi.mock('~/services/supabase', () => ({
   findBestPlan: mockFindBestPlan,
   getAllDashboard: mockGetAllDashboard,
   getLocalConfig: () => ({ supaHost: 'https://supabase.capgo.test' }),

--- a/tests/main-dashboard-range.unit.test.ts
+++ b/tests/main-dashboard-range.unit.test.ts
@@ -1,0 +1,95 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFindBestPlan = vi.fn()
+const mockGetAllDashboard = vi.fn()
+const mockGetTotalStorage = vi.fn()
+const mockNormalizeDashboardDateRange = vi.fn()
+
+vi.mock('../src/services/posthog.ts', () => ({
+  reset: vi.fn(),
+}))
+
+vi.mock('../src/services/supabase.ts', () => ({
+  findBestPlan: mockFindBestPlan,
+  getAllDashboard: mockGetAllDashboard,
+  getLocalConfig: () => ({ supaHost: 'https://supabase.capgo.test' }),
+  getTotalStorage: mockGetTotalStorage,
+  normalizeDashboardDateRange: mockNormalizeDashboardDateRange,
+  unspoofUser: vi.fn(),
+  useSupabase: () => ({
+    auth: {
+      onAuthStateChange: vi.fn(() => ({
+        data: {
+          subscription: {
+            unsubscribe: vi.fn(),
+          },
+        },
+      })),
+      signOut: vi.fn(),
+    },
+  }),
+}))
+
+function createGlobalDashboard() {
+  return Array.from({ length: 30 }, (_, index) => ({
+    bandwidth: index,
+    build_time_unit: index,
+    date: `2026-04-${String(index + 1).padStart(2, '0')}`,
+    get: index,
+    mau: index,
+    storage: index,
+  }))
+}
+
+describe('main store dashboard range normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-21T12:00:00.000Z'))
+    setActivePinia(createPinia())
+
+    const global = createGlobalDashboard()
+    global[28] = {
+      ...global[28],
+      get: 2220,
+      mau: 111,
+    }
+    global[29] = {
+      ...global[29],
+      get: 9990,
+      mau: 999,
+    }
+
+    mockNormalizeDashboardDateRange.mockReturnValue({
+      end: '2026-04-22T00:00:00.000Z',
+      start: '2026-03-23T00:00:00.000Z',
+    })
+    mockGetAllDashboard.mockResolvedValue({
+      byApp: [],
+      global,
+    })
+    mockGetTotalStorage.mockResolvedValue(321)
+    mockFindBestPlan.mockResolvedValue('team')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the normalized range when selecting the current dashboard bucket', async () => {
+    const { useMainStore } = await import('../src/stores/main.ts')
+    const store = useMainStore()
+
+    await store.updateDashboard('org-123')
+
+    expect(mockNormalizeDashboardDateRange).toHaveBeenCalledWith(undefined, undefined)
+    expect(mockGetAllDashboard).toHaveBeenCalledWith(
+      'org-123',
+      '2026-03-23T00:00:00.000Z',
+      '2026-04-22T00:00:00.000Z',
+    )
+    expect(store.totalDevices).toBe(111)
+    expect(store.totalDownload).toBe(2220)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- normalize dashboard date filters before building the statistics request
- fall back to a stable last-30-day window when a dashboard date is missing or invalid
- add unit coverage for valid, missing, and invalid date ranges

## Motivation (AI generated)

PostHog reported a `RangeError: Invalid time value` in the dashboard flow. The frontend treated optional `startDate` and `endDate` values as always valid, so invalid or missing inputs could throw before the request was sent.

## Business Impact (AI generated)

This removes a dashboard-loading crash in analytics views, which keeps org reporting accessible and reduces avoidable support/debugging work around broken statistics pages.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/dashboard-date-range.unit.test.ts`
- [x] `bunx eslint src/services/supabase.ts tests/dashboard-date-range.unit.test.ts`
- [x] `bun typecheck`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard queries now use robust date-range normalization: missing/invalid dates default to a 30-day rolling window, end aligns to midnight UTC, and inverted ranges revert to the default window.
* **Bug Fixes**
  * Dashboard update flow now consistently uses normalized start/end values and derives reporting day from the normalized range.
* **Tests**
  * Added deterministic tests for valid ranges, missing/invalid inputs, inverted ranges, and store integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->