### PR TITLE
[codex] Fix build log disconnect cancellation authorization

### DIFF
--- a/supabase/functions/_backend/public/build/logs.ts
+++ b/supabase/functions/_backend/public/build/logs.ts
@@ -161,7 +161,21 @@ export async function streamBuildLogs(
 
   const requestId = c.get('requestId')
   // Security: align disconnect-triggered cancellation with the explicit cancel endpoint.
-  if (await checkPermission(c, 'app.build_native', { appId: buildRequest.app_id })) {
+  let canCancelOnDisconnect = false
+  try {
+    canCancelOnDisconnect = await checkPermission(c, 'app.build_native', { appId: buildRequest.app_id })
+  }
+  catch (err) {
+    cloudlogErr({
+      requestId,
+      message: 'Failed to verify cancel permission for build logs disconnect',
+      job_id: jobId,
+      app_id: buildRequest.app_id,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  if (canCancelOnDisconnect) {
     const cancelOnAbort = () => {
       // Fire and forget - cancel the build when an authorized client disconnects.
       cancelBuildOnDisconnect(builderUrl, builderApiKey, jobId, buildRequest.app_id, requestId)

--- a/supabase/functions/_backend/public/build/logs.ts
+++ b/supabase/functions/_backend/public/build/logs.ts
@@ -159,12 +159,14 @@ export async function streamBuildLogs(
     job_id: jobId,
   })
 
-  // Listen for client disconnect to cancel the build
   const requestId = c.get('requestId')
-  c.req.raw.signal.addEventListener('abort', () => {
-    // Fire and forget - cancel the build when client disconnects
-    cancelBuildOnDisconnect(builderUrl, builderApiKey, jobId, buildRequest.app_id, requestId)
-  })
+  // Security: align disconnect-triggered cancellation with the explicit cancel endpoint.
+  if (await checkPermission(c, 'app.build_native', { appId: buildRequest.app_id })) {
+    c.req.raw.signal.addEventListener('abort', () => {
+      // Fire and forget - cancel the build when an authorized client disconnects.
+      cancelBuildOnDisconnect(builderUrl, builderApiKey, jobId, buildRequest.app_id, requestId)
+    })
+  }
 
   // Directly return the builder's response body as an SSE stream
   // The builder already returns proper SSE format with Content-Type: text/event-stream

--- a/supabase/functions/_backend/public/build/logs.ts
+++ b/supabase/functions/_backend/public/build/logs.ts
@@ -162,10 +162,17 @@ export async function streamBuildLogs(
   const requestId = c.get('requestId')
   // Security: align disconnect-triggered cancellation with the explicit cancel endpoint.
   if (await checkPermission(c, 'app.build_native', { appId: buildRequest.app_id })) {
-    c.req.raw.signal.addEventListener('abort', () => {
+    const cancelOnAbort = () => {
       // Fire and forget - cancel the build when an authorized client disconnects.
       cancelBuildOnDisconnect(builderUrl, builderApiKey, jobId, buildRequest.app_id, requestId)
-    })
+    }
+
+    if (c.req.raw.signal.aborted) {
+      cancelOnAbort()
+    }
+    else {
+      c.req.raw.signal.addEventListener('abort', cancelOnAbort, { once: true })
+    }
   }
 
   // Directly return the builder's response body as an SSE stream

--- a/tests/build-logs-disconnect-auth.test.ts
+++ b/tests/build-logs-disconnect-auth.test.ts
@@ -119,7 +119,6 @@ describe('build log disconnect authorization', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1)
 
       controller.abort()
-      await new Promise(resolve => setTimeout(resolve, 0))
 
       expect(fetchMock).toHaveBeenCalledTimes(1)
       expect(mockCheckPermission).toHaveBeenNthCalledWith(1, context, 'app.read_logs', { appId })
@@ -131,6 +130,13 @@ describe('build log disconnect authorization', () => {
   })
 
   it('cancels the build on disconnect when the caller can build natively', async () => {
+    let resolveCancelObserved: () => void = () => {
+      throw new Error('Cancel observer not initialized')
+    }
+    const cancelObserved = new Promise<void>((resolve) => {
+      resolveCancelObserved = resolve
+    })
+
     mockCheckPermission
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true)
@@ -147,6 +153,7 @@ describe('build log disconnect authorization', () => {
       }
 
       if (url === `${builderUrl}/jobs/${jobId}/cancel`) {
+        resolveCancelObserved()
         expect(init).toMatchObject({
           method: 'POST',
           headers: {
@@ -183,7 +190,7 @@ describe('build log disconnect authorization', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1)
 
       controller.abort()
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await cancelObserved
 
       expect(fetchMock).toHaveBeenCalledTimes(2)
       expect(fetchMock).toHaveBeenNthCalledWith(2, `${builderUrl}/jobs/${jobId}/cancel`, {
@@ -204,8 +211,14 @@ describe('build log disconnect authorization', () => {
     let resolveBuildPermission: (value: boolean) => void = () => {
       throw new Error('Build permission resolver not initialized')
     }
+    let resolveCancelObserved: () => void = () => {
+      throw new Error('Cancel observer not initialized')
+    }
     const buildPermissionPromise = new Promise<boolean>((resolve) => {
       resolveBuildPermission = resolve
+    })
+    const cancelObserved = new Promise<void>((resolve) => {
+      resolveCancelObserved = resolve
     })
 
     mockCheckPermission
@@ -224,6 +237,7 @@ describe('build log disconnect authorization', () => {
       }
 
       if (url === `${builderUrl}/jobs/${jobId}/cancel`) {
+        resolveCancelObserved()
         expect(init).toMatchObject({
           method: 'POST',
           headers: {
@@ -263,7 +277,7 @@ describe('build log disconnect authorization', () => {
       const response = await responsePromise
       expect(response.status).toBe(200)
 
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await cancelObserved
 
       expect(fetchMock).toHaveBeenCalledTimes(2)
       expect(fetchMock).toHaveBeenNthCalledWith(2, `${builderUrl}/jobs/${jobId}/cancel`, {

--- a/tests/build-logs-disconnect-auth.test.ts
+++ b/tests/build-logs-disconnect-auth.test.ts
@@ -199,4 +199,84 @@ describe('build log disconnect authorization', () => {
       fetchMock.mockRestore()
     }
   })
+
+  it('cancels immediately when an authorized request already aborted before listener registration', async () => {
+    let resolveBuildPermission: (value: boolean) => void = () => {
+      throw new Error('Build permission resolver not initialized')
+    }
+    const buildPermissionPromise = new Promise<boolean>((resolve) => {
+      resolveBuildPermission = resolve
+    })
+
+    mockCheckPermission
+      .mockResolvedValueOnce(true)
+      .mockImplementationOnce(() => buildPermissionPromise)
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === `${builderUrl}/jobs/${jobId}/logs`) {
+        return new Response('data: log line\n\n', {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+          },
+        })
+      }
+
+      if (url === `${builderUrl}/jobs/${jobId}/cancel`) {
+        expect(init).toMatchObject({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': builderApiKey,
+          },
+          body: JSON.stringify({ app_id: appId }),
+        })
+
+        return new Response(JSON.stringify({ status: 'cancelled' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      const { context, controller } = createContext()
+      const responsePromise = streamBuildLogs(
+        context as any,
+        jobId,
+        appId,
+        {
+          key: 'all-key',
+          user_id: 'user-build-native',
+        } as any,
+      )
+
+      await Promise.resolve()
+      controller.abort()
+      resolveBuildPermission(true)
+
+      const response = await responsePromise
+      expect(response.status).toBe(200)
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenNthCalledWith(2, `${builderUrl}/jobs/${jobId}/cancel`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': builderApiKey,
+        },
+        body: JSON.stringify({ app_id: appId }),
+      })
+    }
+    finally {
+      fetchMock.mockRestore()
+    }
+  })
 })

--- a/tests/build-logs-disconnect-auth.test.ts
+++ b/tests/build-logs-disconnect-auth.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { streamBuildLogs } from '../supabase/functions/_backend/public/build/logs.ts'
+
+const { mockSupabaseApikey, mockCheckPermission, mockGetEnv } = vi.hoisted(() => ({
+  mockSupabaseApikey: vi.fn(),
+  mockCheckPermission: vi.fn(),
+  mockGetEnv: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseApikey: mockSupabaseApikey,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: mockCheckPermission,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  getEnv: mockGetEnv,
+}))
+
+describe('build log disconnect authorization', () => {
+  const requestId = 'req-build-logs-disconnect-auth'
+  const jobId = 'job-build-logs-123'
+  const appId = 'com.test.build.logs.disconnect'
+  const builderUrl = 'https://builder.capgo.test'
+  const builderApiKey = 'builder-api-key'
+
+  function createContext() {
+    const controller = new AbortController()
+    const request = new Request(`http://localhost/build/logs/${jobId}?app_id=${appId}`, {
+      method: 'GET',
+      signal: controller.signal,
+    })
+
+    return {
+      controller,
+      context: {
+        req: {
+          raw: request,
+        },
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key === 'requestId')
+            return requestId
+          return undefined
+        }),
+      },
+    }
+  }
+
+  beforeEach(() => {
+    mockSupabaseApikey.mockReset()
+    mockCheckPermission.mockReset()
+    mockGetEnv.mockReset()
+
+    const selectBuilder = {
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: { app_id: appId },
+        error: null,
+      }),
+    }
+
+    mockSupabaseApikey.mockReturnValue({
+      from: vi.fn().mockImplementation((table: string) => {
+        expect(table).toBe('build_requests')
+        return {
+          select: vi.fn().mockReturnValue(selectBuilder),
+        }
+      }),
+    })
+
+    mockGetEnv.mockImplementation((_, key: string) => {
+      if (key === 'BUILDER_URL')
+        return builderUrl
+      if (key === 'BUILDER_API_KEY')
+        return builderApiKey
+      return ''
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not cancel the build when a read-only caller disconnects', async () => {
+    mockCheckPermission
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === `${builderUrl}/jobs/${jobId}/logs`) {
+        return new Response('data: log line\n\n', {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+          },
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      const { context, controller } = createContext()
+      const response = await streamBuildLogs(
+        context as any,
+        jobId,
+        appId,
+        {
+          key: 'read-key',
+          user_id: 'user-read-only',
+        } as any,
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toBe('text/event-stream')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      controller.abort()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(mockCheckPermission).toHaveBeenNthCalledWith(1, context, 'app.read_logs', { appId })
+      expect(mockCheckPermission).toHaveBeenNthCalledWith(2, context, 'app.build_native', { appId })
+    }
+    finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it('cancels the build on disconnect when the caller can build natively', async () => {
+    mockCheckPermission
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === `${builderUrl}/jobs/${jobId}/logs`) {
+        return new Response('data: log line\n\n', {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+          },
+        })
+      }
+
+      if (url === `${builderUrl}/jobs/${jobId}/cancel`) {
+        expect(init).toMatchObject({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': builderApiKey,
+          },
+          body: JSON.stringify({ app_id: appId }),
+        })
+
+        return new Response(JSON.stringify({ status: 'cancelled' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      const { context, controller } = createContext()
+      const response = await streamBuildLogs(
+        context as any,
+        jobId,
+        appId,
+        {
+          key: 'all-key',
+          user_id: 'user-build-native',
+        } as any,
+      )
+
+      expect(response.status).toBe(200)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      controller.abort()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenNthCalledWith(2, `${builderUrl}/jobs/${jobId}/cancel`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': builderApiKey,
+        },
+        body: JSON.stringify({ app_id: appId }),
+      })
+    }
+    finally {
+      fetchMock.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- require `app.build_native` before wiring the `/build/logs/:jobId` disconnect cancellation path
- add a regression test proving read-only log viewers cannot cancel builds by dropping the SSE connection

## Motivation (AI generated)

The security advisory GHSA-95g7-xwwx-j737 identified a privilege inversion where a read-only principal could cancel a native build indirectly through the deprecated log-stream endpoint. This change aligns the disconnect side effect with the explicit cancel endpoint authorization boundary.

## Business Impact (AI generated)

This closes a native-build disruption path that could let read-only API keys interfere with customer CI/CD workflows. Tightening that boundary protects trust in Capgos RBAC model and reduces operational support risk.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/build-logs-disconnect-auth.test.ts --reporter=verbose`
- [x] `bunx vitest run tests/build-job-scope.test.ts --reporter=verbose`
- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bunx eslint tests/build-logs-disconnect-auth.test.ts`
- [x] `bun typecheck`
- [x] `bun test:backend`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build cancellation triggered by client disconnect now properly enforces authorization permissions, ensuring only users with appropriate build permissions can cancel builds. This prevents unintended cancellations from unauthorized users experiencing connection loss.

* **Tests**
  * Added comprehensive test coverage validating authorization behavior during build log streaming when client connections disconnect, confirming that only authorized users can trigger build cancellation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->