### PR TITLE
[codex] fix hashed API key RLS auth bypass

### DIFF
--- a/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
+++ b/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
@@ -60,6 +60,16 @@ BEGIN
 
           UNION
 
+          SELECT rb.org_id AS org_uuid
+          FROM public.role_bindings AS rb
+          WHERE apikey_row.rbac_id IS NOT NULL
+            AND rb.principal_type = public.rbac_principal_apikey()
+            AND rb.principal_id = apikey_row.rbac_id
+            AND rb.org_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+
+          UNION
+
           SELECT apps.owner_org AS org_uuid
           FROM public.role_bindings AS rb
           JOIN public.apps ON apps.id = rb.app_id
@@ -83,6 +93,17 @@ BEGIN
           JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
           WHERE rb.principal_type = public.rbac_principal_group()
             AND gm.user_id = apikey_row.user_id
+            AND rb.app_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.apps ON apps.id = rb.app_id
+          WHERE apikey_row.rbac_id IS NOT NULL
+            AND rb.principal_type = public.rbac_principal_apikey()
+            AND rb.principal_id = apikey_row.rbac_id
             AND rb.app_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
 
@@ -113,6 +134,18 @@ BEGIN
           JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
           WHERE rb.principal_type = public.rbac_principal_group()
             AND gm.user_id = apikey_row.user_id
+            AND rb.channel_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.channels AS ch ON ch.rbac_id = rb.channel_id
+          JOIN public.apps ON apps.app_id = ch.app_id
+          WHERE apikey_row.rbac_id IS NOT NULL
+            AND rb.principal_type = public.rbac_principal_apikey()
+            AND rb.principal_id = apikey_row.rbac_id
             AND rb.channel_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
         ) AS accessible_orgs
@@ -153,3 +186,5 @@ AS $$
 $$;
 
 ALTER FUNCTION "public"."find_apikey_by_value"("key_value" "text") OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."find_apikey_by_value"("key_value" "text") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."find_apikey_by_value"("key_value" "text") TO "service_role";

--- a/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
+++ b/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
@@ -1,0 +1,65 @@
+CREATE OR REPLACE FUNCTION "public"."check_apikey_hashed_key_enforcement"("apikey_row" "public"."apikeys")
+RETURNS boolean
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+DECLARE
+  user_has_hashed_key_enforced_org boolean;
+BEGIN
+  IF apikey_row.key IS NULL AND apikey_row.key_hash IS NOT NULL THEN
+    RETURN true;
+  END IF;
+
+  -- API keys are user-scoped and can reach org-agnostic RLS helpers such as
+  -- apikey listing. Once any org for the user enforces hashed keys, reject
+  -- legacy plain-text keys on the shared lookup path to keep both auth planes aligned.
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.orgs AS org
+    WHERE org.enforce_hashed_api_keys = true
+      AND (
+        org.created_by = apikey_row.user_id
+        OR EXISTS (
+          SELECT 1
+          FROM public.org_users AS org_user
+          WHERE org_user.org_id = org.id
+            AND org_user.user_id = apikey_row.user_id
+        )
+      )
+  )
+  INTO user_has_hashed_key_enforced_org;
+
+  IF user_has_hashed_key_enforced_org THEN
+    PERFORM public.pg_log(
+      'deny: ORG_REQUIRES_HASHED_API_KEY',
+      jsonb_build_object('apikey_id', apikey_row.id, 'user_id', apikey_row.user_id)
+    );
+    RETURN false;
+  END IF;
+
+  RETURN true;
+END;
+$$;
+
+ALTER FUNCTION "public"."check_apikey_hashed_key_enforcement"("apikey_row" "public"."apikeys") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."check_apikey_hashed_key_enforcement"("apikey_row" "public"."apikeys") FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION "public"."find_apikey_by_value"("key_value" "text")
+RETURNS SETOF "public"."apikeys"
+LANGUAGE "sql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+  SELECT apikey_row.*
+  FROM public.apikeys AS apikey_row
+  WHERE (
+    apikey_row.key = key_value
+    OR apikey_row.key_hash = encode(extensions.digest(key_value, 'sha256'), 'hex')
+  )
+    AND public.check_apikey_hashed_key_enforcement(apikey_row)
+  LIMIT 1;
+$$;
+
+ALTER FUNCTION "public"."find_apikey_by_value"("key_value" "text") OWNER TO "postgres";

--- a/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
+++ b/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
@@ -18,15 +18,104 @@ BEGIN
     SELECT 1
     FROM public.orgs AS org
     WHERE org.enforce_hashed_api_keys = true
-      AND (
-        org.created_by = apikey_row.user_id
-        OR EXISTS (
-          SELECT 1
+      AND org.id IN (
+        SELECT org_uuid
+        FROM (
+          SELECT created_org.id AS org_uuid
+          FROM public.orgs AS created_org
+          WHERE created_org.created_by = apikey_row.user_id
+
+          UNION
+
+          SELECT org_user.org_id AS org_uuid
           FROM public.org_users AS org_user
-          WHERE org_user.org_id = org.id
-            AND org_user.user_id = apikey_row.user_id
+          WHERE org_user.user_id = apikey_row.user_id
             AND org_user.user_right::text NOT LIKE 'invite_%'
-        )
+
+          UNION
+
+          SELECT rb.org_id AS org_uuid
+          FROM public.role_bindings AS rb
+          WHERE rb.principal_type = public.rbac_principal_user()
+            AND rb.principal_id = apikey_row.user_id
+            AND rb.org_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.org_users AS invited_org_user
+              WHERE invited_org_user.org_id = rb.org_id
+                AND invited_org_user.user_id = apikey_row.user_id
+                AND invited_org_user.user_right::text LIKE 'invite_%'
+            )
+
+          UNION
+
+          SELECT rb.org_id AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
+          WHERE rb.principal_type = public.rbac_principal_group()
+            AND gm.user_id = apikey_row.user_id
+            AND rb.org_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.apps ON apps.id = rb.app_id
+          WHERE rb.principal_type = public.rbac_principal_user()
+            AND rb.principal_id = apikey_row.user_id
+            AND rb.app_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.org_users AS invited_org_user
+              WHERE invited_org_user.org_id = apps.owner_org
+                AND invited_org_user.user_id = apikey_row.user_id
+                AND invited_org_user.user_right::text LIKE 'invite_%'
+            )
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.apps ON apps.id = rb.app_id
+          JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
+          WHERE rb.principal_type = public.rbac_principal_group()
+            AND gm.user_id = apikey_row.user_id
+            AND rb.app_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.channels AS ch ON ch.rbac_id = rb.channel_id
+          JOIN public.apps ON apps.app_id = ch.app_id
+          WHERE rb.principal_type = public.rbac_principal_user()
+            AND rb.principal_id = apikey_row.user_id
+            AND rb.channel_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.org_users AS invited_org_user
+              WHERE invited_org_user.org_id = apps.owner_org
+                AND invited_org_user.user_id = apikey_row.user_id
+                AND invited_org_user.user_right::text LIKE 'invite_%'
+            )
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.role_bindings AS rb
+          JOIN public.channels AS ch ON ch.rbac_id = rb.channel_id
+          JOIN public.apps ON apps.app_id = ch.app_id
+          JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
+          WHERE rb.principal_type = public.rbac_principal_group()
+            AND gm.user_id = apikey_row.user_id
+            AND rb.channel_id IS NOT NULL
+            AND (rb.expires_at IS NULL OR rb.expires_at > now())
+        ) AS accessible_orgs
       )
   )
   INTO user_has_hashed_key_enforced_org;

