### PR TITLE
fix(backend): harden statistics rpc retries

### DIFF
--- a/supabase/functions/_backend/public/statistics/index.ts
+++ b/supabase/functions/_backend/public/statistics/index.ts
@@ -55,6 +55,7 @@ interface AppMetricRow {
 interface QueryResult<T> {
   data: T | null
   error: unknown
+  status?: number | null
 }
 
 interface AppOwnerOrgRow {
@@ -102,9 +103,17 @@ function getMissingAppStatsError(errors: unknown[]) {
     if (!error || typeof error !== 'object')
       return false
 
-    const appError = error as { error?: unknown, status?: unknown }
-    return appError.error === 'app_not_found' || appError.status === 404
+    const appError = error as { app_id?: unknown, error?: unknown, status?: unknown }
+    return appError.error === 'app_not_found'
+      || (appError.status === 404 && typeof appError.app_id === 'string')
   })
+}
+
+function isRetryableStatsResult(result: QueryResult<unknown>) {
+  if (typeof result.status === 'number')
+    return result.status >= 500 && result.status < 600
+
+  return Boolean(result.error) && isRetryableStatsError(result.error)
 }
 
 async function executeStatsQueryWithRetry<T>(
@@ -122,7 +131,7 @@ async function executeStatsQueryWithRetry<T>(
   }, {
     attempts: STATS_QUERY_RETRY_ATTEMPTS,
     baseDelayMs: STATS_QUERY_RETRY_DELAY_MS,
-    shouldRetry: current => Boolean(current.error) && isRetryableStatsError(current.error),
+    shouldRetry: current => isRetryableStatsResult(current),
   })
 
   const finalResult = result ?? { data: null, error: lastError }

--- a/supabase/functions/_backend/public/statistics/index.ts
+++ b/supabase/functions/_backend/public/statistics/index.ts
@@ -97,6 +97,16 @@ function isRetryableStatsError(error: unknown) {
   return status !== null && status >= 500 && status < 600
 }
 
