### PR TITLE
[codex] Fix Stripe subscription change tracking

### DIFF
--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -29,6 +29,7 @@ interface Org {
 
 type StripeInfoRow = Database['public']['Tables']['stripe_info']['Row']
 type StripeInfoUpdate = Database['public']['Tables']['stripe_info']['Update']
+type PlanRow = Database['public']['Tables']['plans']['Row']
 
 const checkoutSessionEventTypes = new Set([
   'checkout.session.completed',
@@ -69,6 +70,58 @@ function toStripeInfoUpdate(data: StripeData['data']): StripeInfoUpdate {
   return Object.fromEntries(
     Object.entries(data).filter(([_, value]) => value !== undefined),
   ) as StripeInfoUpdate
+}
+
+function compactMetadata(metadata: Record<string, string | undefined>) {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([_, value]) => value !== undefined),
+  ) as Record<string, string>
+}
+
+function getPlanType(
+  plan: Pick<PlanRow, 'price_m_id' | 'price_y_id'>,
+  priceId: string | null | undefined,
+) {
+  if (!priceId)
+    return undefined
+  if (plan.price_m_id === priceId)
+    return 'monthly'
+  if (plan.price_y_id === priceId)
+    return 'yearly'
+  return undefined
+}
+
+function getSubscriptionTrackingState(
+  stripeData: Pick<StripeData, 'data' | 'isUpgrade' | 'previousPriceId' | 'previousProductId'>,
+  originalStatus: Database['public']['Enums']['stripe_status'] | null | undefined,
+) {
+  return {
+    shouldSendPlanChange: Boolean(
+      stripeData.previousProductId
+      && stripeData.data.product_id
+      && stripeData.previousProductId !== stripeData.data.product_id,
+    ),
+    statusName: stripeData.isUpgrade ? 'upgraded' : originalStatus ?? '',
+  }
+}
+
+function buildSubscriptionEventMetadata(
+  stripeData: Pick<StripeData, 'data' | 'previousPriceId' | 'previousProductId'>,
+  currentPlan: Pick<PlanRow, 'name' | 'price_m_id' | 'price_y_id' | 'stripe_id'>,
+  previousPlan?: Pick<PlanRow, 'name' | 'price_m_id' | 'price_y_id' | 'stripe_id'> | null,
+) {
+  const currentPlanType = getPlanType(currentPlan, stripeData.data.price_id)
+  const fallbackPreviousPlan = stripeData.previousProductId === currentPlan.stripe_id ? currentPlan : previousPlan
+  const previousPlanType = fallbackPreviousPlan
+    ? getPlanType(fallbackPreviousPlan, stripeData.previousPriceId)
+    : undefined
+
+  return compactMetadata({
+    plan_name: currentPlan.name,
+    plan_type: currentPlanType,
+    previous_plan_name: fallbackPreviousPlan?.name,
+    previous_plan_type: previousPlanType,
+  })
 }
 
 async function writePaidAtAtomically(c: Context, customerId: string, eventOccurredAtIso: string) {
@@ -358,6 +411,8 @@ async function createdOrUpdated(
     .eq('stripe_id', stripeData.data.product_id)
     .single()
   if (plan) {
+    const trackingState = getSubscriptionTrackingState(stripeData, status)
+    statusName = trackingState.statusName
     const updateData = toStripeInfoUpdate(stripeData.data)
     const paidAt = getPaidAtUpdate(currentStripeInfo, status, eventOccurredAtIso)
     if (paidAt)
@@ -366,20 +421,19 @@ async function createdOrUpdated(
       .from('stripe_info')
       .update(updateData)
       .eq('customer_id', stripeData.data.customer_id)
-    if (stripeData.isUpgrade && stripeData.previousProductId) {
-      statusName = 'upgraded'
+    let previousPlan: PlanRow | null = null
+    if (trackingState.shouldSendPlanChange && stripeData.previousProductId) {
       const previousProduct = await supabaseAdmin(c)
         .from('plans')
         .select()
         .eq('stripe_id', stripeData.previousProductId)
         .single()
+      previousPlan = previousProduct.data
+      const planChangeMetadata = buildSubscriptionEventMetadata(stripeData, plan, previousPlan)
       await sendEventToTracking(c, {
         bento: {
           cron: '* * * * *',
-          data: {
-            plan_name: plan.name,
-            previous_plan_name: previousProduct.data?.name ?? '',
-          },
+          data: planChangeMetadata,
           event: 'user:plan_change',
           preferenceKey: 'credit_usage',
           uniqId: 'user:plan_change',
@@ -391,10 +445,7 @@ async function createdOrUpdated(
         user_id: org.id,
         groups: { organization: org.id },
         notify: true,
-        tags: {
-          plan_name: plan.name,
-          previous_plan_name: previousProduct.data?.name ?? '',
-        },
+        tags: planChangeMetadata,
       })
     }
 
@@ -409,12 +460,13 @@ async function createdOrUpdated(
     const segment = await customerToSegmentOrg(c, org.id, stripeData.data.price_id, plan)
     const isMonthly = plan.price_m_id === stripeData.data.price_id
     const eventName = `user:subscribe_${statusName}:${isMonthly ? 'monthly' : 'yearly'}`
+    const subscriptionMetadata = buildSubscriptionEventMetadata(stripeData, plan, previousPlan)
     await addTagBento(c, org.management_email, segment)
     const isNewSubscription = status === 'created'
     await sendEventToTracking(c, {
       bento: {
         cron: '* * * * *',
-        data: { plan_name: plan.name },
+        data: subscriptionMetadata,
         event: eventName,
         preferenceKey: 'credit_usage',
         uniqId: `subscription:${eventName}:${plan.name}`,
@@ -426,9 +478,7 @@ async function createdOrUpdated(
       user_id: org.id,
       groups: { organization: org.id },
       notify: isNewSubscription,
-      tags: {
-        plan_name: plan.name,
-      },
+      tags: subscriptionMetadata,
     })
 
     await backgroundTask(c, groupIdentifyPosthog(c, {
@@ -608,6 +658,8 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
 })
 
 export const stripeEventTestUtils = {
+  buildSubscriptionEventMetadata,
   getPaidAtUpdate,
+  getSubscriptionTrackingState,
   isCustomerProfileEvent,
 }

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -124,6 +124,10 @@ function buildSubscriptionEventMetadata(
   })
 }
 
+function getPlanChangeTrackingEventName(statusName: string) {
+  return statusName === 'upgraded' ? 'User Upgraded' : 'User Plan Changed'
+}
+
 async function writePaidAtAtomically(c: Context, customerId: string, eventOccurredAtIso: string) {
   const pgClient = getPgClient(c, false)
   const drizzleClient = getDrizzleClient(pgClient)
@@ -430,6 +434,7 @@ async function createdOrUpdated(
         .single()
       previousPlan = previousProduct.data
       const planChangeMetadata = buildSubscriptionEventMetadata(stripeData, plan, previousPlan)
+      const planChangeEventName = getPlanChangeTrackingEventName(trackingState.statusName)
       await sendEventToTracking(c, {
         bento: {
           cron: '* * * * *',
@@ -439,7 +444,7 @@ async function createdOrUpdated(
           uniqId: 'user:plan_change',
         },
         channel: 'usage',
-        event: 'User Upgraded',
+        event: planChangeEventName,
         icon: '💰',
         sentToBento: true,
         user_id: org.id,
@@ -660,6 +665,7 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
 export const stripeEventTestUtils = {
   buildSubscriptionEventMetadata,
   getPaidAtUpdate,
+  getPlanChangeTrackingEventName,
   getSubscriptionTrackingState,
   isCustomerProfileEvent,
 }

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -425,6 +425,10 @@ async function createdOrUpdated(
       .from('stripe_info')
       .update(updateData)
       .eq('customer_id', stripeData.data.customer_id)
+    if (dbError2) {
+      return quickError(404, 'succeeded_customer_id_not_found', `succeeded: customer_id not found`, { dbError2, stripeData })
+    }
+
     let previousPlan: PlanRow | null = null
     if (trackingState.shouldSendPlanChange && stripeData.previousProductId) {
       const previousProduct = await supabaseAdmin(c)
@@ -452,10 +456,6 @@ async function createdOrUpdated(
         notify: true,
         tags: planChangeMetadata,
       })
-    }
-
-    if (dbError2) {
-      return quickError(404, 'succeeded_customer_id_not_found', `succeeded: customer_id not found`, { dbError2, stripeData })
     }
 
     if (paidAt) {

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -465,6 +465,7 @@ export interface CreditCheckoutDetails {
 export interface StripeData {
   data: Database['public']['Tables']['stripe_info']['Insert']
   isUpgrade: boolean
+  previousPriceId: string | undefined
   previousProductId: string | undefined
 }
 

--- a/supabase/functions/_backend/utils/stripe_event.ts
+++ b/supabase/functions/_backend/utils/stripe_event.ts
@@ -18,6 +18,17 @@ export function parseStripeEvent(c: Context, body: string, signature: string) {
   )
 }
 
+function getLicensedSubscriptionItem(items: Stripe.SubscriptionItem[] | undefined) {
+  return items?.find(item => item.plan.usage_type === 'licensed') ?? items?.[0]
+}
+
+function getSubscriptionInterval(item: Stripe.SubscriptionItem | undefined) {
+  const interval = item?.plan?.interval
+  if (interval === 'month' || interval === 'year')
+    return interval
+  return undefined
+}
+
 function subscriptionUpdated(c: Context, event: Stripe.CustomerSubscriptionCreatedEvent | Stripe.CustomerSubscriptionDeletedEvent | Stripe.CustomerSubscriptionUpdatedEvent, data: Database['public']['Tables']['stripe_info']['Insert']) {
   let isUpgrade = false
   const subscription = event.data.object
@@ -25,7 +36,12 @@ function subscriptionUpdated(c: Context, event: Stripe.CustomerSubscriptionCreat
 
   // Get previous items if available
   const previousItems = previousAttributes?.items?.data as Stripe.SubscriptionItem[] | undefined
-  const previousProductId = previousItems?.[0]?.plan.product as string | undefined
+  const previousLicensedItem = getLicensedSubscriptionItem(previousItems)
+  const previousPriceId = previousLicensedItem?.plan.id
+  const previousProductId = previousLicensedItem?.plan.product as string | undefined
+  const previousInterval = getSubscriptionInterval(previousLicensedItem)
+  const currentLicensedItem = getLicensedSubscriptionItem(subscription.items.data)
+  const currentInterval = getSubscriptionInterval(currentLicensedItem)
 
   const res = parsePriceIds(c, subscription.items.data)
   data.price_id = res.priceId
@@ -41,8 +57,10 @@ function subscriptionUpdated(c: Context, event: Stripe.CustomerSubscriptionCreat
   data.subscription_anchor_end = firstItem?.current_period_end
     ? new Date(firstItem.current_period_end * 1000).toISOString()
     : undefined
-  data.price_id = subscription.items.data.length ? subscription.items.data[0].plan.id : undefined
-  data.product_id = (subscription.items.data.length ? subscription.items.data[0].plan.product : undefined) as string
+  data.price_id = currentLicensedItem?.plan.id
+  data.product_id = currentLicensedItem?.plan.product
+    ? String(currentLicensedItem.plan.product)
+    : undefined as any
   if (event.type === 'customer.subscription.deleted') {
     data.status = 'deleted'
   }
@@ -56,11 +74,11 @@ function subscriptionUpdated(c: Context, event: Stripe.CustomerSubscriptionCreat
   data.subscription_id = subscription.id
   data.customer_id = String(subscription.customer)
 
-  // Check if this is an upgrade
-  if (previousProductId && data.product_id !== previousProductId) {
+  // Only treat a billing cadence change from monthly to yearly as an upgrade.
+  if (previousInterval === 'month' && currentInterval === 'year') {
     isUpgrade = true
   }
-  return { data, isUpgrade, previousProductId }
+  return { data, isUpgrade, previousPriceId, previousProductId }
 }
 
 function invoiceUpcoming(event: Stripe.InvoiceUpcomingEvent, data: Database['public']['Tables']['stripe_info']['Insert']) {
@@ -101,17 +119,19 @@ export function extractDataEvent(c: Context, event: Stripe.Event): StripeData {
     status: 'succeeded',
   }
   let isUpgrade = false
+  let previousPriceId: string | undefined
   let previousProductId: string | undefined
 
   cloudlog({ requestId: c.get('requestId'), message: 'event', event: JSON.stringify(event, null, 2) })
   if (!event?.data?.object) {
-    return { data, isUpgrade, previousProductId }
+    return { data, isUpgrade, previousPriceId, previousProductId }
   }
 
   if (event.type === 'customer.subscription.updated' || event.type === 'customer.subscription.deleted' || event.type === 'customer.subscription.created') {
     const res = subscriptionUpdated(c, event, data)
     data = res.data
     isUpgrade = res.isUpgrade
+    previousPriceId = res.previousPriceId
     previousProductId = res.previousProductId
   }
   else if (event.type === 'charge.failed') {
@@ -135,5 +155,5 @@ export function extractDataEvent(c: Context, event: Stripe.Event): StripeData {
   else {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Other event', event })
   }
-  return { data, isUpgrade, previousProductId }
+  return { data, isUpgrade, previousPriceId, previousProductId }
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -614,7 +614,7 @@ BEGIN
 
     -- Drop replicated orgs but keet the the seed ones
     DELETE from "public"."orgs" where POSITION('organization' in orgs.name)=1;
-    PERFORM setval('public.apikeys_id_seq', 111, false);
+    PERFORM setval('public.apikeys_id_seq', 111, true);
     PERFORM setval('public.app_versions_id_seq', 16, true);
     PERFORM setval('public.channel_id_seq', 6, false);
     PERFORM setval('public.deploy_history_id_seq', 5, false);

--- a/tests/stripe-subscription-events.unit.test.ts
+++ b/tests/stripe-subscription-events.unit.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+import { stripeEventTestUtils } from '../supabase/functions/_backend/triggers/stripe_event.ts'
+import { extractDataEvent } from '../supabase/functions/_backend/utils/stripe_event.ts'
+
+const mockContext = {
+  get: () => 'test-request-id',
+} as any
+
+function makeSubscriptionItem({
+  interval,
+  priceId,
+  productId,
+}: {
+  interval: 'month' | 'year'
+  priceId: string
+  productId: string
+}) {
+  return {
+    current_period_end: 1_714_517_200,
+    current_period_start: 1_711_925_200,
+    plan: {
+      id: priceId,
+      interval,
+      product: productId,
+      usage_type: 'licensed',
+    },
+  } as any
+}
+
+function makePlan({
+  name,
+  monthlyPriceId,
+  stripeId,
+  yearlyPriceId,
+}: {
+  name: string
+  monthlyPriceId: string
+  stripeId: string
+  yearlyPriceId: string
+}) {
+  return {
+    name,
+    price_m_id: monthlyPriceId,
+    price_y_id: yearlyPriceId,
+    stripe_id: stripeId,
+  } as any
+}
+
+describe('stripe subscription event classification', () => {
+  it.concurrent('marks monthly to yearly cadence changes as upgraded without a plan change', () => {
+    const stripeData = extractDataEvent(mockContext, {
+      data: {
+        object: {
+          customer: 'cus_upgrade_same_plan',
+          id: 'sub_upgrade_same_plan',
+          items: {
+            data: [
+              makeSubscriptionItem({
+                interval: 'year',
+                priceId: 'price_yearly_same_plan',
+                productId: 'prod_same_plan',
+              }),
+            ],
+          },
+        },
+        previous_attributes: {
+          items: {
+            data: [
+              makeSubscriptionItem({
+                interval: 'month',
+                priceId: 'price_monthly_same_plan',
+                productId: 'prod_same_plan',
+              }),
+            ],
+          },
+        },
+      },
+      type: 'customer.subscription.updated',
+    } as any)
+
+    expect(stripeData.isUpgrade).toBe(true)
+    expect(stripeData.previousPriceId).toBe('price_monthly_same_plan')
+    expect(stripeData.previousProductId).toBe('prod_same_plan')
+    expect(stripeEventTestUtils.getSubscriptionTrackingState(stripeData, 'updated')).toEqual({
+      shouldSendPlanChange: false,
+      statusName: 'upgraded',
+    })
+    expect(
+      stripeEventTestUtils.buildSubscriptionEventMetadata(
+        stripeData,
+        makePlan({
+          name: 'Solo',
+          monthlyPriceId: 'price_monthly_same_plan',
+          stripeId: 'prod_same_plan',
+          yearlyPriceId: 'price_yearly_same_plan',
+        }),
+      ),
+    ).toEqual({
+      plan_name: 'Solo',
+      plan_type: 'yearly',
+      previous_plan_name: 'Solo',
+      previous_plan_type: 'monthly',
+    })
+  })
+
+  it.concurrent('keeps same-cadence plan switches as plan changes instead of upgrades', () => {
+    const stripeData = extractDataEvent(mockContext, {
+      data: {
+        object: {
+          customer: 'cus_plan_change_monthly',
+          id: 'sub_plan_change_monthly',
+          items: {
+            data: [
+              makeSubscriptionItem({
+                interval: 'month',
+                priceId: 'price_monthly_new_plan',
+                productId: 'prod_new_plan',
+              }),
+            ],
+          },
+        },
+        previous_attributes: {
+          items: {
+            data: [
+              makeSubscriptionItem({
+                interval: 'month',
+                priceId: 'price_monthly_old_plan',
+                productId: 'prod_old_plan',
+              }),
+            ],
+          },
+        },
+      },
+      type: 'customer.subscription.updated',
+    } as any)
+
+    expect(stripeData.isUpgrade).toBe(false)
+    expect(stripeData.previousPriceId).toBe('price_monthly_old_plan')
+    expect(stripeData.previousProductId).toBe('prod_old_plan')
+    expect(stripeEventTestUtils.getSubscriptionTrackingState(stripeData, 'updated')).toEqual({
+      shouldSendPlanChange: true,
+      statusName: 'updated',
+    })
+    expect(
+      stripeEventTestUtils.buildSubscriptionEventMetadata(
+        stripeData,
+        makePlan({
+          name: 'Maker',
+          monthlyPriceId: 'price_monthly_new_plan',
+          stripeId: 'prod_new_plan',
+          yearlyPriceId: 'price_yearly_new_plan',
+        }),
+        makePlan({
+          name: 'Solo',
+          monthlyPriceId: 'price_monthly_old_plan',
+          stripeId: 'prod_old_plan',
+          yearlyPriceId: 'price_yearly_old_plan',
+        }),
+      ),
+    ).toEqual({
+      plan_name: 'Maker',
+      plan_type: 'monthly',
+      previous_plan_name: 'Solo',
+      previous_plan_type: 'monthly',
+    })
+  })
+
+  it.concurrent('does not treat yearly to monthly switches as upgrades', () => {
+    const stripeData = extractDataEvent(mockContext, {
+      data: {
+        object: {
+          customer: 'cus_downgrade_same_plan',
+          id: 'sub_downgrade_same_plan',
+          items: {
+            data: [
+              makeSubscriptionItem({
+                interval: 'month',
+                priceId: 'price_monthly_same_plan',
+                productId: 'prod_same_plan',
+              }),
+            ],
+          },
+        },
+        previous_attributes: {
+          items: {
+            data: [
+              makeSubscriptionItem({
+                interval: 'year',
+                priceId: 'price_yearly_same_plan',
+                productId: 'prod_same_plan',
+              }),
+            ],
+          },
+        },
+      },
+      type: 'customer.subscription.updated',
+    } as any)
+
+    expect(stripeData.isUpgrade).toBe(false)
+    expect(stripeData.previousPriceId).toBe('price_yearly_same_plan')
+    expect(stripeEventTestUtils.getSubscriptionTrackingState(stripeData, 'updated')).toEqual({
+      shouldSendPlanChange: false,
+      statusName: 'updated',
+    })
+    expect(
+      stripeEventTestUtils.buildSubscriptionEventMetadata(
+        stripeData,
+        makePlan({
+          name: 'Solo',
+          monthlyPriceId: 'price_monthly_same_plan',
+          stripeId: 'prod_same_plan',
+          yearlyPriceId: 'price_yearly_same_plan',
+        }),
+      ),
+    ).toEqual({
+      plan_name: 'Solo',
+      plan_type: 'monthly',
+      previous_plan_name: 'Solo',
+      previous_plan_type: 'yearly',
+    })
+  })
+})

--- a/tests/stripe-subscription-events.unit.test.ts
+++ b/tests/stripe-subscription-events.unit.test.ts
@@ -85,6 +85,7 @@ describe('stripe subscription event classification', () => {
       shouldSendPlanChange: false,
       statusName: 'upgraded',
     })
+    expect(stripeEventTestUtils.getPlanChangeTrackingEventName('upgraded')).toBe('User Upgraded')
     expect(
       stripeEventTestUtils.buildSubscriptionEventMetadata(
         stripeData,
@@ -141,6 +142,7 @@ describe('stripe subscription event classification', () => {
       shouldSendPlanChange: true,
       statusName: 'updated',
     })
+    expect(stripeEventTestUtils.getPlanChangeTrackingEventName('updated')).toBe('User Plan Changed')
     expect(
       stripeEventTestUtils.buildSubscriptionEventMetadata(
         stripeData,


### PR DESCRIPTION
## Summary (AI generated)

- Fix Stripe subscription webhook classification so `user:subscribe_upgraded:*` only fires on real monthly-to-yearly billing changes
- Add from/to subscription metadata (`plan_name`, `plan_type`, `previous_plan_name`, `previous_plan_type`) to subscription tracking events
- Add focused unit coverage for cadence changes, same-cadence plan switches, and downgrade cases

## Motivation (AI generated)

The Stripe webhook parser was treating any product switch as an upgrade and then labeling the subscription event with the current interval. That produced false `user:subscribe_upgraded:monthly` events for same-cadence plan changes and did not expose clear before/after metadata for billing cadence changes.

## Business Impact (AI generated)

This keeps billing lifecycle analytics and notifications accurate, reduces noisy upgrade events, and gives downstream automation enough metadata to understand exactly what changed.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/stripe-subscription-events.unit.test.ts tests/stripe-event-paid-at.unit.test.ts tests/stripe-country.unit.test.ts`
- [x] `bunx eslint supabase/functions/_backend/utils/stripe.ts supabase/functions/_backend/utils/stripe_event.ts supabase/functions/_backend/triggers/stripe_event.ts tests/stripe-subscription-events.unit.test.ts`
- [x] Pre-commit `vue-tsc --noEmit` hook passed during commit

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate detection of upgrades vs. plan changes (monthly↔yearly transitions).
  * Richer subscription metadata in tracking events (current + previous plan names and plan types).
  * Dynamic tracking event names that reflect subscription status and transition type.
* **Tests**
  * New unit tests validating subscription event classification, metadata construction, and tracking behavior across scenarios.
* **Chores**
  * Adjusted seed/reset sequence behavior during data seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->