--- a/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
+++ b/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
@@ -31,6 +31,26 @@ BEGIN
           FROM public.org_users AS org_user
           WHERE org_user.user_id = apikey_row.user_id
             AND org_user.user_right::text NOT LIKE 'invite_%'
+            AND org_user.app_id IS NULL
+            AND org_user.channel_id IS NULL
+
+          UNION
+
+          SELECT apps.owner_org AS org_uuid
+          FROM public.org_users AS org_user
+          JOIN public.apps ON apps.app_id = org_user.app_id
+          WHERE org_user.user_id = apikey_row.user_id
+            AND org_user.user_right::text NOT LIKE 'invite_%'
+            AND org_user.app_id IS NOT NULL
+
+          UNION
+
+          SELECT ch.owner_org AS org_uuid
+          FROM public.org_users AS org_user
+          JOIN public.channels AS ch ON ch.id = org_user.channel_id
+          WHERE org_user.user_id = apikey_row.user_id
+            AND org_user.user_right::text NOT LIKE 'invite_%'
+            AND org_user.channel_id IS NOT NULL
 
           UNION
 

--- a/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
+++ b/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
@@ -25,6 +25,7 @@ BEGIN
           FROM public.org_users AS org_user
           WHERE org_user.org_id = org.id
             AND org_user.user_id = apikey_row.user_id
+            AND org_user.user_right::text NOT LIKE 'invite_%'
         )
       )
   )

--- a/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
+++ b/supabase/migrations/20260424091645_enforce_hashed_api_keys_on_rls_identity_path.sql
@@ -38,6 +38,7 @@ BEGIN
           FROM public.role_bindings AS rb
           WHERE rb.principal_type = public.rbac_principal_user()
             AND rb.principal_id = apikey_row.user_id
+            AND rb.scope_type = public.rbac_scope_org()
             AND rb.org_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
             AND NOT EXISTS (
@@ -55,6 +56,7 @@ BEGIN
           JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
           WHERE rb.principal_type = public.rbac_principal_group()
             AND gm.user_id = apikey_row.user_id
+            AND rb.scope_type = public.rbac_scope_org()
             AND rb.org_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
 
@@ -65,6 +67,7 @@ BEGIN
           WHERE apikey_row.rbac_id IS NOT NULL
             AND rb.principal_type = public.rbac_principal_apikey()
             AND rb.principal_id = apikey_row.rbac_id
+            AND rb.scope_type = public.rbac_scope_org()
             AND rb.org_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
 
@@ -75,6 +78,7 @@ BEGIN
           JOIN public.apps ON apps.id = rb.app_id
           WHERE rb.principal_type = public.rbac_principal_user()
             AND rb.principal_id = apikey_row.user_id
+            AND rb.scope_type = public.rbac_scope_app()
             AND rb.app_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
             AND NOT EXISTS (
@@ -93,6 +97,7 @@ BEGIN
           JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
           WHERE rb.principal_type = public.rbac_principal_group()
             AND gm.user_id = apikey_row.user_id
+            AND rb.scope_type = public.rbac_scope_app()
             AND rb.app_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
 
@@ -104,6 +109,7 @@ BEGIN
           WHERE apikey_row.rbac_id IS NOT NULL
             AND rb.principal_type = public.rbac_principal_apikey()
             AND rb.principal_id = apikey_row.rbac_id
+            AND rb.scope_type = public.rbac_scope_app()
             AND rb.app_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
 
@@ -115,6 +121,7 @@ BEGIN
           JOIN public.apps ON apps.app_id = ch.app_id
           WHERE rb.principal_type = public.rbac_principal_user()
             AND rb.principal_id = apikey_row.user_id
+            AND rb.scope_type = public.rbac_scope_channel()
             AND rb.channel_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
             AND NOT EXISTS (
@@ -134,6 +141,7 @@ BEGIN
           JOIN public.group_members AS gm ON gm.group_id = rb.principal_id
           WHERE rb.principal_type = public.rbac_principal_group()
             AND gm.user_id = apikey_row.user_id
+            AND rb.scope_type = public.rbac_scope_channel()
             AND rb.channel_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
 
@@ -146,6 +154,7 @@ BEGIN
           WHERE apikey_row.rbac_id IS NOT NULL
             AND rb.principal_type = public.rbac_principal_apikey()
             AND rb.principal_id = apikey_row.rbac_id
+            AND rb.scope_type = public.rbac_scope_channel()
             AND rb.channel_id IS NOT NULL
             AND (rb.expires_at IS NULL OR rb.expires_at > now())
         ) AS accessible_orgs

--- a/supabase/migrations/20260427092702_fix_transfer_app_guard_allowlist.sql
+++ b/supabase/migrations/20260427092702_fix_transfer_app_guard_allowlist.sql
@@ -159,6 +159,10 @@ BEGIN
   SET owner_org = p_new_org_id
   WHERE app_id = p_app_id;
 
+  UPDATE public.deploy_history
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
 END;
 $$;
 

--- a/supabase/migrations/20260427092702_fix_transfer_app_guard_allowlist.sql
+++ b/supabase/migrations/20260427092702_fix_transfer_app_guard_allowlist.sql
@@ -128,40 +128,48 @@ BEGIN
     END IF;
   END IF;
 
-  -- Allow the guarded owner_org cascade only inside the approved transfer path.
-  PERFORM set_config('capgo.allow_owner_org_transfer', 'true', true);
+  BEGIN
+    -- Allow the guarded owner_org cascade only inside the approved transfer path.
+    PERFORM set_config('capgo.allow_owner_org_transfer', 'true', true);
 
-  UPDATE public.apps
-  SET
-      owner_org = p_new_org_id,
-      updated_at = now(),
-      transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
-          'transferred_at', now(),
-          'transferred_from', v_old_org_id,
-          'transferred_to', p_new_org_id,
-          'initiated_by', v_user_id
-      )::jsonb
-  WHERE app_id = p_app_id;
+    UPDATE public.apps
+    SET
+        owner_org = p_new_org_id,
+        updated_at = now(),
+        transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
+            'transferred_at', now(),
+            'transferred_from', v_old_org_id,
+            'transferred_to', p_new_org_id,
+            'initiated_by', v_user_id
+        )::jsonb
+    WHERE app_id = p_app_id;
 
-  UPDATE public.app_versions
-  SET owner_org = p_new_org_id
-  WHERE app_id = p_app_id;
+    UPDATE public.app_versions
+    SET owner_org = p_new_org_id
+    WHERE app_id = p_app_id;
 
-  UPDATE public.app_versions_meta
-  SET owner_org = p_new_org_id
-  WHERE app_id = p_app_id;
+    UPDATE public.app_versions_meta
+    SET owner_org = p_new_org_id
+    WHERE app_id = p_app_id;
 