+function getMissingAppStatsError(errors: unknown[]) {
+  return errors.find((error) => {
+    if (!error || typeof error !== 'object')
+      return false
+
+    const appError = error as { error?: unknown, status?: unknown }
+    return appError.error === 'app_not_found' || appError.status === 404
+  })
+}
+
 async function executeStatsQueryWithRetry<T>(
   c: Context,
   label: string,
@@ -175,6 +185,7 @@ async function getStatsAppOwnerOrgOrThrow(
 
 export const statisticsTestUtils = {
   executeStatsQueryWithRetry,
+  getMissingAppStatsError,
   getRetryableStatus,
   isRetryableStatsError,
   getStatsAppOwnerOrgOrThrow,
@@ -814,6 +825,10 @@ app.get('/user', async (c) => {
 
   const errors = stats.filter(stat => stat.error).map(stat => stat.error)
   if (errors.length > 0) {
+    const missingAppError = getMissingAppStatsError(errors)
+    if (missingAppError)
+      throw quickError(404, 'app_not_found', 'App not found', { error: missingAppError })
+
     throw quickError(500, 'cannot_get_user_statistics', 'Cannot get user statistics', { error: errors })
   }
 

--- a/supabase/functions/_backend/public/statistics/index.ts
+++ b/supabase/functions/_backend/public/statistics/index.ts
@@ -7,6 +7,7 @@ import { honoFactory, quickError, simpleError, useCors } from '../../utils/hono.
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
 import { cloudlog } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
+import { retryWithBackoff } from '../../utils/retry.ts'
 import { supabaseApikey, supabaseClient } from '../../utils/supabase.ts'
 import { isStripeConfigured } from '../../utils/utils.ts'
 import { buildDailyReportedCountsByName, convertCountsToPercentagesByName, fillMissingDailyCounts } from '../../utils/version_stats_helpers.ts'
@@ -51,6 +52,18 @@ interface AppMetricRow {
   uninstall: number
 }
 
+interface QueryResult<T> {
+  data: T | null
+  error: unknown
+}
+
+interface AppOwnerOrgRow {
+  owner_org: string | null
+}
+
+const STATS_QUERY_RETRY_ATTEMPTS = 3
+const STATS_QUERY_RETRY_DELAY_MS = 250
+
 // Helper to get authenticated supabase client based on auth type
 function getAuthenticatedSupabase(c: Context, auth: AuthInfo) {
   if (auth.authType === 'apikey' && auth.apikey) {
@@ -62,6 +75,89 @@ function getAuthenticatedSupabase(c: Context, auth: AuthInfo) {
     throw quickError(401, 'no_authorization', 'No authorization header')
   }
   return supabaseClient(c, authorization)
+}
+
+function getRetryableStatus(error: unknown): number | null {
+  if (error && typeof error === 'object') {
+    if ('status' in error && typeof (error as { status?: unknown }).status === 'number')
+      return (error as { status: number }).status
+
+    if ('message' in error && typeof (error as { message?: unknown }).message === 'string') {
+      const match = /error code:\s*(\d{3})/i.exec((error as { message: string }).message)
+      if (match)
+        return Number.parseInt(match[1], 10)
+    }
+  }
+
+  return null
+}
+
+function isRetryableStatsError(error: unknown) {
+  const status = getRetryableStatus(error)
+  return status !== null && status >= 500 && status < 600
+}
+
+async function executeStatsQueryWithRetry<T>(
+  c: Context,
+  label: string,
+  query: () => Promise<QueryResult<T>>,
+): Promise<QueryResult<T>> {
+  const { result, lastError, attempts } = await retryWithBackoff(async () => {
+    try {
+      return await query()
+    }
+    catch (error) {
+      return { data: null, error }
+    }
+  }, {
+    attempts: STATS_QUERY_RETRY_ATTEMPTS,
+    baseDelayMs: STATS_QUERY_RETRY_DELAY_MS,
+    shouldRetry: current => Boolean(current.error) && isRetryableStatsError(current.error),
+  })
+
+  const finalResult = result ?? { data: null, error: lastError }
+  if (attempts > 1) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'statistics query retried',
+      label,
+      attempts,
+      hasError: Boolean(finalResult.error),
+    })
+  }
+
+  return finalResult
+}
+
+async function resolveAppOwnerOrg(
+  c: Context,
+  appId: string,
+  supabase: ReturnType<typeof supabaseClient>,
+): Promise<{ ownerOrg: string | null, error: unknown, notFound: boolean }> {
+  const { data, error } = await executeStatsQueryWithRetry<AppOwnerOrgRow>(
+    c,
+    'statistics_app_lookup',
+    async () => await supabase
+      .from('apps')
+      .select('owner_org')
+      .eq('app_id', appId)
+      .maybeSingle() as QueryResult<AppOwnerOrgRow>,
+  )
+
+  if (error)
+    return { ownerOrg: null, error, notFound: false }
+
+  if (!data)
+    return { ownerOrg: null, error: null, notFound: true }
+
+  return { ownerOrg: data.owner_org ?? null, error: null, notFound: false }
+}
+
+export const statisticsTestUtils = {
+  executeStatsQueryWithRetry,
+  getRetryableStatus,
+  isRetryableStatsError,
+  resolveAppOwnerOrg,
 }
 
 async function checkOrganizationAccess(c: Context, orgId: string, supabase: ReturnType<typeof supabaseClient>) {
@@ -96,10 +192,13 @@ async function getNormalStats(c: Context, appId: string | null, ownerOrg: string
 
   let ownerOrgId = ownerOrg
   if (appId && !ownerOrgId) {
-    const { data, error } = await supabase.from('apps').select('*').eq('app_id', appId).single()
+    const { ownerOrg: resolvedOwnerOrg, error, notFound } = await resolveAppOwnerOrg(c, appId, supabase)
     if (error)
       return { data: null, error }
-    ownerOrgId = data.owner_org
+    if (notFound) {
+      return { data: null, error: { error: 'app_not_found', status: 404, app_id: appId } }
+    }
+    ownerOrgId = resolvedOwnerOrg
   }
 
   const startDate = dayjs(from).utc().format('YYYY-MM-DD')
@@ -109,19 +208,27 @@ async function getNormalStats(c: Context, appId: string | null, ownerOrg: string
   let metricsError: unknown
 
   if (appId) {
-    ({ data: rawMetrics, error: metricsError } = await supabase.rpc('get_app_metrics' as any, {
-      p_org_id: ownerOrgId!,
-      p_app_id: appId,
-      p_start_date: startDate,
-      p_end_date: endDate,
-    }) as { data: AppMetricRow[] | null, error: unknown })
+    ({ data: rawMetrics, error: metricsError } = await executeStatsQueryWithRetry<AppMetricRow[]>(
+      c,
+      'get_app_metrics_for_app',
+      async () => await supabase.rpc('get_app_metrics' as any, {
+        p_org_id: ownerOrgId!,
+        p_app_id: appId,
+        p_start_date: startDate,
+        p_end_date: endDate,
+      }) as QueryResult<AppMetricRow[]>,
+    ))
   }
   else {
-    ({ data: rawMetrics, error: metricsError } = await supabase.rpc('get_app_metrics', {
-      org_id: ownerOrgId!,
-      start_date: startDate,
-      end_date: endDate,
-    }))
+    ({ data: rawMetrics, error: metricsError } = await executeStatsQueryWithRetry<AppMetricRow[]>(
+      c,
+      'get_app_metrics_for_org',
+      async () => await supabase.rpc('get_app_metrics', {
+        org_id: ownerOrgId!,
+        start_date: startDate,
+        end_date: endDate,
+      }) as QueryResult<AppMetricRow[]>,
+    ))
   }
 
   if (metricsError)
@@ -200,13 +307,18 @@ async function getNormalStats(c: Context, appId: string | null, ownerOrg: string
 
   if (storage.length !== 0) {
     // some magic, copied from the frontend without much understanding
-    const { data: currentStorageBytes, error: storageError } = await supabase.rpc(appId ? 'get_total_app_storage_size_orgs' : 'get_total_storage_size_org', appId ? { org_id: ownerOrgId!, app_id: appId } : { org_id: ownerOrgId! })
-      .single()
+    const { data: currentStorageBytes, error: storageError } = await executeStatsQueryWithRetry<number>(
+      c,
+      appId ? 'get_total_app_storage_size_orgs' : 'get_total_storage_size_org',
+      async () => await supabase
+        .rpc(appId ? 'get_total_app_storage_size_orgs' : 'get_total_storage_size_org', appId ? { org_id: ownerOrgId!, app_id: appId } : { org_id: ownerOrgId! })
+        .single() as QueryResult<number>,
+    )
     if (storageError)
       return { data: null, error: storageError }
 
     const storageVariance = storage.reduce((p, c) => (p + (c ?? 0)), 0)
-    const currentStorage = currentStorageBytes
+    const currentStorage = currentStorageBytes ?? 0
     const initValue = Math.max(0, (currentStorage - storageVariance + (storage[0] ?? 0)))
     storage[0] = initValue
   }
@@ -556,20 +668,22 @@ app.get('/app/:app_id', async (c) => {
   const supabase = getAuthenticatedSupabase(c, auth)
 
   // Get the organization ID for this app and check organization access
-  const { data: app } = await supabase
-    .from('apps')
-    .select('owner_org')
-    .eq('app_id', appId)
-    .single()
+  const { ownerOrg, error: ownerOrgError, notFound } = await resolveAppOwnerOrg(c, appId, supabase)
 
-  if (app?.owner_org && auth.authType !== 'jwt') {
-    await checkOrganizationAccess(c, app.owner_org, supabase)
+  if (ownerOrgError)
+    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error: ownerOrgError })
+
+  if (notFound)
+    throw quickError(404, 'app_not_found', 'App not found', { app_id: appId })
+
+  if (ownerOrg && auth.authType !== 'jwt') {
+    await checkOrganizationAccess(c, ownerOrg, supabase)
   }
 
-  const { data: finalStats, error } = await getNormalStats(c, appId, app?.owner_org ?? null, body.from, body.to, supabase, c.get('auth')?.authType === 'jwt', false, body.noAccumulate ?? false)
+  const { data: finalStats, error: statsError } = await getNormalStats(c, appId, ownerOrg, body.from, body.to, supabase, c.get('auth')?.authType === 'jwt', false, body.noAccumulate ?? false)
 
-  if (error) {
-    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error })
+  if (statsError) {
+    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error: statsError })
   }
 
   return c.json(finalStats)
@@ -637,14 +751,16 @@ app.get('/app/:app_id/bundle_usage', async (c) => {
   const supabase = getAuthenticatedSupabase(c, auth)
 
   // Get the organization ID for this app and check organization access
-  const { data: app } = await supabase
-    .from('apps')
-    .select('owner_org')
-    .eq('app_id', appId)
-    .single()
+  const { ownerOrg, error: ownerOrgError, notFound } = await resolveAppOwnerOrg(c, appId, supabase)
 
-  if (app?.owner_org && auth.authType !== 'jwt') {
-    await checkOrganizationAccess(c, app.owner_org, supabase)
+  if (ownerOrgError)
+    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error: ownerOrgError })
+
+  if (notFound)
+    throw quickError(404, 'app_not_found', 'App not found', { app_id: appId })
+
+  if (ownerOrg && auth.authType !== 'jwt') {
+    await checkOrganizationAccess(c, ownerOrg, supabase)
   }
 
   const { data, error } = await getBundleUsage(appId, body.from, body.to, useDashboard, supabase)

--- a/supabase/functions/_backend/public/statistics/index.ts
+++ b/supabase/functions/_backend/public/statistics/index.ts
@@ -153,10 +153,31 @@ async function resolveAppOwnerOrg(
   return { ownerOrg: data.owner_org ?? null, error: null, notFound: false }
 }
 
+async function getStatsAppOwnerOrgOrThrow(
+  c: Context,
+  auth: AuthInfo,
+  appId: string,
+  supabase: ReturnType<typeof supabaseClient>,
+) {
+  const { ownerOrg, error, notFound } = await resolveAppOwnerOrg(c, appId, supabase)
+
+  if (error)
+    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error })
+
+  if (notFound)
+    throw quickError(404, 'app_not_found', 'App not found', { app_id: appId })
+
+  if (ownerOrg && auth.authType !== 'jwt')
+    await checkOrganizationAccess(c, ownerOrg, supabase)
+
+  return ownerOrg
+}
+
 export const statisticsTestUtils = {
   executeStatsQueryWithRetry,
   getRetryableStatus,
   isRetryableStatsError,
+  getStatsAppOwnerOrgOrThrow,
   resolveAppOwnerOrg,
 }
 
@@ -667,18 +688,7 @@ app.get('/app/:app_id', async (c) => {
   // Use authenticated client - RLS will enforce access
   const supabase = getAuthenticatedSupabase(c, auth)
 
-  // Get the organization ID for this app and check organization access
-  const { ownerOrg, error: ownerOrgError, notFound } = await resolveAppOwnerOrg(c, appId, supabase)
-
-  if (ownerOrgError)
-    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error: ownerOrgError })
-
-  if (notFound)
-    throw quickError(404, 'app_not_found', 'App not found', { app_id: appId })
-
-  if (ownerOrg && auth.authType !== 'jwt') {
-    await checkOrganizationAccess(c, ownerOrg, supabase)
-  }
+  const ownerOrg = await getStatsAppOwnerOrgOrThrow(c, auth, appId, supabase)
 
   const { data: finalStats, error: statsError } = await getNormalStats(c, appId, ownerOrg, body.from, body.to, supabase, c.get('auth')?.authType === 'jwt', false, body.noAccumulate ?? false)
 
@@ -750,18 +760,7 @@ app.get('/app/:app_id/bundle_usage', async (c) => {
   // Use authenticated client - RLS will enforce access
   const supabase = getAuthenticatedSupabase(c, auth)
 
-  // Get the organization ID for this app and check organization access
-  const { ownerOrg, error: ownerOrgError, notFound } = await resolveAppOwnerOrg(c, appId, supabase)
-
-  if (ownerOrgError)
-    throw quickError(500, 'cannot_get_app_statistics', 'Cannot get app statistics', { error: ownerOrgError })
-
-  if (notFound)
-    throw quickError(404, 'app_not_found', 'App not found', { app_id: appId })
-
-  if (ownerOrg && auth.authType !== 'jwt') {
-    await checkOrganizationAccess(c, ownerOrg, supabase)
-  }
+  await getStatsAppOwnerOrgOrThrow(c, auth, appId, supabase)
 
   const { data, error } = await getBundleUsage(appId, body.from, body.to, useDashboard, supabase)
 

--- a/tests/statistics-retries.unit.test.ts
+++ b/tests/statistics-retries.unit.test.ts
@@ -8,21 +8,21 @@ const fakeContext = {
 describe('statistics retry helpers', () => {
   it('retries transient statistics query failures and returns the recovered result', async () => {
     const query = vi.fn()
-      .mockResolvedValueOnce({ data: null, error: { status: 502, message: 'error code: 502' } })
-      .mockResolvedValueOnce({ data: [{ app_id: 'com.demo.app' }], error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: 'error code: 502' }, status: 502 })
+      .mockResolvedValueOnce({ data: [{ app_id: 'com.demo.app' }], error: null, status: 200 })
 
     const result = await statisticsTestUtils.executeStatsQueryWithRetry(fakeContext, 'test_metrics', query)
 
-    expect(result).toEqual({ data: [{ app_id: 'com.demo.app' }], error: null })
+    expect(result).toEqual({ data: [{ app_id: 'com.demo.app' }], error: null, status: 200 })
     expect(query).toHaveBeenCalledTimes(2)
   })
 
   it('does not retry non-retryable statistics query failures', async () => {
-    const query = vi.fn().mockResolvedValue({ data: null, error: { status: 400, message: 'bad request' } })
+    const query = vi.fn().mockResolvedValue({ data: null, error: { message: 'bad request' }, status: 400 })
 
     const result = await statisticsTestUtils.executeStatsQueryWithRetry(fakeContext, 'test_metrics', query)
 
-    expect(result).toEqual({ data: null, error: { status: 400, message: 'bad request' } })
+    expect(result).toEqual({ data: null, error: { message: 'bad request' }, status: 400 })
     expect(query).toHaveBeenCalledTimes(1)
   })
 
@@ -49,5 +49,13 @@ describe('statistics retry helpers', () => {
     ])
 
     expect(result).toEqual({ error: 'app_not_found', status: 404 })
+  })
+
+  it('ignores unrelated 404 errors when looking for missing apps', () => {
+    const result = statisticsTestUtils.getMissingAppStatsError([
+      { error: 'rpc_not_found', status: 404 },
+    ])
+
+    expect(result).toBeUndefined()
   })
 })

--- a/tests/statistics-retries.unit.test.ts
+++ b/tests/statistics-retries.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { statisticsTestUtils } from '../supabase/functions/_backend/public/statistics/index.ts'
+
+const fakeContext = {
+  get: vi.fn(() => undefined),
+} as any
+
+describe('statistics retry helpers', () => {
+  it('retries transient statistics query failures and returns the recovered result', async () => {
+    const query = vi.fn()
+      .mockResolvedValueOnce({ data: null, error: { status: 502, message: 'error code: 502' } })
+      .mockResolvedValueOnce({ data: [{ app_id: 'com.demo.app' }], error: null })
+
+    const result = await statisticsTestUtils.executeStatsQueryWithRetry(fakeContext, 'test_metrics', query)
+
+    expect(result).toEqual({ data: [{ app_id: 'com.demo.app' }], error: null })
+    expect(query).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry non-retryable statistics query failures', async () => {
+    const query = vi.fn().mockResolvedValue({ data: null, error: { status: 400, message: 'bad request' } })
+
+    const result = await statisticsTestUtils.executeStatsQueryWithRetry(fakeContext, 'test_metrics', query)
+
+    expect(result).toEqual({ data: null, error: { status: 400, message: 'bad request' } })
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks missing apps as not found when the lookup returns no rows', async () => {
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        })),
+      })),
+    } as any
+
+    const result = await statisticsTestUtils.resolveAppOwnerOrg(fakeContext, 'com.demo.missing', supabase)
+
+    expect(result).toEqual({ ownerOrg: null, error: null, notFound: true })
+  })
+})

