### PR TITLE
fix(backend): harden cron sync retries

### DIFF
--- a/supabase/functions/_backend/triggers/cron_sync_sub.ts
+++ b/supabase/functions/_backend/triggers/cron_sync_sub.ts
@@ -1,13 +1,81 @@
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import { HTTPException } from 'hono/http-exception'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, parseBody, simpleError } from '../utils/hono.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { syncSubscriptionAndEvents } from '../utils/plans.ts'
+import { retryWithBackoff } from '../utils/retry.ts'
 
 interface OrgToGet {
   orgId?: string
   customerId?: string
+}
+
+const SYNC_RETRY_ATTEMPTS = 3
+const SYNC_RETRY_DELAY_MS = 500
+
+function getRetryableStatus(error: unknown): number | null {
+  if (error instanceof HTTPException)
+    return error.status
+
+  if (error && typeof error === 'object') {
+    if ('status' in error && typeof (error as { status?: unknown }).status === 'number')
+      return (error as { status: number }).status
+
+    if ('message' in error && typeof (error as { message?: unknown }).message === 'string') {
+      const match = /error code:\s*(\d{3})/i.exec((error as { message: string }).message)
+      if (match)
+        return Number.parseInt(match[1], 10)
+    }
+  }
+
+  return null
+}
+
+function getErrorCode(error: unknown): string | null {
+  const cause = error instanceof HTTPException
+    ? error.cause
+    : (error && typeof error === 'object' && 'cause' in error ? (error as { cause?: unknown }).cause : undefined)
+
+  if (cause && typeof cause === 'object' && 'error' in cause && typeof (cause as { error?: unknown }).error === 'string')
+    return (cause as { error: string }).error
+
+  return null
+}
+
+function isRetryableCronSyncError(error: unknown): boolean {
+  const status = getRetryableStatus(error)
+  return status !== null && status >= 500 && status < 600
+}
+
+function isMissingOrgError(error: unknown): boolean {
+  return getRetryableStatus(error) === 404 && getErrorCode(error) === 'org_not_found'
+}
+
+async function syncSubscriptionAndEventsWithRetry(
+  c: Parameters<typeof syncSubscriptionAndEvents>[0],
+  orgId: string,
+  drizzleClient: Parameters<typeof syncSubscriptionAndEvents>[2],
+) {
+  const { result, attempts } = await retryWithBackoff(async () => {
+    try {
+      await syncSubscriptionAndEvents(c, orgId, drizzleClient)
+      return { ok: true as const, error: null as unknown }
+    }
+    catch (error) {
+      return { ok: false as const, error }
+    }
+  }, {
+    attempts: SYNC_RETRY_ATTEMPTS,
+    baseDelayMs: SYNC_RETRY_DELAY_MS,
+    shouldRetry: current => !current.ok && isRetryableCronSyncError(current.error),
+  })
+
+  if (!result)
+    return { attempts, error: null as unknown }
+
+  return { attempts, error: result.ok ? null : result.error }
 }
 
 export const app = new Hono<MiddlewareKeyVariables>()