-  UPDATE public.channel_devices
-  SET owner_org = p_new_org_id
-  WHERE app_id = p_app_id;
+    UPDATE public.channel_devices
+    SET owner_org = p_new_org_id
+    WHERE app_id = p_app_id;
 
-  UPDATE public.channels
-  SET owner_org = p_new_org_id
-  WHERE app_id = p_app_id;
+    UPDATE public.channels
+    SET owner_org = p_new_org_id
+    WHERE app_id = p_app_id;
 
-  UPDATE public.deploy_history
-  SET owner_org = p_new_org_id
-  WHERE app_id = p_app_id;
+    UPDATE public.deploy_history
+    SET owner_org = p_new_org_id
+    WHERE app_id = p_app_id;
+
+    PERFORM set_config('capgo.allow_owner_org_transfer', 'false', true);
+  EXCEPTION
+    WHEN OTHERS THEN
+      PERFORM set_config('capgo.allow_owner_org_transfer', 'false', true);
+      RAISE;
+  END;
 
 END;
 $$;

--- a/supabase/migrations/20260427092702_fix_transfer_app_guard_allowlist.sql
+++ b/supabase/migrations/20260427092702_fix_transfer_app_guard_allowlist.sql
@@ -1,0 +1,168 @@
+CREATE OR REPLACE FUNCTION public.guard_owner_org_reassignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.owner_org IS DISTINCT FROM OLD.owner_org
+    AND current_setting('capgo.allow_owner_org_transfer', true) IS DISTINCT FROM 'true' THEN
+    RAISE EXCEPTION 'owner_org must be changed through public.transfer_app()';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.guard_owner_org_reassignment() OWNER TO "postgres";
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_apps ON public.apps;
+CREATE TRIGGER guard_owner_org_reassignment_apps
+BEFORE UPDATE OF owner_org ON public.apps
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_app_versions ON public.app_versions;
+CREATE TRIGGER guard_owner_org_reassignment_app_versions
+BEFORE UPDATE OF owner_org ON public.app_versions
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_app_versions_meta ON public.app_versions_meta;
+CREATE TRIGGER guard_owner_org_reassignment_app_versions_meta
+BEFORE UPDATE OF owner_org ON public.app_versions_meta
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_channel_devices ON public.channel_devices;
+CREATE TRIGGER guard_owner_org_reassignment_channel_devices
+BEFORE UPDATE OF owner_org ON public.channel_devices
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+DROP TRIGGER IF EXISTS guard_owner_org_reassignment_channels ON public.channels;
+CREATE TRIGGER guard_owner_org_reassignment_channels
+BEFORE UPDATE OF owner_org ON public.channels
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_owner_org_reassignment();
+
+CREATE OR REPLACE FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+    v_old_org_id uuid;
+    v_user_id uuid;
+    v_last_transfer jsonb;
+    v_last_transfer_date timestamp;
+    v_transfer_error constant text := 'Unable to process transfer request.';
+    v_app_id_key constant text := 'app_id';
+    v_old_org_id_key constant text := 'old_org_id';
+    v_new_org_id_key constant text := 'new_org_id';
+    v_uid_key constant text := 'uid';
+BEGIN
+  SELECT owner_org, transfer_history[array_length(transfer_history, 1)]
+  INTO v_old_org_id, v_last_transfer
+  FROM public.apps
+  WHERE app_id = p_app_id;
+
+  IF v_old_org_id IS NULL THEN
+    RAISE EXCEPTION '%', v_transfer_error;
+  END IF;
+
+  v_user_id := (SELECT auth.uid());
+
+  IF v_user_id IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NO_AUTH',
+      jsonb_build_object(v_app_id_key, p_app_id, v_new_org_id_key, p_new_org_id)
+    );
+    RAISE EXCEPTION '%', v_transfer_error;
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      v_old_org_id,
+      p_app_id,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_OLD_ORG_RIGHTS',
+      jsonb_build_object(
+        v_app_id_key, p_app_id,
+        v_old_org_id_key, v_old_org_id,
+        v_new_org_id_key, p_new_org_id,
+        v_uid_key, v_user_id
+      )
+    );
+    RAISE EXCEPTION '%', v_transfer_error;
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      p_new_org_id,
+      NULL::character varying,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NEW_ORG_RIGHTS',
+      jsonb_build_object(
+        v_app_id_key, p_app_id,
+        v_old_org_id_key, v_old_org_id,
+        v_new_org_id_key, p_new_org_id,
+        v_uid_key, v_user_id
+      )
+    );
+    RAISE EXCEPTION '%', v_transfer_error;
+  END IF;
+
+  IF v_last_transfer IS NOT NULL THEN
+    v_last_transfer_date := (v_last_transfer->>'transferred_at')::timestamp;
+    IF v_last_transfer_date + interval '32 days' > now() THEN
+      RAISE EXCEPTION
+          'Cannot transfer app. Must wait at least 32 days '
+          'between transfers. Last transfer was on %',
+          v_last_transfer_date;
+    END IF;
+  END IF;
+
+  -- Allow the guarded owner_org cascade only inside the approved transfer path.
+  PERFORM set_config('capgo.allow_owner_org_transfer', 'true', true);
+
+  UPDATE public.apps
+  SET
+      owner_org = p_new_org_id,
+      updated_at = now(),
+      transfer_history = COALESCE(transfer_history, '{}') || jsonb_build_object(
+          'transferred_at', now(),
+          'transferred_from', v_old_org_id,
+          'transferred_to', p_new_org_id,
+          'initiated_by', v_user_id
+      )::jsonb
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions_meta
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channel_devices
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channels
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+END;
+$$;
+
+ALTER FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) OWNER TO "postgres";

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -302,7 +302,7 @@ beforeAll(async () => {
   ])
   if (channelError)
     throw channelError
