### PR TITLE
fix(frontend): correct stats refresh timezone display

### DIFF
--- a/src/components/dashboard/Usage.vue
+++ b/src/components/dashboard/Usage.vue
@@ -24,6 +24,7 @@ import {
   requestOrgChartRefresh,
   shouldAutoRequestChartRefresh,
 } from '~/services/dashboardRefresh'
+import { formatUtcDateTimeAsLocal } from '~/services/date'
 import { DEMO_APP_NAMES, generateDemoBandwidthData, generateDemoMauData, generateDemoStorageData } from '~/services/demoChartData'
 import { getPlans, useSupabase } from '~/services/supabase'
 import { useDashboardAppsStore } from '~/stores/dashboardApps'
@@ -165,7 +166,7 @@ const subscriptionAnchorEnd = computed(() => {
 })
 const lastRunDisplay = computed(() => {
   const source = scopeStatsUpdatedAt.value
-  return source ? dayjs(source).format('MMMM D, YYYY HH:mm') : t('unknown')
+  return formatUtcDateTimeAsLocal(source) || t('unknown')
 })
 const nextRunDisplay = computed(() => {
   const source = effectiveOrganization.value?.next_stats_update_at

--- a/src/pages/settings/organization/Usage.vue
+++ b/src/pages/settings/organization/Usage.vue
@@ -10,6 +10,7 @@ import { toast } from 'vue-sonner'
 import CreditsCta from '~/components/CreditsCta.vue'
 import Spinner from '~/components/Spinner.vue'
 import { bytesToGb } from '~/services/conversion'
+import { formatUtcDateTimeAsLocal } from '~/services/date'
 import { calculateCreditCost, getCurrentPlanNameOrg, getPlans, getPlanUsagePercent, getTotalStorage, getUsageCreditDeductions } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -324,7 +325,7 @@ function lastRunDate() {
   if (!source)
     return `${t('last-run')}: ${t('unknown')}`
 
-  const lastRun = dayjs(source).format('MMMM D, YYYY HH:mm')
+  const lastRun = formatUtcDateTimeAsLocal(source) || t('unknown')
   return `${t('last-run')}: ${lastRun}`
 }
 function nextRunDate() {

--- a/src/services/date.ts
+++ b/src/services/date.ts
@@ -1,6 +1,20 @@
 import dayjs from 'dayjs'
 import { i18n } from '~/modules/i18n'
 
+const ZONELESS_ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/
+
+function parseDatePreservingUtc(date: Date | string | undefined | null): Date | null {
+  if (!date)
+    return null
+
+  if (date instanceof Date)
+    return Number.isNaN(date.getTime()) ? null : date
+
+  const normalized = ZONELESS_ISO_DATETIME_RE.test(date) ? `${date}Z` : date
+  const parsed = new Date(normalized)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
 /**
  * Get the current app locale for date formatting
  */
@@ -36,12 +50,17 @@ export function formatLocalDateLong(date: Date | string | undefined | null): str
  * Format a date/time using the app's locale (e.g., "Dec 15, 2025, 3:45 PM" in English)
  */
 export function formatLocalDateTime(date: Date | string | undefined | null): string {
-  if (!date)
-    return ''
-  const d = typeof date === 'string' ? new Date(date) : date
-  if (Number.isNaN(d.getTime()))
+  const d = parseDatePreservingUtc(date)
+  if (!d)
     return ''
   return d.toLocaleString(getAppLocale(), { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export function formatUtcDateTimeAsLocal(date: Date | string | undefined | null, format = 'MMMM D, YYYY HH:mm'): string {
+  const parsed = parseDatePreservingUtc(date)
+  if (!parsed)
+    return ''
+  return dayjs(parsed).format(format)
 }
 
 export function formatDate(date: string | undefined) {

--- a/tests/date.unit.test.ts
+++ b/tests/date.unit.test.ts
@@ -1,0 +1,20 @@
+import dayjs from 'dayjs'
+import { describe, expect, it } from 'vitest'
+import { formatLocalDateTime, formatUtcDateTimeAsLocal } from '../src/services/date'
+
+describe('date helpers', () => {
+  it.concurrent('treats zone-less UTC stats timestamps as UTC before local formatting', () => {
+    const expected = dayjs(new Date('2026-04-22T20:22:00Z')).format('MMMM D, YYYY HH:mm')
+
+    expect(formatUtcDateTimeAsLocal('2026-04-22T20:22:00')).toBe(expected)
+    expect(formatUtcDateTimeAsLocal('2026-04-22T20:22:00Z')).toBe(expected)
+  })
+
+  it.concurrent('keeps local date-time formatting consistent for zone-less UTC inputs', () => {
+    expect(formatLocalDateTime('2026-04-22T20:22:00')).toBe(formatLocalDateTime('2026-04-22T20:22:00Z'))
+  })
+
+  it.concurrent('returns an empty string for invalid UTC timestamp inputs', () => {
+    expect(formatUtcDateTimeAsLocal('not-a-date')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- treat zone-less `stats_updated_at` values as UTC before formatting them in the dashboard and organization usage views
- keep `next_stats_update_at` unchanged because it is already a timezone-aware timestamp
- add a focused unit test covering zone-less and `Z`-suffixed stats timestamps

## Motivation (AI generated)

The new stats refresh flow stores `stats_updated_at` as `timestamp without time zone`. The frontend was formatting that raw value as if it were already local time, which made the refreshed timestamp appear offset from the user clock.

## Business Impact (AI generated)

This keeps refresh metadata trustworthy for users after charts regenerate. The UI now shows the real local refresh time instead of looking stale or inconsistent right after a successful refresh.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/date.unit.test.ts tests/dashboard-refresh.unit.test.ts`
- [x] `bunx eslint --no-warn-ignored src/services/date.ts src/components/dashboard/Usage.vue src/pages/settings/organization/Usage.vue tests/date.unit.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date and time display formatting to ensure consistent, accurate representation of "last run" timestamps across usage pages with proper timezone localization.

* **Tests**
  * Added unit tests for date formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->