### PR TITLE
fix: guard app ownership transfers

### DIFF
--- a/supabase/migrations/20260424090125_protect_owner_org_transfer_path.sql
+++ b/supabase/migrations/20260424090125_protect_owner_org_transfer_path.sql
@@ -1,0 +1,163 @@
+CREATE OR REPLACE FUNCTION public.guard_owner_org_reassignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.owner_org IS DISTINCT FROM OLD.owner_org
+    AND current_setting('capgo.allow_owner_org_transfer', true) IS DISTINCT FROM 'true' THEN
+    RAISE EXCEPTION 'owner_org must be changed through public.transfer_app()';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.guard_owner_org_reassignment() OWNER TO "postgres";
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_apps ON public.apps;
+CREATE TRIGGER guard_owner_org_reassignment_apps
+BEFORE UPDATE OF owner_org ON public.apps
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_app_versions ON public.app_versions;
+CREATE TRIGGER guard_owner_org_reassignment_app_versions
+BEFORE UPDATE OF owner_org ON public.app_versions
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_app_versions_meta ON public.app_versions_meta;
+CREATE TRIGGER guard_owner_org_reassignment_app_versions_meta
+BEFORE UPDATE OF owner_org ON public.app_versions_meta
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_channel_devices ON public.channel_devices;
+CREATE TRIGGER guard_owner_org_reassignment_channel_devices
+BEFORE UPDATE OF owner_org ON public.channel_devices
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_channels ON public.channels;
+CREATE TRIGGER guard_owner_org_reassignment_channels
+BEFORE UPDATE OF owner_org ON public.channels
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+CREATE OR REPLACE FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+    v_old_org_id uuid;
+    v_user_id uuid;
+    v_last_transfer jsonb;
+    v_last_transfer_date timestamp;
+BEGIN
+  SELECT owner_org, transfer_history[array_length(transfer_history, 1)]
+  INTO v_old_org_id, v_last_transfer
+  FROM public.apps
+  WHERE app_id = p_app_id;
+
+  IF v_old_org_id IS NULL THEN
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  v_user_id := (SELECT auth.uid());
+
+  IF v_user_id IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NO_AUTH',
+      jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      v_old_org_id,
+      p_app_id,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_OLD_ORG_RIGHTS',
+      jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      p_new_org_id,
+      NULL::character varying,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NEW_ORG_RIGHTS',
+      jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF v_last_transfer IS NOT NULL THEN
+    v_last_transfer_date := (v_last_transfer->>'transferred_at')::timestamp;
+    IF v_last_transfer_date + interval '32 days' > now() THEN
+      RAISE EXCEPTION
+          'Cannot transfer app. Must wait at least 32 days '
+          'between transfers. Last transfer was on %',
+          v_last_transfer_date;
+    END IF;
+  END IF;
+
+  -- Allow the guarded owner_org cascade only inside the approved transfer path.
+  PERFORM set_config('capgo.allow_owner_org_transfer', 'true', true);
+
+  UPDATE public.apps
+  SET
+      owner_org = p_new_org_id,
+      updated_at = now(),
+      transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
+          'transferred_at', now(),
+          'transferred_from', v_old_org_id,
+          'transferred_to', p_new_org_id,
+          'initiated_by', v_user_id
+      )::jsonb
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions_meta
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channel_devices
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channels
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+END;
+$$;
+
+ALTER FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) OWNER TO "postgres";

--- a/supabase/migrations/20260424090125_protect_owner_org_transfer_path.sql
+++ b/supabase/migrations/20260424090125_protect_owner_org_transfer_path.sql
@@ -57,6 +57,11 @@ DECLARE
     v_user_id uuid;
     v_last_transfer jsonb;
     v_last_transfer_date timestamp;
+    v_transfer_error constant text := 'Unable to process transfer request.';
+    v_app_id_key constant text := 'app_id';
+    v_old_org_id_key constant text := 'old_org_id';
+    v_new_org_id_key constant text := 'new_org_id';
+    v_uid_key constant text := 'uid';
 BEGIN
   SELECT owner_org, transfer_history[array_length(transfer_history, 1)]
   INTO v_old_org_id, v_last_transfer