-}, 30000)
+}, 90000)
 
 afterAll(async () => {
   const supabase = getSupabaseClient()
@@ -312,7 +312,7 @@ afterAll(async () => {
   await supabase.from('apps').delete().in('app_id', [TRIAL_APP_ID, ONBOARDING_APP_ID, ONBOARDING_LATE_SUBSCRIPTION_APP_ID])
   await supabase.from('orgs').delete().in('id', [TRIAL_ORG_ID, CANCELLED_YEARLY_ORG_ID, CANCELLED_MONTHLY_ORG_ID, ONBOARDING_ORG_ID, ONBOARDING_NO_BUNDLE_ORG_ID, ONBOARDING_LATE_SUBSCRIPTION_ORG_ID])
   await supabase.from('stripe_info').delete().in('customer_id', [TRIAL_CUSTOMER_ID, CANCELLED_YEARLY_CUSTOMER_ID, CANCELLED_MONTHLY_CUSTOMER_ID, ONBOARDING_CUSTOMER_ID, ONBOARDING_NO_BUNDLE_CUSTOMER_ID, ONBOARDING_LATE_SUBSCRIPTION_CUSTOMER_ID])
-})
+}, 90000)
 
 describe('/private/admin_stats', () => {
   it.concurrent('returns last bundle upload for trial organizations and excludes builtin versions', async () => {

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -435,6 +435,36 @@ async function deleteStaleAppScopedBindingForUser(userId: string, staleOrgId: st
   }
 }
 
+async function createStaleAppScopedOrgUserForUser(userId: string, staleOrgId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      `INSERT INTO public.org_users (org_id, user_id, user_right, app_id)
+       VALUES ($1, $2, 'read', $3)`,
+      [staleOrgId, userId, APP_NAME_RLS],
+    )
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deleteStaleAppScopedOrgUserForUser(userId: string, staleOrgId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      `DELETE FROM public.org_users
+       WHERE org_id = $1
+         AND user_id = $2
+         AND app_id = $3`,
+      [staleOrgId, userId, APP_NAME_RLS],
+    )
+  }
+  finally {
+    client.release()
+  }
+}
+
 beforeAll(async () => {
   pool = new Pool({ connectionString: POSTGRES_URL })
   const client = await pool.connect()
@@ -675,6 +705,26 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
     }
     finally {
       await deleteStaleAppScopedBindingForUser(RLS_TEST_USER_ID, staleEnforcedOrgId)
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
+      await deleteStandaloneOrg(staleEnforcedOrgId)
+    }
+  })
+
+  it('ignores stale org_id values on app-scoped legacy org_users rows when deriving org enforcement', async () => {
+    const staleEnforcedOrgId = await createStandaloneOrg(true)
+
+    try {
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, false)
+      await createStaleAppScopedOrgUserForUser(RLS_TEST_USER_ID, staleEnforcedOrgId)
+
+      const rows = await execWithCapgkey(
+        `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+        plainKey.key,
+      )
+      expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
+    }
+    finally {
+      await deleteStaleAppScopedOrgUserForUser(RLS_TEST_USER_ID, staleEnforcedOrgId)
       await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
       await deleteStandaloneOrg(staleEnforcedOrgId)
     }

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -86,6 +86,41 @@ async function execWithAuthAndCapgkey(
   }
 }
 
+async function execAsRoleWithCapgkey(
+  sql: string,
+  role: 'anon' | 'authenticated',
+  capgkey: string,
+  params: unknown[] = [],
+): Promise<{ rows: any[], rowCount: number }> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    try {
+      await client.query(`SET LOCAL ROLE ${role}`)
+      await client.query(
+        'SELECT set_config(\'request.headers\', $1, true)',
+        [JSON.stringify({ capgkey })],
+      )
+
+      const result = await client.query(sql, params)
+      await client.query('COMMIT')
+      return { rows: result.rows, rowCount: result.rowCount ?? 0 }
+    }
+    catch (error) {
+      try {
+        await client.query('ROLLBACK')
+      }
+      catch {
+        // Ignore rollback failures for clearer root error handling.
+      }
+      throw error
+    }
+  }
+  finally {
+    client.release()
+  }
+}
+
 // Helper to create a hashed API key via the API
 async function createHashedApiKey(
   name: string,
@@ -150,6 +185,19 @@ async function setApiKeyExpiration(id: number, expiresAt: Date | null): Promise<
     await client.query(
       'UPDATE apikeys SET expires_at = $1 WHERE id = $2',
       [expiresAt?.toISOString() ?? null, id],
+    )
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function setOrgHashedApiKeyEnforcement(orgId: string, enforce: boolean): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      'UPDATE orgs SET enforce_hashed_api_keys = $1 WHERE id = $2',
+      [enforce, orgId],
     )
   }
   finally {
@@ -278,6 +326,88 @@ describe('get_identity() with hashed API keys', () => {
     expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
 
     await deleteApiKey(futureKey.id)
+  })
+})
+
+describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane', () => {
+  let hashedKey: { id: number, key: string, key_hash: string }
+  let plainKey: { id: number, key: string }
+  let originalEnforceHashedApiKeys: boolean | null = null
+
+  beforeAll(async () => {
+    hashedKey = await createHashedApiKey('test-hashed-enforced-rls')
+    plainKey = await createPlainApiKey('test-plain-enforced-rls')
+
+    const client = await pool.connect()
+    try {
+      const { rows } = await client.query(
+        'SELECT enforce_hashed_api_keys FROM orgs WHERE id = $1',
+        [ORG_ID_RLS],
+      )
+      originalEnforceHashedApiKeys = rows[0]?.enforce_hashed_api_keys ?? null
+    }
+    finally {
+      client.release()
+    }
+
+    await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
+  }, 60000)
+
+  afterAll(async () => {
+    await deleteApiKey(hashedKey.id)
+    await deleteApiKey(plainKey.id)
+
+    if (originalEnforceHashedApiKeys !== null) {
+      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, originalEnforceHashedApiKeys)
+    }
+  })
+
+  it('find_apikey_by_value returns empty for a plain API key after hashed enforcement is enabled', async () => {
+    const client = await pool.connect()
+    try {
+      const result = await client.query(
+        'SELECT id FROM find_apikey_by_value($1)',
+        [plainKey.key],
+      )
+      expect(result.rows).toEqual([])
+    }
+    finally {
+      client.release()
+    }
+  })
+
+  it('get_identity rejects a plain API key after hashed enforcement is enabled', async () => {
+    const rows = await execWithCapgkey(
+      `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+      plainKey.key,
+    )
+    expect(rows[0].user_id).toBeNull()
+  })
+
+  it('get_identity still accepts a hashed API key after hashed enforcement is enabled', async () => {
+    const rows = await execWithCapgkey(
+      `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+      hashedKey.key,
+    )
+    expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
+  })
+
+  it('blocks direct anon RLS reads from the apikeys table for plain API keys', async () => {
+    const { rows } = await execAsRoleWithCapgkey(
+      'SELECT id, name FROM public.apikeys ORDER BY id DESC LIMIT 1',
+      'anon',
+      plainKey.key,
+    )
+
+    expect(rows).toEqual([])
+  })
+
+  it('rejects get_orgs_v7 over the anon RPC path for plain API keys', async () => {
+    await expect(execAsRoleWithCapgkey(
+      'SELECT * FROM public.get_orgs_v7()',
+      'anon',
+      plainKey.key,
+    )).rejects.toThrow('Invalid API key provided')
   })
 })
 

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -206,6 +206,38 @@ async function setOrgHashedApiKeyEnforcement(orgId: string, enforce: boolean): P
   }
 }
 
+async function createEnforcedMemberOrgForUser(userId: string, enforceHashedApiKeys = true): Promise<string> {
+  const client = await pool.connect()
+  const orgId = randomUUID()
+  try {
+    await client.query(
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [orgId, USER_ID_2, `hashed-enforcement-org-${orgId}`, `hashed-enforcement-${orgId}@capgo.test`, enforceHashedApiKeys],
+    )
+    await client.query(
+      `INSERT INTO public.org_users (org_id, user_id, user_right)
+       VALUES ($1, $2, 'super_admin')`,
+      [orgId, userId],
+    )
+    return orgId
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deleteEnforcedMemberOrgForUser(orgId: string, userId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query('DELETE FROM public.org_users WHERE org_id = $1 AND user_id = $2', [orgId, userId])
+    await client.query('DELETE FROM public.orgs WHERE id = $1', [orgId])
+  }
+  finally {
+    client.release()
+  }
+}
+
 async function createPendingInviteOrgForUser(userId: string): Promise<string> {
   const client = await pool.connect()
   const orgId = randomUUID()
@@ -278,6 +310,54 @@ async function deleteEnforcedRbacOnlyOrgForUser(orgId: string, userId: string): 
          AND principal_id = $1
          AND org_id = $2`,
       [userId, orgId],
+    )
+    await client.query('DELETE FROM public.orgs WHERE id = $1', [orgId])
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function createEnforcedApikeyPrincipalOrgForKey(apikeyId: number): Promise<string> {
+  const client = await pool.connect()
+  const orgId = randomUUID()
+  try {
+    await client.query(
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys, use_new_rbac)
+       VALUES ($1, $2, $3, $4, true, true)`,
+      [orgId, USER_ID_2, `apikey-rbac-org-${orgId}`, `apikey-rbac-${orgId}@capgo.test`],
+    )
+    await client.query(
+      `INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, granted_by, reason, is_direct
+      ) VALUES (
+        public.rbac_principal_apikey(),
+        (SELECT rbac_id FROM public.apikeys WHERE id = $1),
+        (SELECT id FROM public.roles WHERE name = public.rbac_role_org_member()),
+        public.rbac_scope_org(),
+        $2,
+        $3,
+        'hashed-apikey-rls test',
+        true
+      )`,
+      [apikeyId, orgId, USER_ID_2],
+    )
+    return orgId
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deleteEnforcedApikeyPrincipalOrgForKey(orgId: string, apikeyId: number): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      `DELETE FROM public.role_bindings
+       WHERE principal_type = public.rbac_principal_apikey()
+         AND principal_id = (SELECT rbac_id FROM public.apikeys WHERE id = $1)
+         AND org_id = $2`,
+      [apikeyId, orgId],
     )
     await client.query('DELETE FROM public.orgs WHERE id = $1', [orgId])
   }
@@ -413,34 +493,18 @@ describe('get_identity() with hashed API keys', () => {
 describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane', () => {
   let hashedKey: { id: number, key: string, key_hash: string }
   let plainKey: { id: number, key: string }
-  let originalEnforceHashedApiKeys: boolean | null = null
+  let suiteOrgId: string
 
   beforeAll(async () => {
+    suiteOrgId = await createEnforcedMemberOrgForUser(RLS_TEST_USER_ID, true)
     hashedKey = await createHashedApiKey('test-hashed-enforced-rls')
     plainKey = await createPlainApiKey('test-plain-enforced-rls')
-
-    const client = await pool.connect()
-    try {
-      const { rows } = await client.query(
-        'SELECT enforce_hashed_api_keys FROM orgs WHERE id = $1',
-        [ORG_ID_RLS],
-      )
-      originalEnforceHashedApiKeys = rows[0]?.enforce_hashed_api_keys ?? null
-    }
-    finally {
-      client.release()
-    }
-
-    await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
   }, 60000)
 
   afterAll(async () => {
     await deleteApiKey(hashedKey.id)
     await deleteApiKey(plainKey.id)
-
-    if (originalEnforceHashedApiKeys !== null) {
-      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, originalEnforceHashedApiKeys)
-    }
+    await deleteEnforcedMemberOrgForUser(suiteOrgId, RLS_TEST_USER_ID)
   })
 
   it('find_apikey_by_value returns empty for a plain API key after hashed enforcement is enabled', async () => {
@@ -477,7 +541,7 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
     const pendingInviteOrgId = await createPendingInviteOrgForUser(RLS_TEST_USER_ID)
 
     try {
-      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, false)
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, false)
 
       const rows = await execWithCapgkey(
         `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
@@ -486,7 +550,7 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
       expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
     }
     finally {
-      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
       await deletePendingInviteOrgForUser(pendingInviteOrgId, RLS_TEST_USER_ID)
     }
   })
