### PR TITLE
[codex] fix preview subdomain collision

### DIFF
--- a/shared/preview-subdomain.ts
+++ b/shared/preview-subdomain.ts
@@ -1,0 +1,99 @@
+const PREVIEW_HOSTNAME_REGEX = /^([^.]+)\.preview(?:\.[^.]+)?\.(?:capgo\.app|usecapgo\.com)$/
+const PREVIEW_VERSION_SEPARATOR = '--'
+
+export interface ParsedPreviewSubdomain {
+  appId: string
+  versionId: number
+}
+
+function isLowercaseAlphaNumeric(char: string) {
+  return /^[a-z0-9]$/.test(char)
+}
+
+function encodeEscapedByte(char: string) {
+  return `-${char.charCodeAt(0).toString(16).padStart(2, '0')}`
+}
+
+export function encodePreviewAppId(appId: string): string {
+  return Array.from(appId).map(char => isLowercaseAlphaNumeric(char) ? char : encodeEscapedByte(char)).join('')
+}
+
+export function buildPreviewSubdomain(appId: string, versionId: number): string {
+  return `${encodePreviewAppId(appId)}${PREVIEW_VERSION_SEPARATOR}${versionId}`
+}
+
+export function decodePreviewAppId(encodedAppId: string): string | null {
+  let decoded = ''
+
+  for (let index = 0; index < encodedAppId.length; index += 1) {
+    const char = encodedAppId[index]
+    if (char !== '-') {
+      if (!isLowercaseAlphaNumeric(char))
+        return null
+      decoded += char
+      continue
+    }
+
+    const escapedByte = encodedAppId.slice(index + 1, index + 3)
+    if (!/^[0-9a-f]{2}$/.test(escapedByte))
+      return null
+
+    decoded += String.fromCharCode(Number.parseInt(escapedByte, 16))
+    index += 2
+  }
+
+  return decoded
+}
+
+function parseVersionId(value: string): number | null {
+  if (!/^\d+$/.test(value))
+    return null
+
+  const versionId = Number.parseInt(value, 10)
+  return Number.isNaN(versionId) ? null : versionId
+}
+
+function parseEncodedPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
+  const separatorIndex = subdomain.lastIndexOf(PREVIEW_VERSION_SEPARATOR)
+  if (separatorIndex <= 0)
+    return null
+
+  const encodedAppId = subdomain.slice(0, separatorIndex)
+  const versionId = parseVersionId(subdomain.slice(separatorIndex + PREVIEW_VERSION_SEPARATOR.length))
+  if (versionId === null)
+    return null
+
+  const appId = decodePreviewAppId(encodedAppId)
+  if (!appId)
+    return null
+
+  return { appId, versionId }
+}
+
+function parseLegacyPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
+  const separatorIndex = subdomain.lastIndexOf('-')
+  if (separatorIndex <= 0)
+    return null
+
+  const encodedAppId = subdomain.slice(0, separatorIndex)
+  const versionId = parseVersionId(subdomain.slice(separatorIndex + 1))
+  if (versionId === null)
+    return null
+
+  return {
+    appId: encodedAppId.replace(/__/g, '.'),
+    versionId,
+  }
+}
+
+export function parsePreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
+  return parseEncodedPreviewSubdomain(subdomain) ?? parseLegacyPreviewSubdomain(subdomain)
+}
+
+export function parsePreviewHostname(hostname: string): ParsedPreviewSubdomain | null {
+  const match = hostname.match(PREVIEW_HOSTNAME_REGEX)
+  if (!match)
+    return null
+
+  return parsePreviewSubdomain(match[1])
+}

--- a/shared/preview-subdomain.ts
+++ b/shared/preview-subdomain.ts
@@ -1,27 +1,45 @@
 const PREVIEW_HOSTNAME_REGEX = /^([^.]+)\.preview(?:\.[^.]+)?\.(?:capgo\.app|usecapgo\.com)$/
 const PREVIEW_VERSION_SEPARATOR = '--'
 
