### PR TITLE
fix(backend): harden cron stat app follow-up

### DIFF
--- a/supabase/functions/_backend/triggers/cron_stat_app.ts
+++ b/supabase/functions/_backend/triggers/cron_stat_app.ts
@@ -2,6 +2,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { Hono } from 'hono/tiny'
 import { middlewareAPISecret, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
+import { retryWithBackoff } from '../utils/retry.ts'
 import { readStatsBandwidth, readStatsMau, readStatsStorage, readStatsVersion } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 
@@ -17,6 +18,9 @@ interface OrgStatsRefreshTarget {
   customerId: string | null
   previousStatsUpdatedAt: string | null
 }
+
+const PLAN_REFRESH_RETRY_ATTEMPTS = 3
+const PLAN_REFRESH_RETRY_DELAY_MS = 300
 
 async function getOrgStatsRefreshTarget(
   supabase: ReturnType<typeof supabaseAdmin>,
@@ -62,8 +66,47 @@ async function queueOrgPlanRefresh(
     org_id: orgId,
     customer_id: customerId,
   }).throwOnError()
+}
 
-  cloudlog({ requestId: c.get('requestId'), message: 'plan processing queued for org', orgId, customerId })
+async function queueOrgPlanRefreshWithRetry(
+  c: Parameters<typeof supabaseAdmin>[0],
+  supabase: ReturnType<typeof supabaseAdmin>,
+  orgId: string,
+  customerId: string,
+): Promise<void> {
+  const { result, attempts } = await retryWithBackoff(async () => {
+    try {
+      await queueOrgPlanRefresh(c, supabase, orgId, customerId)
+      return { ok: true as const }
+    }
+    catch (error) {
+      return { ok: false as const, error }
+    }
+  }, {
+    attempts: PLAN_REFRESH_RETRY_ATTEMPTS,
+    baseDelayMs: PLAN_REFRESH_RETRY_DELAY_MS,
+    shouldRetry: result => !result.ok,
+  })
+
+  if (!result?.ok) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Failed to queue cron_stat_app org plan refresh',
+      orgId,
+      customerId,
+      attempts,
+      error: result?.error,
+    })
+    return
+  }
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: attempts > 1 ? 'plan processing queued for org after retries' : 'plan processing queued for org',
+    orgId,
+    customerId,
+    attempts,
+  })
 }
 
 app.use('/', useCors)
@@ -207,7 +250,7 @@ app.post('/', middlewareAPISecret, async (c) => {
   }
 
   if (orgStatsRefreshTarget?.customerId) {
-    await queueOrgPlanRefresh(c, supabase, body.orgId, orgStatsRefreshTarget.customerId)
+    await queueOrgPlanRefreshWithRetry(c, supabase, body.orgId, orgStatsRefreshTarget.customerId)
   }
 
   return c.json({ status: 'Stats saved', mau, bandwidth, storage, versionUsage })

--- a/tests/cron_stat_app_followup.unit.test.ts
+++ b/tests/cron_stat_app_followup.unit.test.ts
@@ -184,7 +184,7 @@ describe('cron_stat_app follow-up failures', () => {
     ])
   })
 
-  it('returns 500 when queuing plan processing fails after stats writes', async () => {
+  it('returns success when queuing plan processing fails after stats writes', async () => {
     const { client, builders } = createSupabaseStub({
       queueError: new Error('error code: 502'),
     })
@@ -194,7 +194,7 @@ describe('cron_stat_app follow-up failures', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        apisecret: 'testsecret',
+        'apisecret': 'testsecret',
       },
       body: JSON.stringify({
         appId: 'com.test.app',
@@ -204,16 +204,45 @@ describe('cron_stat_app follow-up failures', () => {
       waitUntil: () => { },
     } as any)
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(200)
     expect(builders.dailyMauBuilder.throwOnError).toHaveBeenCalledTimes(1)
     expect(builders.dailyBandwidthBuilder.throwOnError).toHaveBeenCalledTimes(1)
     expect(builders.dailyStorageBuilder.throwOnError).toHaveBeenCalledTimes(1)
     expect(builders.dailyVersionBuilder.throwOnError).toHaveBeenCalledTimes(1)
     expect(builders.orgUpdateBuilder.throwOnError).toHaveBeenCalledTimes(1)
-    expect(builders.queueBuilder.throwOnError).toHaveBeenCalledTimes(1)
+    expect(builders.queueBuilder.throwOnError).toHaveBeenCalledTimes(3)
 
-    const payload = await response.json() as { error: string }
-    expect(payload.error).toBe('unknown_error')
+    const payload = await response.json() as { status: string }
+    expect(payload.status).toBe('Stats saved')
+  })
+
+  it('retries queuing plan processing before succeeding', async () => {
+    const { client, builders } = createSupabaseStub()
+    builders.queueBuilder.throwOnError
+      .mockRejectedValueOnce(new Error('error code: 502'))
+      .mockRejectedValueOnce(new Error('error code: 502'))
+      .mockResolvedValue({ data: null, error: null })
+    supabaseAdminMock.mockReturnValue(client)
+
+    const response = await createApp().fetch(new Request('http://localhost/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apisecret': 'testsecret',
+      },
+      body: JSON.stringify({
+        appId: 'com.test.app',
+        orgId: 'org-test',
+      }),
+    }), {}, {
+      waitUntil: () => { },
+    } as any)
+
+    expect(response.status).toBe(200)
+    expect(builders.queueBuilder.throwOnError).toHaveBeenCalledTimes(3)
+
+    const payload = await response.json() as { status: string }
+    expect(payload.status).toBe('Stats saved')
   })
 
   it('returns success and still queues plan processing when org timestamp refresh fails after stats writes', async () => {
@@ -226,7 +255,7 @@ describe('cron_stat_app follow-up failures', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        apisecret: 'testsecret',
+        'apisecret': 'testsecret',
       },
       body: JSON.stringify({
         appId: 'com.test.app',
@@ -258,7 +287,7 @@ describe('cron_stat_app follow-up failures', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        apisecret: 'testsecret',
+        'apisecret': 'testsecret',
       },
       body: JSON.stringify({
         appId: 'com.test.app',


### PR DESCRIPTION
## Summary (AI generated)

- retry `cron_stat_app` plan-refresh queueing when the downstream RPC returns transient failures
- stop converting a follow-up queue miss into a full trigger failure after stats rows already persisted
- cover exhausted-retry and eventual-success behavior in `cron_stat_app` follow-up unit tests

## Motivation (AI generated)

`cron_stat_app` already saves the daily stats before it queues the downstream org-plan refresh. When that follow-up RPC returned a transient `502`, the trigger still ended as a `500`, which caused noisy Discord alerts and unnecessary queue retries even though the primary work had succeeded.

## Business Impact (AI generated)

This reduces false-positive backend alert noise and avoids reprocessing already-saved stats for transient downstream failures. The result is cleaner operations around billing/statistics jobs without changing customer-visible stats behavior.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/cron_stat_app_followup.unit.test.ts`
- [x] `bunx eslint supabase/functions/_backend/triggers/cron_stat_app.ts tests/cron_stat_app_followup.unit.test.ts`
- [x] `bun typecheck`
- [ ] `bunx vitest run tests/cron_stat_app.test.ts` (blocked locally: Supabase on `127.0.0.1:54321` was not running)

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of organization plan refresh with automatic retry logic and exponential backoff on failures.
  * Enhanced error logging to capture retry attempts and provide better diagnostics.

* **Tests**
  * Added test coverage for plan refresh retry scenarios and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->