### PR TITLE
fix(db): deny retention metrics user access

### DIFF
--- a/supabase/migrations/20260427110612_retention_metrics_service_role_rls.sql
+++ b/supabase/migrations/20260427110612_retention_metrics_service_role_rls.sql
@@ -1,21 +1,24 @@
 -- Keep retention metrics internal to backend workers while satisfying the
--- project-wide RLS convention for public tables.
+-- project-wide RLS convention for public tables. service_role bypasses RLS, so
+-- backend-only tables use deny-all policies instead of service_role policies.
 ALTER TABLE public.daily_revenue_metrics ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE public.processed_stripe_events ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS "Allow service_role full access" ON public.daily_revenue_metrics;
+DROP POLICY IF EXISTS "Deny all access" ON public.daily_revenue_metrics;
 
-CREATE POLICY "Allow service_role full access" ON public.daily_revenue_metrics FOR ALL TO service_role USING (
-    true
+CREATE POLICY "Deny all access" ON public.daily_revenue_metrics FOR ALL USING (
+    false
 )
 WITH
-CHECK (true);
+CHECK (false);
 
 DROP POLICY IF EXISTS "Allow service_role full access" ON public.processed_stripe_events;
+DROP POLICY IF EXISTS "Deny all access" ON public.processed_stripe_events;
 
-CREATE POLICY "Allow service_role full access" ON public.processed_stripe_events FOR ALL TO service_role USING (
-    true
+CREATE POLICY "Deny all access" ON public.processed_stripe_events FOR ALL USING (
+    false
 )
 WITH
-CHECK (true);
+CHECK (false);

--- a/supabase/migrations/20260427110612_retention_metrics_service_role_rls.sql
+++ b/supabase/migrations/20260427110612_retention_metrics_service_role_rls.sql
@@ -1,0 +1,21 @@
+-- Keep retention metrics internal to backend workers while satisfying the
+-- project-wide RLS convention for public tables.
+ALTER TABLE public.daily_revenue_metrics ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.processed_stripe_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow service_role full access" ON public.daily_revenue_metrics;
+
+CREATE POLICY "Allow service_role full access" ON public.daily_revenue_metrics FOR ALL TO service_role USING (
+    true
+)
+WITH
+CHECK (true);
+
+DROP POLICY IF EXISTS "Allow service_role full access" ON public.processed_stripe_events;
+
+CREATE POLICY "Allow service_role full access" ON public.processed_stripe_events FOR ALL TO service_role USING (
+    true
+)
+WITH
+CHECK (true);

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -3,7 +3,7 @@
 BEGIN;
 
 -- Plan the number of tests
-SELECT plan(41);
+SELECT plan(43);
 
 -- Test app_versions policies
 SELECT
@@ -244,6 +244,30 @@ SELECT
         'processed_stripe_events',
         ARRAY['Allow service_role full access'],
         'processed_stripe_events should stay service_role-only'
+    );
+
+SELECT
+    ok(
+        (
+            SELECT c.relrowsecurity
+            FROM pg_class AS c
+            JOIN pg_namespace AS n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public'
+              AND c.relname = 'daily_revenue_metrics'
+        ),
+        'daily_revenue_metrics should have RLS enabled'
+    );
+
+SELECT
+    ok(
+        (
+            SELECT c.relrowsecurity
+            FROM pg_class AS c
+            JOIN pg_namespace AS n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public'
+              AND c.relname = 'processed_stripe_events'
+        ),
+        'processed_stripe_events should have RLS enabled'
     );
 
 -- Test manifest policies

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -3,7 +3,7 @@
 BEGIN;
 
 -- Plan the number of tests
-SELECT plan(39);
+SELECT plan(41);
 
 -- Test app_versions policies
 SELECT
@@ -226,6 +226,24 @@ SELECT
         'stripe_info',
         ARRAY['Allow org member to select stripe_info'],
         'stripe_info should have correct policies'
+    );
+
+-- Test daily_revenue_metrics policies
+SELECT
+    policies_are(
+        'public',
+        'daily_revenue_metrics',
+        ARRAY['Allow service_role full access'],
+        'daily_revenue_metrics should stay service_role-only'
+    );
+
+-- Test processed_stripe_events policies
+SELECT
+    policies_are(
+        'public',
+        'processed_stripe_events',
+        ARRAY['Allow service_role full access'],
+        'processed_stripe_events should stay service_role-only'
     );
 
 -- Test manifest policies

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -233,8 +233,8 @@ SELECT
     policies_are(
         'public',
         'daily_revenue_metrics',
-        ARRAY['Allow service_role full access'],
-        'daily_revenue_metrics should stay service_role-only'
+        ARRAY['Deny all access'],
+        'daily_revenue_metrics should deny all user-context access'
     );
 
 -- Test processed_stripe_events policies