+/**
+ * Parsed preview hostname information after the preview subdomain is decoded.
+ */
 export interface ParsedPreviewSubdomain {
   appId: string
   versionId: number
 }
 
+/**
+ * Returns whether a character can be emitted directly inside the DNS-safe label.
+ */
 function isLowercaseAlphaNumeric(char: string) {
   return /^[a-z0-9]$/.test(char)
 }
 
+/**
+ * Escapes a single character into a lowercase hex byte prefixed with `-`.
+ */
 function encodeEscapedByte(char: string) {
   return `-${char.charCodeAt(0).toString(16).padStart(2, '0')}`
 }
 
+/**
+ * Encodes an app ID into a reversible DNS-safe preview subdomain label.
+ */
 export function encodePreviewAppId(appId: string): string {
   return Array.from(appId).map(char => isLowercaseAlphaNumeric(char) ? char : encodeEscapedByte(char)).join('')
 }
 
+/**
+ * Builds the preview subdomain label used before `.preview.capgo.app`.
+ */
 export function buildPreviewSubdomain(appId: string, versionId: number): string {
   return `${encodePreviewAppId(appId)}${PREVIEW_VERSION_SEPARATOR}${versionId}`
 }
 
+/**
+ * Decodes a DNS-safe preview label back to its original app ID.
+ */
 export function decodePreviewAppId(encodedAppId: string): string | null {
   let decoded = ''
 
@@ -45,6 +63,9 @@ export function decodePreviewAppId(encodedAppId: string): string | null {
   return decoded
 }
 
+/**
+ * Parses a numeric version identifier and rejects malformed values.
+ */
 function parseVersionId(value: string): number | null {
   if (!/^\d+$/.test(value))
     return null
@@ -53,6 +74,9 @@ function parseVersionId(value: string): number | null {
   return Number.isNaN(versionId) ? null : versionId
 }
 
+/**
+ * Parses the new reversible preview subdomain format.
+ */
 function parseEncodedPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
   const separatorIndex = subdomain.lastIndexOf(PREVIEW_VERSION_SEPARATOR)
   if (separatorIndex <= 0)
@@ -70,6 +94,9 @@ function parseEncodedPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain
   return { appId, versionId }
 }
 
+/**
+ * Parses the legacy preview subdomain format that encoded dots as `__`.
+ */
 function parseLegacyPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
   const separatorIndex = subdomain.lastIndexOf('-')
   if (separatorIndex <= 0)
@@ -86,10 +113,16 @@ function parseLegacyPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain 
   }
 }
 
+/**
+ * Parses either the new reversible preview format or the legacy compatibility format.
+ */
 export function parsePreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
   return parseEncodedPreviewSubdomain(subdomain) ?? parseLegacyPreviewSubdomain(subdomain)
 }
 
