### PR TITLE
fix(channel): enforce public channel uniqueness

### DIFF
--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -16,6 +16,7 @@ interface ChannelSet {
   disableAutoUpdate?: Database['public']['Enums']['disable_update']
   ios?: boolean
   android?: boolean
+  electron?: boolean
   allow_device_self_set?: boolean
   allow_emulator?: boolean
   allow_device?: boolean
@@ -54,6 +55,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   if (error || !org) {
     throw simpleError('invalid_app_id', 'You can\'t access this app', { app_id: body.app_id })
   }
+  const inferredElectron = body.electron ?? (body.public && (body.ios === true || body.android === true) ? false : undefined)
   const channel: Database['public']['Tables']['channels']['Insert'] = {
     created_by: apikey.user_id,
     app_id: body.app_id,
@@ -68,6 +70,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
     ...(body.allow_prod == null ? {} : { allow_prod: body.allow_prod }),
     ...(body.ios == null ? {} : { ios: body.ios }),
     ...(body.android == null ? {} : { android: body.android }),
+    ...(inferredElectron == null ? {} : { electron: inferredElectron }),
     version: -1,
     owner_org: org.owner_org,
   }

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -55,7 +55,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   if (error || !org) {
     throw simpleError('invalid_app_id', 'You can\'t access this app', { app_id: body.app_id })
   }
-  const inferredElectron = body.electron ?? (body.public && (body.ios === true || body.android === true) ? false : undefined)
+  const inferredElectron = body.electron ?? (body.public && body.ios !== body.android ? false : undefined)
   const channel: Database['public']['Tables']['channels']['Insert'] = {
     created_by: apikey.user_id,
     app_id: body.app_id,

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -11,6 +11,8 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 const UPDATE_RETRY_ATTEMPTS = 3
 const UPDATE_RETRY_DELAY_MS = 300
+type ChannelRow = Database['public']['Tables']['channels']['Row']
+type ChannelPlatformScope = 'ios' | 'android'
 
 async function updateChannelsWithRetry(
   c: Context<MiddlewareKeyVariables>,
@@ -32,6 +34,65 @@ async function updateChannelsWithRetry(
   }
 }
 
+async function getCurrentChannel(
+  c: Context<MiddlewareKeyVariables>,
+  channelId: number,
+): Promise<Pick<ChannelRow, 'id' | 'app_id' | 'public' | 'ios' | 'android' | 'updated_at' | 'created_at'> | null> {
+  const { data, error } = await supabaseAdmin(c)
+    .from('channels')
+    .select('id, app_id, public, ios, android, updated_at, created_at')
+    .eq('id', channelId)
+    .maybeSingle()
+
+  if (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Failed to reload current channel state',
+      error,
+      channelId,
+    })
+    return null
+  }
+
+  return data
+}
+
+async function isCurrentPublicWinner(
+  c: Context<MiddlewareKeyVariables>,
+  record: Pick<ChannelRow, 'id' | 'app_id'>,
+  scope: ChannelPlatformScope,
+) {
+  const currentRecord = await getCurrentChannel(c, record.id)
+  if (!currentRecord?.public || !currentRecord[scope])
+    return false
+
+  const { data: winner, error } = await supabaseAdmin(c)
+    .from('channels')
+    .select('id')
+    .eq('app_id', currentRecord.app_id)
+    .eq('public', true)
+    .eq(scope, true)
+    .order('updated_at', { ascending: false })
+    .order('created_at', { ascending: false })
+    .order('id', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Failed to resolve current public channel winner',
+      error,
+      app_id: currentRecord.app_id,
+      channelId: currentRecord.id,
+      scope,
+    })
+    return false
+  }
+
+  return winner?.id === currentRecord.id
+}
+
 app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['channels']['Row']
   cloudlog({ requestId: c.get('requestId'), message: 'record', record })
@@ -46,29 +107,33 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
   }
 
   if (record.public && record.ios) {
-    await updateChannelsWithRetry(
-      c,
-      async () => await supabaseAdmin(c)
-        .from('channels')
-        .update({ public: false })
-        .eq('app_id', record.app_id)
-        .eq('ios', true)
-        .neq('id', record.id),
-      { app_id: record.app_id, record_id: record.id, scope: 'ios' },
-    )
+    if (await isCurrentPublicWinner(c, record, 'ios')) {
+      await updateChannelsWithRetry(
+        c,
+        async () => await supabaseAdmin(c)
+          .from('channels')
+          .update({ public: false })
+          .eq('app_id', record.app_id)
+          .eq('ios', true)
+          .neq('id', record.id),
+        { app_id: record.app_id, record_id: record.id, scope: 'ios' },
+      )
+    }
   }
 
   if (record.public && record.android) {
-    await updateChannelsWithRetry(
-      c,
-      async () => await supabaseAdmin(c)
-        .from('channels')
-        .update({ public: false })
-        .eq('app_id', record.app_id)
-        .eq('android', true)
-        .neq('id', record.id),
-      { app_id: record.app_id, record_id: record.id, scope: 'android' },
-    )
+    if (await isCurrentPublicWinner(c, record, 'android')) {
+      await updateChannelsWithRetry(
+        c,
+        async () => await supabaseAdmin(c)
+          .from('channels')
+          .update({ public: false })
+          .eq('app_id', record.app_id)
+          .eq('android', true)
+          .neq('id', record.id),
+        { app_id: record.app_id, record_id: record.id, scope: 'android' },
+      )
+    }
   }
 
   return c.json(BRES)

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -12,7 +12,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 const UPDATE_RETRY_ATTEMPTS = 3
 const UPDATE_RETRY_DELAY_MS = 300
 type ChannelRow = Database['public']['Tables']['channels']['Row']