@@ -495,7 +559,7 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
     const rbacOnlyOrgId = await createEnforcedRbacOnlyOrgForUser(RLS_TEST_USER_ID)
 
     try {
-      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, false)
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, false)
 
       const rows = await execWithCapgkey(
         `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
@@ -504,8 +568,26 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
       expect(rows[0].user_id).toBeNull()
     }
     finally {
-      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
       await deleteEnforcedRbacOnlyOrgForUser(rbacOnlyOrgId, RLS_TEST_USER_ID)
+    }
+  })
+
+  it('rejects a plain API key when hashed enforcement is reached through RBAC API-key bindings', async () => {
+    const apikeyPrincipalOrgId = await createEnforcedApikeyPrincipalOrgForKey(plainKey.id)
+
+    try {
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, false)
+
+      const rows = await execWithCapgkey(
+        `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+        plainKey.key,
+      )
+      expect(rows[0].user_id).toBeNull()
+    }
+    finally {
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
+      await deleteEnforcedApikeyPrincipalOrgForKey(apikeyPrincipalOrgId, plainKey.id)
     }
   })
 

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -18,6 +18,7 @@ import {
   ORG_ID_2FA_TEST,
   ORG_ID_RLS,
   POSTGRES_URL,
+  USER_ID_2,
   USER_ID_RLS,
 } from './test-utils.ts'
 
@@ -199,6 +200,38 @@ async function setOrgHashedApiKeyEnforcement(orgId: string, enforce: boolean): P
       'UPDATE orgs SET enforce_hashed_api_keys = $1 WHERE id = $2',
       [enforce, orgId],
     )
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function createPendingInviteOrgForUser(userId: string): Promise<string> {
+  const client = await pool.connect()
+  const orgId = randomUUID()
+  try {
+    await client.query(
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys)
+       VALUES ($1, $2, $3, $4, true)`,
+      [orgId, USER_ID_2, `pending-invite-org-${orgId}`, `pending-invite-${orgId}@capgo.test`],
+    )
+    await client.query(
+      `INSERT INTO public.org_users (org_id, user_id, user_right)
+       VALUES ($1, $2, 'invite_read')`,
+      [orgId, userId],
+    )
+    return orgId
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deletePendingInviteOrgForUser(orgId: string, userId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query('DELETE FROM public.org_users WHERE org_id = $1 AND user_id = $2', [orgId, userId])
+    await client.query('DELETE FROM public.orgs WHERE id = $1', [orgId])
   }
   finally {
     client.release()
@@ -390,6 +423,24 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
       hashedKey.key,
     )
     expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
+  })
+
+  it('does not reject a plain API key for users with only a pending invite to an enforced org', async () => {
+    const pendingInviteOrgId = await createPendingInviteOrgForUser(RLS_TEST_USER_ID)
+
+    try {
+      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, false)
+
+      const rows = await execWithCapgkey(
+        `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+        plainKey.key,
+      )
+      expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
+    }
+    finally {
+      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
+      await deletePendingInviteOrgForUser(pendingInviteOrgId, RLS_TEST_USER_ID)
+    }
   })
 
   it('blocks direct anon RLS reads from the apikeys table for plain API keys', async () => {

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -238,6 +238,54 @@ async function deletePendingInviteOrgForUser(orgId: string, userId: string): Pro
   }
 }
 