+/**
+ * Extracts and parses the preview label from a full preview hostname.
+ */
 export function parsePreviewHostname(hostname: string): ParsedPreviewSubdomain | null {
   const match = hostname.match(PREVIEW_HOSTNAME_REGEX)
   if (!match)

--- a/shared/preview-subdomain.ts
+++ b/shared/preview-subdomain.ts
@@ -1,5 +1,5 @@
 const PREVIEW_HOSTNAME_REGEX = /^([^.]+)\.preview(?:\.[^.]+)?\.(?:capgo\.app|usecapgo\.com)$/
-const PREVIEW_VERSION_SEPARATOR = '--'
+const PREVIEW_VERSION_SEPARATOR = '-'
 
 /**
  * Parsed preview hostname information after the preview subdomain is decoded.
@@ -17,24 +17,40 @@ function isLowercaseAlphaNumeric(char: string) {
 }
 
 /**
- * Escapes a single character into a lowercase hex byte prefixed with `-`.
+ * Returns whether a character can be emitted directly inside the preview app-id payload.
+ */
+function isDirectPreviewCharacter(char: string) {
+  return isLowercaseAlphaNumeric(char) || char === '_'
+}
+
+/**
+ * Escapes a single character into a compact reversible preview token.
  */
 function encodeEscapedByte(char: string) {
-  return `-${char.charCodeAt(0).toString(16).padStart(2, '0')}`
+  if (char === '.')
+    return '-0'
+
+  if (char === '-')
+    return '-1'
+
+  if (/^[A-Z]$/.test(char))
+    return `-${char.toLowerCase()}`
+
+  throw new Error(`Unsupported preview app id character: ${char}`)
 }
 
 /**
  * Encodes an app ID into a reversible DNS-safe preview subdomain label.
  */
 export function encodePreviewAppId(appId: string): string {
-  return Array.from(appId).map(char => isLowercaseAlphaNumeric(char) ? char : encodeEscapedByte(char)).join('')
+  return Array.from(appId).map(char => isDirectPreviewCharacter(char) ? char : encodeEscapedByte(char)).join('')
 }
 
 /**
  * Builds the preview subdomain label used before `.preview.capgo.app`.
  */
 export function buildPreviewSubdomain(appId: string, versionId: number): string {
-  return `${encodePreviewAppId(appId)}${PREVIEW_VERSION_SEPARATOR}${versionId}`
+  return `${versionId}${PREVIEW_VERSION_SEPARATOR}${encodePreviewAppId(appId)}`
 }
 
 /**
@@ -46,18 +62,35 @@ export function decodePreviewAppId(encodedAppId: string): string | null {
   for (let index = 0; index < encodedAppId.length; index += 1) {
     const char = encodedAppId[index]
     if (char !== '-') {
-      if (!isLowercaseAlphaNumeric(char))
+      if (!isDirectPreviewCharacter(char))
         return null
       decoded += char
       continue
     }
 
-    const escapedByte = encodedAppId.slice(index + 1, index + 3)
-    if (!/^[0-9a-f]{2}$/.test(escapedByte))
+    const escapedByte = encodedAppId[index + 1]
+    if (!escapedByte)
       return null
 
-    decoded += String.fromCharCode(Number.parseInt(escapedByte, 16))
-    index += 2
+    if (escapedByte === '0') {
+      decoded += '.'
+      index += 1
+      continue
+    }
+
+    if (escapedByte === '1') {
+      decoded += '-'
+      index += 1
+      continue
+    }
+
+    if (/^[a-z]$/.test(escapedByte)) {
+      decoded += escapedByte.toUpperCase()
+      index += 1
+      continue
+    }
+
+    return null
   }
 
   return decoded
@@ -78,15 +111,15 @@ function parseVersionId(value: string): number | null {
  * Parses the new reversible preview subdomain format.
  */
 function parseEncodedPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
-  const separatorIndex = subdomain.lastIndexOf(PREVIEW_VERSION_SEPARATOR)
+  const separatorIndex = subdomain.indexOf(PREVIEW_VERSION_SEPARATOR)
   if (separatorIndex <= 0)
     return null
 
-  const encodedAppId = subdomain.slice(0, separatorIndex)
-  const versionId = parseVersionId(subdomain.slice(separatorIndex + PREVIEW_VERSION_SEPARATOR.length))
+  const versionId = parseVersionId(subdomain.slice(0, separatorIndex))
   if (versionId === null)
     return null
 
+  const encodedAppId = subdomain.slice(separatorIndex + PREVIEW_VERSION_SEPARATOR.length)
   const appId = decodePreviewAppId(encodedAppId)
   if (!appId)
     return null
@@ -108,7 +141,7 @@ function parseLegacyPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain 
     return null
 
   return {
-    appId: encodedAppId.replace(/__/g, '.'),
+    appId: encodedAppId.replaceAll('__', '.'),
     versionId,
   }
 }

--- a/src/components/BundlePreviewFrame.vue
+++ b/src/components/BundlePreviewFrame.vue
@@ -4,6 +4,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import IconExternalLink from '~icons/lucide/external-link'
 import IconSmartphone from '~icons/lucide/smartphone'
