### PR TITLE
[codex] restore transfer_app guard flag and CI stability

### DIFF
--- a/supabase/migrations/20260427092630_restore_transfer_app_guard_flag.sql
+++ b/supabase/migrations/20260427092630_restore_transfer_app_guard_flag.sql
@@ -1,0 +1,140 @@
+CREATE OR REPLACE FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+    v_old_org_id uuid;
+    v_user_id uuid;
+    v_last_transfer jsonb;
+    v_last_transfer_date timestamp;
+    v_transfer_request_error constant text := 'Unable to process transfer request.';
+BEGIN
+  SELECT owner_org, transfer_history[pg_catalog.array_length(transfer_history, 1)]
+  INTO v_old_org_id, v_last_transfer
+  FROM public.apps
+  WHERE app_id = p_app_id
+  FOR UPDATE;
+
+  IF v_old_org_id IS NULL THEN
+    RAISE EXCEPTION '%', v_transfer_request_error;
+  END IF;
+
+  v_user_id := (SELECT auth.uid());
+
+  IF v_user_id IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NO_AUTH',
+      pg_catalog.jsonb_build_object('app_id', p_app_id, 'new_org_id', p_new_org_id)
+    );
+    RAISE EXCEPTION '%', v_transfer_request_error;
+  END IF;
+
+  IF v_old_org_id = p_new_org_id THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_SAME_ORG',
+      pg_catalog.jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION '%', v_transfer_request_error;
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      v_old_org_id,
+      p_app_id,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_OLD_ORG_RIGHTS',
+      pg_catalog.jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION '%', v_transfer_request_error;
+  END IF;
+
+  IF NOT public.rbac_check_permission(
+      public.rbac_perm_app_transfer(),
+      p_new_org_id,
+      NULL::character varying,
+      NULL::bigint
+  ) THEN
+    PERFORM public.pg_log(
+      'deny: TRANSFER_NEW_ORG_RIGHTS',
+      pg_catalog.jsonb_build_object(
+        'app_id', p_app_id,
+        'old_org_id', v_old_org_id,
+        'new_org_id', p_new_org_id,
+        'uid', v_user_id
+      )
+    );
+    RAISE EXCEPTION '%', v_transfer_request_error;
+  END IF;
+
+  IF v_last_transfer IS NOT NULL THEN
+    v_last_transfer_date := (v_last_transfer->>'transferred_at')::timestamp;
+    IF v_last_transfer_date + interval '32 days' > pg_catalog.now() THEN
+      RAISE EXCEPTION
+          'Cannot transfer app. Must wait at least 32 days '
+          'between transfers. Last transfer was on %',
+          v_last_transfer_date;
+    END IF;
+  END IF;
+
+  -- Allow the guarded owner_org cascade only inside the approved transfer path.
+  PERFORM pg_catalog.set_config('capgo.allow_owner_org_transfer', 'true', true);
+
+  UPDATE public.apps
+  SET
+      owner_org = p_new_org_id,
+      updated_at = pg_catalog.now(),
+      transfer_history = (
+          CASE
+            WHEN transfer_history IS NULL THEN '{}'::jsonb[]
+            ELSE transfer_history
+          END
+      ) || pg_catalog.jsonb_build_object(
+          'transferred_at', pg_catalog.now(),
+          'transferred_from', v_old_org_id,
+          'transferred_to', p_new_org_id,
+          'initiated_by', v_user_id
+      )
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.app_versions_meta
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channel_devices
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.channels
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+  UPDATE public.deploy_history
+  SET owner_org = p_new_org_id
+  WHERE app_id = p_app_id;
+
+END;
+$$;
+
+ALTER FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) OWNER TO postgres;

--- a/supabase/migrations/20260427092630_restore_transfer_app_guard_flag.sql
+++ b/supabase/migrations/20260427092630_restore_transfer_app_guard_flag.sql
@@ -138,3 +138,35 @@ ALTER FUNCTION public.transfer_app(
     p_app_id character varying,
     p_new_org_id uuid
 ) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM anon;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM authenticated;
+REVOKE ALL ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) TO service_role;
+
+COMMENT ON FUNCTION public.transfer_app(
+    p_app_id character varying,
+    p_new_org_id uuid
+) IS 'Transfers an app and all its related data to a new '
+'organization. Requires app.transfer permission on both '
+'source and destination organizations.';

--- a/tests/email-preferences.test.ts
+++ b/tests/email-preferences.test.ts
@@ -24,6 +24,8 @@ const defaultEmailPreferences: EmailPreferences = {
   channel_self_rejected: true,
 }
 
+const hookTimeoutMs = 60_000
+
 function isBentoConfiguredForTests() {
   const publishableKey = (process.env.BENTO_PUBLISHABLE_KEY || '').trim()
   const secretKey = (process.env.BENTO_SECRET_KEY || '').trim()
@@ -52,7 +54,7 @@ beforeAll(async () => {
     userId: USER_ID_EMAIL_PREFS,
     stripeCustomerId: STRIPE_CUSTOMER_ID_EMAIL_PREFS,
   })
-})
+}, hookTimeoutMs)
 
 beforeEach(async () => {
   await resetEmailPreferences()
@@ -65,7 +67,7 @@ afterEach(async () => {
 afterAll(async () => {
   await resetAppData(APPNAME_PREFS)
   await resetEmailPreferences()
-})
+}, hookTimeoutMs)
 
 // Helper to check if migration has been applied
 async function isMigrationApplied(): Promise<boolean> {


### PR DESCRIPTION
## Summary (AI generated)

- Restore the `capgo.allow_owner_org_transfer` guard flag inside `public.transfer_app`
- Extend the Cloudflare email-preferences suite hook timeout so CI does not fail on slow isolated app seeding

## Motivation (AI generated)

Current `main` fails `supabase test db` because `public.transfer_app` updates `owner_org` without setting the bypass flag expected by the new reassignment guard trigger. After that database issue is fixed, the Cloudflare email-preferences suite can still fail from a CI-only setup timeout, so the prerequisite branch also carries the minimal timeout adjustment needed for stable checks.

## Business Impact (AI generated)

This restores green CI on the current base branch and unblocks focused application fixes from shipping without mixing unrelated changes into their PRs.

## Test Plan (AI generated)

- [x] Reproduce that focused PRs on current `main` fail in `Run Supabase Test DB`
- [ ] Verify GitHub Actions passes for this prerequisite branch

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure app ownership transfer flow with organization validation, permission checks, transfer cooldown to prevent rapid reassignments, and automatic propagation of ownership updates across related app data.

* **Tests**
  * Increased the email preferences test suite setup/teardown timeout to 60 seconds for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->