### PR TITLE
fix: transfer deploy history ownership with app

### DIFF
--- a/supabase/migrations/20260424090941_fix_transfer_app_deploy_history_owner_org.sql
+++ b/supabase/migrations/20260424090941_fix_transfer_app_deploy_history_owner_org.sql
@@ -1,0 +1,131 @@
+CREATE OR REPLACE FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+    v_old_org_id uuid;
+    v_user_id uuid;
+    v_last_transfer jsonb;
+    v_last_transfer_date timestamp;
+BEGIN
+  SELECT owner_org, transfer_history[array_length(transfer_history, 1)]
+  INTO v_old_org_id, v_last_transfer
+  FROM public.apps
+  WHERE app_id = p_app_id;
+
+  IF v_old_org_id IS NULL THEN
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  v_user_id := (SELECT auth.uid());
+
+  IF v_user_id IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NO_AUTH',
+      jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      v_old_org_id,
+      p_app_id,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_OLD_ORG_RIGHTS',
+      jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      p_new_org_id,
+      NULL::character varying,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NEW_ORG_RIGHTS',
+      jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION 'Unable to process transfer request.';
+  END IF;
+
+  IF v_last_transfer IS NOT NULL THEN
+    v_last_transfer_date := (v_last_transfer->>'transferred_at')::timestamp;
+    IF v_last_transfer_date + interval '32 days' > now() THEN
+      RAISE EXCEPTION
+          'Cannot transfer app. Must wait at least 32 days '
+          'between transfers. Last transfer was on %',
+          v_last_transfer_date;
+    END IF;
+  END IF;
+
+  UPDATE public.apps
+  SET
+      owner_org = p_new_org_id,
+      updated_at = now(),
+      transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
+          'transferred_at', now(),
+          'transferred_from', v_old_org_id,
+          'transferred_to', p_new_org_id,
+          'initiated_by', v_user_id
+      )::jsonb
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions_meta
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channel_devices
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channels
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.deploy_history
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+END;
+$$;
+
+ALTER FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) IS 'Transfers an app and all its related data to a new '
+'organization. Requires app.transfer permission on both '
+'source and destination organizations.';
+
+-- Repair stale deploy_history ownership left behind by previous app transfers.
+UPDATE public.deploy_history AS deploy_history
+SET owner_org = apps.owner_org
+FROM public.apps AS apps
+WHERE apps.app_id = deploy_history.app_id
+  AND deploy_history.owner_org IS DISTINCT FROM apps.owner_org;

--- a/supabase/migrations/20260424090941_fix_transfer_app_deploy_history_owner_org.sql
+++ b/supabase/migrations/20260424090941_fix_transfer_app_deploy_history_owner_org.sql
@@ -10,14 +10,16 @@ DECLARE
     v_user_id uuid;
     v_last_transfer jsonb;
     v_last_transfer_date timestamp;
+    v_transfer_request_error constant text := 'Unable to process transfer request.';
 BEGIN
-  SELECT owner_org, transfer_history[array_length(transfer_history, 1)]
+  SELECT owner_org, transfer_history[pg_catalog.array_length(transfer_history, 1)]
   INTO v_old_org_id, v_last_transfer
   FROM public.apps
-  WHERE app_id = p_app_id;
+  WHERE app_id = p_app_id
+  FOR UPDATE;
 
   IF v_old_org_id IS NULL THEN
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_request_error;
   END IF;
 
   v_user_id := (SELECT auth.uid());
