### PR TITLE
[codex] fix admin upgraded organization chart

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1730,6 +1730,8 @@
   "updated-default-upload-channel": "Updated the default upload channel",
   "updated-devices": "Updated devices",
   "updated-min-version": "Updated minimal version",
+  "upgraded-organizations": "Upgraded Organizations",
+  "upgraded-organizations-latest-day": "Plan upgrades in the latest completed day",
   "updates": "Updates",
   "updates-flowing-smoothly": "Your updates are flowing smoothly! Recent bundles detected.",
   "updates-trend": "Updates Trend",

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -132,7 +132,7 @@ const upgradeTrendSeries = computed(() => {
 
   return [
     {
-      label: 'Organizations Needing Upgrade',
+      label: t('need-upgrade-trend'),
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.need_upgrade,
@@ -140,7 +140,7 @@ const upgradeTrendSeries = computed(() => {
       color: '#ef4444', // red
     },
     {
-      label: 'Upgraded Organizations (24h)',
+      label: t('upgraded-organizations'),
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.upgraded_orgs || 0,
@@ -488,7 +488,7 @@ displayStore.defaultBack = '/dashboard'
               </div>
               <div>
                 <p class="text-sm text-slate-600 dark:text-slate-400">
-                  Orgs Upgraded (24h)
+                  {{ t('upgraded-organizations') }}
                 </p>
                 <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-success">
                   {{ (latestGlobalStats.upgraded_orgs || 0).toLocaleString() }}
@@ -497,7 +497,7 @@ displayStore.defaultBack = '/dashboard'
                   0
                 </p>
                 <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                  Plan upgrades in the last 24 hours
+                  {{ t('upgraded-organizations-latest-day') }}
                 </p>
               </div>
             </div>

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -279,6 +279,13 @@ function hasRevenueMovement(movement: RevenueMovement) {
     || movement.churnMrr > 0
 }
 
+function shouldTrackOrganizationUpgrade(isUpgrade: boolean, movement: RevenueMovement) {
+  if (isUpgrade)
+    return true
+
+  return movement.currentMrr > 0 && movement.nextMrr > movement.currentMrr
+}
+
 function isStaleStripeEvent(
   currentStripeInfo: Pick<StripeInfoRow, 'last_stripe_event_at'> | null | undefined,
   eventOccurredAtIso: string,
@@ -749,7 +756,7 @@ async function createdOrUpdated(
       updateData.paid_at = paidAt
     const revenuePlans = await getRevenuePlans(c)
     const revenueMovement = classifyRevenueMovement(currentStripeInfo, updateData, revenuePlans)
-    if (revenueMovement.currentMrr > 0 && revenueMovement.nextMrr > revenueMovement.currentMrr)
+    if (shouldTrackOrganizationUpgrade(stripeData.isUpgrade, revenueMovement))
       updateData.upgraded_at = eventOccurredAtIso
     const didPersist = await persistStripeInfoAndRevenueMovement(
       c,
@@ -1073,4 +1080,5 @@ export const stripeEventTestUtils = {
   getSubscriptionTrackingState,
   isStaleStripeEvent,
   isCustomerProfileEvent,
+  shouldTrackOrganizationUpgrade,
 }

--- a/tests/stripe-revenue-movement.unit.test.ts
+++ b/tests/stripe-revenue-movement.unit.test.ts
@@ -72,6 +72,57 @@ describe('stripe revenue movement classification', () => {
     })
   })
 
+  it.concurrent('tracks monthly to yearly cadence upgrades for admin metrics even when MRR stays flat', () => {
+    const movement = stripeEventTestUtils.classifyRevenueMovement(
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_solo_monthly',
+        product_id: 'prod_solo',
+        status: 'succeeded',
+      },
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-01T00:00:00.000Z',
+        price_id: 'price_solo_yearly',
+        product_id: 'prod_solo',
+        status: 'succeeded',
+      },
+      plans as any,
+    )
+
+    expect(movement).toMatchObject({
+      currentMrr: 12,
+      nextMrr: 10,
+      newBusinessMrr: 0,
+      expansionMrr: 0,
+      contractionMrr: 2,
+      churnMrr: 0,
+    })
+    expect(stripeEventTestUtils.shouldTrackOrganizationUpgrade(true, movement)).toBe(true)
+  })
+
+  it.concurrent('does not track first-time subscriptions as organization upgrades for admin metrics', () => {
+    const movement = stripeEventTestUtils.classifyRevenueMovement(
+      {
+        paid_at: null,
+        price_id: null,
+        product_id: null,
+        status: 'created',
+      },
+      {
+        is_good_plan: true,
+        paid_at: '2026-04-22T12:00:00.000Z',
+        price_id: 'price_solo_monthly',
+        product_id: 'prod_solo',
+        status: 'succeeded',
+      },
+      plans as any,
+    )
+
+    expect(stripeEventTestUtils.shouldTrackOrganizationUpgrade(false, movement)).toBe(false)
+  })
+
   it.concurrent('records downgrades as contraction MRR', () => {
     expect(stripeEventTestUtils.classifyRevenueMovement(
       {


### PR DESCRIPTION
## Summary (AI generated)

- fix admin revenue upgrade tracking so same-plan monthly-to-yearly upgrades are counted
- align the admin revenue chart copy with the existing daily snapshot model instead of a misleading rolling 24h label
- add regression coverage for organization upgrade tracking

## Motivation (AI generated)

The admin revenue dashboard could show zero upgraded organizations even when upgrade events happened. The initial metric only stamped `upgraded_at` when MRR increased, which skipped same-plan cadence upgrades, and the UI wording implied a rolling 24 hour window even though the metric is stored as a completed daily snapshot.

## Business Impact (AI generated)

This makes internal billing analytics more trustworthy for support, finance, and product decisions. It reduces false negatives in upgrade reporting and avoids confusion when reading daily admin revenue metrics.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bunx vitest run tests/stripe-revenue-movement.unit.test.ts tests/stripe-subscription-events.unit.test.ts tests/logsnag-insights-revenue.unit.test.ts`

Generated with AI