@@ -21,7 +89,24 @@ app.post('/', middlewareAPISecret, async (c) => {
   const pgClient = getPgClient(c, true)
   const drizzleClient = getDrizzleClient(pgClient)
   try {
-    await syncSubscriptionAndEvents(c, body.orgId, drizzleClient)
+    const { error, attempts } = await syncSubscriptionAndEventsWithRetry(c, body.orgId, drizzleClient)
+    if (error) {
+      if (isMissingOrgError(error)) {
+        cloudlog({ requestId: c.get('requestId'), message: 'cron_sync_sub skipping missing org', body, attempts })
+        return c.json({ status: 'skipped', reason: 'org_not_found' })
+      }
+
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'cron_sync_sub failed after retries',
+        body,
+        attempts,
+        error: serializeError(error),
+      })
+
+      throw error
+    }
+
     return c.json(BRES)
   }
   finally {

--- a/supabase/functions/_backend/utils/plans.ts
+++ b/supabase/functions/_backend/utils/plans.ts
@@ -385,9 +385,11 @@ export async function getOrgWithCustomerInfo(c: Context, orgId: string) {
     .from('orgs')
     .select('customer_id, name, website, stripe_info(status, subscription_id, subscription_anchor_start, subscription_anchor_end)')
     .eq('id', orgId)
-    .single()
-  if (userError || !org)
-    return quickError(404, 'org_not_found', 'Org not found', { orgId, userError })
+    .maybeSingle()
+  if (userError)
+    return quickError(500, 'cannot_get_org', 'Cannot get org', { orgId, userError })
+  if (!org)
+    return quickError(404, 'org_not_found', 'Org not found', { orgId })
   return org
 }
 

--- a/tests/cron_sync_sub.unit.test.ts
+++ b/tests/cron_sync_sub.unit.test.ts
@@ -2,16 +2,7 @@ import { HTTPException } from 'hono/http-exception'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('cron_sync_sub resilience', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.clearAllMocks()
-  })
-
-  it('retries transient cron_sync_sub failures and succeeds', async () => {
-    const syncSubscriptionAndEvents = vi.fn()
-      .mockRejectedValueOnce({ status: 502, message: 'error code: 502' })
-      .mockResolvedValueOnce(undefined)
-
+  function setupCommonMocks(syncSubscriptionAndEvents: ReturnType<typeof vi.fn>) {
     vi.doMock('../supabase/functions/_backend/utils/hono.ts', () => ({
       BRES: { status: 'ok' },
       middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => await next(),
@@ -28,6 +19,19 @@ describe('cron_sync_sub resilience', () => {
     vi.doMock('../supabase/functions/_backend/utils/plans.ts', () => ({
       syncSubscriptionAndEvents,
     }))
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('retries transient cron_sync_sub failures and succeeds', async () => {
+    const syncSubscriptionAndEvents = vi.fn()
+      .mockRejectedValueOnce({ status: 502, message: 'error code: 502' })
+      .mockResolvedValueOnce(undefined)
+
+    setupCommonMocks(syncSubscriptionAndEvents)
 
     const { app: cronSyncSub } = await import('../supabase/functions/_backend/triggers/cron_sync_sub.ts')
 
@@ -47,22 +51,7 @@ describe('cron_sync_sub resilience', () => {
       new HTTPException(404, { message: 'Org not found', cause: { error: 'org_not_found' } }),
     )
 
-    vi.doMock('../supabase/functions/_backend/utils/hono.ts', () => ({
-      BRES: { status: 'ok' },
-      middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => await next(),
-      parseBody: async (c: { req: { json: () => Promise<unknown> } }) => await c.req.json(),
-      simpleError: (errorCode: string, message: string, moreInfo: Record<string, unknown> = {}) => {
-        throw new HTTPException(400, { message, cause: { error: errorCode, ...moreInfo } })
-      },
-    }))
-    vi.doMock('../supabase/functions/_backend/utils/pg.ts', () => ({
-      closeClient: vi.fn(),
-      getDrizzleClient: vi.fn(() => ({ drizzle: true })),
-      getPgClient: vi.fn(() => ({ pg: true })),
-    }))
-    vi.doMock('../supabase/functions/_backend/utils/plans.ts', () => ({
-      syncSubscriptionAndEvents,
-    }))
+    setupCommonMocks(syncSubscriptionAndEvents)
 
     const { app: cronSyncSub } = await import('../supabase/functions/_backend/triggers/cron_sync_sub.ts')
 

--- a/tests/cron_sync_sub.unit.test.ts
+++ b/tests/cron_sync_sub.unit.test.ts
@@ -1,5 +1,11 @@
 import { HTTPException } from 'hono/http-exception'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockedModules = [
+  '../supabase/functions/_backend/utils/hono.ts',
+  '../supabase/functions/_backend/utils/pg.ts',
+  '../supabase/functions/_backend/utils/plans.ts',
+]
 
 describe('cron_sync_sub resilience', () => {
   function setupCommonMocks(syncSubscriptionAndEvents: ReturnType<typeof vi.fn>) {
@@ -24,6 +30,11 @@ describe('cron_sync_sub resilience', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    mockedModules.forEach(path => vi.doUnmock(path))
+    vi.resetModules()
   })
 
   it('retries transient cron_sync_sub failures and succeeds', async () => {

--- a/tests/cron_sync_sub.unit.test.ts
+++ b/tests/cron_sync_sub.unit.test.ts
@@ -1,0 +1,79 @@
+import { HTTPException } from 'hono/http-exception'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('cron_sync_sub resilience', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('retries transient cron_sync_sub failures and succeeds', async () => {
+    const syncSubscriptionAndEvents = vi.fn()
+      .mockRejectedValueOnce({ status: 502, message: 'error code: 502' })
+      .mockResolvedValueOnce(undefined)
+
+    vi.doMock('../supabase/functions/_backend/utils/hono.ts', () => ({
+      BRES: { status: 'ok' },
+      middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => await next(),
+      parseBody: async (c: { req: { json: () => Promise<unknown> } }) => await c.req.json(),
+      simpleError: (errorCode: string, message: string, moreInfo: Record<string, unknown> = {}) => {
+        throw new HTTPException(400, { message, cause: { error: errorCode, ...moreInfo } })
+      },
+    }))
+    vi.doMock('../supabase/functions/_backend/utils/pg.ts', () => ({
+      closeClient: vi.fn(),
+      getDrizzleClient: vi.fn(() => ({ drizzle: true })),
+      getPgClient: vi.fn(() => ({ pg: true })),
+    }))
+    vi.doMock('../supabase/functions/_backend/utils/plans.ts', () => ({
+      syncSubscriptionAndEvents,
+    }))
+
+    const { app: cronSyncSub } = await import('../supabase/functions/_backend/triggers/cron_sync_sub.ts')
+
+    const response = await cronSyncSub.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orgId: 'org-retry' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ status: 'ok' })
+    expect(syncSubscriptionAndEvents).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips stale cron_sync_sub jobs when the org no longer exists', async () => {
+    const syncSubscriptionAndEvents = vi.fn().mockRejectedValue(
+      new HTTPException(404, { message: 'Org not found', cause: { error: 'org_not_found' } }),
+    )
+
+    vi.doMock('../supabase/functions/_backend/utils/hono.ts', () => ({
+      BRES: { status: 'ok' },
+      middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => await next(),
+      parseBody: async (c: { req: { json: () => Promise<unknown> } }) => await c.req.json(),
+      simpleError: (errorCode: string, message: string, moreInfo: Record<string, unknown> = {}) => {
+        throw new HTTPException(400, { message, cause: { error: errorCode, ...moreInfo } })
+      },
+    }))
+    vi.doMock('../supabase/functions/_backend/utils/pg.ts', () => ({
+      closeClient: vi.fn(),
+      getDrizzleClient: vi.fn(() => ({ drizzle: true })),
+      getPgClient: vi.fn(() => ({ pg: true })),
+    }))
+    vi.doMock('../supabase/functions/_backend/utils/plans.ts', () => ({
+      syncSubscriptionAndEvents,
+    }))
+
+    const { app: cronSyncSub } = await import('../supabase/functions/_backend/triggers/cron_sync_sub.ts')
+
+    const response = await cronSyncSub.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orgId: 'org-missing' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ status: 'skipped', reason: 'org_not_found' })
+    expect(syncSubscriptionAndEvents).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- retry `cron_sync_sub` when the trigger fails with transient 5xx / PostgREST-style errors
- skip stale queue jobs cleanly when the target organization no longer exists
- preserve real org lookup failures as `cannot_get_org` instead of misreporting them as `org_not_found`
- add unit coverage for retry success and stale-org skip behavior

## Motivation (AI generated)

`cron_sync_sub` queue alerts were retrying noisy transient backend failures and stale queue payloads without any handler-side resilience. The trigger needed the same kind of retry-and-skip behavior already added for other hot queue paths.

## Business Impact (AI generated)

This should reduce avoidable billing-sync alert noise, keep queue retries focused on real failures, and prevent stale org jobs from repeatedly surfacing in Discord and PostHog. It lowers operational noise without changing the successful subscription-sync path.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/cron_sync_sub.unit.test.ts`
- [x] `bunx eslint supabase/functions/_backend/triggers/cron_sync_sub.ts supabase/functions/_backend/utils/plans.ts tests/cron_sync_sub.unit.test.ts`
- [x] `bun typecheck`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry with exponential backoff for subscription sync, tracking attempts.

* **Bug Fixes**
  * Sync now skips gracefully when an organization is missing, returning a clear reason.
  * Better distinction between transient (retryable) and permanent errors, with improved final-error logging.

* **Tests**
  * Added resilience tests for retry behavior and missing-organization skip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->