-type ChannelPlatformScope = 'ios' | 'android'
+type ChannelPlatformScope = 'ios' | 'android' | 'electron'
 
 async function updateChannelsWithRetry(
   c: Context<MiddlewareKeyVariables>,
@@ -37,10 +37,10 @@ async function updateChannelsWithRetry(
 async function getCurrentChannel(
   c: Context<MiddlewareKeyVariables>,
   channelId: number,
-): Promise<Pick<ChannelRow, 'id' | 'app_id' | 'public' | 'ios' | 'android' | 'updated_at' | 'created_at'> | null> {
+): Promise<Pick<ChannelRow, 'id' | 'app_id' | 'public' | 'ios' | 'android' | 'electron' | 'updated_at' | 'created_at'> | null> {
   const { data, error } = await supabaseAdmin(c)
     .from('channels')
-    .select('id, app_id, public, ios, android, updated_at, created_at')
+    .select('id, app_id, public, ios, android, electron, updated_at, created_at')
     .eq('id', channelId)
     .maybeSingle()
 
@@ -132,6 +132,21 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
           .eq('android', true)
           .neq('id', record.id),
         { app_id: record.app_id, record_id: record.id, scope: 'android' },
+      )
+    }
+  }
+
+  if (record.public && record.electron) {
+    if (await isCurrentPublicWinner(c, record, 'electron')) {
+      await updateChannelsWithRetry(
+        c,
+        async () => await supabaseAdmin(c)
+          .from('channels')
+          .update({ public: false })
+          .eq('app_id', record.app_id)
+          .eq('electron', true)
+          .neq('id', record.id),
+        { app_id: record.app_id, record_id: record.id, scope: 'electron' },
       )
     }
   }

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -57,14 +57,14 @@ async function getCurrentChannel(
   return data
 }
 
-async function isCurrentPublicWinner(
+async function getCurrentPublicWinner(
   c: Context<MiddlewareKeyVariables>,
   record: Pick<ChannelRow, 'id' | 'app_id'>,
   scope: ChannelPlatformScope,
 ) {
   const currentRecord = await getCurrentChannel(c, record.id)
   if (!currentRecord?.public || !currentRecord[scope])
-    return false
+    return null
 
   const { data: winner, error } = await supabaseAdmin(c)
     .from('channels')
@@ -87,10 +87,10 @@ async function isCurrentPublicWinner(
       channelId: currentRecord.id,
       scope,
     })
-    return false
+    return null
   }
 
-  return winner?.id === currentRecord.id
+  return winner?.id === currentRecord.id ? currentRecord : null
 }
 
 app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async (c) => {
@@ -107,46 +107,49 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
   }
 
   if (record.public && record.ios) {
-    if (await isCurrentPublicWinner(c, record, 'ios')) {
+    const currentWinner = await getCurrentPublicWinner(c, record, 'ios')
+    if (currentWinner) {
       await updateChannelsWithRetry(
         c,
         async () => await supabaseAdmin(c)
           .from('channels')
           .update({ public: false })
-          .eq('app_id', record.app_id)
+          .eq('app_id', currentWinner.app_id)
           .eq('ios', true)
           .neq('id', record.id),
-        { app_id: record.app_id, record_id: record.id, scope: 'ios' },
+        { app_id: currentWinner.app_id, record_id: record.id, scope: 'ios' },
       )
     }
   }
 
   if (record.public && record.android) {
-    if (await isCurrentPublicWinner(c, record, 'android')) {
+    const currentWinner = await getCurrentPublicWinner(c, record, 'android')
+    if (currentWinner) {
       await updateChannelsWithRetry(
         c,
         async () => await supabaseAdmin(c)
           .from('channels')
           .update({ public: false })
-          .eq('app_id', record.app_id)
+          .eq('app_id', currentWinner.app_id)
           .eq('android', true)
           .neq('id', record.id),
-        { app_id: record.app_id, record_id: record.id, scope: 'android' },
+        { app_id: currentWinner.app_id, record_id: record.id, scope: 'android' },
       )
     }
   }
 
   if (record.public && record.electron) {
-    if (await isCurrentPublicWinner(c, record, 'electron')) {
+    const currentWinner = await getCurrentPublicWinner(c, record, 'electron')
+    if (currentWinner) {
       await updateChannelsWithRetry(
         c,
         async () => await supabaseAdmin(c)
           .from('channels')
           .update({ public: false })
-          .eq('app_id', record.app_id)
+          .eq('app_id', currentWinner.app_id)
           .eq('electron', true)
           .neq('id', record.id),
-        { app_id: record.app_id, record_id: record.id, scope: 'electron' },
+        { app_id: currentWinner.app_id, record_id: record.id, scope: 'electron' },
       )
     }
   }

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -56,16 +56,6 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
         .neq('id', record.id),
       { app_id: record.app_id, record_id: record.id, scope: 'ios' },
     )
-    await updateChannelsWithRetry(
-      c,
-      async () => await supabaseAdmin(c)
-        .from('channels')
-        .update({ public: false })
-        .eq('app_id', record.app_id)
-        .eq('android', false)
-        .eq('ios', false),
-      { app_id: record.app_id, record_id: record.id, scope: 'hidden_ios' },
-    )
   }
 
   if (record.public && record.android) {
@@ -79,28 +69,18 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
         .neq('id', record.id),
       { app_id: record.app_id, record_id: record.id, scope: 'android' },
     )
-    await updateChannelsWithRetry(
-      c,
-      async () => await supabaseAdmin(c)
-        .from('channels')
-        .update({ public: false })
-        .eq('app_id', record.app_id)
-        .eq('android', false)
-        .eq('ios', false),
-      { app_id: record.app_id, record_id: record.id, scope: 'hidden_android' },
-    )
   }
 
-  if (record.public && (record.ios === record.android)) {
+  if (record.public && record.electron) {
     await updateChannelsWithRetry(
       c,
       async () => await supabaseAdmin(c)
         .from('channels')
         .update({ public: false })
         .eq('app_id', record.app_id)
-        .eq('public', true)
+        .eq('electron', true)
         .neq('id', record.id),
-      { app_id: record.app_id, record_id: record.id, scope: 'public' },
+      { app_id: record.app_id, record_id: record.id, scope: 'electron' },
     )
   }
 

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -71,18 +71,5 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
     )
   }
 
-  if (record.public && record.electron) {
-    await updateChannelsWithRetry(
-      c,
-      async () => await supabaseAdmin(c)
-        .from('channels')
-        .update({ public: false })
-        .eq('app_id', record.app_id)
-        .eq('electron', true)
-        .neq('id', record.id),
-      { app_id: record.app_id, record_id: record.id, scope: 'electron' },
-    )
-  }
-
   return c.json(BRES)
 })

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -498,7 +498,7 @@ export function requestInfosChannelPostgres(
     )
     .groupBy(channelAlias.id, versionAlias.id)
   const channelQuery = !defaultChannel
