### PR TITLE
fix(api): enforce API key expiration policy for app scopes

### DIFF
--- a/supabase/functions/_backend/public/apikey/post.ts
+++ b/supabase/functions/_backend/public/apikey/post.ts
@@ -2,7 +2,7 @@ import type { AuthInfo } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { honoFactory, parseBody, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
-import { resolveApikeyPolicyOrgIds, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
+import { resolveApikeyPolicyOrgIds, supabaseAdmin, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
 import { Constants } from '../../utils/supabase.types.ts'
 
 const app = honoFactory.createApp()
@@ -60,6 +60,7 @@ app.post('/', middlewareV2(['all']), async (c) => {
 
   // Use supabaseWithAuth which handles both JWT and API key authentication
   const supabase = supabaseWithAuth(c, auth)
+  const policyLookupSupabase = supabaseAdmin(c)
 
   if (orgId) {
     const { data: org, error } = await supabase.from('orgs').select('*').eq('id', orgId).single()
@@ -80,6 +81,7 @@ app.post('/', middlewareV2(['all']), async (c) => {
   const allOrgIds = await resolveApikeyPolicyOrgIds(supabase, {
     limitedToApps,
     limitedToOrgs,
+    policyLookupSupabase,
   })
   await validateExpirationAgainstOrgPolicies(allOrgIds, expiresAt, supabase)
 

--- a/supabase/functions/_backend/public/apikey/post.ts
+++ b/supabase/functions/_backend/public/apikey/post.ts
@@ -2,7 +2,7 @@ import type { AuthInfo } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { honoFactory, parseBody, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
-import { supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
+import { resolveApikeyPolicyOrgIds, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
 import { Constants } from '../../utils/supabase.types.ts'
 
 const app = honoFactory.createApp()
@@ -61,16 +61,12 @@ app.post('/', middlewareV2(['all']), async (c) => {
   // Use supabaseWithAuth which handles both JWT and API key authentication
   const supabase = supabaseWithAuth(c, auth)
 
-  // Collect all org IDs for policy validation
-  let allOrgIds: string[] = [...limitedToOrgs]
-
   if (orgId) {
     const { data: org, error } = await supabase.from('orgs').select('*').eq('id', orgId).single()
     if (!org || error) {
       throw quickError(404, 'org_not_found', 'Org not found', { supabaseError: error })
     }
     limitedToOrgs.splice(0, limitedToOrgs.length, org.id)
-    allOrgIds = [org.id]
   }
   if (appId) {
     const { data: app, error } = await supabase.from('apps').select('*').eq('id', appId).single()
@@ -81,6 +77,10 @@ app.post('/', middlewareV2(['all']), async (c) => {
   }
 
   // Validate expiration against org policies (throws if invalid)
+  const allOrgIds = await resolveApikeyPolicyOrgIds(supabase, {
+    limitedToApps,
+    limitedToOrgs,
+  })
   await validateExpirationAgainstOrgPolicies(allOrgIds, expiresAt, supabase)
 
   let apikeyData: Database['public']['Tables']['apikeys']['Row'] | null = null

--- a/supabase/functions/_backend/public/apikey/put.ts
+++ b/supabase/functions/_backend/public/apikey/put.ts
@@ -31,9 +31,11 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
   const auth = c.get('auth') as AuthInfo
   const authApikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
 
-  // Only check limited_to_orgs constraint for API key auth (not JWT)
-  if (auth.authType === 'apikey' && authApikey?.limited_to_orgs?.length) {
-    throw quickError(401, 'cannot_update_apikey', 'You cannot do that as a limited API key', { requestId, apikeyId: authApikey.id })
+  // Block any constrained API key from mutating other keys owned by the same user.
+  const callerHasLimitedScope = (authApikey?.limited_to_orgs?.length ?? 0) > 0
+    || (authApikey?.limited_to_apps?.length ?? 0) > 0
+  if (auth.authType === 'apikey' && callerHasLimitedScope) {
+    throw quickError(401, 'cannot_update_apikey', 'You cannot do that as a limited API key', { requestId, apikeyId: authApikey?.id })
   }
 
   const body = await parseBody<ApiKeyPut>(c)

--- a/supabase/functions/_backend/public/apikey/put.ts
+++ b/supabase/functions/_backend/public/apikey/put.ts
@@ -3,7 +3,7 @@ import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { honoFactory, parseBody, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
-import { resolveApikeyPolicyOrgIds, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
+import { resolveApikeyPolicyOrgIds, supabaseAdmin, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
 import { Constants } from '../../utils/supabase.types.ts'
 
 const app = honoFactory.createApp()
@@ -103,6 +103,7 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
 
   // Use supabaseWithAuth which handles both JWT and API key authentication
   const supabase = supabaseWithAuth(c, auth)
+  const policyLookupSupabase = supabaseAdmin(c)
 
   // Check if the apikey to update exists (RLS handles ownership)
   const baseQuery = supabase
@@ -137,6 +138,7 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
     const orgsToValidate = await resolveApikeyPolicyOrgIds(supabase, {
       limitedToApps: nextLimitedToApps,
       limitedToOrgs: nextLimitedToOrgs,
+      policyLookupSupabase,
     })
     await validateExpirationAgainstOrgPolicies(orgsToValidate, expirationToValidate, supabase)
   }

--- a/supabase/functions/_backend/public/apikey/put.ts
+++ b/supabase/functions/_backend/public/apikey/put.ts
@@ -3,7 +3,7 @@ import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { honoFactory, parseBody, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
-import { supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
+import { resolveApikeyPolicyOrgIds, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
 import { Constants } from '../../utils/supabase.types.ts'
 
 const app = honoFactory.createApp()
@@ -105,7 +105,7 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
   // Check if the apikey to update exists (RLS handles ownership)
   const baseQuery = supabase
     .from('apikeys')
-    .select('id, limited_to_orgs, expires_at, key, key_hash') // Also fetch expires_at for policy validation
+    .select('id, limited_to_orgs, limited_to_apps, expires_at, key, key_hash') // Also fetch scope + expires_at for policy validation
     .eq('user_id', auth.userId)
 
   // Avoid PostgREST cast errors by querying only the relevant column:
@@ -125,13 +125,17 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
     throw quickError(404, 'api_key_not_found_or_access_denied', 'API key not found or access denied', { requestId })
   }
 
-  // Determine the org IDs to validate against (use new ones if provided, otherwise existing)
-  const orgsToValidate = limited_to_orgs?.length ? limited_to_orgs : (existingApikey.limited_to_orgs || [])
+  const nextLimitedToOrgs = limited_to_orgs !== undefined ? limited_to_orgs : (existingApikey.limited_to_orgs || [])
+  const nextLimitedToApps = limited_to_apps !== undefined ? limited_to_apps : (existingApikey.limited_to_apps || [])
 
-  // Validate expiration against org policies (only if expires_at is being set or orgs are being changed)
-  if (expires_at !== undefined || limited_to_orgs?.length) {
+  // Validate expiration against org policies (only if expiration or scopes are changing)
+  if (expires_at !== undefined || limited_to_orgs !== undefined || limited_to_apps !== undefined) {
     // Use new expires_at if provided, otherwise fall back to existing
     const expirationToValidate = expires_at !== undefined ? expires_at : (existingApikey.expires_at ?? null)
+    const orgsToValidate = await resolveApikeyPolicyOrgIds(supabase, {
+      limitedToApps: nextLimitedToApps,
+      limitedToOrgs: nextLimitedToOrgs,
+    })
     await validateExpirationAgainstOrgPolicies(orgsToValidate, expirationToValidate, supabase)
   }
 

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1561,17 +1561,24 @@ export async function resolveApikeyPolicyOrgIds(
 
   const { data: apps, error } = await supabase
     .from('apps')
-    .select('owner_org')
+    .select('app_id, owner_org')
     .in('app_id', limitedToApps)
 
   if (error) {
     throw simpleError('failed_to_resolve_apikey_policy_scope', 'Failed to resolve API key policy scope', { supabaseError: error })
   }
 
+  const resolvedAppIds = new Set<string>()
   for (const app of apps ?? []) {
-    if (app.owner_org) {
-      orgIds.add(app.owner_org)
-    }
+    if (!app.app_id || !app.owner_org)
+      continue
+    resolvedAppIds.add(app.app_id)
+    orgIds.add(app.owner_org)
+  }
+
+  const unresolvedAppIds = limitedToApps.filter(appId => !resolvedAppIds.has(appId))
+  if (unresolvedAppIds.length > 0) {
+    throw simpleError('failed_to_resolve_apikey_policy_scope', 'Failed to resolve API key policy scope', { unresolvedAppIds })
   }
 
   return [...orgIds]

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1542,6 +1542,38 @@ export function validateExpirationDate(expiresAt: string | null | undefined): vo
 }
 
 /**
+ * Resolve all organization IDs affected by API key scopes.
+ * App-scoped keys inherit expiration policy from the app owner organization.
+ */
+export async function resolveApikeyPolicyOrgIds(
+  supabase: SupabaseClient<Database>,
+  options: {
+    limitedToApps?: string[] | null
+    limitedToOrgs?: string[] | null
+  },
+): Promise<string[]> {
+  const orgIds = new Set((options.limitedToOrgs ?? []).filter(Boolean))
+  const limitedToApps = [...new Set((options.limitedToApps ?? []).filter(Boolean))]
+
+  if (limitedToApps.length === 0) {
+    return [...orgIds]
+  }
+
+  const { data: apps } = await supabase
+    .from('apps')
+    .select('owner_org')
+    .in('app_id', limitedToApps)
+
+  for (const app of apps ?? []) {
+    if (app.owner_org) {
+      orgIds.add(app.owner_org)
+    }
+  }
+
+  return [...orgIds]
+}
+
+/**
  * Validate API key expiration against org policies for multiple orgs.
  * Throws simpleError if any org policy is violated.
  * @param orgIds - Array of org IDs to validate against

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1559,10 +1559,14 @@ export async function resolveApikeyPolicyOrgIds(
     return [...orgIds]
   }
 
-  const { data: apps } = await supabase
+  const { data: apps, error } = await supabase
     .from('apps')
     .select('owner_org')
     .in('app_id', limitedToApps)
+
+  if (error) {
+    throw simpleError('failed_to_resolve_apikey_policy_scope', 'Failed to resolve API key policy scope', { supabaseError: error })
+  }
 
   for (const app of apps ?? []) {
     if (app.owner_org) {

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1550,6 +1550,7 @@ export async function resolveApikeyPolicyOrgIds(
   options: {
     limitedToApps?: string[] | null
     limitedToOrgs?: string[] | null
+    policyLookupSupabase?: SupabaseClient<Database>
   },
 ): Promise<string[]> {
   const orgIds = new Set((options.limitedToOrgs ?? []).filter(Boolean))
@@ -1559,24 +1560,39 @@ export async function resolveApikeyPolicyOrgIds(
     return [...orgIds]
   }
 
-  const { data: apps, error } = await supabase
-    .from('apps')
-    .select('app_id, owner_org')
-    .in('app_id', limitedToApps)
-
-  if (error) {
-    throw simpleError('failed_to_resolve_apikey_policy_scope', 'Failed to resolve API key policy scope', { supabaseError: error })
-  }
-
   const resolvedAppIds = new Set<string>()
-  for (const app of apps ?? []) {
-    if (!app.app_id || !app.owner_org)
-      continue
-    resolvedAppIds.add(app.app_id)
-    orgIds.add(app.owner_org)
+
+  async function addResolvedApps(client: SupabaseClient<Database>, appIds: string[]) {
+    if (appIds.length === 0) {
+      return
+    }
+
+    const { data: apps, error } = await client
+      .from('apps')
+      .select('app_id, owner_org')
+      .in('app_id', appIds)
+
+    if (error) {
+      throw simpleError('failed_to_resolve_apikey_policy_scope', 'Failed to resolve API key policy scope', { supabaseError: error })
+    }
+
+    for (const app of apps ?? []) {
+      if (!app.app_id || !app.owner_org)
+        continue
+      resolvedAppIds.add(app.app_id)
+      orgIds.add(app.owner_org)
+    }
   }
 
-  const unresolvedAppIds = limitedToApps.filter(appId => !resolvedAppIds.has(appId))
+  await addResolvedApps(supabase, limitedToApps)
+
+  let unresolvedAppIds = limitedToApps.filter(appId => !resolvedAppIds.has(appId))
+  if (unresolvedAppIds.length > 0 && options.policyLookupSupabase) {
+    // Hidden apps still need owner-org policy enforcement even when caller RLS cannot see them.
+    await addResolvedApps(options.policyLookupSupabase, unresolvedAppIds)
+    unresolvedAppIds = unresolvedAppIds.filter(appId => !resolvedAppIds.has(appId))
+  }
+
   if (unresolvedAppIds.length > 0) {
     throw simpleError('failed_to_resolve_apikey_policy_scope', 'Failed to resolve API key policy scope', { unresolvedAppIds })
   }

--- a/supabase/migrations/20260427105838_enforce_apikey_expiration_policy.sql
+++ b/supabase/migrations/20260427105838_enforce_apikey_expiration_policy.sql
@@ -1,0 +1,66 @@
+CREATE OR REPLACE FUNCTION public.enforce_apikey_expiration_policy()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  scoped_org RECORD;
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND NEW.expires_at IS NOT DISTINCT FROM OLD.expires_at
+    AND NEW.limited_to_orgs IS NOT DISTINCT FROM OLD.limited_to_orgs
+    AND NEW.limited_to_apps IS NOT DISTINCT FROM OLD.limited_to_apps THEN
+    RETURN NEW;
+  END IF;
+
+  FOR scoped_org IN
+    WITH scope_orgs AS (
+      SELECT unnest(COALESCE(NEW.limited_to_orgs, '{}'::uuid[])) AS org_id
+      UNION
+      SELECT public.apps.owner_org
+      FROM public.apps
+      WHERE public.apps.app_id = ANY(COALESCE(NEW.limited_to_apps, '{}'::text[]))
+    )
+    SELECT
+      public.orgs.id,
+      public.orgs.require_apikey_expiration,
+      public.orgs.max_apikey_expiration_days
+    FROM public.orgs
+    JOIN scope_orgs ON scope_orgs.org_id = public.orgs.id
+  LOOP
+    IF scoped_org.require_apikey_expiration AND NEW.expires_at IS NULL THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = 'expiration_required',
+        DETAIL = 'This organization requires API keys to have an expiration date';
+    END IF;
+
+    IF scoped_org.max_apikey_expiration_days IS NOT NULL
+      AND NEW.expires_at IS NOT NULL
+      AND NEW.expires_at > clock_timestamp()
+        + make_interval(days => scoped_org.max_apikey_expiration_days) THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = 'expiration_exceeds_max',
+        DETAIL = format(
+          'API key expiration cannot exceed %s days for this organization',
+          scoped_org.max_apikey_expiration_days
+        );
+    END IF;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.enforce_apikey_expiration_policy() OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.enforce_apikey_expiration_policy() FROM public;
+
+DROP TRIGGER IF EXISTS apikeys_enforce_expiration_policy ON public.apikeys;
+
+CREATE TRIGGER apikeys_enforce_expiration_policy
+BEFORE INSERT OR UPDATE ON public.apikeys
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_apikey_expiration_policy();

--- a/tests/apikeys-expiration.test.ts
+++ b/tests/apikeys-expiration.test.ts
@@ -400,6 +400,71 @@ describe('organization API key expiration policy', () => {
     expect(data.error).toBe('expiration_exceeds_max')
   })
 
+  it('fail to update api key scope to app owner org without expiration (scope-change regression)', async () => {
+    const createResponse = await apiFetch('/apikey', {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-app-scope-update',
+      }),
+    })
+    expect(createResponse.status).toBe(200)
+    const createdKey = await createResponse.json<{ id: number }>()
+
+    const updateResponse = await apiFetch(`/apikey/${createdKey.id}`, {
+      method: 'PUT',
+      headers: authHeaders,
+      body: JSON.stringify({
+        limited_to_apps: [POLICY_APPNAME],
+      }),
+    })
+    const data = await updateResponse.json() as { error: string }
+
+    expect(updateResponse.status).toBe(400)
+    expect(data.error).toBe('expiration_required')
+  })
+
+  it('reject limited app-scoped api keys from updating sibling keys', async () => {
+    const validDate = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString()
+    const limitedKeyResponse = await apiFetch('/apikey', {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-limited-updater',
+        limited_to_apps: [POLICY_APPNAME],
+        expires_at: validDate,
+      }),
+    })
+    expect(limitedKeyResponse.status).toBe(200)
+    const limitedKey = await limitedKeyResponse.json<{ key: string }>()
+
+    const siblingKeyResponse = await apiFetch('/apikey', {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-sibling-target',
+      }),
+    })
+    expect(siblingKeyResponse.status).toBe(200)
+    const siblingKey = await siblingKeyResponse.json<{ id: number }>()
+
+    const limitedAuthHeaders = {
+      'Content-Type': 'application/json',
+      'Authorization': limitedKey.key,
+    }
+    const updateResponse = await apiFetch(`/apikey/${siblingKey.id}`, {
+      method: 'PUT',
+      headers: limitedAuthHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-escalation-attempt',
+      }),
+    })
+    const data = await updateResponse.json() as { error: string }
+
+    expect(updateResponse.status).toBe(401)
+    expect(data.error).toBe('cannot_update_apikey')
+  })
+
   it('reject direct apikey inserts that bypass app-scoped expiration policy', async () => {
     const supabase = createAuthenticatedSupabaseClient(authHeaders)
     const { data, error } = await supabase

--- a/tests/apikeys-expiration.test.ts
+++ b/tests/apikeys-expiration.test.ts
@@ -400,6 +400,21 @@ describe('organization API key expiration policy', () => {
     expect(data.error).toBe('expiration_exceeds_max')
   })
 
+  it('fail to create app-scoped api key for unknown app ids', async () => {
+    const response = await apiFetch('/apikey', {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-app-scope-missing-app',
+        limited_to_apps: [`com.app.expiration.missing.${id}`],
+      }),
+    })
+    const data = await response.json() as { error: string }
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('failed_to_resolve_apikey_policy_scope')
+  })
+
   it('fail to update api key scope to app owner org without expiration (scope-change regression)', async () => {
     const createResponse = await apiFetch('/apikey', {
       method: 'POST',
@@ -472,7 +487,7 @@ describe('organization API key expiration policy', () => {
       .insert({
         user_id: USER_ID,
         key: null,
-        key_hash: null,
+        key_hash: '0'.repeat(64),
         mode: 'all',
         name: 'direct-insert-policy-bypass',
         limited_to_apps: [POLICY_APPNAME],

--- a/tests/apikeys-expiration.test.ts
+++ b/tests/apikeys-expiration.test.ts
@@ -1,18 +1,44 @@
+import type { Database } from '../src/types/supabase.types'
 import { randomUUID } from 'node:crypto'
+import { env } from 'node:process'
+import { createClient } from '@supabase/supabase-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, fetchWithRetry, getAuthHeaders, getSupabaseClient, ORG_ID, resetAndSeedAppData, resetAppData, TEST_EMAIL, USER_ID } from './test-utils.ts'
+import { BASE_URL, fetchWithRetry, getAuthHeaders, getSupabaseClient, normalizeLocalhostUrl, ORG_ID, resetAndSeedAppData, resetAppData, TEST_EMAIL, USER_ID } from './test-utils.ts'
 
 const id = randomUUID()
 const APPNAME = `com.app.expiration.${id}`
+const POLICY_APPNAME = `com.app.expiration.policy.${id}`
 
 // Org for testing expiration policies
 const POLICY_ORG_ID = randomUUID()
 const POLICY_ORG_CUSTOMER_ID = `cus_test_policy_${id}`
 const POLICY_ORG_NAME = `Test Policy Org ${id}`
 let authHeaders: Record<string, string>
+let policyAppUuid: string
 
 function apiFetch(path: string, init?: RequestInit) {
   return fetchWithRetry(`${BASE_URL}${path}`, init)
+}
+
+function createAuthenticatedSupabaseClient(headers: Record<string, string>) {
+  const supabaseUrl = normalizeLocalhostUrl(env.SUPABASE_URL)
+  const supabaseAnonKey = env.SUPABASE_ANON_KEY
+  const authorization = headers.Authorization ?? headers.authorization
+
+  if (!supabaseUrl || !supabaseAnonKey || !authorization) {
+    throw new Error('Missing Supabase auth environment for authenticated client')
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: {
+        Authorization: authorization,
+      },
+    },
+    auth: {
+      persistSession: false,
+    },
+  })
 }
 
 beforeAll(async () => {
@@ -42,10 +68,28 @@ beforeAll(async () => {
   })
   if (orgError)
     throw orgError
+
+  await resetAndSeedAppData(POLICY_APPNAME, {
+    orgId: POLICY_ORG_ID,
+    stripeCustomerId: POLICY_ORG_CUSTOMER_ID,
+    userId: USER_ID,
+  })
+
+  const { data: policyApp, error: policyAppError } = await getSupabaseClient()
+    .from('apps')
+    .select('id')
+    .eq('app_id', POLICY_APPNAME)
+    .single()
+
+  if (policyAppError || !policyApp?.id)
+    throw policyAppError ?? new Error('Missing policy app')
+
+  policyAppUuid = policyApp.id
 })
 
 afterAll(async () => {
   await resetAppData(APPNAME)
+  await resetAppData(POLICY_APPNAME)
   // Clean up policy org
   await getSupabaseClient().from('orgs').delete().eq('id', POLICY_ORG_ID)
   await getSupabaseClient().from('stripe_info').delete().eq('customer_id', POLICY_ORG_CUSTOMER_ID)
@@ -324,6 +368,72 @@ describe('organization API key expiration policy', () => {
     expect(response.status).toBe(200)
     expect(data).toHaveProperty('key')
     // Should succeed even without expiration since org doesn't require it
+  })
+
+  it('fail to create app-scoped api key without expiration for org requiring expiration', async () => {
+    const response = await apiFetch('/apikey', {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-app-scope',
+        app_id: policyAppUuid,
+      }),
+    })
+    const data = await response.json() as { error: string }
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('expiration_required')
+  })
+
+  it('fail to create app-scoped api key with expiration exceeding org max days', async () => {
+    const tooFarDate = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString()
+    const response = await apiFetch('/apikey', {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        name: 'key-policy-app-scope-too-far',
+        limited_to_apps: [POLICY_APPNAME],
+        expires_at: tooFarDate,
+      }),
+    })
+    const data = await response.json() as { error: string }
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('expiration_exceeds_max')
+  })
+
+  it('reject direct apikey inserts that bypass app-scoped expiration policy', async () => {
+    const supabase = createAuthenticatedSupabaseClient(authHeaders)
+    const { data, error } = await supabase
+      .from('apikeys')
+      .insert({
+        user_id: USER_ID,
+        key: null,
+        key_hash: null,
+        mode: 'all',
+        name: 'direct-insert-policy-bypass',
+        limited_to_apps: [POLICY_APPNAME],
+        limited_to_orgs: [],
+        expires_at: null,
+      })
+      .select()
+      .single()
+
+    expect(data).toBeNull()
+    expect(error?.message).toBe('expiration_required')
+  })
+
+  it('reject hashed apikey RPC creation that exceeds app owner org max expiration', async () => {
+    const supabase = createAuthenticatedSupabaseClient(authHeaders)
+    const tooFarDate = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString()
+    const { data, error } = await supabase.rpc('create_hashed_apikey', {
+      p_mode: 'all',
+      p_name: 'direct-rpc-policy-bypass',
+      p_limited_to_orgs: [],
+      p_limited_to_apps: [POLICY_APPNAME],
+      p_expires_at: tooFarDate,
+    })
+
+    expect(data).toBeNull()
+    expect(error?.message).toBe('expiration_exceeds_max')
   })
 })
 


### PR DESCRIPTION
## Summary (AI generated)

- enforce API key expiration policy for app-scoped keys created through `POST /apikey`
- validate expiration policy when API key scopes are updated through `PUT /apikey/:id`
- add a database trigger to block direct insert and hashed-key RPC bypasses
- add regression coverage for app-scoped, direct insert, and hashed RPC creation paths

## Motivation (AI generated)

`POST /apikey` could create app-scoped API keys without applying the owner organization's expiration policy when the request used `app_id` or `limited_to_apps` without explicitly scoping to an organization. That bypass weakened org-level key rotation controls and left a second bypass through direct table writes and the hashed key RPC.

## Business Impact (AI generated)

This closes a high-severity policy bypass that allowed long-lived or permanent API keys to be created inside organizations that explicitly require expiring keys. It improves tenant security controls, reduces incident-response risk, and preserves trust in org-level security settings.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx eslint tests/apikeys-expiration.test.ts`
- [x] `bunx sqlfluff lint supabase/migrations/20260427105838_enforce_apikey_expiration_policy.sql --dialect postgres`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/apikeys-expiration.test.ts --hookTimeout=60000 --testTimeout=60000`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key expiration policies are now enforced on create/update, including both organization- and application-scoped keys; violations are rejected.
  * Enforcement is enforced at the database level to prevent bypass via direct inserts or RPCs.

* **Tests**
  * Added comprehensive tests covering org- and app-scoped policy scenarios, bypass attempts, and privilege escalation prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->