@@ -25,9 +27,22 @@ BEGIN
   IF v_user_id IS NULL THEN
     PERFORM public.pg_log(
       'deny: TRANSFER_NO_AUTH',
-      jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
+      pg_catalog.jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
     );
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_request_error;
+  END IF;
+
+  IF v_old_org_id = p_new_org_id THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_SAME_ORG',
+      pg_catalog.jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION '%', v_transfer_request_error;
   END IF;
 
   IF NOT public.rbac_check_permission(
@@ -38,14 +53,14 @@ BEGIN
   ) THEN
     PERFORM public.pg_log(
       'deny: TRANSFER_OLD_ORG_RIGHTS',
-      jsonb_build_object(
+      pg_catalog.jsonb_build_object(
         'app_id', p_app_id,
         'old_org_id', v_old_org_id,
         'new_org_id', p_new_org_id,
         'uid', v_user_id
       )
     );
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_request_error;
   END IF;
 
   IF NOT public.rbac_check_permission(
@@ -56,19 +71,19 @@ BEGIN
   ) THEN
     PERFORM public.pg_log(
       'deny: TRANSFER_NEW_ORG_RIGHTS',
-      jsonb_build_object(
+      pg_catalog.jsonb_build_object(
         'app_id', p_app_id,
         'old_org_id', v_old_org_id,
         'new_org_id', p_new_org_id,
         'uid', v_user_id
       )
     );
-    RAISE EXCEPTION 'Unable to process transfer request.';
+    RAISE EXCEPTION '%', v_transfer_request_error;
   END IF;
 
   IF v_last_transfer IS NOT NULL THEN
     v_last_transfer_date := (v_last_transfer->>'transferred_at')::timestamp;
-    IF v_last_transfer_date + interval '32 days' > now() THEN
+    IF v_last_transfer_date + interval '32 days' > pg_catalog.now() THEN
       RAISE EXCEPTION
           'Cannot transfer app. Must wait at least 32 days '
           'between transfers. Last transfer was on %',
@@ -79,13 +94,18 @@ BEGIN
   UPDATE public.apps
   SET
       owner_org = p_new_org_id,
-      updated_at = now(),
-      transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
-          'transferred_at', now(),
+      updated_at = pg_catalog.now(),
+      transfer_history = (
+          CASE
+            WHEN transfer_history IS NULL THEN '{}'::jsonb[]
+            ELSE transfer_history
+          END
+      ) || pg_catalog.jsonb_build_object(
+          'transferred_at', pg_catalog.now(),
           'transferred_from', v_old_org_id,
           'transferred_to', p_new_org_id,
           'initiated_by', v_user_id
-      )::jsonb
+      )
   WHERE app_id = p_app_id;
 
   UPDATE public.app_versions
@@ -115,6 +135,31 @@ ALTER FUNCTION public.transfer_app(
     p_app_id character varying,
     p_new_org_id uuid
 ) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM anon;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM authenticated;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) TO service_role;
 
 COMMENT ON FUNCTION public.transfer_app(
     p_app_id character varying,

--- a/supabase/tests/24_test_data_functions.sql
+++ b/supabase/tests/24_test_data_functions.sql
@@ -386,6 +386,17 @@ SELECT
     );
 
 -- Test transfer_app
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM public.channels
+        WHERE id = 9876501001
+    ) THEN
+        RAISE EXCEPTION 'transfer_app test fixture channel id already exists';
+    END IF;
+END $$;
+
 INSERT INTO public.org_users (org_id, user_id, user_right)
 VALUES (
     '34a8c55d-2d0f-4652-a43f-684c7a9403ac',
@@ -396,13 +407,16 @@ ON CONFLICT DO NOTHING;
 
 WITH seeded_channel AS (
     INSERT INTO public.channels (
+        id,
         name,
         app_id,
         version,
         owner_org,
         created_by
     )
+    OVERRIDING SYSTEM VALUE
     VALUES (
+        9876501001,
         'transfer-history-test',
         'com.demoadmin.app',
         10,
@@ -448,13 +462,13 @@ SELECT
 SELECT
     is(
         (
-            SELECT count(*)::bigint
+            SELECT owner_org::text
             FROM public.deploy_history
             WHERE
-                app_id = 'com.demoadmin.app'
-                AND owner_org = '34a8c55d-2d0f-4652-a43f-684c7a9403ac'
+                channel_id = 9876501001
+                AND app_id = 'com.demoadmin.app'
         ),
-        1::bigint,
+        '34a8c55d-2d0f-4652-a43f-684c7a9403ac',
         'transfer_app test - deploy history ownership moves to destination org'
     );
 

--- a/supabase/tests/24_test_data_functions.sql
+++ b/supabase/tests/24_test_data_functions.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 
-SELECT plan(32);
+SELECT plan(34);
 
 -- Test read_bandwidth_usage
 SELECT
@@ -386,12 +386,76 @@ SELECT
     );
 
 -- Test transfer_app
+INSERT INTO public.org_users (org_id, user_id, user_right)
+VALUES (
+    '34a8c55d-2d0f-4652-a43f-684c7a9403ac',
+    tests.get_supabase_uid('test_admin'),
+    'super_admin'::public.user_min_right
+)
+ON CONFLICT DO NOTHING;
+
+WITH seeded_channel AS (
+    INSERT INTO public.channels (
+        name,
+        app_id,
+        version,
+        owner_org,
+        created_by
+    )
+    VALUES (
+        'transfer-history-test',
+        'com.demoadmin.app',
+        10,
+        '22dbad8a-b885-4309-9b3b-a09f8460fb6d',
+        tests.get_supabase_uid('test_admin')
+    )
+    RETURNING id
+)
+INSERT INTO public.deploy_history (
+    channel_id,
+    app_id,
+    version_id,
+    created_by,
+    owner_org
+)
+SELECT
+    id,
+    'com.demoadmin.app',
+    10,
+    tests.get_supabase_uid('test_admin'),
+    '22dbad8a-b885-4309-9b3b-a09f8460fb6d'
+FROM seeded_channel;
+
 SELECT tests.authenticate_as('test_admin');
 
 SELECT
     lives_ok(
-        'SELECT transfer_app(''com.demoadmin.app'', ''22dbad8a-b885-4309-9b3b-a09f8460fb6d'')',
+        'SELECT transfer_app(''com.demoadmin.app'', ''34a8c55d-2d0f-4652-a43f-684c7a9403ac'')',
         'transfer_app test - function executes without error'
+    );
+
+SELECT
+    is(
+        (
+            SELECT owner_org::text
+            FROM public.apps
+            WHERE app_id = 'com.demoadmin.app'
+        ),
+        '34a8c55d-2d0f-4652-a43f-684c7a9403ac',
+        'transfer_app test - app ownership moves to destination org'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)::bigint
+            FROM public.deploy_history
+            WHERE
+                app_id = 'com.demoadmin.app'
+                AND owner_org = '34a8c55d-2d0f-4652-a43f-684c7a9403ac'
+        ),
+        1::bigint,
+        'transfer_app test - deploy history ownership moves to destination org'
     );
 
 SELECT tests.clear_authentication();