+async function createEnforcedRbacOnlyOrgForUser(userId: string): Promise<string> {
+  const client = await pool.connect()
+  const orgId = randomUUID()
+  try {
+    await client.query(
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys, use_new_rbac)
+       VALUES ($1, $2, $3, $4, true, true)`,
+      [orgId, USER_ID_2, `rbac-only-org-${orgId}`, `rbac-only-${orgId}@capgo.test`],
+    )
+    await client.query(
+      `INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, granted_by, reason, is_direct
+      ) VALUES (
+        public.rbac_principal_user(),
+        $1,
+        (SELECT id FROM public.roles WHERE name = public.rbac_role_org_member()),
+        public.rbac_scope_org(),
+        $2,
+        $3,
+        'hashed-apikey-rls test',
+        true
+      )`,
+      [userId, orgId, USER_ID_2],
+    )
+    return orgId
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deleteEnforcedRbacOnlyOrgForUser(orgId: string, userId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      `DELETE FROM public.role_bindings
+       WHERE principal_type = public.rbac_principal_user()
+         AND principal_id = $1
+         AND org_id = $2`,
+      [userId, orgId],
+    )
+    await client.query('DELETE FROM public.orgs WHERE id = $1', [orgId])
+  }
+  finally {
+    client.release()
+  }
+}
+
 beforeAll(async () => {
   pool = new Pool({ connectionString: POSTGRES_URL })
   const client = await pool.connect()
@@ -440,6 +488,24 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
     finally {
       await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
       await deletePendingInviteOrgForUser(pendingInviteOrgId, RLS_TEST_USER_ID)
+    }
+  })
+
+  it('rejects a plain API key when hashed enforcement is reached through RBAC-only org membership', async () => {
+    const rbacOnlyOrgId = await createEnforcedRbacOnlyOrgForUser(RLS_TEST_USER_ID)
+
+    try {
+      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, false)
+
+      const rows = await execWithCapgkey(
+        `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+        plainKey.key,
+      )
+      expect(rows[0].user_id).toBeNull()
+    }
+    finally {
+      await setOrgHashedApiKeyEnforcement(ORG_ID_RLS, true)
+      await deleteEnforcedRbacOnlyOrgForUser(rbacOnlyOrgId, RLS_TEST_USER_ID)
     }
   })
 

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -366,6 +366,75 @@ async function deleteEnforcedApikeyPrincipalOrgForKey(orgId: string, apikeyId: n
   }
 }
 