-    ? baseChannelQuery.orderBy(desc(channelAlias.id)).limit(1)
+    ? baseChannelQuery.orderBy(desc(channelAlias.updated_at), desc(channelAlias.id)).limit(1)
     : baseChannelQuery.limit(1)
   cloudlog({ requestId: c.get('requestId'), message: 'channel Query:', channelQuery: channelQuery.toSQL() })
   const channel = channelQuery.then(data => data.at(0))

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono'
-import { and, desc, eq, or, sql } from 'drizzle-orm'
+import { and, eq, or, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { alias } from 'drizzle-orm/pg-core'
 import { getRuntimeKey } from 'hono/adapter'
@@ -481,7 +481,7 @@ export function requestInfosChannelPostgres(
     .from(channelAlias)
     .innerJoin(versionAlias, activeChannelVersionJoin(channelAlias.version, versionAlias))
 
-  const baseChannelQuery = (includeManifest
+  const channelQuery = (includeManifest
     ? baseQuery.leftJoin(schema.manifest, eq(schema.manifest.app_version_id, versionAlias.id))
     : baseQuery)
     .where(
@@ -497,9 +497,7 @@ export function requestInfosChannelPostgres(
           ),
     )
     .groupBy(channelAlias.id, versionAlias.id)
-  const channelQuery = !defaultChannel
-    ? baseChannelQuery.orderBy(desc(channelAlias.updated_at), desc(channelAlias.id)).limit(1)
-    : baseChannelQuery.limit(1)
+    .limit(1)
   cloudlog({ requestId: c.get('requestId'), message: 'channel Query:', channelQuery: channelQuery.toSQL() })
   const channel = channelQuery.then(data => data.at(0))
 

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono'
-import { and, eq, or, sql } from 'drizzle-orm'
+import { and, desc, eq, or, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { alias } from 'drizzle-orm/pg-core'
 import { getRuntimeKey } from 'hono/adapter'
@@ -481,7 +481,7 @@ export function requestInfosChannelPostgres(
     .from(channelAlias)
     .innerJoin(versionAlias, activeChannelVersionJoin(channelAlias.version, versionAlias))
 
-  const channelQuery = (includeManifest
+  const baseChannelQuery = (includeManifest
     ? baseQuery.leftJoin(schema.manifest, eq(schema.manifest.app_version_id, versionAlias.id))
     : baseQuery)
     .where(
@@ -497,7 +497,9 @@ export function requestInfosChannelPostgres(
           ),
     )
     .groupBy(channelAlias.id, versionAlias.id)
-    .limit(1)
+  const channelQuery = !defaultChannel
+    ? baseChannelQuery.orderBy(desc(channelAlias.id)).limit(1)
+    : baseChannelQuery.limit(1)
   cloudlog({ requestId: c.get('requestId'), message: 'channel Query:', channelQuery: channelQuery.toSQL() })
   const channel = channelQuery.then(data => data.at(0))
 

--- a/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
+++ b/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
@@ -11,7 +11,8 @@ AS $$
 BEGIN
   -- Serialize public-channel changes per app so concurrent writers cannot
   -- reintroduce overlapping public state between the normalization update and
-  -- the row write itself.
+  -- the row write itself. Taking this lock before the cross-row UPDATE also
+  -- makes same-app writers wait here instead of deadlocking on channel rows.
   PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtext(NEW.app_id));
 
   IF NEW.public IS DISTINCT FROM true THEN

--- a/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
+++ b/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
@@ -12,7 +12,7 @@ BEGIN
   -- Serialize public-channel changes per app so concurrent writers cannot
   -- reintroduce overlapping public state between the normalization update and
   -- the row write itself.
-  PERFORM pg_advisory_xact_lock(hashtext(NEW.app_id));
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtext(NEW.app_id));
 
   IF NEW.public IS DISTINCT FROM true THEN
     RETURN NEW;

--- a/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
+++ b/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
@@ -1,4 +1,4 @@
--- Enforce one public channel winner per mobile platform at write time.
+-- Enforce one public channel winner per platform at write time.
 -- This closes the race where overlapping public channels can coexist briefly
 -- and unnamed /updates requests silently pick an implicit winner.
 
@@ -26,6 +26,7 @@ BEGIN
     AND (
       (NEW.ios = true AND existing.ios = true)
       OR (NEW.android = true AND existing.android = true)
+      OR (NEW.electron = true AND existing.electron = true)
     );
 
   RETURN NEW;
@@ -37,7 +38,7 @@ REVOKE ALL ON FUNCTION public.normalize_public_channel_overlap() FROM PUBLIC;
 
 DROP TRIGGER IF EXISTS normalize_public_channel_overlap_before_upsert ON public.channels;
 CREATE TRIGGER normalize_public_channel_overlap_before_upsert
-BEFORE INSERT OR UPDATE OF public, ios, android, app_id
+BEFORE INSERT OR UPDATE OF public, ios, android, electron, app_id
 ON public.channels
 FOR EACH ROW
 EXECUTE FUNCTION public.normalize_public_channel_overlap();
@@ -57,6 +58,7 @@ WHERE older.public = true
       AND (
         (older.ios = true AND newer.ios = true)
         OR (older.android = true AND newer.android = true)
+        OR (older.electron = true AND newer.electron = true)
       )
       AND (
         newer.updated_at > older.updated_at
@@ -72,3 +74,7 @@ WHERE public = true AND ios = true;
 CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_android_per_app_key
 ON public.channels (app_id)
 WHERE public = true AND android = true;
+
+CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_electron_per_app_key
+ON public.channels (app_id)
+WHERE public = true AND electron = true;

--- a/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
+++ b/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
@@ -1,4 +1,4 @@
--- Enforce one public channel winner per app/platform at write time.
+-- Enforce one public channel winner per mobile platform at write time.
 -- This closes the race where overlapping public channels can coexist briefly
 -- and unnamed /updates requests silently pick an implicit winner.
 
@@ -26,7 +26,6 @@ BEGIN
     AND (
       (NEW.ios = true AND existing.ios = true)
       OR (NEW.android = true AND existing.android = true)
-      OR (NEW.electron = true AND existing.electron = true)
     );
 
   RETURN NEW;
@@ -38,7 +37,7 @@ REVOKE ALL ON FUNCTION public.normalize_public_channel_overlap() FROM PUBLIC;
 
 DROP TRIGGER IF EXISTS normalize_public_channel_overlap_before_upsert ON public.channels;
 CREATE TRIGGER normalize_public_channel_overlap_before_upsert
-BEFORE INSERT OR UPDATE OF public, ios, android, electron, app_id
+BEFORE INSERT OR UPDATE OF public, ios, android, app_id
 ON public.channels
 FOR EACH ROW
 EXECUTE FUNCTION public.normalize_public_channel_overlap();
@@ -58,7 +57,6 @@ WHERE older.public = true
       AND (
         (older.ios = true AND newer.ios = true)
         OR (older.android = true AND newer.android = true)
-        OR (older.electron = true AND newer.electron = true)
       )
       AND (
         newer.updated_at > older.updated_at
@@ -74,7 +72,3 @@ WHERE public = true AND ios = true;
 CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_android_per_app_key
 ON public.channels (app_id)
 WHERE public = true AND android = true;
-
-CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_electron_per_app_key
-ON public.channels (app_id)
-WHERE public = true AND electron = true;

--- a/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
+++ b/supabase/migrations/20260424090854_enforce_public_channel_uniqueness.sql
@@ -1,0 +1,80 @@
+-- Enforce one public channel winner per app/platform at write time.
+-- This closes the race where overlapping public channels can coexist briefly
+-- and unnamed /updates requests silently pick an implicit winner.
+
+CREATE OR REPLACE FUNCTION public.normalize_public_channel_overlap()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- Serialize public-channel changes per app so concurrent writers cannot
+  -- reintroduce overlapping public state between the normalization update and
+  -- the row write itself.
+  PERFORM pg_advisory_xact_lock(hashtext(NEW.app_id));
+
+  IF NEW.public IS DISTINCT FROM true THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.channels AS existing
+  SET public = false
+  WHERE existing.app_id = NEW.app_id
+    AND existing.public = true
+    AND existing.id IS DISTINCT FROM NEW.id
+    AND (
+      (NEW.ios = true AND existing.ios = true)
+      OR (NEW.android = true AND existing.android = true)
+      OR (NEW.electron = true AND existing.electron = true)
+    );
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.normalize_public_channel_overlap() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION public.normalize_public_channel_overlap() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS normalize_public_channel_overlap_before_upsert ON public.channels;
+CREATE TRIGGER normalize_public_channel_overlap_before_upsert
+BEFORE INSERT OR UPDATE OF public, ios, android, electron, app_id
+ON public.channels
+FOR EACH ROW
+EXECUTE FUNCTION public.normalize_public_channel_overlap();
+
+-- Normalize any pre-existing conflicting public rows so the unique indexes can
+-- be added safely. Keep the newest overlapping row and demote older ones,
+-- matching the intended "last public write wins" behavior.
+UPDATE public.channels AS older
+SET public = false
+WHERE older.public = true
+  AND EXISTS (
+    SELECT 1
+    FROM public.channels AS newer
+    WHERE newer.app_id = older.app_id
+      AND newer.public = true
+      AND newer.id <> older.id
+      AND (
+        (older.ios = true AND newer.ios = true)
+        OR (older.android = true AND newer.android = true)
+        OR (older.electron = true AND newer.electron = true)
+      )
+      AND (
+        newer.updated_at > older.updated_at
+        OR (newer.updated_at = older.updated_at AND newer.created_at > older.created_at)
+        OR (newer.updated_at = older.updated_at AND newer.created_at = older.created_at AND newer.id > older.id)
+      )
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_ios_per_app_key
+ON public.channels (app_id)
+WHERE public = true AND ios = true;
+
+CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_android_per_app_key
+ON public.channels (app_id)
+WHERE public = true AND android = true;
+
+CREATE UNIQUE INDEX IF NOT EXISTS channels_one_public_electron_per_app_key
+ON public.channels (app_id)
+WHERE public = true AND electron = true;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -593,7 +593,7 @@ BEGIN
     INSERT INTO "public"."channels" ("id", "created_at", "name", "app_id", "version", "updated_at", "public", "disable_auto_update_under_native", "disable_auto_update", "ios", "android", "electron", "allow_device_self_set", "allow_emulator", "allow_device", "allow_dev", "allow_prod", "created_by") VALUES
     (1, NOW(), 'production', 'com.demo.app', 3, NOW(), 't', 't', 'major'::"public"."disable_update", 'f', 't', 't', 't', 't', 't', 't', 't', '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid),
     (2, NOW(), 'no_access', 'com.demo.app', 5, NOW(), 'f', 't', 'major'::"public"."disable_update", 't', 't', 'f', 't', 't', 't', 't', 't', '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid),
-    (3, NOW(), 'two_default', 'com.demo.app', 3, NOW(), 't', 't', 'major'::"public"."disable_update", 't', 'f', 't', 't', 't', 't', 't', 't', '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid),
+    (3, NOW(), 'two_default', 'com.demo.app', 3, NOW(), 't', 't', 'major'::"public"."disable_update", 't', 'f', 'f', 't', 't', 't', 't', 't', '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid),
     (4, NOW(), 'production', 'com.stats.app', 13, NOW(), 't', 't', 'major'::"public"."disable_update", 'f', 't', 't', 't', 't', 't', 't', 't', '7a1b2c3d-4e5f-4a6b-7c8d-9e0f1a2b3c4d'::uuid),
     (5, NOW(), 'electron_only', 'com.demo.app', 3, NOW(), 'f', 't', 'major'::"public"."disable_update", 'f', 'f', 't', 't', 't', 't', 't', 't', '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid);
 

--- a/supabase/tests/35_test_deploy_install_stats_email.sql
+++ b/supabase/tests/35_test_deploy_install_stats_email.sql
@@ -87,7 +87,7 @@ SET
 
 WITH ios_channel AS (
     INSERT INTO public.channels (
-        created_by, app_id, name, version, public, ios, android, owner_org
+        created_by, app_id, name, version, public, ios, android, electron, owner_org
     )
     SELECT
         user_id,
@@ -97,6 +97,7 @@ WITH ios_channel AS (
         true,
         true,
         false,
+        false,
         org_id
     FROM deploy_stats_context
     RETURNING id
@@ -104,7 +105,7 @@ WITH ios_channel AS (
 
 android_channel AS (
     INSERT INTO public.channels (
-        created_by, app_id, name, version, public, ios, android, owner_org
+        created_by, app_id, name, version, public, ios, android, electron, owner_org
     )
     SELECT
         user_id,
@@ -114,6 +115,7 @@ android_channel AS (
         true,
         false,
         true,
+        false,
         org_id
     FROM deploy_stats_context
     RETURNING id
@@ -121,7 +123,7 @@ android_channel AS (
 
 private_channel AS (
     INSERT INTO public.channels (
-        created_by, app_id, name, version, public, ios, android, owner_org
+        created_by, app_id, name, version, public, ios, android, electron, owner_org
     )
     SELECT
         user_id,
@@ -130,6 +132,7 @@ private_channel AS (
         ios_version_id,
         false,
         true,
+        false,
         false,
         org_id
     FROM deploy_stats_context

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -124,4 +124,28 @@ describe('public channel post', () => {
       }),
     )
   })
+
+  it('keeps legacy all-platform public writes electron-compatible when both mobile flags are true', async () => {
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json: vi.fn() } as any,
+      {
+        app_id: 'com.test.legacy-all-platforms',
+        channel: 'production',
+        version: '1.0.0',
+        public: true,
+        ios: true,
+        android: true,
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({
+        electron: false,
+      }),
+    )
+  })
 })

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const updateOrCreateChannel = vi.fn()
+const checkPermission = vi.fn()
+const supabaseApikey = vi.fn()
+const isValidAppId = vi.fn()
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
+  BRES: { status: 'ok' },
+  simpleError: (error: string, message: string, details: Record<string, unknown> = {}) => {
+    const issue = new Error(message)
+    ;(issue as Error & { cause?: unknown }).cause = { error, ...details }
+    throw issue
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlogErr: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseApikey,
+  updateOrCreateChannel,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  isValidAppId,
+}))
+
+function buildSupabaseChain(body: { ownerOrg?: string, versionId?: number }) {
+  return {
+    from(table: string) {
+      if (table === 'apps') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: { owner_org: body.ownerOrg ?? 'org-test' }, error: null }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'app_versions') {
+        return {
+          select: () => ({
+            eq() {
+              return this
+            },
+            single: async () => ({ data: { id: body.versionId ?? 123 }, error: null }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    },
+  }
+}
+
+describe('public channel post', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkPermission.mockResolvedValue(true)
+    isValidAppId.mockReturnValue(true)
+    supabaseApikey.mockImplementation(() => buildSupabaseChain({}))
+    updateOrCreateChannel.mockResolvedValue({ error: null })
+  })
+
+  it('defaults legacy public mobile channel writes to electron false', async () => {
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    const json = vi.fn().mockReturnValue({ ok: true })
+    await post(
+      { json } as any,
+      {
+        app_id: 'com.test.legacy-mobile',
+        channel: 'ios-default',
+        version: '1.0.0',
+        public: true,
+        ios: true,
+        android: false,
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        app_id: 'com.test.legacy-mobile',
+        name: 'ios-default',
+        public: true,
+        ios: true,
+        android: false,
+        electron: false,
+      }),
+    )
+    expect(json).toHaveBeenCalledWith({ status: 'ok' })
+  })
+
+  it('preserves explicit electron platform selection', async () => {
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json: vi.fn() } as any,
+      {
+        app_id: 'com.test.explicit-electron',
+        channel: 'all-platforms',
+        version: '1.0.0',
+        public: true,
+        ios: true,
+        android: true,
+        electron: true,
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        electron: true,
+      }),
+    )
+  })
+})

--- a/tests/manifest-rls.test.ts
+++ b/tests/manifest-rls.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
   APIKEY_TEST2_ALL,
   APIKEY_TEST_ALL,
+  fetchWithRetry,
   getAuthHeaders,
   getAuthHeadersForCredentials,
   getSupabaseClient,
@@ -47,7 +48,7 @@ async function fetchManifestRows(headers: Record<string, string>, appVersionId: 
   if (!anonKey)
     throw new Error('SUPABASE_ANON_KEY is missing')
 
-  const response = await fetch(getRestManifestUrl(appVersionId), {
+  const response = await fetchWithRetry(getRestManifestUrl(appVersionId), {
     method: 'GET',
     headers: {
       ...headers,

--- a/tests/public-channel-uniqueness.test.ts
+++ b/tests/public-channel-uniqueness.test.ts
@@ -1,8 +1,6 @@
-import type { Context } from 'hono'
 import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, it } from 'vitest'
-import { getDrizzleClient, requestInfosChannelPostgres } from '../supabase/functions/_backend/utils/pg.ts'
-import { cleanupPostgresClient, executeSQL, getPostgresClient, ORG_ID, USER_ID } from './test-utils.ts'
+import { cleanupPostgresClient, executeSQL, ORG_ID, USER_ID } from './test-utils.ts'
 
 interface ChannelStateRow {
   name: string
@@ -142,110 +140,46 @@ afterAll(async () => {
 })
 
 describe('public channel uniqueness', () => {
-  it('uses the most recently updated public electron channel as the deterministic winner', async () => {
-    const appId = `com.public.channel.electron.${randomUUID()}`
-    const oldVersion = await createAppFixture(appId)
-    const newVersionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
-    const [newVersion] = await executeSQL(
-      `INSERT INTO public.app_versions (
-        created_at,
-        app_id,
-        name,
-        r2_path,
-        updated_at,
-        deleted,
-        external_url,
-        checksum,
-        storage_provider,
-        owner_org,
-        comment,
-        link,
-        user_id
-      ) VALUES (
-        NOW(),
-        $1,
-        $2,
-        $3,
-        NOW(),
-        false,
-        NULL,
-        '',
-        'r2',
-        $4,
-        NULL,
-        NULL,
-        $5
-      )
-      RETURNING id`,
-      [appId, newVersionName, `orgs/${ORG_ID}/apps/${appId}/${newVersionName}.zip`, ORG_ID, USER_ID],
-    )
-    const oldChannel = `electron-public-${randomUUID().slice(0, 8)}`
-    const newChannel = `electron-public-${randomUUID().slice(0, 8)}`
-
-    await insertChannel(appId, oldVersion, oldChannel, {
-      public: true,
-      ios: false,
-      android: false,
-      electron: true,
-    })
-    await insertChannel(appId, Number(newVersion.id), newChannel, {
-      public: true,
-      ios: false,
-      android: false,
-      electron: true,
-    })
-    await executeSQL(
-      `UPDATE public.channels
-       SET updated_at = NOW() + INTERVAL '1 minute'
-       WHERE app_id = $1
-         AND name = $2`,
-      [appId, oldChannel],
-    )
-
-    const drizzleClient = getDrizzleClient(await getPostgresClient())
-    const context = {
-      get(key: string) {
-        return key === 'requestId' ? 'public-channel-uniqueness-test' : undefined
-      },
-    } as Context
-
-    const channel = await requestInfosChannelPostgres(context, 'electron', appId, '', drizzleClient, false)
-
-    expect(channel?.channels.name).toBe(oldChannel)
-    expect(channel?.version.name).toBe('1.0.0')
-  })
-
-  it('allows one public iOS channel and one public Android channel when both keep electron enabled', async () => {
-    const appId = `com.public.channel.mobile-defaults.${randomUUID()}`
+  it('allows one public channel per platform', async () => {
+    const appId = `com.public.channel.platform-defaults.${randomUUID()}`
     const versionId = await createAppFixture(appId)
     const iosPublic = `ios-public-${randomUUID().slice(0, 8)}`
     const androidPublic = `android-public-${randomUUID().slice(0, 8)}`
+    const electronPublic = `electron-public-${randomUUID().slice(0, 8)}`
 
     await insertChannel(appId, versionId, iosPublic, {
       public: true,
       ios: true,
       android: false,
-      electron: true,
+      electron: false,
     })
     await insertChannel(appId, versionId, androidPublic, {
       public: true,
       ios: false,
       android: true,
+      electron: false,
+    })
+    await insertChannel(appId, versionId, electronPublic, {
+      public: true,
+      ios: false,
+      android: false,
       electron: true,
     })
 
-    const states = await getChannelStates(appId, [iosPublic, androidPublic])
+    const states = await getChannelStates(appId, [iosPublic, androidPublic, electronPublic])
 
     expect(states.get(iosPublic)).toBe(true)
     expect(states.get(androidPublic)).toBe(true)
+    expect(states.get(electronPublic)).toBe(true)
   })
 
-  it('demotes overlapping public channels on insert while preserving other platforms', async () => {
+  it('demotes overlapping public electron channels on insert while preserving other platforms', async () => {
     const appId = `com.public.channel.insert.${randomUUID()}`
     const versionId = await createAppFixture(appId)
     const iosPublic = `ios-public-${randomUUID().slice(0, 8)}`
     const androidPublic = `android-public-${randomUUID().slice(0, 8)}`
-    const nextIosPublic = `ios-next-${randomUUID().slice(0, 8)}`
+    const electronPublic = `electron-public-${randomUUID().slice(0, 8)}`
+    const nextElectronPublic = `electron-next-${randomUUID().slice(0, 8)}`
 
     await insertChannel(appId, versionId, iosPublic, {
       public: true,
@@ -259,26 +193,34 @@ describe('public channel uniqueness', () => {
       android: true,
       electron: false,
     })
-    await insertChannel(appId, versionId, nextIosPublic, {
+    await insertChannel(appId, versionId, electronPublic, {
       public: true,
-      ios: true,
+      ios: false,
       android: false,
-      electron: false,
+      electron: true,
+    })
+    await insertChannel(appId, versionId, nextElectronPublic, {
+      public: true,
+      ios: false,
+      android: false,
+      electron: true,
     })
 
-    const states = await getChannelStates(appId, [iosPublic, androidPublic, nextIosPublic])
+    const states = await getChannelStates(appId, [iosPublic, androidPublic, electronPublic, nextElectronPublic])
 
-    expect(states.get(iosPublic)).toBe(false)
+    expect(states.get(iosPublic)).toBe(true)
     expect(states.get(androidPublic)).toBe(true)
-    expect(states.get(nextIosPublic)).toBe(true)
+    expect(states.get(electronPublic)).toBe(false)
+    expect(states.get(nextElectronPublic)).toBe(true)
   })
 
-  it('demotes overlapping public channels on update while preserving other platforms', async () => {
+  it('demotes overlapping public electron channels on update while preserving other platforms', async () => {
     const appId = `com.public.channel.update.${randomUUID()}`
     const versionId = await createAppFixture(appId)
     const iosPublic = `ios-public-${randomUUID().slice(0, 8)}`
     const androidPublic = `android-public-${randomUUID().slice(0, 8)}`
-    const privateCandidate = `ios-private-${randomUUID().slice(0, 8)}`
+    const electronPublic = `electron-public-${randomUUID().slice(0, 8)}`
+    const privateCandidate = `electron-private-${randomUUID().slice(0, 8)}`
 
     await insertChannel(appId, versionId, iosPublic, {
       public: true,
@@ -292,11 +234,17 @@ describe('public channel uniqueness', () => {
       android: true,
       electron: false,
     })
+    await insertChannel(appId, versionId, electronPublic, {
+      public: true,
+      ios: false,
+      android: false,
+      electron: true,
+    })
     await insertChannel(appId, versionId, privateCandidate, {
       public: false,
-      ios: true,
+      ios: false,
       android: false,
-      electron: false,
+      electron: true,
     })
 
     await executeSQL(
@@ -307,10 +255,11 @@ describe('public channel uniqueness', () => {
       [appId, privateCandidate],
     )
 
-    const states = await getChannelStates(appId, [iosPublic, androidPublic, privateCandidate])
+    const states = await getChannelStates(appId, [iosPublic, androidPublic, electronPublic, privateCandidate])
 
-    expect(states.get(iosPublic)).toBe(false)
+    expect(states.get(iosPublic)).toBe(true)
     expect(states.get(androidPublic)).toBe(true)
+    expect(states.get(electronPublic)).toBe(false)
     expect(states.get(privateCandidate)).toBe(true)
   })
 })

--- a/tests/public-channel-uniqueness.test.ts
+++ b/tests/public-channel-uniqueness.test.ts
@@ -142,7 +142,7 @@ afterAll(async () => {
 })
 
 describe('public channel uniqueness', () => {
-  it('uses a deterministic winner when multiple public electron channels exist', async () => {
+  it('uses the most recently updated public electron channel as the deterministic winner', async () => {
     const appId = `com.public.channel.electron.${randomUUID()}`
     const oldVersion = await createAppFixture(appId)
     const newVersionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
@@ -194,6 +194,13 @@ describe('public channel uniqueness', () => {
       android: false,
       electron: true,
     })
+    await executeSQL(
+      `UPDATE public.channels
+       SET updated_at = NOW() + INTERVAL '1 minute'
+       WHERE app_id = $1
+         AND name = $2`,
+      [appId, oldChannel],
+    )
 
     const drizzleClient = getDrizzleClient(await getPostgresClient())
     const context = {
@@ -204,8 +211,8 @@ describe('public channel uniqueness', () => {
 
     const channel = await requestInfosChannelPostgres(context, 'electron', appId, '', drizzleClient, false)
 
-    expect(channel?.channels.name).toBe(newChannel)
-    expect(channel?.version.name).toBe(newVersionName)
+    expect(channel?.channels.name).toBe(oldChannel)
+    expect(channel?.version.name).toBe('1.0.0')
   })
 
   it('allows one public iOS channel and one public Android channel when both keep electron enabled', async () => {

--- a/tests/public-channel-uniqueness.test.ts
+++ b/tests/public-channel-uniqueness.test.ts
@@ -140,6 +140,31 @@ afterAll(async () => {
 })
 
 describe('public channel uniqueness', () => {
+  it('allows one public iOS channel and one public Android channel when both keep electron enabled', async () => {
+    const appId = `com.public.channel.mobile-defaults.${randomUUID()}`
+    const versionId = await createAppFixture(appId)
+    const iosPublic = `ios-public-${randomUUID().slice(0, 8)}`
+    const androidPublic = `android-public-${randomUUID().slice(0, 8)}`
+
+    await insertChannel(appId, versionId, iosPublic, {
+      public: true,
+      ios: true,
+      android: false,
+      electron: true,
+    })
+    await insertChannel(appId, versionId, androidPublic, {
+      public: true,
+      ios: false,
+      android: true,
+      electron: true,
+    })
+
+    const states = await getChannelStates(appId, [iosPublic, androidPublic])
+
+    expect(states.get(iosPublic)).toBe(true)
+    expect(states.get(androidPublic)).toBe(true)
+  })
+
   it('demotes overlapping public channels on insert while preserving other platforms', async () => {
     const appId = `com.public.channel.insert.${randomUUID()}`
     const versionId = await createAppFixture(appId)

--- a/tests/public-channel-uniqueness.test.ts
+++ b/tests/public-channel-uniqueness.test.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, describe, expect, it } from 'vitest'
+import { cleanupPostgresClient, executeSQL, ORG_ID, USER_ID } from './test-utils.ts'
+
+interface ChannelStateRow {
+  name: string
+  public: boolean
+}
+
+async function createAppFixture(appId: string) {
+  await executeSQL(
+    `INSERT INTO public.apps (
+      created_at,
+      app_id,
+      icon_url,
+      name,
+      last_version,
+      updated_at,
+      owner_org,
+      user_id
+    ) VALUES (
+      NOW(),
+      $1,
+      '',
+      $1,
+      '1.0.0',
+      NOW(),
+      $2,
+      $3
+    )`,
+    [appId, ORG_ID, USER_ID],
+  )
+
+  const [version] = await executeSQL(
+    `INSERT INTO public.app_versions (
+      created_at,
+      app_id,
+      name,
+      r2_path,
+      updated_at,
+      deleted,
+      external_url,
+      checksum,
+      storage_provider,
+      owner_org,
+      comment,
+      link,
+      user_id
+    ) VALUES (
+      NOW(),
+      $1,
+      '1.0.0',
+      $2,
+      NOW(),
+      false,
+      NULL,
+      '',
+      'r2',
+      $3,
+      NULL,
+      NULL,
+      $4
+    )
+    RETURNING id`,
+    [appId, `orgs/${ORG_ID}/apps/${appId}/1.0.0.zip`, ORG_ID, USER_ID],
+  )
+
+  return Number(version.id)
+}
+
+async function insertChannel(
+  appId: string,
+  versionId: number,
+  name: string,
+  options: {
+    public: boolean
+    ios: boolean
+    android: boolean
+    electron: boolean
+  },
+) {
+  await executeSQL(
+    `INSERT INTO public.channels (
+      created_at,
+      name,
+      app_id,
+      version,
+      updated_at,
+      public,
+      disable_auto_update_under_native,
+      disable_auto_update,
+      ios,
+      android,
+      electron,
+      allow_device_self_set,
+      allow_emulator,
+      allow_device,
+      allow_dev,
+      allow_prod,
+      created_by,
+      owner_org
+    ) VALUES (
+      NOW(),
+      $1,
+      $2,
+      $3,
+      NOW(),
+      $4,
+      false,
+      'none'::public.disable_update,
+      $5,
+      $6,
+      $7,
+      false,
+      true,
+      true,
+      true,
+      true,
+      $8,
+      $9
+    )`,
+    [name, appId, versionId, options.public, options.ios, options.android, options.electron, USER_ID, ORG_ID],
+  )
+}
+
+async function getChannelStates(appId: string, channelNames: string[]) {
+  const rows = await executeSQL(
+    `SELECT name, public
+     FROM public.channels
+     WHERE app_id = $1
+       AND name = ANY($2::text[])`,
+    [appId, channelNames],
+  ) as ChannelStateRow[]
+
+  return new Map(rows.map(row => [row.name, row.public]))
+}
+
+afterAll(async () => {
+  await cleanupPostgresClient()
+})
+
+describe('public channel uniqueness', () => {
+  it('demotes overlapping public channels on insert while preserving other platforms', async () => {
+    const appId = `com.public.channel.insert.${randomUUID()}`
+    const versionId = await createAppFixture(appId)
+    const iosPublic = `ios-public-${randomUUID().slice(0, 8)}`
+    const androidPublic = `android-public-${randomUUID().slice(0, 8)}`
+    const nextIosPublic = `ios-next-${randomUUID().slice(0, 8)}`
+
+    await insertChannel(appId, versionId, iosPublic, {
+      public: true,
+      ios: true,
+      android: false,
+      electron: false,
+    })
+    await insertChannel(appId, versionId, androidPublic, {
+      public: true,
+      ios: false,
+      android: true,
+      electron: false,
+    })
+    await insertChannel(appId, versionId, nextIosPublic, {
+      public: true,
+      ios: true,
+      android: false,
+      electron: false,
+    })
+
+    const states = await getChannelStates(appId, [iosPublic, androidPublic, nextIosPublic])
+
+    expect(states.get(iosPublic)).toBe(false)
+    expect(states.get(androidPublic)).toBe(true)
+    expect(states.get(nextIosPublic)).toBe(true)
+  })
+
+  it('demotes overlapping public channels on update while preserving other platforms', async () => {
+    const appId = `com.public.channel.update.${randomUUID()}`
+    const versionId = await createAppFixture(appId)
+    const iosPublic = `ios-public-${randomUUID().slice(0, 8)}`
+    const androidPublic = `android-public-${randomUUID().slice(0, 8)}`
+    const privateCandidate = `ios-private-${randomUUID().slice(0, 8)}`
+
+    await insertChannel(appId, versionId, iosPublic, {
+      public: true,
+      ios: true,
+      android: false,
+      electron: false,
+    })
+    await insertChannel(appId, versionId, androidPublic, {
+      public: true,
+      ios: false,
+      android: true,
+      electron: false,
+    })
+    await insertChannel(appId, versionId, privateCandidate, {
+      public: false,
+      ios: true,
+      android: false,
+      electron: false,
+    })
+
+    await executeSQL(
+      `UPDATE public.channels
+       SET public = true
+       WHERE app_id = $1
+         AND name = $2`,
+      [appId, privateCandidate],
+    )
+
+    const states = await getChannelStates(appId, [iosPublic, androidPublic, privateCandidate])
+
+    expect(states.get(iosPublic)).toBe(false)
+    expect(states.get(androidPublic)).toBe(true)
+    expect(states.get(privateCandidate)).toBe(true)
+  })
+})

--- a/tests/public-channel-uniqueness.test.ts
+++ b/tests/public-channel-uniqueness.test.ts
@@ -1,6 +1,8 @@
+import type { Context } from 'hono'
 import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, it } from 'vitest'
-import { cleanupPostgresClient, executeSQL, ORG_ID, USER_ID } from './test-utils.ts'
+import { getDrizzleClient, requestInfosChannelPostgres } from '../supabase/functions/_backend/utils/pg.ts'
+import { cleanupPostgresClient, executeSQL, getPostgresClient, ORG_ID, USER_ID } from './test-utils.ts'
 
 interface ChannelStateRow {
   name: string
@@ -140,6 +142,72 @@ afterAll(async () => {
 })
 
 describe('public channel uniqueness', () => {
+  it('uses a deterministic winner when multiple public electron channels exist', async () => {
+    const appId = `com.public.channel.electron.${randomUUID()}`
+    const oldVersion = await createAppFixture(appId)
+    const newVersionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
+    const [newVersion] = await executeSQL(
+      `INSERT INTO public.app_versions (
+        created_at,
+        app_id,
+        name,
+        r2_path,
+        updated_at,
+        deleted,
+        external_url,
+        checksum,
+        storage_provider,
+        owner_org,
+        comment,
+        link,
+        user_id
+      ) VALUES (
+        NOW(),
+        $1,
+        $2,
+        $3,
+        NOW(),
+        false,
+        NULL,
+        '',
+        'r2',
+        $4,
+        NULL,
+        NULL,
+        $5
+      )
+      RETURNING id`,
+      [appId, newVersionName, `orgs/${ORG_ID}/apps/${appId}/${newVersionName}.zip`, ORG_ID, USER_ID],
+    )
+    const oldChannel = `electron-public-${randomUUID().slice(0, 8)}`
+    const newChannel = `electron-public-${randomUUID().slice(0, 8)}`
+
+    await insertChannel(appId, oldVersion, oldChannel, {
+      public: true,
+      ios: false,
+      android: false,
+      electron: true,
+    })
+    await insertChannel(appId, Number(newVersion.id), newChannel, {
+      public: true,
+      ios: false,
+      android: false,
+      electron: true,
+    })
+
+    const drizzleClient = getDrizzleClient(await getPostgresClient())
+    const context = {
+      get(key: string) {
+        return key === 'requestId' ? 'public-channel-uniqueness-test' : undefined
+      },
+    } as Context
+
+    const channel = await requestInfosChannelPostgres(context, 'electron', appId, '', drizzleClient, false)
+
+    expect(channel?.channels.name).toBe(newChannel)
+    expect(channel?.version.name).toBe(newVersionName)
+  })
+
   it('allows one public iOS channel and one public Android channel when both keep electron enabled', async () => {
     const appId = `com.public.channel.mobile-defaults.${randomUUID()}`
     const versionId = await createAppFixture(appId)


### PR DESCRIPTION
## Summary (AI generated)

- add a database trigger that serializes public-channel writes per app and demotes overlapping public channels before commit
- add partial unique indexes for public iOS, Android, and Electron channels so concurrent writes cannot leave multiple winners
- align the async `on_channel_update` fallback with the same overlap rules and add a direct Postgres regression test

## Motivation (AI generated)

The GHSA-3cmp-pm5x-8464 advisory shows that overlapping public channels could coexist long enough for unnamed update routing to silently pick an implicit winner. The fix needs to happen at the write boundary, not only in asynchronous cleanup, so the database never persists ambiguous public-channel state.

## Business Impact (AI generated)

This removes an OTA release-routing integrity issue that could make production update behavior unpredictable for customers. It reduces the risk of shipping devices from the wrong channel and improves trust in default channel behavior.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bunx eslint tests/public-channel-uniqueness.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/public-channel-uniqueness.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced one public channel per app and platform (iOS, Android, Electron); conflicts now resolve so only the most recent overlapping channel stays public per platform.
* **Tests**
  * Added integration tests covering public-channel uniqueness and conflict resolution across iOS, Android, and Electron.
* **Chores**
  * Updated seed and test fixtures to include the new Electron platform flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->