### PR TITLE
[codex] fix build TUS HEAD fallback on mounted routes

### DIFF
--- a/supabase/functions/_backend/public/build/index.ts
+++ b/supabase/functions/_backend/public/build/index.ts
@@ -89,22 +89,43 @@ app.post('/upload/:jobId', middlewareKey(['all', 'write']), async (c) => {
   return tusProxy(c, jobId, apikey)
 })
 
-// HEAD /build/upload/:jobId/* - Check TUS upload progress (proxied to builder)
-// Hono resolves HEAD via GET route matching, so we gate by request method here.
+async function proxyTusHead(c: Parameters<typeof tusProxy>[0]) {
+  const jobId = c.req.param('jobId')
+  if (!jobId) {
+    throw new Error('jobId is required in request path')
+  }
+  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
+  return tusProxy(c, jobId, apikey, 'HEAD')
+}
+
+function isTusHeadProbe(c: Parameters<typeof tusProxy>[0]) {
+  return !!c.req.header('Tus-Resumable')
+}
+
+// Some runtimes normalize HEAD to GET on mounted routes.
+// Accept only TUS-shaped GET probes here and forward them upstream as HEAD.
 app.get(
-  '/upload/:jobId/*',
+  '/upload/:jobId',
   async (c, next) => {
-    if (c.req.method !== 'HEAD') {
+    if (!isTusHeadProbe(c)) {
       return c.notFound()
     }
     return next()
   },
   uploadWriteMiddleware,
-  async (c) => {
-    const jobId = c.req.param('jobId')
-    const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
-    return tusProxy(c, jobId, apikey)
+  proxyTusHead,
+)
+
+app.get(
+  '/upload/:jobId/*',
+  async (c, next) => {
+    if (!isTusHeadProbe(c)) {
+      return c.notFound()
+    }
+    return next()
   },
+  uploadWriteMiddleware,
+  proxyTusHead,
 )
 
 // PATCH /build/upload/:jobId/* - Upload TUS chunk (proxied to builder)

--- a/supabase/functions/_backend/public/build/upload.ts
+++ b/supabase/functions/_backend/public/build/upload.ts
@@ -15,12 +15,14 @@ export async function tusProxy(
   c: Context,
   jobId: string,
   apikey: Database['public']['Tables']['apikeys']['Row'],
+  forwardMethod = c.req.method,
 ): Promise<Response> {
   cloudlog({
     requestId: c.get('requestId'),
     message: 'TUS proxy request',
     job_id: jobId,
     method: c.req.method,
+    forward_method: forwardMethod,
   })
 
   // Get builder config
@@ -182,6 +184,7 @@ export async function tusProxy(
     message: 'Proxying TUS request to builder',
     job_id: jobId,
     method: c.req.method,
+    forward_method: forwardMethod,
     original_path: originalPath,
     upload_prefix: uploadPrefix,
     tus_path: safeTusPath,
@@ -196,7 +199,7 @@ export async function tusProxy(
   // For POST requests, rewrite Upload-Metadata to use the correct artifact key
   // Use the upload_path from the build request which contains the full orgs/apps path structure
   // Example: orgs/${org_id}/apps/${app_id}/native-builds/${upload_session_key}.zip
-  if (c.req.method === 'POST') {
+  if (forwardMethod === 'POST') {
     const artifactKey = buildRequest.upload_path
 
     // Parse existing Upload-Metadata header to preserve other fields like filetype
@@ -242,7 +245,7 @@ export async function tusProxy(
 
   // Forward the request
   const builderResponse = await fetch(builderTusUrl, {
-    method: c.req.method,
+    method: forwardMethod,
     headers,
     body: c.req.raw.body,
     // @ts-expect-error - duplex is valid for streaming

--- a/tests/build-upload-head-routing.test.ts
+++ b/tests/build-upload-head-routing.test.ts
@@ -45,6 +45,18 @@ describe('build upload HEAD routing', () => {
     expect([400, 401]).toContain(response.status)
   })
 
+  it.concurrent('treats GET /build/upload/:jobId with Tus-Resumable as a TUS HEAD fallback', async () => {
+    const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job', {
+      method: 'GET',
+      headers: {
+        'Tus-Resumable': '1.0.0',
+      },
+    }))
+
+    expect(response.status).not.toBe(404)
+    expect([400, 401]).toContain(response.status)
+  })
+
   it.concurrent('keeps GET /build/upload/:jobId/* as not found', async () => {
     const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job/file.zip', {
       method: 'GET',

--- a/tests/build-upload-head-routing.test.ts
+++ b/tests/build-upload-head-routing.test.ts
@@ -1,11 +1,16 @@
+import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
-import { app } from '../supabase/functions/_backend/public/build/index.ts'
+import { app as buildApp } from '../supabase/functions/_backend/public/build/index.ts'
 
-// Intentionally uses app.request() as a lightweight routing smoke test:
-// this validates Hono HEAD-via-GET matching and guard ordering before worker/binding setup.
+function createMountedBuildApp() {
+  return new Hono().basePath('/build').route('/', buildApp)
+}
+
+// Intentionally uses a mounted Hono app as a lightweight routing smoke test:
+// this validates the deployed /build/upload path before worker/binding setup.
 describe('build upload HEAD routing', () => {
-  it.concurrent('routes HEAD /upload/:jobId/* through auth middleware', async () => {
-    const response = await app.request(new Request('http://localhost/upload/test-job/file.zip', {
+  it.concurrent('routes HEAD /build/upload/:jobId/* through auth middleware', async () => {
+    const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job/file.zip', {
       method: 'HEAD',
       headers: {
         'Tus-Resumable': '1.0.0',
@@ -16,8 +21,32 @@ describe('build upload HEAD routing', () => {
     expect([400, 401]).toContain(response.status)
   })
 
-  it.concurrent('keeps GET /upload/:jobId/* as not found', async () => {
-    const response = await app.request(new Request('http://localhost/upload/test-job/file.zip', {
+  it.concurrent('routes HEAD /build/upload/:jobId through auth middleware', async () => {
+    const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job', {
+      method: 'HEAD',
+      headers: {
+        'Tus-Resumable': '1.0.0',
+      },
+    }))
+
+    expect(response.status).not.toBe(404)
+    expect([400, 401]).toContain(response.status)
+  })
+
+  it.concurrent('treats GET /build/upload/:jobId/* with Tus-Resumable as a TUS HEAD fallback', async () => {
+    const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job/file.zip', {
+      method: 'GET',
+      headers: {
+        'Tus-Resumable': '1.0.0',
+      },
+    }))
+
+    expect(response.status).not.toBe(404)
+    expect([400, 401]).toContain(response.status)
+  })
+
+  it.concurrent('keeps GET /build/upload/:jobId/* as not found', async () => {
+    const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job/file.zip', {
       method: 'GET',
     }))
 


### PR DESCRIPTION
## Summary (AI generated)

- Treat `GET` requests carrying `Tus-Resumable` as a runtime fallback for TUS `HEAD` on build upload routes
- Forward those fallback requests upstream as real `HEAD` requests
- Add regression coverage for mounted `/build/upload/:jobId` and `/build/upload/:jobId/*` routing

## Motivation (AI generated)

The advisory reports that TUS uploads succeed for `POST` and `PATCH`, but `HEAD` on the returned upload URL still responds with `404` in production. Some runtimes normalize `HEAD` to `GET` on mounted routes, so the proxy needs to recognize TUS `HEAD` probes by header and forward them correctly.

## Business Impact (AI generated)

This restores resumable upload compatibility for native build uploads, reducing failed or stalled build sessions and preventing support load around broken build pipelines.

## Test Plan (AI generated)

- [x] Run `bun run lint:backend`
- [x] Run `bun typecheck`
- [x] Run `bunx vitest run tests/build-upload-head-routing.test.ts tests/build-upload-security.test.ts`
- [x] Verify GitHub Actions passes on the focused branch

Generated with AI