@@ -64,7 +69,7 @@ BEGIN
   WHERE app_id = p_app_id;
 
   IF v_old_org_id IS NULL THEN
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_error;
   END IF;
 
   v_user_id := (SELECT auth.uid());
@@ -72,9 +77,9 @@ BEGIN
   IF v_user_id IS NULL THEN
     PERFORM public.pg_log(
       'deny: TRANSFER_NO_AUTH',
-      jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
+      jsonb_build_object(v_app_id_key, p_app_id, v_new_org_id_key, p_new_org_id)
     );
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_error;
   END IF;
 
   IF NOT public.rbac_check_permission(
@@ -86,13 +91,13 @@ BEGIN
     PERFORM public.pg_log(
       'deny: TRANSFER_OLD_ORG_RIGHTS',
       jsonb_build_object(
-        'app_id', p_app_id,
-        'old_org_id', v_old_org_id,
-        'new_org_id', p_new_org_id,
-        'uid', v_user_id
+        v_app_id_key, p_app_id,
+        v_old_org_id_key, v_old_org_id,
+        v_new_org_id_key, p_new_org_id,
+        v_uid_key, v_user_id
       )
     );
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_error;
   END IF;
 
   IF NOT public.rbac_check_permission(
@@ -104,13 +109,13 @@ BEGIN
     PERFORM public.pg_log(
       'deny: TRANSFER_NEW_ORG_RIGHTS',
       jsonb_build_object(
-        'app_id', p_app_id,
-        'old_org_id', v_old_org_id,
-        'new_org_id', p_new_org_id,
-        'uid', v_user_id
+        v_app_id_key, p_app_id,
+        v_old_org_id_key, v_old_org_id,
+        v_new_org_id_key, p_new_org_id,
+        v_uid_key, v_user_id
       )
     );
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_error;
   END IF;
 
   IF v_last_transfer IS NOT NULL THEN

--- a/supabase/tests/13_test_plan_math.sql
+++ b/supabase/tests/13_test_plan_math.sql
@@ -42,7 +42,14 @@ BEGIN
   -- Let's now add a second app to this org. 
   ALTER TABLE app_versions DISABLE TRIGGER force_valid_owner_org_app_versions;
 
-  UPDATE apps set owner_org='046a36ac-e03c-4590-9257-bd6c9dba9ee8' where app_id='com.demoadmin.app';
+  UPDATE public.org_users
+  SET user_right = 'super_admin'::public.user_min_right
+  WHERE org_id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    AND user_id = 'c591b04e-cf29-4945-b9a0-776d0672061a';
+
+  PERFORM tests.authenticate_as('test_admin');
+  PERFORM public.transfer_app('com.demoadmin.app', '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid);
+  PERFORM tests.authenticate_as_service_role();
 
   UPDATE app_versions set app_id='com.demoadmin.app', r2_path='orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.demoadmin.app/1.359.0.zip' where id=7;
   INSERT INTO "public"."daily_mau" ("app_id", "mau", "date") VALUES 

--- a/tests/app-transfer-security.test.ts
+++ b/tests/app-transfer-security.test.ts
@@ -1,0 +1,134 @@
+import type { Database } from '../src/types/supabase.types'
+import { randomUUID } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  getSupabaseClient,
+  ORG_ID,
+  resetAndSeedAppData,
+  resetAppData,
+  SUPABASE_ANON_KEY,
+  SUPABASE_BASE_URL,
+  USER_EMAIL,
+  USER_ID,
+  USER_PASSWORD,
+} from './test-utils.ts'
+
+const appId = `com.transfer.security.${randomUUID()}`
+const destinationOrgId = randomUUID()
+const destinationOrgName = `Transfer Destination ${destinationOrgId}`
+const destinationOrgEmail = `transfer-${destinationOrgId}@capgo.app`
+
+function createAuthClient() {
+  return createClient<Database>(SUPABASE_BASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+    },
+  })
+}
+
+describe('app transfer security', () => {
+  const authClient = createAuthClient()
+
+  beforeAll(async () => {
+    const { error: signInError } = await authClient.auth.signInWithPassword({
+      email: USER_EMAIL,
+      password: USER_PASSWORD,
+    })
+
+    if (signInError)
+      throw signInError
+
+    await resetAndSeedAppData(appId)
+
+    const supabase = getSupabaseClient()
+
+    await supabase.from('orgs').insert({
+      id: destinationOrgId,
+      created_by: USER_ID,
+      management_email: destinationOrgEmail,
+      name: destinationOrgName,
+      updated_at: new Date().toISOString(),
+    }).throwOnError()
+
+    await supabase.from('org_users').insert({
+      org_id: destinationOrgId,
+      user_id: USER_ID,
+      user_right: 'super_admin',
+    }).throwOnError()
+  })
+
+  afterAll(async () => {
+    const supabase = getSupabaseClient()
+
+    await resetAppData(appId)
+    await supabase.from('org_users').delete().eq('org_id', destinationOrgId).eq('user_id', USER_ID)
+    await supabase.from('orgs').delete().eq('id', destinationOrgId)
+  })
+
+  it('rejects raw PostgREST owner_org updates on apps', async () => {
+    const updateAttempt = await authClient
+      .from('apps')
+      .update({ owner_org: destinationOrgId })
+      .eq('app_id', appId)
+      .select('owner_org,transfer_history')
+      .single()
+
+    expect(updateAttempt.error).toBeTruthy()
+    expect(updateAttempt.error?.message).toContain('owner_org must be changed through public.transfer_app()')
+
+    const supabase = getSupabaseClient()
+    const { data: appRow, error: appError } = await supabase
+      .from('apps')
+      .select('owner_org,transfer_history')
+      .eq('app_id', appId)
+      .single()
+
+    if (appError)
+      throw appError
+
+    const { data: versionRows, error: versionError } = await supabase
+      .from('app_versions')
+      .select('owner_org')
+      .eq('app_id', appId)
+
+    if (versionError)
+      throw versionError
+
+    expect(appRow.owner_org).toBe(ORG_ID)
+    expect(appRow.transfer_history ?? []).toHaveLength(0)
+    expect(versionRows.every(version => version.owner_org === ORG_ID)).toBe(true)
+  })
+
+  it('still allows the approved transfer_app RPC to move ownership consistently', async () => {
+    const transferResult = await authClient.rpc('transfer_app', {
+      p_app_id: appId,
+      p_new_org_id: destinationOrgId,
+    })
+
+    expect(transferResult.error).toBeNull()
+
+    const supabase = getSupabaseClient()
+    const { data: appRow, error: appError } = await supabase
+      .from('apps')
+      .select('owner_org,transfer_history')
+      .eq('app_id', appId)
+      .single()
+
+    if (appError)
+      throw appError
+
+    const { data: versionRows, error: versionError } = await supabase
+      .from('app_versions')
+      .select('owner_org')
+      .eq('app_id', appId)
+
+    if (versionError)
+      throw versionError
+
+    expect(appRow.owner_org).toBe(destinationOrgId)
+    expect(appRow.transfer_history ?? []).toHaveLength(1)
+    expect(versionRows.length).toBeGreaterThan(0)
+    expect(versionRows.every(version => version.owner_org === destinationOrgId)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- add a Postgres trigger guard that blocks direct `owner_org` reassignment on transfer-owned tables
- route legitimate ownership changes through `public.transfer_app()` by setting an internal transfer-only guard flag
- add a regression test covering the raw PostgREST patch attempt and the approved transfer RPC path

## Motivation (AI generated)

The repository advisory [GHSA-v9jp-r5wh-qqcp](https://github.com/Cap-go/capgo/security/advisories/GHSA-v9jp-r5wh-qqcp) shows that callers could patch `public.apps.owner_org` directly through PostgREST, bypass `transfer_app()`, and leave related rows in the previous organization. This change restores the single-owner invariant by making raw ownership changes fail unless they happen inside the dedicated transfer workflow.

## Business Impact (AI generated)

This closes a cross-org access bug on a security-sensitive ownership boundary. It reduces the risk of customers exposing version-layer data to the wrong organization and avoids trust damage from inconsistent app ownership state.

## Test Plan (AI generated)

- [x] `bun run supabase:with-env -- bunx vitest run tests/app-transfer-security.test.ts`
- [x] `bun typecheck`

Generated with AI