### PR DESCRIPTION
## Summary (AI generated)

- update `public.transfer_app(...)` to move `deploy_history.owner_org` during app transfers
- harden the transfer RPC against concurrent cooldown bypasses and same-org no-op transfers
- restate `transfer_app` function ACLs in the migration and tighten the pgTAP assertion to the seeded deploy row
- backfill stale `deploy_history.owner_org` values to match current app ownership

## Motivation (AI generated)

App transfers were leaving historical deployment rows attached to the source organization. Because deploy history read access is authorized from the row's stored `owner_org`, old orgs could retain access and destination orgs could lose access after a transfer. The follow-up review also identified concurrency and no-op transfer edge cases that could leave the cooldown logic inconsistent.

## Business Impact (AI generated)

This closes a cross-org authorization gap on a sensitive ownership flow, preserves correct deployment audit history after transfers, and reduces the risk of support incidents or trust issues around org-boundary isolation.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bunx supabase db query --workdir .context/supabase-worktrees/aec510ca --local "SELECT pg_get_functiondef('public.transfer_app(character varying, uuid)'::regprocedure) LIKE '%UPDATE public.deploy_history%' AS has_deploy_history_update;"`
- [x] `bunx supabase test db .context/supabase-worktrees/aec510ca/supabase/tests/00-supabase_test_helpers.sql supabase/tests/24_test_data_functions.sql --workdir .context/supabase-worktrees/aec510ca --local`
- [x] GitHub Actions

## Checklist (AI generated)

- [x] Backward-compatible change only
- [x] No customer-facing command/docs changes needed
- [x] No screenshots needed (database-only change)

Generated with AI
