### PR TITLE
fix: use MAIN_SUPABASE_DB_URL for retention backfill

### DIFF
--- a/scripts/backfill_retention_metrics.ts
+++ b/scripts/backfill_retention_metrics.ts
@@ -30,6 +30,14 @@ const EVENT_FETCH_PAGE_SIZE = 100
 const DB_CHUNK_SIZE = 500
 const FAILURE_OUTPUT = './tmp/retention_metric_backfill_failures.json'
 const DATE_ID_REGEX = /^\d{4}-\d{2}-\d{2}$/
+const DATABASE_URL_ENV_KEYS = [
+  'MAIN_SUPABASE_DB_URL',
+  'DATABASE_URL',
+  'POSTGRES_URL',
+  'SUPABASE_DB_URL',
+  'SUPABASE_DB_DIRECT_URL',
+  'DIRECT_URL',
+] as const
 const SUBSCRIPTION_EVENT_TYPES = [
   'customer.subscription.created',
   'customer.subscription.updated',
@@ -215,18 +223,18 @@ function getRequiredEnv(env: Record<string, string | undefined>, key: string) {
 export function getRequiredDatabaseUrl(env: Record<string, string | undefined>) {
   const value = getDatabaseUrl(env)
   if (!value)
-    throw new Error('--apply requires MAIN_SUPABASE_DB_URL, DATABASE_URL, POSTGRES_URL, SUPABASE_DB_URL, SUPABASE_DB_DIRECT_URL, or DIRECT_URL so metric writes and processed-event markers are committed atomically')
+    throw new Error(`--apply requires ${DATABASE_URL_ENV_KEYS.join(', ')} so metric writes and processed-event markers are committed atomically`)
   return value
 }
 
 export function getDatabaseUrl(env: Record<string, string | undefined>) {
-  return env.MAIN_SUPABASE_DB_URL?.trim()
-    || env.DATABASE_URL?.trim()
-    || env.POSTGRES_URL?.trim()
-    || env.SUPABASE_DB_URL?.trim()
-    || env.SUPABASE_DB_DIRECT_URL?.trim()
-    || env.DIRECT_URL?.trim()
-    || null
+  for (const key of DATABASE_URL_ENV_KEYS) {
+    const value = env[key]?.trim()
+    if (value)
+      return value
+  }
+
+  return null
 }
 
 function shouldAllowSelfSignedPgCertificate(env: Record<string, string | undefined>) {

--- a/scripts/backfill_retention_metrics.ts
+++ b/scripts/backfill_retention_metrics.ts
@@ -212,15 +212,16 @@ function getRequiredEnv(env: Record<string, string | undefined>, key: string) {
   return value
 }
 
-function getRequiredDatabaseUrl(env: Record<string, string | undefined>) {
+export function getRequiredDatabaseUrl(env: Record<string, string | undefined>) {
   const value = getDatabaseUrl(env)
   if (!value)
-    throw new Error('--apply requires DATABASE_URL, POSTGRES_URL, SUPABASE_DB_URL, SUPABASE_DB_DIRECT_URL, or DIRECT_URL so metric writes and processed-event markers are committed atomically')
+    throw new Error('--apply requires MAIN_SUPABASE_DB_URL, DATABASE_URL, POSTGRES_URL, SUPABASE_DB_URL, SUPABASE_DB_DIRECT_URL, or DIRECT_URL so metric writes and processed-event markers are committed atomically')
   return value
 }
 
-function getDatabaseUrl(env: Record<string, string | undefined>) {
-  return env.DATABASE_URL?.trim()
+export function getDatabaseUrl(env: Record<string, string | undefined>) {
+  return env.MAIN_SUPABASE_DB_URL?.trim()
+    || env.DATABASE_URL?.trim()
     || env.POSTGRES_URL?.trim()
     || env.SUPABASE_DB_URL?.trim()
     || env.SUPABASE_DB_DIRECT_URL?.trim()

--- a/tests/backfill-retention-metrics.unit.test.ts
+++ b/tests/backfill-retention-metrics.unit.test.ts
@@ -1,6 +1,6 @@
 import type Stripe from 'stripe'
 import { describe, expect, it } from 'vitest'
-import { aggregateRevenueMovementEvents, buildRevenueMovementEvents, fetchStripeEvents, findMissingResetSnapshotEventIds, mergeMetricRows, summarizeDailyRevenueMetrics } from '../scripts/backfill_retention_metrics.ts'
+import { aggregateRevenueMovementEvents, buildRevenueMovementEvents, fetchStripeEvents, findMissingResetSnapshotEventIds, getDatabaseUrl, getRequiredDatabaseUrl, mergeMetricRows, summarizeDailyRevenueMetrics } from '../scripts/backfill_retention_metrics.ts'
 
 const plans = [
   {
@@ -370,6 +370,19 @@ describe('retention metric backfill helpers', () => {
     expect(result.reachedLimit).toBe(true)
     expect(result.events).toHaveLength(1)
     expect(result.events[0]?.id).toBe('evt_first')
+  })
+
+  it.concurrent('prefers MAIN_SUPABASE_DB_URL for apply writes', () => {
+    expect(getDatabaseUrl({
+      MAIN_SUPABASE_DB_URL: 'postgres://main-writer',
+      SUPABASE_DB_URL: 'postgres://fallback-direct',
+    })).toBe('postgres://main-writer')
+  })
+
+  it.concurrent('accepts MAIN_SUPABASE_DB_URL as the required apply database url', () => {
+    expect(getRequiredDatabaseUrl({
+      MAIN_SUPABASE_DB_URL: 'postgres://main-writer',
+    })).toBe('postgres://main-writer')
   })
 
   it.concurrent('skips deleted events when pre-range state tracks a different subscription id', () => {

--- a/tests/backfill-retention-metrics.unit.test.ts
+++ b/tests/backfill-retention-metrics.unit.test.ts
@@ -385,6 +385,20 @@ describe('retention metric backfill helpers', () => {
     })).toBe('postgres://main-writer')
   })
 
+  it.concurrent('falls back to DATABASE_URL before direct-url env names', () => {
+    expect(getDatabaseUrl({
+      DATABASE_URL: 'postgres://database-url',
+      SUPABASE_DB_DIRECT_URL: 'postgres://direct',
+      DIRECT_URL: 'postgres://direct-legacy',
+    })).toBe('postgres://database-url')
+
+    expect(getRequiredDatabaseUrl({
+      DATABASE_URL: 'postgres://database-url',
+      SUPABASE_DB_DIRECT_URL: 'postgres://direct',
+      DIRECT_URL: 'postgres://direct-legacy',
+    })).toBe('postgres://database-url')
+  })
+
   it.concurrent('skips deleted events when pre-range state tracks a different subscription id', () => {
     const result = buildRevenueMovementEvents([
       subscriptionEvent('evt_pre_range_create', 'customer.subscription.created', 1774267200, 'cus_active', 'sub_new', 'price_team_monthly', 'prod_team'),


### PR DESCRIPTION
## Summary (AI generated)

- make the retention backfill script accept MAIN_SUPABASE_DB_URL for apply writes
- prefer the main write URL over fallback direct URL names to match the backend DB selection logic
- add focused unit coverage for the DB URL resolver

## Motivation (AI generated)

The production env file used to run this script exposes the write connection as MAIN_SUPABASE_DB_URL. The backfill script ignored that variable, so --apply aborted before any rows were written even though the required database URL was already configured.

## Business Impact (AI generated)

This restores the backfill path for retention metrics in production, which unblocks NRR and churn revenue chart data repair without requiring manual env rewrites or one-off commands.

## Test Plan (AI generated)

- [x] bunx vitest run tests/backfill-retention-metrics.unit.test.ts
- [x] bun lint
- [x] bun typecheck

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated database connection configuration to prioritize an alternate environment variable for improved setup flexibility
* **Tests**
  * Added test coverage for database URL resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->