@@ -242,8 +242,8 @@ SELECT
     policies_are(
         'public',
         'processed_stripe_events',
-        ARRAY['Allow service_role full access'],
-        'processed_stripe_events should stay service_role-only'
+        ARRAY['Deny all access'],
+        'processed_stripe_events should deny all user-context access'
     );
 
 SELECT

--- a/tests/cli-meta.test.ts
+++ b/tests/cli-meta.test.ts
@@ -12,32 +12,67 @@ async function assertCompatibilityTableColumns(appId: string, column1: string, c
   const nodeModulesPath = join(process.cwd(), 'node_modules')
 
   const sdk = createTestSDK()
-  const result = await sdk.checkBundleCompatibility({
-    appId,
-    channel: 'production',
-    packageJson: packageJsonPath,
-    nodeModules: nodeModulesPath,
-  })
+  let lastError: unknown
 
-  expect(result.success).toBe(true)
-  expect(result.data).toBeDefined()
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const result = await sdk.checkBundleCompatibility({
+      appId,
+      channel: 'production',
+      packageJson: packageJsonPath,
+      nodeModules: nodeModulesPath,
+    })
 
-  // Find the package in the compatibility data
-  const packageEntry = result.data!.find((entry: any) => entry.name === column1)
-  expect(packageEntry).toBeDefined()
-  expect(packageEntry!.localVersion).toContain(column2)
-  expect(packageEntry!.remoteVersion).toContain(column3)
-  // Note: SDK compatibility field structure may differ from CLI output
-  // The ✅/❌ symbols are in the CLI's text rendering, SDK returns the data
-  // We'll check if versions match for compatibility
-  if (column4 === '✅') {
-    // Compatible - versions should match (considering semver resolution)
-    expect(packageEntry!.remoteVersion).toBeDefined()
+    try {
+      expect(result.success).toBe(true)
+      expect(result.data).toBeDefined()
+
+      // Find the package in the compatibility data
+      const packageEntry = result.data!.find((entry: any) => entry.name === column1)
+      expect(packageEntry).toBeDefined()
+      expect(packageEntry!.localVersion).toContain(column2)
+      expect(packageEntry!.remoteVersion).toContain(column3)
+      // Note: SDK compatibility field structure may differ from CLI output
+      // The ✅/❌ symbols are in the CLI's text rendering, SDK returns the data
+      // We'll check if versions match for compatibility
+      if (column4 === '✅') {
+        // Compatible - versions should match (considering semver resolution)
+        expect(packageEntry!.remoteVersion).toBeDefined()
+      }
+      else {
+        // Incompatible - just verify the entry exists
+        expect(packageEntry!.localVersion).toBeDefined()
+      }
+      return
+    }
+    catch (error) {
+      lastError = error
+      if (attempt === 4)
+        throw error
+
+      await new Promise(resolve => setTimeout(resolve, 250 * (attempt + 1)))
+    }
   }
-  else {
-    // Incompatible - just verify the entry exists
-    expect(packageEntry!.localVersion).toBeDefined()
-  }
+
+  throw lastError
+}
+
+async function writeBundleContent(appId: string, marker: string) {
+  const indexHtmlPath = join(tempFileFolder(appId), 'dist', 'index.html')
+  await writeFile(indexHtmlPath, `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CLI Metadata Test</title>
+</head>
+<body>
+  <h1>${marker}</h1>
+  <script>
+    if (window.CapacitorUpdater) {
+      window.CapacitorUpdater.notifyAppReady();
+    }
+  </script>
+</body>
+</html>`)
 }
 
 async function getInstalledDependencyVersion(packageName: string): Promise<string> {
@@ -84,6 +119,7 @@ describe('tests CLI metadata', () => {
   it('should upload bundle with metadata check', async () => {
     const testSemver = getSemver()
     const packageJsonPath = join(process.cwd(), 'temp_cli_test', APPNAME, 'package.json')
+    await writeBundleContent(APPNAME, `metadata-${testSemver}`)
 
     // First upload a bundle WITH metadata to establish baseline
     const result = await uploadBundleSDK(APPNAME, testSemver, 'production', {

--- a/tests/cli-meta.test.ts
+++ b/tests/cli-meta.test.ts
@@ -15,14 +15,14 @@ async function assertCompatibilityTableColumns(appId: string, column1: string, c
   let lastError: unknown
 
   for (let attempt = 0; attempt < 5; attempt++) {
-    const result = await sdk.checkBundleCompatibility({
-      appId,
-      channel: 'production',
-      packageJson: packageJsonPath,
-      nodeModules: nodeModulesPath,
-    })
-
     try {
+      const result = await sdk.checkBundleCompatibility({
+        appId,
+        channel: 'production',
+        packageJson: packageJsonPath,
+        nodeModules: nodeModulesPath,
+      })
+
       expect(result.success).toBe(true)
       expect(result.data).toBeDefined()
 
@@ -53,7 +53,7 @@ async function assertCompatibilityTableColumns(appId: string, column1: string, c
     }
   }
 
-  throw lastError
+  throw lastError ?? new Error('Compatibility check failed without a captured error')
 }
 
 async function writeBundleContent(appId: string, marker: string) {


### PR DESCRIPTION
## Summary (AI generated)

- keep `public.daily_revenue_metrics` and `public.processed_stripe_events` as backend-only tables under the repo's deny-all RLS pattern
- replace the incorrect `service_role` policy approach with explicit deny-all policies on both internal Stripe retention tables
- extend the RLS pgTAP coverage so those deny-all policies stay explicit
- harden the CLI metadata test against upload retries by varying bundle contents per attempt and retrying the post-upload compatibility read

## Motivation (AI generated)

The retention metrics tables are backend-only Stripe webhook ledgers. In environments where RLS is auto-enabled for new `public` tables, they can end up with RLS enabled but no policies, which triggers the Supabase linter and leaves the intended access model implicit.

For backend-only tables in this repo, `service_role` is not modeled through RLS policies because it bypasses RLS. The established pattern is to keep grants restricted and add an explicit deny-all policy so user-context access stays impossible while the linter remains satisfied.

The branch also needed a small test-only fix because the existing CLI metadata test could fail on Vitest retries: once an initial upload partially succeeded, the retry re-used identical bundle contents and hit the duplicate-checksum guard before it could re-check metadata.

## Business Impact (AI generated)

This removes noisy security-linter findings on admin retention analytics tables, makes the backend-only access model explicit in the same way as similar internal tables, and reduces migration review friction without changing customer-facing behavior.

The metadata test hardening lowers false-negative CI failures, which keeps schema changes from getting blocked by an unrelated flaky retry path.

## Test Plan (AI generated)

- [x] `bunx supabase db reset --yes --workdir .context/supabase-worktrees/f5206569`
- [x] `bunx supabase test db supabase/tests/26_test_rls_policies.sql --workdir .context/supabase-worktrees/f5206569`
- [x] `bunx eslint tests/cli-meta.test.ts`
- [ ] GitHub CI passes
- [ ] local `tests/cli-meta.test.ts` upload path is healthy enough to re-run without `name resolution failed`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced database security by strengthening Row Level Security policies on critical data tables to prevent unauthorized access.
  * Improved system reliability through enhanced test coverage for security policies and added retry mechanisms to ensure stability in compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->