### PR TITLE
fix: enforce scoped subkey context on middlewareKey routes

### DIFF
--- a/supabase/functions/_backend/public/webhooks/index.ts
+++ b/supabase/functions/_backend/public/webhooks/index.ts
@@ -79,7 +79,7 @@ export async function checkWebhookPermissionV2(
   orgId: string,
   auth: AuthInfo,
 ): Promise<void> {
-  const parentApikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
+  const parentApikey = c.get('parentApikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
   const policyApikey = parentApikey ?? auth.apikey
 
   if (auth.authType === 'apikey' && policyApikey) {

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -85,6 +85,7 @@ export interface MiddlewareKeyVariables {
   Bindings: Bindings
   Variables: {
     apikey?: Database['public']['Tables']['apikeys']['Row']
+    parentApikey?: Database['public']['Tables']['apikeys']['Row']
     capgkey?: string
     requestId: string
     fileId?: string

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -330,6 +330,7 @@ function setApiKeyAuthContext(c: Context, apikey: Database['public']['Tables']['
     jwt: null,
   })
   c.set('apikey', apikey)
+  c.set('parentApikey', apikey)
   c.set('capgkey', keyString)
 }
 
@@ -347,7 +348,13 @@ function setSubkeyAuthContext(c: Context, userId: string, subkey: Database['publ
     apikey: subkey,
     jwt: null,
   })
+  c.set('apikey', subkey)
   c.set('subkey', subkey)
+
+  // Prefer the subkey's own secret for downstream RLS/policy checks when it exists.
+  if (subkey.key) {
+    c.set('capgkey', subkey.key)
+  }
 }
 
 /**

--- a/tests/app-error-cases.test.ts
+++ b/tests/app-error-cases.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, getSupabaseClient, headers, NON_ACCESS_APP_NAME, resetAndSeedAppData, resetAppData, USER_ID } from './test-utils.ts'
+import { BASE_URL, getAuthHeaders, getSupabaseClient, NON_ACCESS_APP_NAME, resetAndSeedAppData, resetAppData, USER_ID } from './test-utils.ts'
 
 const id = randomUUID()
 const APPNAME = `com.app.error.${id}`
@@ -8,8 +8,11 @@ const testOrgId = randomUUID()
 const testStripeCustomerId = `cus_app_error_${id.replace(/-/g, '').slice(0, 18)}`
 let testApiKeyId: number | null = null
 let testHeaders: Record<string, string>
+let authHeaders: Record<string, string>
 
 beforeAll(async () => {
+  authHeaders = await getAuthHeaders()
+
   await resetAndSeedAppData(APPNAME, {
     orgId: testOrgId,
     userId: USER_ID,
@@ -18,7 +21,7 @@ beforeAll(async () => {
 
   const createResponse = await fetch(`${BASE_URL}/apikey`, {
     method: 'POST',
-    headers,
+    headers: authHeaders,
     body: JSON.stringify({
       name: `app-error-cases-${id}`,
       mode: 'all',
@@ -48,7 +51,7 @@ afterAll(async () => {
   if (testApiKeyId !== null) {
     await fetch(`${BASE_URL}/apikey/${testApiKeyId}`, {
       method: 'DELETE',
-      headers,
+      headers: authHeaders,
     })
   }
   await getSupabaseClient().from('org_users').delete().eq('org_id', testOrgId)

--- a/tests/organization-api.test.ts
+++ b/tests/organization-api.test.ts
@@ -267,6 +267,150 @@ describe('read-mode API keys cannot access destructive organization routes', () 
   })
 })
 
+describe('x-limited-key-id subkeys enforce organization scope on middlewareKey routes', () => {
+  const scopedOrgId = randomUUID()
+  const blockedOrgId = randomUUID()
+  const scopedCustomerId = `cus_scoped_${scopedOrgId}`
+  const blockedCustomerId = `cus_blocked_${blockedOrgId}`
+  let parentKey = ''
+  let parentKeyId = 0
+  let scopedSubkeyId = 0
+
+  beforeAll(async () => {
+    const supabase = getSupabaseClient()
+
+    const { error: scopedStripeError } = await supabase.from('stripe_info').insert({
+      customer_id: scopedCustomerId,
+      status: 'succeeded',
+      product_id: 'prod_LQIregjtNduh4q',
+      subscription_id: `sub_${randomUUID()}`,
+      trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+      is_good_plan: true,
+    })
+    expect(scopedStripeError).toBeNull()
+
+    const { error: blockedStripeError } = await supabase.from('stripe_info').insert({
+      customer_id: blockedCustomerId,
+      status: 'succeeded',
+      product_id: 'prod_LQIregjtNduh4q',
+      subscription_id: `sub_${randomUUID()}`,
+      trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+      is_good_plan: true,
+    })
+    expect(blockedStripeError).toBeNull()
+
+    const { error: orgError } = await supabase.from('orgs').insert([
+      {
+        id: scopedOrgId,
+        name: `Scoped org ${randomUUID()}`,
+        management_email: TEST_EMAIL,
+        created_by: USER_ID,
+        customer_id: scopedCustomerId,
+        use_new_rbac: false,
+      },
+      {
+        id: blockedOrgId,
+        name: `Blocked org ${randomUUID()}`,
+        management_email: TEST_EMAIL,
+        created_by: USER_ID,
+        customer_id: blockedCustomerId,
+        use_new_rbac: false,
+      },
+    ])
+    expect(orgError).toBeNull()
+
+    const { error: orgUsersError } = await supabase.from('org_users').insert([
+      { org_id: scopedOrgId, user_id: USER_ID, user_right: 'super_admin' },
+      { org_id: blockedOrgId, user_id: USER_ID, user_right: 'super_admin' },
+    ])
+    expect(orgUsersError).toBeNull()
+
+    const { data: parentKeyData, error: parentKeyError } = await supabase
+      .from('apikeys')
+      .insert({
+        user_id: USER_ID,
+        key: randomUUID(),
+        key_hash: null,
+        mode: 'all',
+        name: `Parent key ${randomUUID()}`,
+        limited_to_orgs: [],
+        limited_to_apps: [],
+      })
+      .select('id, key')
+      .single()
+    expect(parentKeyError).toBeNull()
+    if (!parentKeyData?.key || typeof parentKeyData.id !== 'number') {
+      throw new TypeError('Failed to seed parent API key')
+    }
+    parentKey = parentKeyData.key
+    parentKeyId = parentKeyData.id
+
+    const { data: subkeyData, error: subkeyError } = await supabase
+      .from('apikeys')
+      .insert({
+        user_id: USER_ID,
+        key: randomUUID(),
+        key_hash: null,
+        mode: 'read',
+        name: `Scoped subkey ${randomUUID()}`,
+        limited_to_orgs: [scopedOrgId],
+        limited_to_apps: [],
+      })
+      .select('id')
+      .single()
+    expect(subkeyError).toBeNull()
+    if (typeof subkeyData?.id !== 'number') {
+      throw new TypeError('Failed to seed scoped subkey')
+    }
+    scopedSubkeyId = subkeyData.id
+  })
+
+  afterAll(async () => {
+    const supabase = getSupabaseClient()
+
+    if (scopedSubkeyId) {
+      await supabase.from('apikeys').delete().eq('id', scopedSubkeyId)
+    }
+    if (parentKeyId) {
+      await supabase.from('apikeys').delete().eq('id', parentKeyId)
+    }
+
+    await supabase.from('org_users').delete().in('org_id', [scopedOrgId, blockedOrgId])
+    await supabase.from('orgs').delete().in('id', [scopedOrgId, blockedOrgId])
+    await supabase.from('stripe_info').delete().in('customer_id', [scopedCustomerId, blockedCustomerId])
+  })
+
+  it.concurrent('limits GET /organization to the subkey org', async () => {
+    const response = await fetch(`${BASE_URL}/organization`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'authorization': parentKey,
+        'x-limited-key-id': String(scopedSubkeyId),
+      },
+      method: 'GET',
+    })
+
+    expect(response.status).toBe(200)
+    const payload = z.array(z.object({ id: z.string(), name: z.string() })).parse(await response.json())
+    expect(payload.map(org => org.id)).toEqual([scopedOrgId])
+  })
+
+  it.concurrent('rejects GET /organization/members outside the subkey org scope', async () => {
+    const response = await fetch(`${BASE_URL}/organization/members?orgId=${blockedOrgId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'authorization': parentKey,
+        'x-limited-key-id': String(scopedSubkeyId),
+      },
+      method: 'GET',
+    })
+
+    expect(response.status).toBe(400)
+    const payload = await response.json() as { error: string }
+    expect(payload.error).toBe('cannot_access_organization')
+  })
+})
+
 describe('[GET] /organization', () => {
   it('get organization', async () => {
     const response = await fetch(`${BASE_URL}/organization`, {


### PR DESCRIPTION
## Summary (AI generated)

- make `middlewareKey` expose the effective subkey as the request API key context when `x-limited-key-id` is used
- preserve the original parent key separately for flows that intentionally need parent-key policy checks
- add a regression test covering the advisory path on `/organization` and `/organization/members`

## Motivation (AI generated)

`middlewareKey` authenticated the parent key correctly, but downstream handlers still read the parent key from context after a scoped subkey was attached. That let scoped subkey requests behave like the unrestricted parent key on middlewareKey-protected routes.

## Business Impact (AI generated)

This closes a high-severity authorization bypass in the public API surface. Scoped keys used in CI/CD, partner integrations, and delegated automation now respect their intended org limits, which reduces tenant-isolation risk and protects customer trust.

## Test Plan (AI generated)

- [x] Run `bunx eslint supabase/functions/_backend/utils/hono.ts supabase/functions/_backend/utils/hono_middleware.ts supabase/functions/_backend/public/webhooks/index.ts tests/organization-api.test.ts`
- [x] Run `bun run supabase:db:reset`
- [x] Run `bun run supabase:with-env -- bunx vitest run tests/organization-api.test.ts tests/webhooks-apikey-policy.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key subkey authentication mechanism to properly enforce organization-level access scoping and permission boundaries when using subkeys with specific organization limits.

* **Tests**
  * Added comprehensive test coverage validating that organization-scoped API key subkeys correctly restrict access and enforce permission boundaries across multiple organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->