### PR TITLE
fix(frontend): guard chart tooltip canvas lifecycle

### DIFF
--- a/src/services/chartTooltip.ts
+++ b/src/services/chartTooltip.ts
@@ -28,8 +28,14 @@ function getCanvasContext(ctx: unknown): CanvasRenderingContext2D | null {
   return null
 }
 
+function hasConnectedCanvas(chart: Pick<Chart, 'canvas' | 'ctx'>): boolean {
+  const ctx = getCanvasContext(chart.ctx)
+  const canvas = chart.canvas ?? ctx?.canvas
+  return canvas?.isConnected !== false
+}
+
 function canSafelyUpdateChart(chart: Chart): boolean {
-  return !!getCanvasContext(chart.ctx) && !!chart.canvas?.isConnected
+  return !!getCanvasContext(chart.ctx) && hasConnectedCanvas(chart)
 }
 
 function clearTooltipSelection(chart: Chart) {
@@ -507,6 +513,9 @@ function isDarkMode() {
 export const verticalLinePlugin = {
   id: 'verticalLine',
   afterDatasetsDraw(chart: Chart) {
+    if (!hasConnectedCanvas(chart))
+      return
+
     const active = chart.tooltip?.getActiveElements()
     if (chart.tooltip && active && active.length > 0) {
       const activePoint = active[0]
@@ -599,6 +608,9 @@ export const todayLinePlugin = {
   afterDatasetsDraw(chart: Chart, _args: unknown, pluginOptions?: TodayLinePluginOptions) {
     const options = pluginOptions ?? {}
     if (!options.enabled)
+      return
+
+    if (!hasConnectedCanvas(chart))
       return
 
     const xScale = resolveScale(chart, 'x')

--- a/tests/chart-plugins.unit.test.ts
+++ b/tests/chart-plugins.unit.test.ts
@@ -45,7 +45,7 @@ describe('chart plugins', () => {
     })).not.toThrow()
   })
 
-  it('skips drawing the vertical hover line when the canvas is disconnected', () => {
+  it.concurrent('skips drawing the vertical hover line when the canvas is disconnected', () => {
     const ctx = {
       save: vi.fn(),
     }
@@ -72,7 +72,7 @@ describe('chart plugins', () => {
     expect(ctx.save).not.toHaveBeenCalled()
   })
 
-  it('skips drawing the today line when the canvas is disconnected', () => {
+  it.concurrent('skips drawing the today line when the canvas is disconnected', () => {
     const ctx = {
       save: vi.fn(),
     }

--- a/tests/chart-plugins.unit.test.ts
+++ b/tests/chart-plugins.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { inlineAnnotationPlugin } from '../src/services/chartAnnotations'
 import { todayLinePlugin, verticalLinePlugin } from '../src/services/chartTooltip'
@@ -43,6 +43,65 @@ describe('chart plugins', () => {
       xIndex: 2,
       label: 'Today',
     })).not.toThrow()
+  })
+
+  it('skips drawing the vertical hover line when the canvas is disconnected', () => {
+    const ctx = {
+      save: vi.fn(),
+    }
+
+    expect(() => verticalLinePlugin.afterDatasetsDraw({
+      ctx,
+      canvas: {
+        isConnected: false,
+      },
+      tooltip: {
+        getActiveElements: () => [{ element: { x: 12 } }],
+      },
+      scales: {
+        y: {
+          top: 10,
+          bottom: 90,
+        },
+      },
+      options: {
+        plugins: {},
+      },
+    } as any)).not.toThrow()
+
+    expect(ctx.save).not.toHaveBeenCalled()
+  })
+
+  it('skips drawing the today line when the canvas is disconnected', () => {
+    const ctx = {
+      save: vi.fn(),
+    }
+
+    expect(() => todayLinePlugin.afterDatasetsDraw({
+      ctx,
+      canvas: {
+        isConnected: false,
+      },
+      chartArea: {
+        top: 10,
+        bottom: 90,
+      },
+      scales: {
+        x: {
+          getPixelForValue: () => 24,
+        },
+        y: {
+          top: 10,
+          bottom: 90,
+        },
+      },
+    } as any, undefined, {
+      enabled: true,
+      xIndex: 2,
+      label: 'Today',
+    })).not.toThrow()
+
+    expect(ctx.save).not.toHaveBeenCalled()
   })
 
   it('skips inline annotations when the chart context is gone', () => {


### PR DESCRIPTION
## Summary (AI generated)

- skip custom chart overlay drawing when the chart canvas has already been disconnected
- reuse the connected-canvas check in the chart tooltip service instead of assuming the canvas is still alive
- add unit coverage for disconnected canvases in the vertical hover line and today line plugins

## Motivation (AI generated)

PostHog reported a `TypeError: Cannot read properties of null (reading 'save')` from the chart tooltip bundle. Our custom Chart.js plugins were still attempting to draw after the canvas lifecycle had already ended, which can happen during teardown or navigation.

## Business Impact (AI generated)

This removes a chart crash from statistics screens, especially around fast navigation or mobile teardown paths, which keeps analytics views stable and reduces noisy client-side errors in PostHog.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/chart-plugins.unit.test.ts`
- [x] `bunx eslint src/services/chartTooltip.ts tests/chart-plugins.unit.test.ts`
- [x] `bun typecheck`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart rendering stability by skipping drawing when the chart's canvas or rendering context is not connected, preventing spurious tooltip/line rendering and errors.

* **Tests**
  * Added unit tests covering plugin behavior when the canvas connection is absent to ensure no drawing or state changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->