+import { buildPreviewSubdomain } from '../../shared/preview-subdomain.ts'
 
 const props = defineProps<{
   appId: string
@@ -49,11 +50,9 @@ function checkMobile() {
 
 const currentDevice = computed(() => devices[selectedDevice.value])
 
-// Build the preview URL using subdomain format (no auth - relies on obscure subdomain)
+// Build the preview URL using a reversible preview subdomain format.
 const previewUrl = computed(() => {
-  // Encode app_id: lowercase for DNS, replace . with __ (underscores work in practice)
-  const encodedAppId = props.appId.toLowerCase().replace(/\./g, '__')
-  const subdomain = `${encodedAppId}-${props.versionId}`
+  const subdomain = buildPreviewSubdomain(props.appId, props.versionId)
   // Extract base domain from current host, default to capgo.app for localhost
   // Preserve environment segments (e.g., 'dev' in console.dev.capgo.app)
   const hostname = window.location.hostname

--- a/supabase/functions/_backend/files/preview.ts
+++ b/supabase/functions/_backend/files/preview.ts
@@ -3,11 +3,12 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { Buffer } from 'node:buffer'
 import { brotliDecompressSync } from 'node:zlib'
 import { getRuntimeKey } from 'hono/adapter'
+import { buildPreviewSubdomain, parsePreviewHostname } from '../../../../shared/preview-subdomain.ts'
 import { CacheHelper } from '../utils/cache.ts'
 import { simpleError } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
-import { backgroundTask } from '../utils/utils.ts'
+import { backgroundTask, isValidAppId } from '../utils/utils.ts'
 import { DEFAULT_RETRY_PARAMS, RetryBucket } from './retry.ts'
 // Cache settings
 const PREVIEW_AUTH_CACHE_PATH = '/.preview-auth'
@@ -35,7 +36,7 @@ function buildPreviewAuthRequest(c: Context, appId: string) {
     return null
   return {
     helper,
-    request: helper.buildRequest(PREVIEW_AUTH_CACHE_PATH, { app_id: appId.toLowerCase() }),
+    request: helper.buildRequest(PREVIEW_AUTH_CACHE_PATH, { app_id: appId }),
   }
 }
 
@@ -116,32 +117,12 @@ function getContentType(filePath: string): string {
   return MIME_TYPES[ext] || 'application/octet-stream'
 }
 
-// Parse subdomain format: {app_id_with_dots_as_underscores}-{version_id}.preview[.env].capgo.app
-// Example: ee__forgr__capacitor_go-222063.preview.capgo.app
 function parsePreviewSubdomain(hostname: string): { appId: string, versionId: number } | null {
-  // Match pattern: {something}.preview[.optional-env].capgo.app or usecapgo.com
-  const match = hostname.match(/^([^.]+)\.preview(?:\.[^.]+)?\.(?:capgo\.app|usecapgo\.com)$/)
-  if (!match)
+  const parsed = parsePreviewHostname(hostname)
+  if (!parsed || !isValidAppId(parsed.appId))
     return null
 
-  const subdomain = match[1]
-  // Split by last hyphen to get app_id and version_id
-  // app_id has dots replaced with double underscores
-  const lastHyphen = subdomain.lastIndexOf('-')
-  if (lastHyphen === -1)
-    return null
-
-  const appIdEncoded = subdomain.substring(0, lastHyphen)
-  const versionIdStr = subdomain.substring(lastHyphen + 1)
-
-  // Decode app_id: replace __ with . (frontend lowercases and encodes . as __)
-  const appId = appIdEncoded.replace(/__/g, '.')
-  const versionId = Number.parseInt(versionIdStr, 10)
-
-  if (!appId || Number.isNaN(versionId))
-    return null
-
-  return { appId, versionId }
+  return parsed
 }
 
 // Export the handler directly for use in the main app
@@ -152,7 +133,7 @@ export async function handlePreviewRequest(c: Context<MiddlewareKeyVariables>): 
 
   if (!parsed) {
     cloudlog({ requestId: c.get('requestId'), message: 'invalid preview subdomain', hostname })
-    throw simpleError('invalid_subdomain', 'Invalid preview subdomain format. Expected: {app_id}-{version_id}.preview.capgo.app')
+    throw simpleError('invalid_subdomain', 'Invalid preview subdomain format. Expected: {preview_app_id}--{version_id}.preview.capgo.app')
   }
 
   const { appId, versionId } = parsed
@@ -349,10 +330,6 @@ export async function handlePreviewRequest(c: Context<MiddlewareKeyVariables>): 
 
 // Export helper for generating preview URLs
 export function generatePreviewUrl(appId: string, versionId: number, env: 'prod' | 'preprod' | 'dev' = 'prod'): string {
-  // Encode app_id: replace . with __
-  const encodedAppId = appId.replace(/\./g, '__')
-  const subdomain = `${encodedAppId}-${versionId}`
-
   const envPrefix = env === 'prod' ? '' : `.${env}`
-  return `https://${subdomain}.preview${envPrefix}.capgo.app`
+  return `https://${buildPreviewSubdomain(appId, versionId)}.preview${envPrefix}.capgo.app`
 }

--- a/supabase/functions/_backend/files/preview.ts
+++ b/supabase/functions/_backend/files/preview.ts
@@ -133,7 +133,7 @@ export async function handlePreviewRequest(c: Context<MiddlewareKeyVariables>): 
 
   if (!parsed) {
     cloudlog({ requestId: c.get('requestId'), message: 'invalid preview subdomain', hostname })
-    throw simpleError('invalid_subdomain', 'Invalid preview subdomain format. Expected: {preview_app_id}--{version_id}.preview.capgo.app')
+    throw simpleError('invalid_subdomain', 'Invalid preview subdomain format. Expected: {version_id}-{preview_app_id}.preview.capgo.app')
   }
 
   const { appId, versionId } = parsed

--- a/tests/preview-subdomain.unit.test.ts
+++ b/tests/preview-subdomain.unit.test.ts
@@ -7,7 +7,7 @@ describe('preview subdomain encoding', () => {
     const versionId = 123456
     const subdomain = buildPreviewSubdomain(appId, versionId)
 
-    expect(subdomain).not.toMatch(/[_.A-Z]/)
+    expect(subdomain).not.toMatch(/[.A-Z]/)
     expect(parsePreviewHostname(`${subdomain}.preview.capgo.app`)).toEqual({ appId, versionId })
   })
 
@@ -35,6 +35,19 @@ describe('preview subdomain encoding', () => {
     })
   })
 
+  it.concurrent('returns null for malformed hostnames', () => {
+    expect(parsePreviewHostname('invalid.domain.com')).toBeNull()
+    expect(parsePreviewHostname('')).toBeNull()
+  })
+
+  it.concurrent('supports version zero in the new reversible format', () => {
+    const appId = 'com.example'
+    const versionId = 0
+    const subdomain = buildPreviewSubdomain(appId, versionId)
+
+    expect(parsePreviewHostname(`${subdomain}.preview.capgo.app`)).toEqual({ appId, versionId })
+  })
+
   it.concurrent('does not mistake legacy double-hyphen app IDs for the new separator', () => {
     expect(parsePreviewHostname('com--example__app-42.preview.capgo.app')).toEqual({
       appId: 'com--example.app',
@@ -42,7 +55,16 @@ describe('preview subdomain encoding', () => {
     })
   })
 
+  it.concurrent('keeps long lowercase preview labels within the DNS label limit', () => {
+    const appId = 'com.organizationname.myapplicationproductionreleasex'
+    const versionId = 12345678
+    const subdomain = buildPreviewSubdomain(appId, versionId)
+
+    expect(subdomain.length).toBeLessThanOrEqual(63)
+    expect(parsePreviewHostname(`${subdomain}.preview.capgo.app`)).toEqual({ appId, versionId })
+  })
+
   it.concurrent('escapes underscores instead of collapsing them into dots', () => {
-    expect(encodePreviewAppId('com.example_app')).toContain('-5f')
+    expect(encodePreviewAppId('com.example_app')).toContain('_')
   })
 })

--- a/tests/preview-subdomain.unit.test.ts
+++ b/tests/preview-subdomain.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildPreviewSubdomain, encodePreviewAppId, parsePreviewHostname } from '../shared/preview-subdomain.ts'
+
+describe('preview subdomain encoding', () => {
+  it.concurrent('round-trips app IDs with reserved hostname characters', () => {
+    const appId = 'Com.Example_app-name'
+    const versionId = 123456
+    const subdomain = buildPreviewSubdomain(appId, versionId)
+
+    expect(subdomain).not.toMatch(/[_.A-Z]/)
+    expect(parsePreviewHostname(`${subdomain}.preview.capgo.app`)).toEqual({ appId, versionId })
+  })
+
+  it.concurrent('keeps dotted and double-underscore app IDs in separate preview namespaces', () => {
+    const dottedAppId = 'com.pal0x.preview.cross.1774322988'
+    const underscoredAppId = 'com.pal0x__preview.cross.1774322988'
+    const dottedSubdomain = buildPreviewSubdomain(dottedAppId, 77014920)
+    const underscoredSubdomain = buildPreviewSubdomain(underscoredAppId, 77015428)
+
+    expect(dottedSubdomain).not.toBe(underscoredSubdomain)
+    expect(parsePreviewHostname(`${dottedSubdomain}.preview.capgo.app`)).toEqual({
+      appId: dottedAppId,
+      versionId: 77014920,
+    })
+    expect(parsePreviewHostname(`${underscoredSubdomain}.preview.capgo.app`)).toEqual({
+      appId: underscoredAppId,
+      versionId: 77015428,
+    })
+  })
+
+  it.concurrent('parses legacy preview hostnames for existing links', () => {
+    expect(parsePreviewHostname('com__example__app-42.preview.capgo.app')).toEqual({
+      appId: 'com.example.app',
+      versionId: 42,
+    })
+  })
+
+  it.concurrent('does not mistake legacy double-hyphen app IDs for the new separator', () => {
+    expect(parsePreviewHostname('com--example__app-42.preview.capgo.app')).toEqual({
+      appId: 'com--example.app',
+      versionId: 42,
+    })
+  })
+
+  it.concurrent('escapes underscores instead of collapsing them into dots', () => {
+    expect(encodePreviewAppId('com.example_app')).toContain('-5f')
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- replace the preview `.` to `__` hostname encoding with a reversible escaped format
- keep legacy preview hostnames working while routing new preview links through the collision-safe format
- add focused unit coverage for dotted vs double-underscore app IDs and legacy hostname parsing

## Motivation (AI generated)

`GHSA-76qq-gg2p-pwwj` reports a cross-tenant preview namespace collision because `com.example.app` and `com.example__app` can collapse onto the same public preview hostname when `__` is decoded back into `.`. This change removes that lossy canonicalization while preserving compatibility for existing preview links.

## Business Impact (AI generated)

This protects preview namespace isolation between tenants, prevents one app ID from shadowing another app's preview hostname, and keeps the preview feature trustworthy for customers using app IDs with underscores.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/preview-subdomain.unit.test.ts`
- [x] `bun typecheck`
- [x] `bun run lint:backend`
- [x] `bunx eslint shared/preview-subdomain.ts tests/preview-subdomain.unit.test.ts src/components/BundlePreviewFrame.vue supabase/functions/_backend/files/preview.ts`
- [ ] GitHub Actions

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced preview subdomain generation with improved special character encoding for app identifiers.

* **Refactor**
  * Centralized preview subdomain encoding and parsing logic for consistency across the application.

* **Tests**
  * Added comprehensive test coverage for preview subdomain functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->