### PR TITLE
[codex] add NRR and churn revenue charts

### DIFF
--- a/src/components/admin/AdminMultiLineChart.vue
+++ b/src/components/admin/AdminMultiLineChart.vue
@@ -44,6 +44,18 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  beginAtZero: {
+    type: Boolean,
+    default: true,
+  },
+  suggestedMin: {
+    type: Number,
+    default: undefined,
+  },
+  suggestedMax: {
+    type: Number,
+    default: undefined,
+  },
 })
 
 const isDark = useDark()
@@ -158,7 +170,9 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
       },
     },
     y: {
-      beginAtZero: true,
+      beginAtZero: props.beginAtZero,
+      suggestedMin: props.suggestedMin,
+      suggestedMax: props.suggestedMax,
       grid: {
         color: isDark.value ? 'rgba(75, 85, 99, 0.3)' : 'rgba(229, 231, 235, 0.8)',
       },

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -50,6 +50,8 @@ const globalStatsTrendData = ref<Array<{
   canceled_orgs: number
   upgraded_orgs: number
   mrr: number
+  nrr: number
+  churn_revenue: number
   total_revenue: number
   revenue_solo: number
   revenue_maker: number
@@ -164,6 +166,38 @@ const mrrSeries = computed(() => {
   ]
 })
 
+const nrrSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: 'NRR - Net Revenue Retention (%)',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.nrr || 0,
+      })),
+      color: '#8b5cf6', // violet
+    },
+  ]
+})
+
+const churnRevenueSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: 'Churn Revenue - Lost MRR ($)',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.churn_revenue || 0,
+      })),
+      color: '#ef4444', // red
+    },
+  ]
+})
+
 const arrSeries = computed(() => {
   if (globalStatsTrendData.value.length === 0)
     return []
@@ -178,6 +212,25 @@ const arrSeries = computed(() => {
       color: '#10b981', // green
     },
   ]
+})
+
+const nrrAxisRange = computed(() => {
+  const values = nrrSeries.value.flatMap(series => series.data.map(point => point.value)).filter(value => Number.isFinite(value))
+  if (values.length === 0) {
+    return {
+      suggestedMin: 90,
+      suggestedMax: 110,
+    }
+  }
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const padding = Math.max((max - min) * 0.25, 5)
+
+  return {
+    suggestedMin: Math.max(0, Math.floor(min - padding)),
+    suggestedMax: Math.ceil(max + padding),
+  }
 })
 
 const planARRSeries = computed(() => {
@@ -488,6 +541,7 @@ displayStore.defaultBack = '/dashboard'
               <AdminMultiLineChart
                 :series="mrrSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
+                value-prefix="$"
               />
             </ChartCard>
 
@@ -500,6 +554,7 @@ displayStore.defaultBack = '/dashboard'
               <AdminMultiLineChart
                 :series="arrSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
+                value-prefix="$"
               />
             </ChartCard>
 
@@ -512,6 +567,37 @@ displayStore.defaultBack = '/dashboard'
               <AdminMultiLineChart
                 :series="planARRSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
+                value-prefix="$"
+              />
+            </ChartCard>
+          </div>
+
+          <!-- Retention Charts -->
+          <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard
+              title="NRR - Net Revenue Retention"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="nrrSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="nrrSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
+                :begin-at-zero="false"
+                :suggested-min="nrrAxisRange.suggestedMin"
+                :suggested-max="nrrAxisRange.suggestedMax"
+                value-suffix="%"
+              />
+            </ChartCard>
+
+            <ChartCard
+              title="Churn Revenue - Lost MRR"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="churnRevenueSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="churnRevenueSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
+                value-prefix="$"
               />
             </ChartCard>
           </div>

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -175,7 +175,7 @@ const nrrSeries = computed(() => {
       label: 'NRR - Net Revenue Retention (%)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
-        value: item.nrr || 0,
+        value: item.nrr ?? 100,
       })),
       color: '#8b5cf6', // violet
     },

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1145,6 +1145,7 @@ export type Database = {
           date_id: string
           expansion_mrr: number
           new_business_mrr: number
+          opening_mrr: number
           updated_at: string
         }
         Insert: {
@@ -1155,6 +1156,7 @@ export type Database = {
           date_id: string
           expansion_mrr?: number
           new_business_mrr?: number
+          opening_mrr?: number
           updated_at?: string
         }
         Update: {
@@ -1165,6 +1167,7 @@ export type Database = {
           date_id?: string
           expansion_mrr?: number
           new_business_mrr?: number
+          opening_mrr?: number
           updated_at?: string
         }
         Relationships: []

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -2144,6 +2144,7 @@ export type Database = {
           customer_id: string
           id: number
           is_good_plan: boolean | null
+          last_stripe_event_at: string | null
           mau_exceeded: boolean | null
           paid_at: string | null
           plan_calculated_at: string | null
@@ -2168,6 +2169,7 @@ export type Database = {
           customer_id: string
           id?: number
           is_good_plan?: boolean | null
+          last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
           plan_calculated_at?: string | null
@@ -2192,6 +2194,7 @@ export type Database = {
           customer_id?: string
           id?: number
           is_good_plan?: boolean | null
+          last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
           plan_calculated_at?: string | null

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1136,6 +1136,39 @@ export type Database = {
         }
         Relationships: []
       }
+      daily_revenue_metrics: {
+        Row: {
+          churn_mrr: number
+          contraction_mrr: number
+          created_at: string
+          customer_id: string
+          date_id: string
+          expansion_mrr: number
+          new_business_mrr: number
+          updated_at: string
+        }
+        Insert: {
+          churn_mrr?: number
+          contraction_mrr?: number
+          created_at?: string
+          customer_id: string
+          date_id: string
+          expansion_mrr?: number
+          new_business_mrr?: number
+          updated_at?: string
+        }
+        Update: {
+          churn_mrr?: number
+          contraction_mrr?: number
+          created_at?: string
+          customer_id?: string
+          date_id?: string
+          expansion_mrr?: number
+          new_business_mrr?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
       global_stats: {
         Row: {
           apps: number
@@ -1157,6 +1190,7 @@ export type Database = {
           builds_total: number | null
           bundle_storage_gb: number
           canceled_orgs: number
+          churn_revenue: number
           created_at: string | null
           credits_bought: number
           credits_consumed: number
@@ -1168,6 +1202,7 @@ export type Database = {
           mrr: number
           need_upgrade: number | null
           new_paying_orgs: number
+          nrr: number
           not_paying: number | null
           onboarded: number | null
           org_conversion_rate: number
@@ -1224,6 +1259,7 @@ export type Database = {
           builds_total?: number | null
           bundle_storage_gb?: number
           canceled_orgs?: number
+          churn_revenue?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number
@@ -1235,6 +1271,7 @@ export type Database = {
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number
+          nrr?: number
           not_paying?: number | null
           onboarded?: number | null
           org_conversion_rate?: number
@@ -1291,6 +1328,7 @@ export type Database = {
           builds_total?: number | null
           bundle_storage_gb?: number
           canceled_orgs?: number
+          churn_revenue?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number
@@ -1302,6 +1340,7 @@ export type Database = {
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number
+          nrr?: number
           not_paying?: number | null
           onboarded?: number | null
           org_conversion_rate?: number

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1172,6 +1172,27 @@ export type Database = {
         }
         Relationships: []
       }
+      processed_stripe_events: {
+        Row: {
+          created_at: string
+          customer_id: string
+          date_id: string
+          event_id: string
+        }
+        Insert: {
+          created_at?: string
+          customer_id: string
+          date_id: string
+          event_id: string
+        }
+        Update: {
+          created_at?: string
+          customer_id?: string
+          date_id?: string
+          event_id?: string
+        }
+        Relationships: []
+      }
       global_stats: {
         Row: {
           apps: number

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -62,6 +62,15 @@ interface PlanRevenue {
   plan_enterprise_monthly: number
   plan_enterprise_yearly: number
 }
+interface DailyRevenueChangeSummary {
+  churnMrr: number
+  contractionMrr: number
+  expansionMrr: number
+}
+interface RevenueRetentionMetrics {
+  churnRevenue: number
+  nrr: number
+}
 interface GlobalStats {
   apps: PromiseLike<number>
   updates: PromiseLike<number>
@@ -90,6 +99,7 @@ interface GlobalStats {
   demo_apps_created: PromiseLike<number>
   plugin_breakdown: PromiseLike<PluginBreakdownResult>
   build_stats: PromiseLike<BuildStats>
+  retention_metrics: PromiseLike<RevenueRetentionMetrics>
 }
 interface CustomerIdRow {
   customer_id: string
@@ -137,6 +147,28 @@ function countUniqueCustomers(...rowSets: Array<Array<CustomerIdRow | null | und
       .filter((row): row is CustomerIdRow => Boolean(row?.customer_id))
       .map(row => row.customer_id),
   ).size
+}
+
+function getPreviousDateId(dateId: string) {
+  const target = new Date(`${dateId}T00:00:00.000Z`)
+  target.setUTCDate(target.getUTCDate() - 1)
+  return getDateId(target)
+}
+
+function calculateNrr(previousMrr: number, dailyChanges: DailyRevenueChangeSummary) {
+  if (previousMrr <= 0)
+    return 100
+
+  const retainedMrr = Math.max(
+    previousMrr - dailyChanges.churnMrr - dailyChanges.contractionMrr + dailyChanges.expansionMrr,
+    0,
+  )
+
+  return Number(((retainedMrr / previousMrr) * 100).toFixed(2))
+}
+
+function calculateChurnRevenue(dailyChanges: DailyRevenueChangeSummary) {
+  return Number((dailyChanges.churnMrr + dailyChanges.contractionMrr).toFixed(2))
 }
 
 function isMissingBuildMetricColumnError(error: unknown): boolean {
@@ -441,6 +473,66 @@ async function getBuildStats(c: Context, window?: DailyWindow): Promise<BuildSta
   }
 }
 
+async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<RevenueRetentionMetrics> {
+  const pgClient = getPgClient(c, false)
+  const drizzleClient = getDrizzleClient(pgClient)
+  const previousDateId = getPreviousDateId(dateId)
+
+  try {
+    const result = await drizzleClient.execute<{
+      churn_mrr: number
+      contraction_mrr: number
+      expansion_mrr: number
+      previous_mrr: number
+    }>(sql`
+      WITH daily AS (
+        SELECT
+          COALESCE(SUM(churn_mrr), 0)::float AS churn_mrr,
+          COALESCE(SUM(contraction_mrr), 0)::float AS contraction_mrr,
+          COALESCE(SUM(expansion_mrr), 0)::float AS expansion_mrr
+        FROM public.daily_revenue_metrics
+        WHERE date_id = ${dateId}
+      ),
+      previous_snapshot AS (
+        SELECT COALESCE(mrr, 0)::float AS previous_mrr
+        FROM public.global_stats
+        WHERE date_id = ${previousDateId}
+        LIMIT 1
+      )
+      SELECT
+        daily.churn_mrr,
+        daily.contraction_mrr,
+        daily.expansion_mrr,
+        COALESCE(previous_snapshot.previous_mrr, 0)::float AS previous_mrr
+      FROM daily
+      LEFT JOIN previous_snapshot ON true
+    `)
+
+    const row = result.rows[0]
+    const dailyChanges = {
+      churnMrr: Number(row?.churn_mrr) || 0,
+      contractionMrr: Number(row?.contraction_mrr) || 0,
+      expansionMrr: Number(row?.expansion_mrr) || 0,
+    }
+    const previousMrr = Number(row?.previous_mrr) || 0
+
+    return {
+      churnRevenue: calculateChurnRevenue(dailyChanges),
+      nrr: calculateNrr(previousMrr, dailyChanges),
+    }
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getRevenueRetentionMetrics error', error })
+    return {
+      churnRevenue: 0,
+      nrr: 100,
+    }
+  }
+  finally {
+    closeClient(c, pgClient)
+  }
+}
+
 async function aggregateDailyBuildStats(
   c: Context,
   start: Date,
@@ -723,13 +815,17 @@ function getStats(c: Context, window?: DailyWindow): GlobalStats {
     demo_apps_created: countDemoSeededApps(c, last24h),
     plugin_breakdown: getPluginBreakdownCF(c),
     build_stats: getBuildStats(c, window),
+    retention_metrics: getRevenueRetentionMetrics(c, metricWindow.dayDateId),
   }
 }
 
 export const logsnagInsightsTestUtils = {
+  calculateChurnRevenue,
+  calculateNrr,
   countUniqueCustomers,
   getCompletedDayWindow,
   getCurrentDayWindow,
+  getPreviousDateId,
 }
 
 export const app = new Hono<MiddlewareKeyVariables>()
@@ -766,6 +862,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     demo_apps_created,
     plugin_breakdown,
     build_stats,
+    retention_metrics,
   ] = await Promise.all([
     res.apps,
     res.updates,
@@ -794,6 +891,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     res.demo_apps_created,
     res.plugin_breakdown,
     res.build_stats,
+    res.retention_metrics,
   ])
   const not_paying = users - customers.total - plans.Trial
   const org_conversion_rate = orgs > 0 ? Number((((paying_orgs_for_conversion * 100) / orgs)).toFixed(1)) : 0
@@ -852,6 +950,8 @@ app.post('/', middlewareAPISecret, async (c) => {
     revenue_maker: revenue.revenue_maker,
     revenue_team: revenue.revenue_team,
     revenue_enterprise: revenue.revenue_enterprise,
+    nrr: retention_metrics.nrr,
+    churn_revenue: retention_metrics.churnRevenue,
     plan_solo_monthly: revenue.plan_solo_monthly,
     plan_solo_yearly: revenue.plan_solo_yearly,
     plan_maker_monthly: revenue.plan_maker_monthly,

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -480,16 +480,20 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
 
   try {
     const result = await drizzleClient.execute<{
-      churn_mrr: number
-      contraction_mrr: number
-      expansion_mrr: number
+      retained_churn_mrr: number
+      retained_contraction_mrr: number
+      retained_expansion_mrr: number
+      total_churn_mrr: number
+      total_contraction_mrr: number
       previous_mrr: number
     }>(sql`
       WITH daily AS (
         SELECT
-          COALESCE(SUM(churn_mrr), 0)::float AS churn_mrr,
-          COALESCE(SUM(contraction_mrr), 0)::float AS contraction_mrr,
-          COALESCE(SUM(expansion_mrr), 0)::float AS expansion_mrr
+          COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN churn_mrr ELSE 0 END), 0)::float AS retained_churn_mrr,
+          COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN contraction_mrr ELSE 0 END), 0)::float AS retained_contraction_mrr,
+          COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN expansion_mrr ELSE 0 END), 0)::float AS retained_expansion_mrr,
+          COALESCE(SUM(churn_mrr), 0)::float AS total_churn_mrr,
+          COALESCE(SUM(contraction_mrr), 0)::float AS total_contraction_mrr
         FROM public.daily_revenue_metrics
         WHERE date_id = ${dateId}
       ),
@@ -500,25 +504,32 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
         LIMIT 1
       )
       SELECT
-        daily.churn_mrr,
-        daily.contraction_mrr,
-        daily.expansion_mrr,
+        daily.retained_churn_mrr,
+        daily.retained_contraction_mrr,
+        daily.retained_expansion_mrr,
+        daily.total_churn_mrr,
+        daily.total_contraction_mrr,
         COALESCE(previous_snapshot.previous_mrr, 0)::float AS previous_mrr
       FROM daily
       LEFT JOIN previous_snapshot ON true
     `)
 
     const row = result.rows[0]
-    const dailyChanges = {
-      churnMrr: Number(row?.churn_mrr) || 0,
-      contractionMrr: Number(row?.contraction_mrr) || 0,
-      expansionMrr: Number(row?.expansion_mrr) || 0,
+    const retainedChanges = {
+      churnMrr: Number(row?.retained_churn_mrr) || 0,
+      contractionMrr: Number(row?.retained_contraction_mrr) || 0,
+      expansionMrr: Number(row?.retained_expansion_mrr) || 0,
+    }
+    const totalLostRevenue = {
+      churnMrr: Number(row?.total_churn_mrr) || 0,
+      contractionMrr: Number(row?.total_contraction_mrr) || 0,
+      expansionMrr: 0,
     }
     const previousMrr = Number(row?.previous_mrr) || 0
 
     return {
-      churnRevenue: calculateChurnRevenue(dailyChanges),
-      nrr: calculateNrr(previousMrr, dailyChanges),
+      churnRevenue: calculateChurnRevenue(totalLostRevenue),
+      nrr: calculateNrr(previousMrr, retainedChanges),
     }
   }
   catch (error) {

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -534,10 +534,7 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
   }
   catch (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'getRevenueRetentionMetrics error', error })
-    return {
-      churnRevenue: 0,
-      nrr: 100,
-    }
+    throw error
   }
   finally {
     closeClient(c, pgClient)

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -899,7 +899,10 @@ app.post('/', middlewareAPISecret, async (c) => {
     res.demo_apps_created,
     res.plugin_breakdown,
     res.build_stats,
-    res.retention_metrics,
+    Promise.resolve(res.retention_metrics).catch((error: unknown) => {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'retention metrics unavailable', error })
+      return null
+    }),
   ])
   const not_paying = users - customers.total - plans.Trial
   const org_conversion_rate = orgs > 0 ? Number((((paying_orgs_for_conversion * 100) / orgs)).toFixed(1)) : 0
@@ -958,8 +961,6 @@ app.post('/', middlewareAPISecret, async (c) => {
     revenue_maker: revenue.revenue_maker,
     revenue_team: revenue.revenue_team,
     revenue_enterprise: revenue.revenue_enterprise,
-    nrr: retention_metrics.nrr,
-    churn_revenue: retention_metrics.churnRevenue,
     plan_solo_monthly: revenue.plan_solo_monthly,
     plan_solo_yearly: revenue.plan_solo_yearly,
     plan_maker_monthly: revenue.plan_maker_monthly,
@@ -990,6 +991,12 @@ app.post('/', middlewareAPISecret, async (c) => {
     builds_last_month: build_stats.last_month,
     builds_last_month_ios: build_stats.last_month_ios,
     builds_last_month_android: build_stats.last_month_android,
+    ...(retention_metrics
+      ? {
+          churn_revenue: retention_metrics.churnRevenue,
+          nrr: retention_metrics.nrr,
+        }
+      : {}),
   }
   cloudlog({ requestId: c.get('requestId'), message: 'newData', newData })
   const { error } = await supabaseAdmin(c)

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -276,6 +276,16 @@ function hasRevenueMovement(movement: RevenueMovement) {
     || movement.churnMrr > 0
 }
 
+function isStaleStripeEvent(
+  currentStripeInfo: Pick<StripeInfoRow, 'updated_at'> | null | undefined,
+  eventOccurredAtIso: string,
+) {
+  if (!currentStripeInfo?.updated_at)
+    return false
+
+  return new Date(currentStripeInfo.updated_at).getTime() > new Date(eventOccurredAtIso).getTime()
+}
+
 async function getRevenuePlans(c: Context): Promise<RevenuePlanRow[]> {
   const { data: plans, error } = await supabaseAdmin(c)
     .from('plans')
@@ -667,6 +677,17 @@ async function createdOrUpdated(
 ) {
   const status = originalStatus ?? stripeData.data.status
   let statusName: string = status ?? ''
+  if (isStaleStripeEvent(currentStripeInfo, eventOccurredAtIso)) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Skipping stale Stripe subscription event',
+      customerId: stripeData.data.customer_id,
+      eventOccurredAtIso,
+      currentStripeInfoUpdatedAt: currentStripeInfo?.updated_at,
+      subscriptionId: stripeData.data.subscription_id,
+    })
+    return
+  }
   const { data: plan } = await supabaseAdmin(c)
     .from('plans')
     .select()
@@ -905,11 +926,22 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
     cloudlog({ requestId: c.get('requestId'), message: 'Subscription webhook missing price_id or product_id', stripeData, subscriptionId: stripeData.data.subscription_id })
   }
   else if (['canceled', 'deleted'].includes(stripeData.data.status ?? '')) {
+    const eventOccurredAtIso = new Date(stripeEvent.created * 1000).toISOString()
+    if (isStaleStripeEvent(customer, eventOccurredAtIso)) {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Skipping stale Stripe cancellation event',
+        customerId: stripeData.data.customer_id,
+        eventOccurredAtIso,
+        currentStripeInfoUpdatedAt: customer?.updated_at,
+        subscriptionId: stripeData.data.subscription_id,
+      })
+      return c.json(BRES)
+    }
     // Check if this is the subscription currently in the database
     if (customer && customer.subscription_id === stripeData.data.subscription_id) {
       // This is the known subscription being cancelled
       await didCancel(c, org)
-      const eventOccurredAtIso = new Date(stripeEvent.created * 1000).toISOString()
       // Only mark as 'succeeded' if subscription is still active until period end
       // Check if subscription_anchor_end is in the future
       if (stripeData.data.subscription_anchor_end && new Date(stripeData.data.subscription_anchor_end) > new Date()) {
@@ -945,5 +977,6 @@ export const stripeEventTestUtils = {
   getPlanChangeTrackingEventName,
   getSubscriptionMrr,
   getSubscriptionTrackingState,
+  isStaleStripeEvent,
   isCustomerProfileEvent,
 }

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -30,6 +30,32 @@ interface Org {
 type StripeInfoRow = Database['public']['Tables']['stripe_info']['Row']
 type StripeInfoUpdate = Database['public']['Tables']['stripe_info']['Update']
 type PlanRow = Database['public']['Tables']['plans']['Row']
+type StripeInfoRevenueState = {
+  is_good_plan?: boolean | null
+  paid_at?: string | null
+  price_id?: string | null
+  product_id?: string | null
+  status?: Database['public']['Enums']['stripe_status'] | null
+} | null | undefined
+type RevenuePlanRow = Pick<PlanRow, 'price_m' | 'price_m_id' | 'price_y' | 'price_y_id' | 'stripe_id'>
+
+interface RevenueMovement {
+  currentMrr: number
+  nextMrr: number
+  newBusinessMrr: number
+  expansionMrr: number
+  contractionMrr: number
+  churnMrr: number
+}
+
+const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
+  currentMrr: 0,
+  nextMrr: 0,
+  newBusinessMrr: 0,
+  expansionMrr: 0,
+  contractionMrr: 0,
+  churnMrr: 0,
+}
 
 const checkoutSessionEventTypes = new Set([
   'checkout.session.completed',
@@ -126,6 +152,169 @@ function buildSubscriptionEventMetadata(
 
 function getPlanChangeTrackingEventName(statusName: string) {
   return statusName === 'upgraded' ? 'User Upgraded' : 'User Plan Changed'
+}
+
+function getEventDateId(eventOccurredAtIso: string) {
+  return new Date(eventOccurredAtIso).toISOString().slice(0, 10)
+}
+
+function getPlanMrr(plan: RevenuePlanRow | null | undefined, priceId: string | null | undefined) {
+  if (!plan || !priceId)
+    return 0
+
+  if (plan.price_m_id === priceId)
+    return Number(plan.price_m) || 0
+
+  if (plan.price_y_id === priceId)
+    return (Number(plan.price_y) || 0) / 12
+
+  return 0
+}
+
+function getPlanByProductId(plans: RevenuePlanRow[], productId: string | null | undefined) {
+  if (!productId)
+    return null
+
+  return plans.find(plan => plan.stripe_id === productId) ?? null
+}
+
+function getSubscriptionMrr(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
+  if (!stripeInfo || stripeInfo.status !== 'succeeded' || stripeInfo.is_good_plan === false)
+    return 0
+
+  return getPlanMrr(getPlanByProductId(plans, stripeInfo.product_id), stripeInfo.price_id)
+}
+
+function classifyRevenueMovement(
+  currentStripeInfo: StripeInfoRevenueState,
+  nextStripeInfo: StripeInfoRevenueState,
+  plans: RevenuePlanRow[],
+): RevenueMovement {
+  const currentMrr = getSubscriptionMrr(plans, currentStripeInfo)
+  const nextMrr = getSubscriptionMrr(plans, nextStripeInfo)
+
+  if (currentMrr === 0 && nextMrr === 0)
+    return { ...ZERO_REVENUE_MOVEMENT }
+
+  if (currentMrr === 0 && nextMrr > 0) {
+    if (!currentStripeInfo?.paid_at) {
+      return {
+        ...ZERO_REVENUE_MOVEMENT,
+        currentMrr,
+        nextMrr,
+        newBusinessMrr: nextMrr,
+      }
+    }
+
+    return {
+      ...ZERO_REVENUE_MOVEMENT,
+      currentMrr,
+      nextMrr,
+      expansionMrr: nextMrr,
+    }
+  }
+
+  if (currentMrr > 0 && nextMrr === 0) {
+    return {
+      ...ZERO_REVENUE_MOVEMENT,
+      currentMrr,
+      nextMrr,
+      churnMrr: currentMrr,
+    }
+  }
+
+  if (nextMrr > currentMrr) {
+    return {
+      ...ZERO_REVENUE_MOVEMENT,
+      currentMrr,
+      nextMrr,
+      expansionMrr: nextMrr - currentMrr,
+    }
+  }
+
+  if (currentMrr > nextMrr) {
+    return {
+      ...ZERO_REVENUE_MOVEMENT,
+      currentMrr,
+      nextMrr,
+      contractionMrr: currentMrr - nextMrr,
+    }
+  }
+
+  return {
+    ...ZERO_REVENUE_MOVEMENT,
+    currentMrr,
+    nextMrr,
+  }
+}
+
+function hasRevenueMovement(movement: RevenueMovement) {
+  return movement.newBusinessMrr > 0
+    || movement.expansionMrr > 0
+    || movement.contractionMrr > 0
+    || movement.churnMrr > 0
+}
+
+async function getRevenuePlans(c: Context): Promise<RevenuePlanRow[]> {
+  const { data: plans, error } = await supabaseAdmin(c)
+    .from('plans')
+    .select('stripe_id, price_m, price_y, price_m_id, price_y_id')
+    .in('name', ['Solo', 'Maker', 'Team', 'Enterprise'])
+
+  if (error) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Failed to load revenue plans for Stripe revenue movement tracking',
+      error,
+    })
+    return []
+  }
+
+  return plans ?? []
+}
+
+async function recordRevenueMovement(
+  c: Context,
+  customerId: string,
+  eventOccurredAtIso: string,
+  movement: RevenueMovement,
+) {
+  if (!hasRevenueMovement(movement))
+    return
+
+  const pgClient = getPgClient(c, false)
+  const drizzleClient = getDrizzleClient(pgClient)
+
+  try {
+    await drizzleClient.execute(sql`
+      INSERT INTO public.daily_revenue_metrics (
+        date_id,
+        customer_id,
+        new_business_mrr,
+        expansion_mrr,
+        contraction_mrr,
+        churn_mrr
+      )
+      VALUES (
+        ${getEventDateId(eventOccurredAtIso)},
+        ${customerId},
+        ${movement.newBusinessMrr},
+        ${movement.expansionMrr},
+        ${movement.contractionMrr},
+        ${movement.churnMrr}
+      )
+      ON CONFLICT (date_id, customer_id)
+      DO UPDATE SET
+        updated_at = now(),
+        new_business_mrr = public.daily_revenue_metrics.new_business_mrr + EXCLUDED.new_business_mrr,
+        expansion_mrr = public.daily_revenue_metrics.expansion_mrr + EXCLUDED.expansion_mrr,
+        contraction_mrr = public.daily_revenue_metrics.contraction_mrr + EXCLUDED.contraction_mrr,
+        churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr
+    `)
+  }
+  finally {
+    closeClient(c, pgClient)
+  }
 }
 
 async function writePaidAtAtomically(c: Context, customerId: string, eventOccurredAtIso: string) {
@@ -403,7 +592,7 @@ async function createdOrUpdated(
   c: Context,
   stripeData: StripeData,
   org: Org,
-  currentStripeInfo: Pick<StripeInfoRow, 'paid_at' | 'status'> | null | undefined,
+  currentStripeInfo: StripeInfoRow | null | undefined,
   eventOccurredAtIso: string,
   originalStatus?: Database['public']['Enums']['stripe_status'] | null,
 ) {
@@ -421,6 +610,10 @@ async function createdOrUpdated(
     const paidAt = getPaidAtUpdate(currentStripeInfo, status, eventOccurredAtIso)
     if (paidAt)
       updateData.paid_at = paidAt
+    const revenuePlans = await getRevenuePlans(c)
+    const revenueMovement = classifyRevenueMovement(currentStripeInfo, updateData, revenuePlans)
+    if (revenueMovement.currentMrr > 0 && revenueMovement.nextMrr > revenueMovement.currentMrr)
+      updateData.upgraded_at = eventOccurredAtIso
     const { error: dbError2 } = await supabaseAdmin(c)
       .from('stripe_info')
       .update(updateData)
@@ -428,6 +621,8 @@ async function createdOrUpdated(
     if (dbError2) {
       return quickError(404, 'succeeded_customer_id_not_found', `succeeded: customer_id not found`, { dbError2, stripeData })
     }
+
+    await recordRevenueMovement(c, stripeData.data.customer_id, eventOccurredAtIso, revenueMovement)
 
     let previousPlan: PlanRow | null = null
     if (trackingState.shouldSendPlanChange && stripeData.previousProductId) {
@@ -645,13 +840,17 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
     if (customer && customer.subscription_id === stripeData.data.subscription_id) {
       // This is the known subscription being cancelled
       await didCancel(c, org)
+      const eventOccurredAtIso = new Date(stripeEvent.created * 1000).toISOString()
       // Only mark as 'succeeded' if subscription is still active until period end
       // Check if subscription_anchor_end is in the future
       if (stripeData.data.subscription_anchor_end && new Date(stripeData.data.subscription_anchor_end) > new Date()) {
         stripeData.data.status = 'succeeded'
       }
+      const revenuePlans = await getRevenuePlans(c)
+      const revenueMovement = classifyRevenueMovement(customer, stripeData.data, revenuePlans)
       // Otherwise keep it as 'canceled' since the period has ended
       await updateStripeInfo(c, stripeData)
+      await recordRevenueMovement(c, stripeData.data.customer_id, eventOccurredAtIso, revenueMovement)
     }
     // If it's a different subscription (not the one in DB), ignore it
     // This prevents old subscription webhooks from overwriting newer active subscriptions
@@ -664,8 +863,11 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
 
 export const stripeEventTestUtils = {
   buildSubscriptionEventMetadata,
+  classifyRevenueMovement,
+  getEventDateId,
   getPaidAtUpdate,
   getPlanChangeTrackingEventName,
+  getSubscriptionMrr,
   getSubscriptionTrackingState,
   isCustomerProfileEvent,
 }

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -64,6 +64,7 @@ const STRIPE_INFO_TRANSACTION_COLUMNS = [
   'canceled_at',
   'customer_country',
   'is_good_plan',
+  'last_stripe_event_at',
   'mau_exceeded',
   'paid_at',
   'plan_calculated_at',
@@ -279,13 +280,13 @@ function hasRevenueMovement(movement: RevenueMovement) {
 }
 
 function isStaleStripeEvent(
-  currentStripeInfo: Pick<StripeInfoRow, 'updated_at'> | null | undefined,
+  currentStripeInfo: Pick<StripeInfoRow, 'last_stripe_event_at'> | null | undefined,
   eventOccurredAtIso: string,
 ) {
-  if (!currentStripeInfo?.updated_at)
+  if (!currentStripeInfo?.last_stripe_event_at)
     return false
 
-  return new Date(currentStripeInfo.updated_at).getTime() > new Date(eventOccurredAtIso).getTime()
+  return new Date(currentStripeInfo.last_stripe_event_at).getTime() > new Date(eventOccurredAtIso).getTime()
 }
 
 async function getRevenuePlans(c: Context): Promise<RevenuePlanRow[]> {
@@ -333,7 +334,11 @@ async function persistStripeInfoAndRevenueMovement(
   eventOccurredAtIso: string,
   movement: RevenueMovement,
 ): Promise<PersistRevenueMovementResult> {
-  const updateStatement = buildStripeInfoUpdateStatement(customerId, updateData)
+  const transactionUpdateData: StripeInfoUpdate = {
+    ...updateData,
+    last_stripe_event_at: eventOccurredAtIso,
+  }
+  const updateStatement = buildStripeInfoUpdateStatement(customerId, transactionUpdateData)
   const shouldRecordMovement = hasRevenueMovement(movement)
 
   if (!updateStatement && !shouldRecordMovement)
@@ -346,8 +351,8 @@ async function persistStripeInfoAndRevenueMovement(
 
     // Lock the row so concurrent retries serialize before we classify
     // the event as missing/stale and before we append revenue movement.
-    const stripeInfoRow = await pgClient.query<Pick<StripeInfoRow, 'updated_at'>>(
-      'SELECT updated_at FROM public.stripe_info WHERE customer_id = $1 FOR UPDATE',
+    const stripeInfoRow = await pgClient.query<Pick<StripeInfoRow, 'last_stripe_event_at'>>(
+      'SELECT last_stripe_event_at FROM public.stripe_info WHERE customer_id = $1 FOR UPDATE',
       [customerId],
     )
     const lockedStripeInfo = stripeInfoRow.rows[0]
@@ -725,7 +730,7 @@ async function createdOrUpdated(
       message: 'Skipping stale Stripe subscription event',
       customerId: stripeData.data.customer_id,
       eventOccurredAtIso,
-      currentStripeInfoUpdatedAt: currentStripeInfo?.updated_at,
+      currentStripeInfoLastStripeEventAt: currentStripeInfo?.last_stripe_event_at,
       subscriptionId: stripeData.data.subscription_id,
     })
     return
@@ -999,7 +1004,7 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
         message: 'Skipping stale Stripe cancellation event',
         customerId: stripeData.data.customer_id,
         eventOccurredAtIso,
-        currentStripeInfoUpdatedAt: customer?.updated_at,
+        currentStripeInfoLastStripeEventAt: customer?.last_stripe_event_at,
         subscriptionId: stripeData.data.subscription_id,
       })
       return c.json(BRES)

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -48,6 +48,8 @@ interface RevenueMovement {
   churnMrr: number
 }
 
+type PersistRevenueMovementResult = 'applied' | 'missing' | 'stale'
+
 const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
   currentMrr: 0,
   nextMrr: 0,
@@ -329,23 +331,41 @@ async function persistStripeInfoAndRevenueMovement(
   updateData: StripeInfoUpdate,
   eventOccurredAtIso: string,
   movement: RevenueMovement,
-) {
+): Promise<PersistRevenueMovementResult> {
   const updateStatement = buildStripeInfoUpdateStatement(customerId, updateData)
   const shouldRecordMovement = hasRevenueMovement(movement)
 
   if (!updateStatement && !shouldRecordMovement)
-    return true
+    return 'applied'
 
   const pgClient = getPgClient(c, false)
 
   try {
     await pgClient.query('BEGIN')
 
+    // Lock the row so concurrent retries serialize before we classify
+    // the event as missing/stale and before we append revenue movement.
+    const stripeInfoRow = await pgClient.query<Pick<StripeInfoRow, 'updated_at'>>(
+      'SELECT updated_at FROM public.stripe_info WHERE customer_id = $1 FOR UPDATE',
+      [customerId],
+    )
+    const lockedStripeInfo = stripeInfoRow.rows[0]
+
+    if (!lockedStripeInfo) {
+      await pgClient.query('ROLLBACK')
+      return 'missing'
+    }
+
+    if (isStaleStripeEvent(lockedStripeInfo, eventOccurredAtIso)) {
+      await pgClient.query('ROLLBACK')
+      return 'stale'
+    }
+
     if (updateStatement) {
       const result = await pgClient.query(updateStatement.text, updateStatement.values)
       if ((result.rowCount ?? 0) === 0) {
         await pgClient.query('ROLLBACK')
-        return false
+        return 'missing'
       }
     }
 
@@ -380,7 +400,7 @@ async function persistStripeInfoAndRevenueMovement(
     }
 
     await pgClient.query('COMMIT')
-    return true
+    return 'applied'
   }
   catch (error) {
     try {
@@ -711,7 +731,17 @@ async function createdOrUpdated(
       eventOccurredAtIso,
       revenueMovement,
     )
-    if (!didPersist)
+    if (didPersist === 'stale') {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Skipping stale Stripe subscription event after row lock',
+        customerId: stripeData.data.customer_id,
+        eventOccurredAtIso,
+        subscriptionId: stripeData.data.subscription_id,
+      })
+      return
+    }
+    if (didPersist === 'missing')
       return quickError(404, 'succeeded_customer_id_not_found', `succeeded: customer_id not found`, { stripeData })
 
     let previousPlan: PlanRow | null = null
@@ -940,8 +970,6 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
     }
     // Check if this is the subscription currently in the database
     if (customer && customer.subscription_id === stripeData.data.subscription_id) {
-      // This is the known subscription being cancelled
-      await didCancel(c, org)
       // Only mark as 'succeeded' if subscription is still active until period end
       // Check if subscription_anchor_end is in the future
       if (stripeData.data.subscription_anchor_end && new Date(stripeData.data.subscription_anchor_end) > new Date()) {
@@ -957,8 +985,21 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
         eventOccurredAtIso,
         revenueMovement,
       )
-      if (!didPersist)
+      if (didPersist === 'stale') {
+        cloudlog({
+          requestId: c.get('requestId'),
+          message: 'Skipping stale Stripe cancellation event after row lock',
+          customerId: stripeData.data.customer_id,
+          eventOccurredAtIso,
+          subscriptionId: stripeData.data.subscription_id,
+        })
+        return c.json(BRES)
+      }
+      if (didPersist === 'missing')
         return quickError(404, 'canceled_customer_id_not_found', `canceled: customer_id not found`, { stripeData })
+
+      // This is the known subscription being cancelled.
+      await didCancel(c, org)
     }
     // If it's a different subscription (not the one in DB), ignore it
     // This prevents old subscription webhooks from overwriting newer active subscriptions

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -48,7 +48,7 @@ interface RevenueMovement {
   churnMrr: number
 }
 
-type PersistRevenueMovementResult = 'applied' | 'missing' | 'stale'
+type PersistRevenueMovementResult = 'applied' | 'duplicate' | 'missing' | 'stale'
 
 const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
   currentMrr: 0,
@@ -300,7 +300,7 @@ async function getRevenuePlans(c: Context): Promise<RevenuePlanRow[]> {
       message: 'Failed to load revenue plans for Stripe revenue movement tracking',
       error,
     })
-    return []
+    throw error
   }
 
   return plans ?? []
@@ -328,6 +328,7 @@ function buildStripeInfoUpdateStatement(customerId: string, updateData: StripeIn
 async function persistStripeInfoAndRevenueMovement(
   c: Context,
   customerId: string,
+  stripeEventId: string,
   updateData: StripeInfoUpdate,
   eventOccurredAtIso: string,
   movement: RevenueMovement,
@@ -359,6 +360,27 @@ async function persistStripeInfoAndRevenueMovement(
     if (isStaleStripeEvent(lockedStripeInfo, eventOccurredAtIso)) {
       await pgClient.query('ROLLBACK')
       return 'stale'
+    }
+
+    if (shouldRecordMovement) {
+      const processedEvent = await pgClient.query(`
+        INSERT INTO public.processed_stripe_events (
+          event_id,
+          customer_id,
+          date_id
+        )
+        VALUES ($1, $2, $3)
+        ON CONFLICT (event_id) DO NOTHING
+      `, [
+        stripeEventId,
+        customerId,
+        getEventDateId(eventOccurredAtIso),
+      ])
+
+      if ((processedEvent.rowCount ?? 0) === 0) {
+        await pgClient.query('ROLLBACK')
+        return 'duplicate'
+      }
     }
 
     if (updateStatement) {
@@ -694,7 +716,7 @@ async function createdOrUpdated(
   currentStripeInfo: StripeInfoRow | null | undefined,
   eventOccurredAtIso: string,
   originalStatus?: Database['public']['Enums']['stripe_status'] | null,
-) {
+): Promise<Response | void> {
   const status = originalStatus ?? stripeData.data.status
   let statusName: string = status ?? ''
   if (isStaleStripeEvent(currentStripeInfo, eventOccurredAtIso)) {
@@ -727,10 +749,22 @@ async function createdOrUpdated(
     const didPersist = await persistStripeInfoAndRevenueMovement(
       c,
       stripeData.data.customer_id,
+      c.get('stripeEvent')!.id,
       updateData,
       eventOccurredAtIso,
       revenueMovement,
     )
+    if (didPersist === 'duplicate') {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Skipping duplicate Stripe subscription event',
+        customerId: stripeData.data.customer_id,
+        eventOccurredAtIso,
+        stripeEventId: c.get('stripeEvent')!.id,
+        subscriptionId: stripeData.data.subscription_id,
+      })
+      return
+    }
     if (didPersist === 'stale') {
       cloudlog({
         requestId: c.get('requestId'),
@@ -944,7 +978,9 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
     const originalStatus = stripeData.data.status
     const eventOccurredAtIso = new Date(stripeEvent.created * 1000).toISOString()
     stripeData.data.status = 'succeeded'
-    await createdOrUpdated(c, stripeData, org, customer, eventOccurredAtIso, originalStatus!)
+    const createdOrUpdatedResponse = await createdOrUpdated(c, stripeData, org, customer, eventOccurredAtIso, originalStatus!)
+    if (createdOrUpdatedResponse)
+      return createdOrUpdatedResponse
   }
   else if (stripeData.data.status === 'failed') {
     await trackBentoEvent(c, org.management_email, {}, 'org:failed_payment')
@@ -981,10 +1017,22 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
       const didPersist = await persistStripeInfoAndRevenueMovement(
         c,
         stripeData.data.customer_id,
+        stripeEvent.id,
         toStripeInfoUpdate(stripeData.data),
         eventOccurredAtIso,
         revenueMovement,
       )
+      if (didPersist === 'duplicate') {
+        cloudlog({
+          requestId: c.get('requestId'),
+          message: 'Skipping duplicate Stripe cancellation event',
+          customerId: stripeData.data.customer_id,
+          eventOccurredAtIso,
+          stripeEventId: stripeEvent.id,
+          subscriptionId: stripeData.data.subscription_id,
+        })
+        return c.json(BRES)
+      }
       if (didPersist === 'stale') {
         cloudlog({
           requestId: c.get('requestId'),

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -56,6 +56,27 @@ const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
   contractionMrr: 0,
   churnMrr: 0,
 }
+const STRIPE_INFO_TRANSACTION_COLUMNS = [
+  'bandwidth_exceeded',
+  'build_time_exceeded',
+  'canceled_at',
+  'customer_country',
+  'is_good_plan',
+  'mau_exceeded',
+  'paid_at',
+  'plan_calculated_at',
+  'plan_usage',
+  'price_id',
+  'product_id',
+  'status',
+  'storage_exceeded',
+  'subscription_anchor_end',
+  'subscription_anchor_start',
+  'subscription_id',
+  'trial_at',
+  'upgraded_at',
+] as const
+const STRIPE_INFO_TRANSACTION_COLUMN_SET = new Set<string>(STRIPE_INFO_TRANSACTION_COLUMNS)
 
 const checkoutSessionEventTypes = new Set([
   'checkout.session.completed',
@@ -273,44 +294,92 @@ async function getRevenuePlans(c: Context): Promise<RevenuePlanRow[]> {
   return plans ?? []
 }
 
-async function recordRevenueMovement(
+function buildStripeInfoUpdateStatement(customerId: string, updateData: StripeInfoUpdate) {
+  const entries = Object.entries(updateData)
+    .filter(([key, value]) => value !== undefined && STRIPE_INFO_TRANSACTION_COLUMN_SET.has(key))
+
+  if (entries.length === 0)
+    return null
+
+  const values: unknown[] = [customerId]
+  const assignments = entries.map(([key, value]) => {
+    values.push(value)
+    return `"${key}" = $${values.length}`
+  })
+
+  return {
+    text: `UPDATE public.stripe_info SET ${assignments.join(', ')} WHERE customer_id = $1`,
+    values,
+  }
+}
+
+async function persistStripeInfoAndRevenueMovement(
   c: Context,
   customerId: string,
+  updateData: StripeInfoUpdate,
   eventOccurredAtIso: string,
   movement: RevenueMovement,
 ) {
-  if (!hasRevenueMovement(movement))
-    return
+  const updateStatement = buildStripeInfoUpdateStatement(customerId, updateData)
+  const shouldRecordMovement = hasRevenueMovement(movement)
+
+  if (!updateStatement && !shouldRecordMovement)
+    return true
 
   const pgClient = getPgClient(c, false)
-  const drizzleClient = getDrizzleClient(pgClient)
 
   try {
-    await drizzleClient.execute(sql`
-      INSERT INTO public.daily_revenue_metrics (
-        date_id,
-        customer_id,
-        new_business_mrr,
-        expansion_mrr,
-        contraction_mrr,
-        churn_mrr
-      )
-      VALUES (
-        ${getEventDateId(eventOccurredAtIso)},
-        ${customerId},
-        ${movement.newBusinessMrr},
-        ${movement.expansionMrr},
-        ${movement.contractionMrr},
-        ${movement.churnMrr}
-      )
-      ON CONFLICT (date_id, customer_id)
-      DO UPDATE SET
-        updated_at = now(),
-        new_business_mrr = public.daily_revenue_metrics.new_business_mrr + EXCLUDED.new_business_mrr,
-        expansion_mrr = public.daily_revenue_metrics.expansion_mrr + EXCLUDED.expansion_mrr,
-        contraction_mrr = public.daily_revenue_metrics.contraction_mrr + EXCLUDED.contraction_mrr,
-        churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr
-    `)
+    await pgClient.query('BEGIN')
+
+    if (updateStatement) {
+      const result = await pgClient.query(updateStatement.text, updateStatement.values)
+      if ((result.rowCount ?? 0) === 0) {
+        await pgClient.query('ROLLBACK')
+        return false
+      }
+    }
+
+    if (shouldRecordMovement) {
+      await pgClient.query(`
+        INSERT INTO public.daily_revenue_metrics (
+          date_id,
+          customer_id,
+          opening_mrr,
+          new_business_mrr,
+          expansion_mrr,
+          contraction_mrr,
+          churn_mrr
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ON CONFLICT (date_id, customer_id)
+        DO UPDATE SET
+          updated_at = now(),
+          new_business_mrr = public.daily_revenue_metrics.new_business_mrr + EXCLUDED.new_business_mrr,
+          expansion_mrr = public.daily_revenue_metrics.expansion_mrr + EXCLUDED.expansion_mrr,
+          contraction_mrr = public.daily_revenue_metrics.contraction_mrr + EXCLUDED.contraction_mrr,
+          churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr
+      `, [
+        getEventDateId(eventOccurredAtIso),
+        customerId,
+        movement.currentMrr,
+        movement.newBusinessMrr,
+        movement.expansionMrr,
+        movement.contractionMrr,
+        movement.churnMrr,
+      ])
+    }
+
+    await pgClient.query('COMMIT')
+    return true
+  }
+  catch (error) {
+    try {
+      await pgClient.query('ROLLBACK')
+    }
+    catch {
+      // Ignore rollback failures and rethrow the original error.
+    }
+    throw error
   }
   finally {
     closeClient(c, pgClient)
@@ -614,15 +683,15 @@ async function createdOrUpdated(
     const revenueMovement = classifyRevenueMovement(currentStripeInfo, updateData, revenuePlans)
     if (revenueMovement.currentMrr > 0 && revenueMovement.nextMrr > revenueMovement.currentMrr)
       updateData.upgraded_at = eventOccurredAtIso
-    const { error: dbError2 } = await supabaseAdmin(c)
-      .from('stripe_info')
-      .update(updateData)
-      .eq('customer_id', stripeData.data.customer_id)
-    if (dbError2) {
-      return quickError(404, 'succeeded_customer_id_not_found', `succeeded: customer_id not found`, { dbError2, stripeData })
-    }
-
-    await recordRevenueMovement(c, stripeData.data.customer_id, eventOccurredAtIso, revenueMovement)
+    const didPersist = await persistStripeInfoAndRevenueMovement(
+      c,
+      stripeData.data.customer_id,
+      updateData,
+      eventOccurredAtIso,
+      revenueMovement,
+    )
+    if (!didPersist)
+      return quickError(404, 'succeeded_customer_id_not_found', `succeeded: customer_id not found`, { stripeData })
 
     let previousPlan: PlanRow | null = null
     if (trackingState.shouldSendPlanChange && stripeData.previousProductId) {
@@ -849,8 +918,15 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
       const revenuePlans = await getRevenuePlans(c)
       const revenueMovement = classifyRevenueMovement(customer, stripeData.data, revenuePlans)
       // Otherwise keep it as 'canceled' since the period has ended
-      await updateStripeInfo(c, stripeData)
-      await recordRevenueMovement(c, stripeData.data.customer_id, eventOccurredAtIso, revenueMovement)
+      const didPersist = await persistStripeInfoAndRevenueMovement(
+        c,
+        stripeData.data.customer_id,
+        toStripeInfoUpdate(stripeData.data),
+        eventOccurredAtIso,
+        revenueMovement,
+      )
+      if (!didPersist)
+        return quickError(404, 'canceled_customer_id_not_found', `canceled: customer_id not found`, { stripeData })
     }
     // If it's a different subscription (not the one in DB), ignore it
     // This prevents old subscription webhooks from overwriting newer active subscriptions

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -997,6 +997,8 @@ export interface AdminGlobalStatsTrend {
   canceled_orgs: number
   upgraded_orgs: number
   mrr: number
+  nrr: number
+  churn_revenue: number
   total_revenue: number
   revenue_solo: number
   revenue_maker: number
@@ -1073,6 +1075,8 @@ export async function getAdminGlobalStatsTrend(
         canceled_orgs::int,
         COALESCE(upgraded_orgs, 0)::int AS upgraded_orgs,
         mrr::float,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'nrr', '')::float, 100)::float AS nrr,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'churn_revenue', '')::float, 0)::float AS churn_revenue,
         total_revenue::float,
         revenue_solo::float,
         revenue_maker::float,
@@ -1165,6 +1169,8 @@ export async function getAdminGlobalStatsTrend(
       canceled_orgs: Number(row.canceled_orgs) || 0,
       upgraded_orgs: Number(row.upgraded_orgs) || 0,
       mrr: Number(row.mrr) || 0,
+      nrr: Number(row.nrr) || 0,
+      churn_revenue: Number(row.churn_revenue) || 0,
       total_revenue: Number(row.total_revenue) || 0,
       revenue_solo: Number(row.revenue_solo) || 0,
       revenue_maker: Number(row.revenue_maker) || 0,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1145,6 +1145,7 @@ export type Database = {
           date_id: string
           expansion_mrr: number
           new_business_mrr: number
+          opening_mrr: number
           updated_at: string
         }
         Insert: {
@@ -1155,6 +1156,7 @@ export type Database = {
           date_id: string
           expansion_mrr?: number
           new_business_mrr?: number
+          opening_mrr?: number
           updated_at?: string
         }
         Update: {
@@ -1165,6 +1167,7 @@ export type Database = {
           date_id?: string
           expansion_mrr?: number
           new_business_mrr?: number
+          opening_mrr?: number
           updated_at?: string
         }
         Relationships: []

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -2144,6 +2144,7 @@ export type Database = {
           customer_id: string
           id: number
           is_good_plan: boolean | null
+          last_stripe_event_at: string | null
           mau_exceeded: boolean | null
           paid_at: string | null
           plan_calculated_at: string | null
@@ -2168,6 +2169,7 @@ export type Database = {
           customer_id: string
           id?: number
           is_good_plan?: boolean | null
+          last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
           plan_calculated_at?: string | null
@@ -2192,6 +2194,7 @@ export type Database = {
           customer_id?: string
           id?: number
           is_good_plan?: boolean | null
+          last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
           plan_calculated_at?: string | null

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1136,6 +1136,39 @@ export type Database = {
         }
         Relationships: []
       }
+      daily_revenue_metrics: {
+        Row: {
+          churn_mrr: number
+          contraction_mrr: number
+          created_at: string
+          customer_id: string
+          date_id: string
+          expansion_mrr: number
+          new_business_mrr: number
+          updated_at: string
+        }
+        Insert: {
+          churn_mrr?: number
+          contraction_mrr?: number
+          created_at?: string
+          customer_id: string
+          date_id: string
+          expansion_mrr?: number
+          new_business_mrr?: number
+          updated_at?: string
+        }
+        Update: {
+          churn_mrr?: number
+          contraction_mrr?: number
+          created_at?: string
+          customer_id?: string
+          date_id?: string
+          expansion_mrr?: number
+          new_business_mrr?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
       global_stats: {
         Row: {
           apps: number
@@ -1157,6 +1190,7 @@ export type Database = {
           builds_total: number | null
           bundle_storage_gb: number
           canceled_orgs: number
+          churn_revenue: number
           created_at: string | null
           credits_bought: number
           credits_consumed: number
@@ -1168,6 +1202,7 @@ export type Database = {
           mrr: number
           need_upgrade: number | null
           new_paying_orgs: number
+          nrr: number
           not_paying: number | null
           onboarded: number | null
           org_conversion_rate: number
@@ -1224,6 +1259,7 @@ export type Database = {
           builds_total?: number | null
           bundle_storage_gb?: number
           canceled_orgs?: number
+          churn_revenue?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number
@@ -1235,6 +1271,7 @@ export type Database = {
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number
+          nrr?: number
           not_paying?: number | null
           onboarded?: number | null
           org_conversion_rate?: number
@@ -1291,6 +1328,7 @@ export type Database = {
           builds_total?: number | null
           bundle_storage_gb?: number
           canceled_orgs?: number
+          churn_revenue?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number
@@ -1302,6 +1340,7 @@ export type Database = {
           mrr?: number
           need_upgrade?: number | null
           new_paying_orgs?: number
+          nrr?: number
           not_paying?: number | null
           onboarded?: number | null
           org_conversion_rate?: number

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1172,6 +1172,27 @@ export type Database = {
         }
         Relationships: []
       }
+      processed_stripe_events: {
+        Row: {
+          created_at: string
+          customer_id: string
+          date_id: string
+          event_id: string
+        }
+        Insert: {
+          created_at?: string
+          customer_id: string
+          date_id: string
+          event_id: string
+        }
+        Update: {
+          created_at?: string
+          customer_id?: string
+          date_id?: string
+          event_id?: string
+        }
+        Relationships: []
+      }
       global_stats: {
         Row: {
           apps: number

--- a/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
+++ b/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
@@ -52,6 +52,11 @@ ALTER TABLE public.global_stats
 ADD COLUMN IF NOT EXISTS nrr double precision DEFAULT 100 NOT NULL,
 ADD COLUMN IF NOT EXISTS churn_revenue double precision DEFAULT 0 NOT NULL;
 
+ALTER TABLE public.stripe_info
+ADD COLUMN IF NOT EXISTS last_stripe_event_at timestamp with time zone;
+
+COMMENT ON COLUMN public.stripe_info.last_stripe_event_at IS 'Timestamp of the most recent Stripe event applied to this row, used for webhook ordering checks.';
+
 UPDATE public.global_stats
 SET nrr = 100
 WHERE nrr IS NULL;

--- a/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
+++ b/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS public.daily_revenue_metrics (
   customer_id character varying NOT NULL,
   created_at timestamp with time zone DEFAULT now() NOT NULL,
   updated_at timestamp with time zone DEFAULT now() NOT NULL,
+  opening_mrr double precision DEFAULT 0 NOT NULL,
   new_business_mrr double precision DEFAULT 0 NOT NULL,
   expansion_mrr double precision DEFAULT 0 NOT NULL,
   contraction_mrr double precision DEFAULT 0 NOT NULL,
@@ -13,6 +14,7 @@ CREATE TABLE IF NOT EXISTS public.daily_revenue_metrics (
 ALTER TABLE public.daily_revenue_metrics OWNER TO postgres;
 
 COMMENT ON TABLE public.daily_revenue_metrics IS 'Daily MRR movement rollup per customer, fed by Stripe webhook events for admin retention analytics.';
+COMMENT ON COLUMN public.daily_revenue_metrics.opening_mrr IS 'Customer monthly recurring revenue at the start of the UTC day, before any tracked movement.';
 COMMENT ON COLUMN public.daily_revenue_metrics.new_business_mrr IS 'New monthly recurring revenue created on the day.';
 COMMENT ON COLUMN public.daily_revenue_metrics.expansion_mrr IS 'Expansion monthly recurring revenue added on the day.';
 COMMENT ON COLUMN public.daily_revenue_metrics.contraction_mrr IS 'Monthly recurring revenue lost to downgrades on the day.';

--- a/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
+++ b/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS public.daily_revenue_metrics (
+  date_id character varying NOT NULL,
+  customer_id character varying NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL,
+  new_business_mrr double precision DEFAULT 0 NOT NULL,
+  expansion_mrr double precision DEFAULT 0 NOT NULL,
+  contraction_mrr double precision DEFAULT 0 NOT NULL,
+  churn_mrr double precision DEFAULT 0 NOT NULL,
+  CONSTRAINT daily_revenue_metrics_pkey PRIMARY KEY (date_id, customer_id)
+);
+
+ALTER TABLE public.daily_revenue_metrics OWNER TO postgres;
+
+COMMENT ON TABLE public.daily_revenue_metrics IS 'Daily MRR movement rollup per customer, fed by Stripe webhook events for admin retention analytics.';
+COMMENT ON COLUMN public.daily_revenue_metrics.new_business_mrr IS 'New monthly recurring revenue created on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.expansion_mrr IS 'Expansion monthly recurring revenue added on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.contraction_mrr IS 'Monthly recurring revenue lost to downgrades on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.churn_mrr IS 'Monthly recurring revenue fully lost to churn on the day.';
+
+CREATE INDEX IF NOT EXISTS daily_revenue_metrics_date_id_idx
+ON public.daily_revenue_metrics (date_id);
+
+REVOKE ALL ON TABLE public.daily_revenue_metrics FROM PUBLIC;
+REVOKE ALL ON TABLE public.daily_revenue_metrics FROM anon;
+REVOKE ALL ON TABLE public.daily_revenue_metrics FROM authenticated;
+GRANT ALL ON TABLE public.daily_revenue_metrics TO service_role;
+
+ALTER TABLE public.global_stats
+ADD COLUMN IF NOT EXISTS nrr double precision DEFAULT 100 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_revenue double precision DEFAULT 0 NOT NULL;
+
+UPDATE public.global_stats
+SET nrr = 100
+WHERE nrr IS NULL;
+
+UPDATE public.global_stats
+SET churn_revenue = 0
+WHERE churn_revenue IS NULL;
+
+COMMENT ON COLUMN public.global_stats.nrr IS 'Net Revenue Retention percentage for the day based on prior-day MRR, excluding new business.';
+COMMENT ON COLUMN public.global_stats.churn_revenue IS 'Total monthly recurring revenue lost to churn and downgrades on the day in dollars.';

--- a/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
+++ b/supabase/migrations/20260422203355_add_admin_retention_metrics.sql
@@ -28,6 +28,26 @@ REVOKE ALL ON TABLE public.daily_revenue_metrics FROM anon;
 REVOKE ALL ON TABLE public.daily_revenue_metrics FROM authenticated;
 GRANT ALL ON TABLE public.daily_revenue_metrics TO service_role;
 
+CREATE TABLE IF NOT EXISTS public.processed_stripe_events (
+  event_id text NOT NULL,
+  customer_id character varying NOT NULL,
+  date_id character varying NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT processed_stripe_events_pkey PRIMARY KEY (event_id)
+);
+
+ALTER TABLE public.processed_stripe_events OWNER TO postgres;
+
+COMMENT ON TABLE public.processed_stripe_events IS 'Idempotency ledger for Stripe webhook events that have already updated retention revenue metrics.';
+
+CREATE INDEX IF NOT EXISTS processed_stripe_events_customer_id_date_id_idx
+ON public.processed_stripe_events (customer_id, date_id);
+
+REVOKE ALL ON TABLE public.processed_stripe_events FROM PUBLIC;
+REVOKE ALL ON TABLE public.processed_stripe_events FROM anon;
+REVOKE ALL ON TABLE public.processed_stripe_events FROM authenticated;
+GRANT ALL ON TABLE public.processed_stripe_events TO service_role;
+
 ALTER TABLE public.global_stats
 ADD COLUMN IF NOT EXISTS nrr double precision DEFAULT 100 NOT NULL,
 ADD COLUMN IF NOT EXISTS churn_revenue double precision DEFAULT 0 NOT NULL;

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -40,4 +40,28 @@ describe('logsnag revenue metric helpers', () => {
     expect(nextDayStart.toISOString()).toBe('2026-03-25T00:00:00.000Z')
     expect(dayDateId).toBe('2026-03-24')
   })
+
+  it.concurrent('computes NRR from prior MRR, churn, contraction, and expansion', () => {
+    expect(logsnagInsightsTestUtils.calculateNrr(100, {
+      churnMrr: 15,
+      contractionMrr: 5,
+      expansionMrr: 10,
+    })).toBe(90)
+  })
+
+  it.concurrent('defaults NRR to 100 when there is no starting MRR baseline', () => {
+    expect(logsnagInsightsTestUtils.calculateNrr(0, {
+      churnMrr: 12,
+      contractionMrr: 4,
+      expansionMrr: 0,
+    })).toBe(100)
+  })
+
+  it.concurrent('sums full churn and downgrade revenue into the churn revenue metric', () => {
+    expect(logsnagInsightsTestUtils.calculateChurnRevenue({
+      churnMrr: 18.25,
+      contractionMrr: 7.75,
+      expansionMrr: 0,
+    })).toBe(26)
+  })
 })

--- a/tests/stripe-revenue-movement.unit.test.ts
+++ b/tests/stripe-revenue-movement.unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { stripeEventTestUtils } from '../supabase/functions/_backend/triggers/stripe_event.ts'
+
+const plans = [
+  {
+    stripe_id: 'prod_solo',
+    price_m: 12,
+    price_m_id: 'price_solo_monthly',
+    price_y: 120,
+    price_y_id: 'price_solo_yearly',
+  },
+  {
+    stripe_id: 'prod_team',
+    price_m: 49,
+    price_m_id: 'price_team_monthly',
+    price_y: 468,
+    price_y_id: 'price_team_yearly',
+  },
+] as const
+
+describe('stripe revenue movement classification', () => {
+  it.concurrent('records first-time subscriptions as new business MRR', () => {
+    expect(stripeEventTestUtils.classifyRevenueMovement(
+      {
+        paid_at: null,
+        price_id: null,
+        product_id: null,
+        status: 'created',
+      },
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-22T12:00:00.000Z',
+        price_id: 'price_solo_monthly',
+        product_id: 'prod_solo',
+        status: 'succeeded',
+      },
+      plans as any,
+    )).toMatchObject({
+      currentMrr: 0,
+      nextMrr: 12,
+      newBusinessMrr: 12,
+      expansionMrr: 0,
+      contractionMrr: 0,
+      churnMrr: 0,
+    })
+  })
+
+  it.concurrent('records paid upgrades as expansion MRR', () => {
+    expect(stripeEventTestUtils.classifyRevenueMovement(
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_solo_monthly',
+        product_id: 'prod_solo',
+        status: 'succeeded',
+      },
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_team_monthly',
+        product_id: 'prod_team',
+        status: 'succeeded',
+      },
+      plans as any,
+    )).toMatchObject({
+      currentMrr: 12,
+      nextMrr: 49,
+      expansionMrr: 37,
+      newBusinessMrr: 0,
+      contractionMrr: 0,
+      churnMrr: 0,
+    })
+  })
+
+  it.concurrent('records downgrades as contraction MRR', () => {
+    expect(stripeEventTestUtils.classifyRevenueMovement(
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_team_monthly',
+        product_id: 'prod_team',
+        status: 'succeeded',
+      },
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_solo_monthly',
+        product_id: 'prod_solo',
+        status: 'succeeded',
+      },
+      plans as any,
+    )).toMatchObject({
+      currentMrr: 49,
+      nextMrr: 12,
+      contractionMrr: 37,
+      newBusinessMrr: 0,
+      expansionMrr: 0,
+      churnMrr: 0,
+    })
+  })
+
+  it.concurrent('records cancellations as churned MRR', () => {
+    expect(stripeEventTestUtils.classifyRevenueMovement(
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_team_yearly',
+        product_id: 'prod_team',
+        status: 'succeeded',
+      },
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_team_yearly',
+        product_id: 'prod_team',
+        status: 'canceled',
+      },
+      plans as any,
+    )).toMatchObject({
+      currentMrr: 39,
+      nextMrr: 0,
+      churnMrr: 39,
+      newBusinessMrr: 0,
+      expansionMrr: 0,
+      contractionMrr: 0,
+    })
+  })
+})

--- a/tests/stripe-revenue-movement.unit.test.ts
+++ b/tests/stripe-revenue-movement.unit.test.ts
@@ -125,4 +125,22 @@ describe('stripe revenue movement classification', () => {
       contractionMrr: 0,
     })
   })
+
+  it.concurrent('treats already-persisted newer subscription state as stale', () => {
+    expect(stripeEventTestUtils.isStaleStripeEvent(
+      {
+        updated_at: '2026-04-22T12:10:00.000Z',
+      } as any,
+      '2026-04-22T12:00:00.000Z',
+    )).toBe(true)
+  })
+
+  it.concurrent('keeps newer incoming subscription events eligible for processing', () => {
+    expect(stripeEventTestUtils.isStaleStripeEvent(
+      {
+        updated_at: '2026-04-22T12:10:00.000Z',
+      } as any,
+      '2026-04-22T12:20:00.000Z',
+    )).toBe(false)
+  })
 })

--- a/tests/stripe-revenue-movement.unit.test.ts
+++ b/tests/stripe-revenue-movement.unit.test.ts
@@ -129,7 +129,7 @@ describe('stripe revenue movement classification', () => {
   it.concurrent('treats already-persisted newer subscription state as stale', () => {
     expect(stripeEventTestUtils.isStaleStripeEvent(
       {
-        updated_at: '2026-04-22T12:10:00.000Z',
+        last_stripe_event_at: '2026-04-22T12:10:00.000Z',
       } as any,
       '2026-04-22T12:00:00.000Z',
     )).toBe(true)
@@ -138,7 +138,7 @@ describe('stripe revenue movement classification', () => {
   it.concurrent('keeps newer incoming subscription events eligible for processing', () => {
     expect(stripeEventTestUtils.isStaleStripeEvent(
       {
-        updated_at: '2026-04-22T12:10:00.000Z',
+        last_stripe_event_at: '2026-04-22T12:10:00.000Z',
       } as any,
       '2026-04-22T12:20:00.000Z',
     )).toBe(false)


### PR DESCRIPTION
## Summary (AI generated)

- add daily retention metrics backed by Stripe revenue movement rollups for admin reporting
- expose NRR and churn revenue through `global_stats_trend` and render both charts on the admin revenue dashboard
- add focused unit coverage for Stripe revenue movement classification and retention math

## Motivation (AI generated)

The admin revenue dashboard only showed topline recurring revenue metrics. It was missing the retention view needed to understand whether MRR is being sustained by existing customers or eroded by churn and downgrades.

## Business Impact (AI generated)

This gives Capgo a better operator view of subscription health by surfacing retained revenue and lost recurring revenue alongside MRR. That helps spot leakage earlier and makes revenue trends more actionable.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bun vitest run tests/stripe-revenue-movement.unit.test.ts tests/stripe-subscription-events.unit.test.ts tests/logsnag-insights-revenue.unit.test.ts tests/stripe-event-paid-at.unit.test.ts`
- [x] `bun run build`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NRR and Churn Revenue charts to the admin dashboard with percent and dollar formatting.
  * Chart components now support configurable Y-axis scaling (start-at-zero and suggested min/max).

* **Backend / Data**
  * System collects per-customer daily revenue movement and persists NRR and churn revenue to global stats for dashboard use.

* **Tests**
  * Added unit tests for revenue metric calculations and revenue-movement classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->