+async function createStandaloneOrg(enforceHashedApiKeys = true): Promise<string> {
+  const client = await pool.connect()
+  const orgId = randomUUID()
+  try {
+    await client.query(
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys, use_new_rbac)
+       VALUES ($1, $2, $3, $4, $5, true)`,
+      [orgId, USER_ID_2, `standalone-org-${orgId}`, `standalone-${orgId}@capgo.test`, enforceHashedApiKeys],
+    )
+    return orgId
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deleteStandaloneOrg(orgId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query('DELETE FROM public.orgs WHERE id = $1', [orgId])
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function createStaleAppScopedBindingForUser(userId: string, staleOrgId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      `INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, app_id, granted_by, reason, is_direct
+      ) VALUES (
+        public.rbac_principal_user(),
+        $1,
+        (SELECT id FROM public.roles WHERE name = public.rbac_role_app_reader()),
+        public.rbac_scope_app(),
+        $2,
+        (SELECT id FROM public.apps WHERE app_id = $3),
+        $4,
+        'hashed-apikey-rls stale app scope test',
+        true
+      )`,
+      [userId, staleOrgId, APP_NAME_RLS, USER_ID_2],
+    )
+  }
+  finally {
+    client.release()
+  }
+}
+
+async function deleteStaleAppScopedBindingForUser(userId: string, staleOrgId: string): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query(
+      `DELETE FROM public.role_bindings
+       WHERE principal_type = public.rbac_principal_user()
+         AND principal_id = $1
+         AND scope_type = public.rbac_scope_app()
+         AND org_id = $2
+         AND app_id = (SELECT id FROM public.apps WHERE app_id = $3)`,
+      [userId, staleOrgId, APP_NAME_RLS],
+    )
+  }
+  finally {
+    client.release()
+  }
+}
+
 beforeAll(async () => {
   pool = new Pool({ connectionString: POSTGRES_URL })
   const client = await pool.connect()
@@ -588,6 +657,26 @@ describe('enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane
     finally {
       await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
       await deleteEnforcedApikeyPrincipalOrgForKey(apikeyPrincipalOrgId, plainKey.id)
+    }
+  })
+
+  it('ignores stale org_id values on app-scoped RBAC bindings when deriving org enforcement', async () => {
+    const staleEnforcedOrgId = await createStandaloneOrg(true)
+
+    try {
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, false)
+      await createStaleAppScopedBindingForUser(RLS_TEST_USER_ID, staleEnforcedOrgId)
+
+      const rows = await execWithCapgkey(
+        `SELECT get_identity('{all,write,read,upload}'::key_mode[]) AS user_id`,
+        plainKey.key,
+      )
+      expect(rows[0].user_id).toBe(RLS_TEST_USER_ID)
+    }
+    finally {
+      await deleteStaleAppScopedBindingForUser(RLS_TEST_USER_ID, staleEnforcedOrgId)
+      await setOrgHashedApiKeyEnforcement(suiteOrgId, true)
+      await deleteStandaloneOrg(staleEnforcedOrgId)
     }
   })
 

--- a/tests/organization-api.test.ts
+++ b/tests/organization-api.test.ts
@@ -26,7 +26,6 @@ const globalId = randomUUID()
 const name = `Test Organization ${globalId}`
 const customerId = `cus_test_${ORG_ID}`
 const website = 'https://test-organization.example/'
-let user2AuthHeaders: Record<string, string> | null = null
 
 beforeAll(async () => {
   // Create stripe_info for this test org
@@ -45,7 +44,7 @@ beforeAll(async () => {
     id: ORG_ID,
     name,
     management_email: TEST_EMAIL,
-    created_by: USER_ID_2,
+    created_by: USER_ID,
     customer_id: customerId,
     website,
     use_new_rbac: false, // Explicitly legacy — this suite tests the legacy permission path
@@ -56,13 +55,11 @@ beforeAll(async () => {
   // Add the test user as super_admin to the org so they can access it via API
   const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
     org_id: ORG_ID,
-    user_id: USER_ID_2,
+    user_id: USER_ID,
     user_right: 'super_admin',
   })
   if (orgUserError)
     throw orgUserError
-
-  user2AuthHeaders = await getAuthHeadersForCredentials('test2@capgo.app', USER_PASSWORD)
 })
 
 afterAll(async () => {
@@ -998,32 +995,76 @@ describe('[DELETE] /organization', () => {
 })
 
 describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
+  const enforceOrgId = randomUUID()
+  const enforceGlobalId = randomUUID()
+  const enforceCustomerId = `cus_test_${enforceOrgId}`
+  const enforceWebsite = 'https://hashed-enforcement.example/'
+  let user2AuthHeaders: Record<string, string> | null = null
+
+  beforeAll(async () => {
+    const { error: stripeError } = await getSupabaseClient().from('stripe_info').insert({
+      customer_id: enforceCustomerId,
+      status: 'succeeded',
+      product_id: 'prod_LQIregjtNduh4q',
+      subscription_id: `sub_${enforceGlobalId}`,
+      trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+      is_good_plan: true,
+    })
+    expect(stripeError).toBeNull()
+
+    const { error: orgError } = await getSupabaseClient().from('orgs').insert({
+      id: enforceOrgId,
+      name: `Hashed Enforcement Organization ${enforceGlobalId}`,
+      management_email: TEST_EMAIL,
+      created_by: USER_ID_2,
+      customer_id: enforceCustomerId,
+      website: enforceWebsite,
+      use_new_rbac: false,
+    })
+    expect(orgError).toBeNull()
+
+    const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
+      org_id: enforceOrgId,
+      user_id: USER_ID_2,
+      user_right: 'super_admin',
+    })
+    expect(orgUserError).toBeNull()
+
+    user2AuthHeaders = await getAuthHeadersForCredentials('test2@capgo.app', USER_PASSWORD)
+  })
+
+  afterAll(async () => {
+    await getSupabaseClient().from('org_users').delete().eq('org_id', enforceOrgId)
+    await getSupabaseClient().from('orgs').delete().eq('id', enforceOrgId)
+    await getSupabaseClient().from('stripe_info').delete().eq('customer_id', enforceCustomerId)
+  })
+
   it('update organization enforce_hashed_api_keys to true', async () => {
     if (!user2AuthHeaders)
       throw new Error('Missing auth headers for test2@capgo.app')
 
     // First, ensure it's false
-    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false }).eq('id', ORG_ID)
+    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false }).eq('id', enforceOrgId)
 
     const response = await fetch(`${BASE_URL}/organization`, {
       headers: user2AuthHeaders,
       method: 'PUT',
       body: JSON.stringify({
-        orgId: ORG_ID,
+        orgId: enforceOrgId,
         enforce_hashed_api_keys: true,
       }),
     })
     expect(response.status).toBe(200)
     const responseData = await response.json() as { id: string, data: any }
-    expect(responseData.id).toBe(ORG_ID)
+    expect(responseData.id).toBe(enforceOrgId)
 
     // Verify the setting was updated
-    const { data, error } = await getSupabaseClient().from('orgs').select('enforce_hashed_api_keys').eq('id', ORG_ID).single()
+    const { data, error } = await getSupabaseClient().from('orgs').select('enforce_hashed_api_keys').eq('id', enforceOrgId).single()
     expect(error).toBeNull()
     expect(data?.enforce_hashed_api_keys).toBe(true)
 
     // Reset to false
-    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false }).eq('id', ORG_ID)
+    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false }).eq('id', enforceOrgId)
   })
 
   it('update organization enforce_hashed_api_keys to false', async () => {
@@ -1031,31 +1072,31 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
       throw new Error('Missing auth headers for test2@capgo.app')
 
     // First, set it to true
-    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true }).eq('id', ORG_ID)
+    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true }).eq('id', enforceOrgId)
 
     const response = await fetch(`${BASE_URL}/organization`, {
       headers: user2AuthHeaders,
       method: 'PUT',
       body: JSON.stringify({
-        orgId: ORG_ID,
+        orgId: enforceOrgId,
         enforce_hashed_api_keys: false,
       }),
     })
     expect(response.status).toBe(200)
     const responseData = await response.json() as { id: string, data: any }
-    expect(responseData.id).toBe(ORG_ID)
+    expect(responseData.id).toBe(enforceOrgId)
 
     // Verify the setting was updated
-    const { data, error } = await getSupabaseClient().from('orgs').select('enforce_hashed_api_keys').eq('id', ORG_ID).single()
+    const { data, error } = await getSupabaseClient().from('orgs').select('enforce_hashed_api_keys').eq('id', enforceOrgId).single()
     expect(error).toBeNull()
     expect(data?.enforce_hashed_api_keys).toBe(false)
   })
 
   it('get_orgs_v7 returns enforce_hashed_api_keys field', async () => {
     // Set a known value
-    const rpcWebsite = website
-    const previousWebsite = website
-    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true, website: rpcWebsite }).eq('id', ORG_ID)
+    const rpcWebsite = enforceWebsite
+    const previousWebsite = enforceWebsite
+    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true, website: rpcWebsite }).eq('id', enforceOrgId)
 
     // Call get_orgs_v7 via RPC
     const { data, error } = await getSupabaseClient().rpc('get_orgs_v7', { userid: USER_ID_2 })
@@ -1063,7 +1104,7 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
     expect(Array.isArray(data)).toBe(true)
 
     // Find our test org
-    const testOrg = data?.find((org: { gid: string }) => org.gid === ORG_ID)
+    const testOrg = data?.find((org: { gid: string }) => org.gid === enforceOrgId)
     expect(testOrg).toBeTruthy()
     expect(testOrg).toHaveProperty('enforce_hashed_api_keys')
     expect(testOrg!.enforce_hashed_api_keys).toBe(true)
@@ -1073,7 +1114,7 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
     expect(testOrg!.website).toBe(rpcWebsite)
 
     // Reset
-    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false, website: previousWebsite }).eq('id', ORG_ID)
+    await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false, website: previousWebsite }).eq('id', enforceOrgId)
   })
 
   it.concurrent('rejects public RPC access to get_orgs_v7(userid)', async () => {

--- a/tests/organization-api.test.ts
+++ b/tests/organization-api.test.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 
 import {
   BASE_URL,
+  getAuthHeaders,
   getSupabaseClient,
   headers,
   normalizeLocalhostUrl,
@@ -1021,9 +1022,10 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
   it('update organization enforce_hashed_api_keys to false', async () => {
     // First, set it to true
     await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true }).eq('id', ORG_ID)
+    const authHeaders = await getAuthHeaders()
 
     const response = await fetch(`${BASE_URL}/organization`, {
-      headers,
+      headers: authHeaders,
       method: 'PUT',
       body: JSON.stringify({
         orgId: ORG_ID,

--- a/tests/organization-api.test.ts
+++ b/tests/organization-api.test.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import {
   BASE_URL,
-  getAuthHeaders,
+  getAuthHeadersForCredentials,
   getSupabaseClient,
   headers,
   normalizeLocalhostUrl,
@@ -15,6 +15,7 @@ import {
   USER_ADMIN_EMAIL,
   USER_EMAIL,
   USER_ID,
+  USER_ID_2,
   USER_PASSWORD,
 } from './test-utils.ts'
 
@@ -25,6 +26,7 @@ const globalId = randomUUID()
 const name = `Test Organization ${globalId}`
 const customerId = `cus_test_${ORG_ID}`
 const website = 'https://test-organization.example/'
+let user2AuthHeaders: Record<string, string> | null = null
 
 beforeAll(async () => {
   // Create stripe_info for this test org
@@ -43,7 +45,7 @@ beforeAll(async () => {
     id: ORG_ID,
     name,
     management_email: TEST_EMAIL,
-    created_by: USER_ID,
+    created_by: USER_ID_2,
     customer_id: customerId,
     website,
     use_new_rbac: false, // Explicitly legacy — this suite tests the legacy permission path
@@ -54,11 +56,13 @@ beforeAll(async () => {
   // Add the test user as super_admin to the org so they can access it via API
   const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
     org_id: ORG_ID,
-    user_id: USER_ID,
+    user_id: USER_ID_2,
     user_right: 'super_admin',
   })
   if (orgUserError)
     throw orgUserError
+
+  user2AuthHeaders = await getAuthHeadersForCredentials('test2@capgo.app', USER_PASSWORD)
 })
 
 afterAll(async () => {
@@ -995,11 +999,14 @@ describe('[DELETE] /organization', () => {
 
 describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
   it('update organization enforce_hashed_api_keys to true', async () => {
+    if (!user2AuthHeaders)
+      throw new Error('Missing auth headers for test2@capgo.app')
+
     // First, ensure it's false
     await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: false }).eq('id', ORG_ID)
 
     const response = await fetch(`${BASE_URL}/organization`, {
-      headers,
+      headers: user2AuthHeaders,
       method: 'PUT',
       body: JSON.stringify({
         orgId: ORG_ID,
@@ -1020,12 +1027,14 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
   })
 
   it('update organization enforce_hashed_api_keys to false', async () => {
+    if (!user2AuthHeaders)
+      throw new Error('Missing auth headers for test2@capgo.app')
+
     // First, set it to true
     await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true }).eq('id', ORG_ID)
-    const authHeaders = await getAuthHeaders()
 
     const response = await fetch(`${BASE_URL}/organization`, {
-      headers: authHeaders,
+      headers: user2AuthHeaders,
       method: 'PUT',
       body: JSON.stringify({
         orgId: ORG_ID,
@@ -1049,7 +1058,7 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
     await getSupabaseClient().from('orgs').update({ enforce_hashed_api_keys: true, website: rpcWebsite }).eq('id', ORG_ID)
 
     // Call get_orgs_v7 via RPC
-    const { data, error } = await getSupabaseClient().rpc('get_orgs_v7', { userid: USER_ID })
+    const { data, error } = await getSupabaseClient().rpc('get_orgs_v7', { userid: USER_ID_2 })
     expect(error).toBeNull()
     expect(Array.isArray(data)).toBe(true)
 

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -65,8 +65,40 @@ async function updateChannel(
     }),
   })
 
-  expect(response.status).toBe(200)
-  expect(await response.json<{ status: string }>()).toEqual({ status: 'ok' })
+  const responseText = await response.text()
+  if (response.status !== 200) {
+    throw new Error(`Channel update failed (${response.status}): ${responseText}`)
+  }
+  expect(JSON.parse(responseText) as { status: string }).toEqual({ status: 'ok' })
+}
+
+async function postUpdateAfterChannelMutation(data: Partial<ReturnType<typeof getBaseData>>) {
+  let lastResponse: Response | null = null
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const response = await postUpdate(data)
+    if (response.status !== 429) {
+      return response
+    }
+
+    const responseText = await response.text()
+    if (!responseText.includes('"error":"on_premise_app"')) {
+      throw new Error(`Unexpected update failure after channel mutation (${response.status}): ${responseText}`)
+    }
+
+    lastResponse = new Response(responseText, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
+    await new Promise(resolve => setTimeout(resolve, 250 * (attempt + 1)))
+  }
+
+  if (!lastResponse) {
+    throw new Error('Expected an update response after channel mutation')
+  }
+
+  return lastResponse
 }
 
 beforeAll(async () => {
@@ -678,38 +710,58 @@ describe('update scenarios', () => {
   })
 
   it('disallow emulator', async () => {
-    await updateChannel('production', { allow_emulator: false, disableAutoUpdate: 'major' })
+    await getSupabaseClient()
+      .from('channels')
+      .update({ allow_emulator: false, disable_auto_update: 'major' })
+      .eq('app_id', APP_NAME_UPDATE)
+      .eq('name', 'production')
+      .throwOnError()
 
     try {
       const baseData = getBaseData(APP_NAME_UPDATE)
       baseData.version_name = '1.1.0'
       baseData.is_emulator = true
 
-      const response = await postUpdate(baseData)
+      const response = await postUpdateAfterChannelMutation(baseData)
       expect(response.status).toBe(200)
       const json = await response.json<UpdateRes>()
       expect(json.error).toBe('disable_emulator')
     }
     finally {
-      await updateChannel('production', { allow_emulator: true })
+      await getSupabaseClient()
+        .from('channels')
+        .update({ allow_emulator: true })
+        .eq('app_id', APP_NAME_UPDATE)
+        .eq('name', 'production')
+        .throwOnError()
     }
   })
 
   it('disallow device', async () => {
-    await updateChannel('production', { allow_device: false })
+    await getSupabaseClient()
+      .from('channels')
+      .update({ allow_device: false })
+      .eq('app_id', APP_NAME_UPDATE)
+      .eq('name', 'production')
+      .throwOnError()
 
     try {
       const baseData = getBaseData(APP_NAME_UPDATE)
       baseData.version_name = '1.1.0'
       baseData.is_emulator = false
 
-      const response = await postUpdate(baseData)
+      const response = await postUpdateAfterChannelMutation(baseData)
       expect(response.status).toBe(200)
       const json = await response.json<UpdateRes>()
       expect(json.error).toBe('disable_device')
     }
     finally {
-      await updateChannel('production', { allow_device: true })
+      await getSupabaseClient()
+        .from('channels')
+        .update({ allow_device: true })
+        .eq('app_id', APP_NAME_UPDATE)
+        .eq('name', 'production')
+        .throwOnError()
     }
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- enforce hashed API key policy inside the shared `find_apikey_by_value()` auth path used by PostgREST/RLS
- add a regression helper and focused tests covering plaintext `capgkey` rejection on the anon/RLS plane
- keep hashed API keys working while legacy plaintext keys are blocked once the user belongs to an org with `enforce_hashed_api_keys=true`

## Motivation (AI generated)

Repository security advisory `GHSA-6g74-8cpq-g2c8` showed that hashed API key enforcement only applied on one auth plane. Direct PostgREST/RLS requests could still authenticate with a legacy plaintext API key through the shared lookup path, which bypassed the intended org security control.

## Business Impact (AI generated)

This closes a high-severity authentication bypass on the direct Supabase/PostgREST plane. Organizations that enable hashed API key enforcement now get consistent behavior across both backend and RLS access paths, reducing the chance of silent policy bypass in production.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bunx eslint tests/hashed-apikey-rls.test.ts`
- [x] `bun run supabase:db:reset`
- [x] `bun run supabase:with-env -- bunx vitest run tests/hashed-apikey-rls.test.ts -t "enforce_hashed_api_keys blocks plaintext capgkey auth on the RLS plane" --reporter verbose --testTimeout 30000`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations can enforce hashed-only API keys, blocking plaintext key lookups and access where enforced.
  * App ownership transfers now follow an explicit, audited transfer flow with permission checks and a minimum 32-day interval.

* **Tests**
  * Expanded end-to-end tests for hashed API key enforcement, invite vs. role-based membership, enforcement toggles, transfer flows, and improved channel-update resilience and auth header handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->