--- a/tests/statistics-retries.unit.test.ts
+++ b/tests/statistics-retries.unit.test.ts
@@ -41,4 +41,13 @@ describe('statistics retry helpers', () => {
 
     expect(result).toEqual({ ownerOrg: null, error: null, notFound: true })
   })
+
+  it('detects missing-app errors in aggregated statistics results', () => {
+    const result = statisticsTestUtils.getMissingAppStatsError([
+      { error: 'cannot_get_user_statistics', status: 500 },
+      { error: 'app_not_found', status: 404 },
+    ])
+
+    expect(result).toEqual({ error: 'app_not_found', status: 404 })
+  })
 })


### PR DESCRIPTION
## Summary (AI generated)

- retry transient 5xx/PostgREST failures when statistics endpoints load app ownership, metrics, and storage totals
- return `app_not_found` instead of falling through to a generic app statistics failure when the app lookup returns no row
- add focused unit coverage for the statistics retry helpers and missing-app lookup path

## Motivation (AI generated)

The PostHog backend error stream shows live `statistics` failures (`Cannot get organization statistics`) and older matching app statistics failures. Those routes were treating transient upstream query failures as hard failures and also ignored one app lookup error path entirely.

## Business Impact (AI generated)

This reduces noisy backend alerts and prevents users from seeing intermittent statistics failures when the underlying PostgREST layer briefly returns 5xx errors. It also makes missing-app cases fail with a clearer API response instead of a generic server error.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/statistics-retries.unit.test.ts`
- [x] `bunx eslint supabase/functions/_backend/public/statistics/index.ts tests/statistics-retries.unit.test.ts`
- [x] `bun typecheck`
- [ ] GitHub CI

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry/backoff with centralized logging for statistics queries to recover from transient failures.
  * Improved app-owner lookup and error handling, distinguishing missing apps (now returned as 404) from server errors.
  * Fixed storage-size handling so null values are treated as zero.

* **Tests**
  * Added unit tests covering retry behavior, owner-lookup not-found detection, and missing-app error selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->