### PR TITLE
feat(api): precompute manifest payloads for updates

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -250,6 +250,35 @@ export type Database = {
           },
         ]
       }
+      app_version_manifest_cache: {
+        Row: {
+          app_version_id: number
+          created_at: string
+          entries: Json
+          updated_at: string
+        }
+        Insert: {
+          app_version_id: number
+          created_at?: string
+          entries?: Json
+          updated_at?: string
+        }
+        Update: {
+          app_version_id?: number
+          created_at?: string
+          entries?: Json
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "app_version_manifest_cache_app_version_id_fkey"
+            columns: ["app_version_id"]
+            isOneToOne: true
+            referencedRelation: "app_versions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       apps: {
         Row: {
           allow_device_custom_id: boolean

--- a/supabase/functions/_backend/public/app/demo.ts
+++ b/supabase/functions/_backend/public/app/demo.ts
@@ -1,13 +1,9 @@
 import type { Context } from 'hono'
 import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
-import { eq, sql } from 'drizzle-orm'
 import { lockOnboardingApp, unlockOnboardingApp } from '../../utils/demo.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { cloudlog } from '../../utils/logging.ts'
-import { buildManifestCacheEntries } from '../../utils/manifestCache.ts'
-import { closeClient, getDrizzleClient, getPgClient } from '../../utils/pg.ts'
-import { app_version_manifest_cache, apps, manifest as manifestTable } from '../../utils/postgres_schema.ts'
 import { hasOrgRight, supabaseAdmin, updateOrCreateChannel } from '../../utils/supabase.ts'
 
 /** Request body for creating a demo app */
@@ -36,6 +32,14 @@ interface DemoManifestEntry {
   s3_path: string
   file_hash: string
   file_size: number
+}
+
+function toManifestPayload(entries: DemoManifestEntry[]): Database['public']['CompositeTypes']['manifest_entry'][] {
+  return entries.map(({ file_name, s3_path, file_hash }) => ({
+    file_name,
+    s3_path,
+    file_hash,
+  }))
 }
 
 /**
@@ -351,7 +355,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
 
     // RLS bypass needed: Demo app creation inserts into multiple tables (apps, app_versions,
     // channels, devices, daily_mau, daily_bandwidth, daily_storage, daily_version, build_requests,
-    // manifest, deploy_history) where RLS policies may not grant direct user insert access.
+    // deploy_history) where RLS policies may not grant direct user insert access.
     // Authorization is enforced at endpoint level via hasOrgRight check above.
 
     // Create the demo app
@@ -372,6 +376,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
     const versionInserts = demoVersions.map((v) => {
       const isSystemVersion = v.name === 'unknown' || v.name === 'builtin'
       const manifest = isSystemVersion ? null : getDemoManifest(v.name, appId)
+      const manifestPayload = manifest ? toManifestPayload(manifest) : null
       const nativePackages = isSystemVersion ? null : getDemoNativePackages(v.name)
 
       return {
@@ -383,9 +388,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
         comment: v.comment,
         link: v.link,
         user_id: auth.userId,
-        // Demo seeding writes manifest rows and cache directly below.
-        manifest: null,
-        manifest_count: manifest?.length ?? 0,
+        manifest: manifestPayload,
         native_packages: nativePackages as any,
       }
     })
@@ -415,77 +418,6 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
     }
 
     const versionMap = new Map(allVersions.map(v => [v.name, v.id]))
-
-    // Insert manifest entries into the manifest table for each version
-    // This is required for the bundle file list to show in the UI
-    const manifestInserts: (typeof manifestTable.$inferInsert)[] = []
-    const manifestCacheInserts: (typeof app_version_manifest_cache.$inferInsert)[] = []
-
-    for (const version of demoVersions) {
-      if (version.name === 'unknown' || version.name === 'builtin')
-        continue
-
-      const versionId = versionMap.get(version.name)
-      if (!versionId)
-        continue
-
-      const manifestEntries = getDemoManifest(version.name, appId)
-      manifestCacheInserts.push({
-        app_version_id: versionId,
-        entries: buildManifestCacheEntries(manifestEntries),
-      })
-      for (const entry of manifestEntries) {
-        manifestInserts.push({
-          app_version_id: versionId,
-          file_name: entry.file_name,
-          file_hash: entry.file_hash,
-          s3_path: entry.s3_path,
-          file_size: entry.file_size,
-        })
-      }
-    }
-
-    if (manifestInserts.length > 0 || manifestCacheInserts.length > 0) {
-      const pgClient = getPgClient(c, false)
-      const drizzle = getDrizzleClient(pgClient)
-      try {
-        await drizzle.transaction(async (tx) => {
-          if (manifestInserts.length > 0)
-            await tx.insert(manifestTable).values(manifestInserts)
-
-          if (manifestCacheInserts.length > 0) {
-            await tx
-              .insert(app_version_manifest_cache)
-              .values(manifestCacheInserts)
-              .onConflictDoUpdate({
-                target: app_version_manifest_cache.app_version_id,
-                set: {
-                  entries: sql`excluded.entries`,
-                  updated_at: sql`now()`,
-                },
-              })
-
-            await tx
-              .update(apps)
-              .set({ manifest_bundle_count: manifestCacheInserts.length })
-              .where(eq(apps.app_id, appId))
-          }
-        })
-        cloudlog({
-          requestId,
-          message: 'Manifest entries and cache created',
-          manifestCount: manifestInserts.length,
-          manifestBundleCount: manifestCacheInserts.length,
-        })
-      }
-      catch (error) {
-        cloudlog({ requestId, message: 'Error creating manifest data', error })
-        throw simpleError('cannot_seed_manifest', 'Cannot seed manifest data', { error })
-      }
-      finally {
-        await closeClient(c, pgClient)
-      }
-    }
 
     // Demo channels configuration
     const demoChannels: DemoChannel[] = [

--- a/supabase/functions/_backend/public/app/demo.ts
+++ b/supabase/functions/_backend/public/app/demo.ts
@@ -1,9 +1,13 @@
 import type { Context } from 'hono'
 import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
+import { eq, sql } from 'drizzle-orm'
 import { lockOnboardingApp, unlockOnboardingApp } from '../../utils/demo.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { cloudlog } from '../../utils/logging.ts'
+import { buildManifestCacheEntries } from '../../utils/manifestCache.ts'
+import { closeClient, getDrizzleClient, getPgClient } from '../../utils/pg.ts'
+import { app_version_manifest_cache, apps, manifest as manifestTable } from '../../utils/postgres_schema.ts'
 import { hasOrgRight, supabaseAdmin, updateOrCreateChannel } from '../../utils/supabase.ts'
 
 /** Request body for creating a demo app */
@@ -364,7 +368,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
       { name: '1.2.0', daysAgo: 1, comment: 'New dashboard features', link: 'https://github.com/example/demo-app/pull/123' },
     ]
 
-    // Create all versions with manifest and native_packages for real versions
+    // Create all versions with precomputed manifest counts and native_packages.
     const versionInserts = demoVersions.map((v) => {
       const isSystemVersion = v.name === 'unknown' || v.name === 'builtin'
       const manifest = isSystemVersion ? null : getDemoManifest(v.name, appId)
@@ -379,8 +383,8 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
         comment: v.comment,
         link: v.link,
         user_id: auth.userId,
-        // Add manifest and native_packages for non-system versions
-        manifest: manifest as any,
+        // Demo seeding writes manifest rows and cache directly below.
+        manifest: null,
         manifest_count: manifest?.length ?? 0,
         native_packages: nativePackages as any,
       }
@@ -414,8 +418,8 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
 
     // Insert manifest entries into the manifest table for each version
     // This is required for the bundle file list to show in the UI
-    const manifestInserts: Database['public']['Tables']['manifest']['Insert'][] = []
-    const manifestCacheInserts: Database['public']['Tables']['app_version_manifest_cache']['Insert'][] = []
+    const manifestInserts: (typeof manifestTable.$inferInsert)[] = []
+    const manifestCacheInserts: (typeof app_version_manifest_cache.$inferInsert)[] = []
 
     for (const version of demoVersions) {
       if (version.name === 'unknown' || version.name === 'builtin')
@@ -428,11 +432,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
       const manifestEntries = getDemoManifest(version.name, appId)
       manifestCacheInserts.push({
         app_version_id: versionId,
-        entries: manifestEntries.map(entry => ({
-          file_name: entry.file_name,
-          file_hash: entry.file_hash,
-          s3_path: entry.s3_path,
-        })) as unknown as Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries'],
+        entries: buildManifestCacheEntries(manifestEntries),
       })
       for (const entry of manifestEntries) {
         manifestInserts.push({
@@ -445,26 +445,46 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
       }
     }
 
-    if (manifestInserts.length > 0) {
-      const { error: manifestError } = await supabase
-        .from('manifest')
-        .insert(manifestInserts)
+    if (manifestInserts.length > 0 || manifestCacheInserts.length > 0) {
+      const pgClient = getPgClient(c, false)
+      const drizzle = getDrizzleClient(pgClient)
+      try {
+        await drizzle.transaction(async (tx) => {
+          if (manifestInserts.length > 0)
+            await tx.insert(manifestTable).values(manifestInserts)
 
-      if (manifestError) {
-        cloudlog({ requestId, message: 'Error creating manifest entries', error: manifestError })
+          if (manifestCacheInserts.length > 0) {
+            await tx
+              .insert(app_version_manifest_cache)
+              .values(manifestCacheInserts)
+              .onConflictDoUpdate({
+                target: app_version_manifest_cache.app_version_id,
+                set: {
+                  entries: sql`excluded.entries`,
+                  updated_at: sql`now()`,
+                },
+              })
+
+            await tx
+              .update(apps)
+              .set({ manifest_bundle_count: manifestCacheInserts.length })
+              .where(eq(apps.app_id, appId))
+          }
+        })
+        cloudlog({
+          requestId,
+          message: 'Manifest entries and cache created',
+          manifestCount: manifestInserts.length,
+          manifestBundleCount: manifestCacheInserts.length,
+        })
       }
-      else {
-        cloudlog({ requestId, message: 'Manifest entries created', count: manifestInserts.length })
+      catch (error) {
+        cloudlog({ requestId, message: 'Error creating manifest data', error })
+        throw simpleError('cannot_seed_manifest', 'Cannot seed manifest data', { error })
       }
-    }
-
-    if (manifestCacheInserts.length > 0) {
-      const { error: manifestCacheError } = await supabase
-        .from('app_version_manifest_cache')
-        .upsert(manifestCacheInserts, { onConflict: 'app_version_id' })
-
-      if (manifestCacheError)
-        cloudlog({ requestId, message: 'Error creating manifest cache rows', error: manifestCacheError })
+      finally {
+        await closeClient(c, pgClient)
+      }
     }
 
     // Demo channels configuration

--- a/supabase/functions/_backend/public/app/demo.ts
+++ b/supabase/functions/_backend/public/app/demo.ts
@@ -415,6 +415,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
     // Insert manifest entries into the manifest table for each version
     // This is required for the bundle file list to show in the UI
     const manifestInserts: Database['public']['Tables']['manifest']['Insert'][] = []
+    const manifestCacheInserts: Database['public']['Tables']['app_version_manifest_cache']['Insert'][] = []
 
     for (const version of demoVersions) {
       if (version.name === 'unknown' || version.name === 'builtin')
@@ -425,6 +426,14 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
         continue
 
       const manifestEntries = getDemoManifest(version.name, appId)
+      manifestCacheInserts.push({
+        app_version_id: versionId,
+        entries: manifestEntries.map(entry => ({
+          file_name: entry.file_name,
+          file_hash: entry.file_hash,
+          s3_path: entry.s3_path,
+        })) as unknown as Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries'],
+      })
       for (const entry of manifestEntries) {
         manifestInserts.push({
           app_version_id: versionId,
@@ -447,6 +456,15 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
       else {
         cloudlog({ requestId, message: 'Manifest entries created', count: manifestInserts.length })
       }
+    }
+
+    if (manifestCacheInserts.length > 0) {
+      const { error: manifestCacheError } = await supabase
+        .from('app_version_manifest_cache')
+        .upsert(manifestCacheInserts, { onConflict: 'app_version_id' })
+
+      if (manifestCacheError)
+        cloudlog({ requestId, message: 'Error creating manifest cache rows', error: manifestCacheError })
     }
 
     // Demo channels configuration

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -8,7 +8,7 @@ import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { buildManifestCacheEntries, compactManifestCacheEntries } from '../utils/manifestCache.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
-import { apps, manifest } from '../utils/postgres_schema.ts'
+import { app_version_manifest_cache, apps, manifest } from '../utils/postgres_schema.ts'
 import { getPath, s3 } from '../utils/s3.ts'
 import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
@@ -93,6 +93,8 @@ async function upsertManifestCache(c: Context, appVersionId: number, entries: Ma
 
   if (cacheError)
     cloudlog({ requestId: c.get('requestId'), message: 'error upsert manifest cache', error: cacheError, appVersionId })
+
+  return !cacheError
 }
 
 async function deleteManifestCache(c: Context, appVersionId: number) {
@@ -119,8 +121,10 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     .from('manifest')
     .select('file_name, file_hash, s3_path')
     .eq('app_version_id', record.id)
-  if (existingEntriesError)
+  if (existingEntriesError) {
     cloudlog({ requestId: c.get('requestId'), message: 'error get manifest entries', error: existingEntriesError, appVersionId: record.id })
+    return
+  }
 
   const compactEntries = compactManifestCacheEntries(manifestEntries)
   const validEntries: (typeof manifest.$inferInsert)[] = compactEntries
@@ -134,6 +138,7 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
 
   // Only create entries if none exist
   let hasManifestRows = Boolean(existingEntries?.length)
+  let cachePersisted = false
   if (!existingEntries?.length && validEntries.length > 0) {
     const pgClient = getPgClient(c, false)
     const drizzleClient = getDrizzleClient(pgClient)
@@ -148,8 +153,22 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
             updated_at: sql`now()`,
           })
           .where(eq(apps.app_id, record.app_id))
+        await tx
+          .insert(app_version_manifest_cache)
+          .values({
+            app_version_id: record.id,
+            entries: buildManifestCacheEntries(compactEntries),
+          })
+          .onConflictDoUpdate({
+            target: app_version_manifest_cache.app_version_id,
+            set: {
+              entries: sql`excluded.entries`,
+              updated_at: sql`now()`,
+            },
+          })
       })
       hasManifestRows = true
+      cachePersisted = true
     }
     catch (error) {
       cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest transaction', error, appVersionId: record.id, appId: record.app_id })
@@ -163,10 +182,10 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     ? compactEntries
     : compactManifestCacheEntries(existingEntries ?? [])
 
-  if (hasManifestRows && cacheEntries.length > 0)
-    await upsertManifestCache(c, record.id, cacheEntries)
+  if (hasManifestRows && cacheEntries.length > 0 && !cachePersisted)
+    cachePersisted = await upsertManifestCache(c, record.id, cacheEntries)
 
-  if (record.manifest !== null) {
+  if (record.manifest !== null && (cachePersisted || cacheEntries.length === 0)) {
     // Clear the staging payload once rows and cache are materialized.
     const { error: deleteError } = await supabaseAdmin(c)
       .from('app_versions')

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -1,22 +1,18 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { ManifestCacheEntry } from '../utils/manifestCache.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { buildManifestCacheEntries, compactManifestCacheEntries } from '../utils/manifestCache.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { manifest } from '../utils/postgres_schema.ts'
 import { getPath, s3 } from '../utils/s3.ts'
 import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { backgroundTask } from '../utils/utils.ts'
-
-interface ManifestCacheEntry {
-  file_name: string
-  file_hash: string
-  s3_path: string
-}
 
 /**
  * Resolves `owner_org` for an app version row.
@@ -85,20 +81,12 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
   return true
 }
 
-function buildManifestCacheEntries(entries: ManifestCacheEntry[]): Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries'] {
-  return entries.map(entry => ({
-    file_name: entry.file_name,
-    file_hash: entry.file_hash,
-    s3_path: entry.s3_path,
-  })) as unknown as Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries']
-}
-
 async function upsertManifestCache(c: Context, appVersionId: number, entries: ManifestCacheEntry[]) {
   const { error: cacheError } = await supabaseAdmin(c)
     .from('app_version_manifest_cache')
     .upsert({
       app_version_id: appVersionId,
-      entries: buildManifestCacheEntries(entries),
+      entries: buildManifestCacheEntries(entries) as unknown as Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries'],
     }, {
       onConflict: 'app_version_id',
     })
@@ -122,22 +110,25 @@ async function deleteManifestCache(c: Context, appVersionId: number) {
  */
 async function handleManifest(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   cloudlog({ requestId: c.get('requestId'), message: 'manifest', manifest: record.manifest })
-  const manifestEntries = record.manifest as Database['public']['CompositeTypes']['manifest_entry'][]
+  const manifestEntries = Array.isArray(record.manifest)
+    ? record.manifest as Database['public']['CompositeTypes']['manifest_entry'][]
+    : []
 
   // Check if entries exist
-  const { data: existingEntries } = await supabaseAdmin(c)
+  const { data: existingEntries, error: existingEntriesError } = await supabaseAdmin(c)
     .from('manifest')
-    .select('id')
+    .select('file_name, file_hash, s3_path')
     .eq('app_version_id', record.id)
-    .limit(1)
+  if (existingEntriesError)
+    cloudlog({ requestId: c.get('requestId'), message: 'error get manifest entries', error: existingEntriesError, appVersionId: record.id })
 
-  const validEntries = manifestEntries
-    .filter(entry => entry.file_name && entry.file_hash && entry.s3_path)
+  const compactEntries = compactManifestCacheEntries(manifestEntries)
+  const validEntries = compactEntries
     .map(entry => ({
       app_version_id: record.id,
-      file_name: entry.file_name!,
-      file_hash: entry.file_hash!,
-      s3_path: entry.s3_path!,
+      file_name: entry.file_name,
+      file_hash: entry.file_hash,
+      s3_path: entry.s3_path,
       file_size: 0,
     }))
 
@@ -180,21 +171,22 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     }
   }
 
-  if (hasManifestRows && validEntries.length > 0) {
-    await upsertManifestCache(c, record.id, validEntries.map(entry => ({
-      file_name: entry.file_name,
-      file_hash: entry.file_hash,
-      s3_path: entry.s3_path,
-    })))
-  }
+  const cacheEntries = compactEntries.length > 0
+    ? compactEntries
+    : compactManifestCacheEntries(existingEntries ?? [])
 
-  // delete manifest in app_versions
-  const { error: deleteError } = await supabaseAdmin(c)
-    .from('app_versions')
-    .update({ manifest: null })
-    .eq('id', record.id)
-  if (deleteError)
-    cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
+  if (hasManifestRows && cacheEntries.length > 0)
+    await upsertManifestCache(c, record.id, cacheEntries)
+
+  if (record.manifest !== null) {
+    // Clear the staging payload once rows and cache are materialized.
+    const { error: deleteError } = await supabaseAdmin(c)
+      .from('app_versions')
+      .update({ manifest: null })
+      .eq('id', record.id)
+    if (deleteError)
+      cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
+  }
 }
 
 /**
@@ -232,7 +224,7 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
   }
 
   // Handle manifest entries
-  if (record.manifest) {
+  if (record.manifest || record.manifest_count) {
     await handleManifest(c, record)
   }
 
@@ -389,7 +381,7 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
     cloudlog({ requestId: c.get('requestId'), message: 'no app_id', record })
     return c.json(BRES)
   }
-  if (!record.r2_path && !record.manifest) {
+  if (!record.r2_path && !record.manifest && !record.manifest_count) {
     cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', record })
     return c.json(BRES)
   }

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -2,13 +2,13 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { ManifestCacheEntry } from '../utils/manifestCache.ts'
 import type { Database } from '../utils/supabase.types.ts'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { buildManifestCacheEntries, compactManifestCacheEntries } from '../utils/manifestCache.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
-import { manifest } from '../utils/postgres_schema.ts'
+import { apps, manifest } from '../utils/postgres_schema.ts'
 import { getPath, s3 } from '../utils/s3.ts'
 import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
@@ -123,7 +123,7 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     cloudlog({ requestId: c.get('requestId'), message: 'error get manifest entries', error: existingEntriesError, appVersionId: record.id })
 
   const compactEntries = compactManifestCacheEntries(manifestEntries)
-  const validEntries = compactEntries
+  const validEntries: (typeof manifest.$inferInsert)[] = compactEntries
     .map(entry => ({
       app_version_id: record.id,
       file_name: entry.file_name,
@@ -135,39 +135,27 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
   // Only create entries if none exist
   let hasManifestRows = Boolean(existingEntries?.length)
   if (!existingEntries?.length && validEntries.length > 0) {
-    const { error: insertError } = await supabaseAdmin(c)
-      .from('manifest')
-      .insert(validEntries)
-    if (insertError) {
-      cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest', error: insertError })
-    }
-    else {
+    const pgClient = getPgClient(c, false)
+    const drizzleClient = getDrizzleClient(pgClient)
+    try {
+      await drizzleClient.transaction(async (tx) => {
+        await tx.insert(manifest).values(validEntries)
+        await tx.execute(sql`UPDATE app_versions SET manifest_count = ${validEntries.length} WHERE id = ${record.id}`)
+        await tx
+          .update(apps)
+          .set({
+            manifest_bundle_count: sql`${apps.manifest_bundle_count} + 1`,
+            updated_at: sql`now()`,
+          })
+          .where(eq(apps.app_id, record.app_id))
+      })
       hasManifestRows = true
-      // Update manifest_count on the version
-      const { error: countError } = await supabaseAdmin(c)
-        .from('app_versions')
-        .update({ manifest_count: validEntries.length })
-        .eq('id', record.id)
-      if (countError)
-        cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_count', error: countError })
-
-      // Increment manifest_bundle_count on the app using raw SQL
-      const pgClient = getPgClient(c, false)
-      try {
-        await pgClient.query(
-          `UPDATE apps
-           SET manifest_bundle_count = manifest_bundle_count + 1,
-               updated_at = now()
-           WHERE app_id = $1`,
-          [record.app_id],
-        )
-      }
-      catch (error) {
-        cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_bundle_count', error })
-      }
-      finally {
-        await closeClient(c, pgClient)
-      }
+    }
+    catch (error) {
+      cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest transaction', error, appVersionId: record.id, appId: record.app_id })
+    }
+    finally {
+      await closeClient(c, pgClient)
     }
   }
 

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -12,6 +12,12 @@ import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { backgroundTask } from '../utils/utils.ts'
 
+interface ManifestCacheEntry {
+  file_name: string
+  file_hash: string
+  s3_path: string
+}
+
 /**
  * Resolves `owner_org` for an app version row.
  *
@@ -79,6 +85,38 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
   return true
 }
 
+function buildManifestCacheEntries(entries: ManifestCacheEntry[]): Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries'] {
+  return entries.map(entry => ({
+    file_name: entry.file_name,
+    file_hash: entry.file_hash,
+    s3_path: entry.s3_path,
+  })) as unknown as Database['public']['Tables']['app_version_manifest_cache']['Insert']['entries']
+}
+
+async function upsertManifestCache(c: Context, appVersionId: number, entries: ManifestCacheEntry[]) {
+  const { error: cacheError } = await supabaseAdmin(c)
+    .from('app_version_manifest_cache')
+    .upsert({
+      app_version_id: appVersionId,
+      entries: buildManifestCacheEntries(entries),
+    }, {
+      onConflict: 'app_version_id',
+    })
+
+  if (cacheError)
+    cloudlog({ requestId: c.get('requestId'), message: 'error upsert manifest cache', error: cacheError, appVersionId })
+}
+
+async function deleteManifestCache(c: Context, appVersionId: number) {
+  const { error: cacheDeleteError } = await supabaseAdmin(c)
+    .from('app_version_manifest_cache')
+    .delete()
+    .eq('app_version_id', appVersionId)
+
+  if (cacheDeleteError)
+    cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest cache', error: cacheDeleteError, appVersionId })
+}
+
 /**
  * Persists manifest rows and updates aggregate counters when a version includes a manifest payload.
  */
@@ -93,54 +131,63 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     .eq('app_version_id', record.id)
     .limit(1)
 
+  const validEntries = manifestEntries
+    .filter(entry => entry.file_name && entry.file_hash && entry.s3_path)
+    .map(entry => ({
+      app_version_id: record.id,
+      file_name: entry.file_name!,
+      file_hash: entry.file_hash!,
+      s3_path: entry.s3_path!,
+      file_size: 0,
+    }))
+
   // Only create entries if none exist
-  if (!existingEntries?.length && manifestEntries.length > 0) {
-    const validEntries = manifestEntries
-      .filter(entry => entry.file_name && entry.file_hash && entry.s3_path)
-      .map(entry => ({
-        app_version_id: record.id,
-        file_name: entry.file_name!,
-        file_hash: entry.file_hash!,
-        s3_path: entry.s3_path!,
-        file_size: 0,
-      }))
+  let hasManifestRows = Boolean(existingEntries?.length)
+  if (!existingEntries?.length && validEntries.length > 0) {
+    const { error: insertError } = await supabaseAdmin(c)
+      .from('manifest')
+      .insert(validEntries)
+    if (insertError) {
+      cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest', error: insertError })
+    }
+    else {
+      hasManifestRows = true
+      // Update manifest_count on the version
+      const { error: countError } = await supabaseAdmin(c)
+        .from('app_versions')
+        .update({ manifest_count: validEntries.length })
+        .eq('id', record.id)
+      if (countError)
+        cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_count', error: countError })
 
-    if (validEntries.length > 0) {
-      const { error: insertError } = await supabaseAdmin(c)
-        .from('manifest')
-        .insert(validEntries)
-      if (insertError) {
-        cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest', error: insertError })
+      // Increment manifest_bundle_count on the app using raw SQL
+      const pgClient = getPgClient(c, false)
+      try {
+        await pgClient.query(
+          `UPDATE apps
+           SET manifest_bundle_count = manifest_bundle_count + 1,
+               updated_at = now()
+           WHERE app_id = $1`,
+          [record.app_id],
+        )
       }
-      else {
-        // Update manifest_count on the version
-        const { error: countError } = await supabaseAdmin(c)
-          .from('app_versions')
-          .update({ manifest_count: validEntries.length })
-          .eq('id', record.id)
-        if (countError)
-          cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_count', error: countError })
-
-        // Increment manifest_bundle_count on the app using raw SQL
-        const pgClient = getPgClient(c, false)
-        try {
-          await pgClient.query(
-            `UPDATE apps
-             SET manifest_bundle_count = manifest_bundle_count + 1,
-                 updated_at = now()
-             WHERE app_id = $1`,
-            [record.app_id],
-          )
-        }
-        catch (error) {
-          cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_bundle_count', error })
-        }
-        finally {
-          await closeClient(c, pgClient)
-        }
+      catch (error) {
+        cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_bundle_count', error })
+      }
+      finally {
+        await closeClient(c, pgClient)
       }
     }
   }
+
+  if (hasManifestRows && validEntries.length > 0) {
+    await upsertManifestCache(c, record.id, validEntries.map(entry => ({
+      file_name: entry.file_name,
+      file_hash: entry.file_hash,
+      s3_path: entry.s3_path,
+    })))
+  }
+
   // delete manifest in app_versions
   const { error: deleteError } = await supabaseAdmin(c)
     .from('app_versions')
@@ -206,9 +253,9 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
       .from(manifest)
       .where(eq(manifest.app_version_id, record.id))
 
-    if (manifestEntries && manifestEntries.length > 0) {
-      const manifestCount = manifestEntries.length
+    const manifestCount = Math.max(record.manifest_count ?? 0, manifestEntries?.length ?? 0)
 
+    if (manifestEntries && manifestEntries.length > 0) {
       // Delete each file from S3
       const promisesDeleteS3 = []
       for (const entry of manifestEntries) {
@@ -252,7 +299,9 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
         }
       }
       await backgroundTask(c, Promise.all(promisesDeleteS3))
+    }
 
+    if (manifestCount > 0) {
       // After deleting manifest entries, update manifest_count and decrement manifest_bundle_count
       const updatePgClient = getPgClient(c, false)
       try {
@@ -261,16 +310,13 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
           [record.id],
         )
 
-        // Only decrement if this version had manifests
-        if (manifestCount > 0) {
-          await updatePgClient.query(
-            `UPDATE apps
-             SET manifest_bundle_count = GREATEST(manifest_bundle_count - 1, 0),
-                 updated_at = now()
-             WHERE app_id = $1`,
-            [record.app_id],
-          )
-        }
+        await updatePgClient.query(
+          `UPDATE apps
+           SET manifest_bundle_count = GREATEST(manifest_bundle_count - 1, 0),
+               updated_at = now()
+           WHERE app_id = $1`,
+          [record.app_id],
+        )
       }
       catch (error) {
         cloudlog({ requestId: c.get('requestId'), message: 'error update counters on delete', error })
@@ -286,6 +332,8 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
   finally {
     await closeClient(c, pgClient)
   }
+
+  await deleteManifestCache(c, record.id)
 }
 
 export async function deleteIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {

--- a/supabase/functions/_backend/utils/manifestCache.ts
+++ b/supabase/functions/_backend/utils/manifestCache.ts
@@ -23,6 +23,8 @@ export function compactManifestCacheEntries(entries: readonly ManifestCacheEntry
   })
 }
 
+// Semantic wrapper: callers use `compact` when they need normalized entries
+// in memory and `build` when they are constructing the persisted cache payload.
 export function buildManifestCacheEntries(entries: readonly ManifestCacheEntryLike[]): ManifestCacheEntry[] {
   return compactManifestCacheEntries(entries)
 }

--- a/supabase/functions/_backend/utils/manifestCache.ts
+++ b/supabase/functions/_backend/utils/manifestCache.ts
@@ -1,0 +1,28 @@
+export interface ManifestCacheEntryLike {
+  file_name: string | null | undefined
+  file_hash: string | null | undefined
+  s3_path: string | null | undefined
+}
+
+export interface ManifestCacheEntry {
+  file_name: string
+  file_hash: string
+  s3_path: string
+}
+
+export function compactManifestCacheEntries(entries: readonly ManifestCacheEntryLike[]): ManifestCacheEntry[] {
+  return entries.flatMap((entry) => {
+    if (!entry.file_name || !entry.file_hash || !entry.s3_path)
+      return []
+
+    return [{
+      file_name: entry.file_name,
+      file_hash: entry.file_hash,
+      s3_path: entry.s3_path,
+    }]
+  })
+}
+
+export function buildManifestCacheEntries(entries: readonly ManifestCacheEntryLike[]): ManifestCacheEntry[] {
+  return compactManifestCacheEntries(entries)
+}

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -401,13 +401,7 @@ function getSchemaUpdatesAlias(includeMetadata = false) {
     allow_device_self_set: channelAlias.allow_device_self_set,
     public: channelAlias.public,
   }
-  const manifestSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`COALESCE(json_agg(
-        json_build_object(
-          'file_name', ${schema.manifest.file_name},
-          'file_hash', ${schema.manifest.file_hash},
-          's3_path', ${schema.manifest.s3_path}
-        )
-      ) FILTER (WHERE ${schema.manifest.file_name} IS NOT NULL), '[]'::json)`
+  const manifestSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`COALESCE(${schema.app_version_manifest_cache.entries}, '[]'::jsonb)`
   return { versionSelect, channelDevicesAlias, channelAlias, channelSelect, manifestSelect, versionAlias }
 }
 
@@ -449,10 +443,9 @@ export function requestInfosChannelDevicePostgres(
     .innerJoin(versionAlias, activeChannelVersionJoin(channelAlias.version, versionAlias))
 
   const channelDevice = (includeManifest
-    ? baseQuery.leftJoin(schema.manifest, eq(schema.manifest.app_version_id, versionAlias.id))
+    ? baseQuery.leftJoin(schema.app_version_manifest_cache, eq(schema.app_version_manifest_cache.app_version_id, versionAlias.id))
     : baseQuery)
     .where(and(eq(channelDevicesAlias.device_id, device_id), eq(channelDevicesAlias.app_id, app_id)))
-    .groupBy(channelDevicesAlias.device_id, channelDevicesAlias.app_id, channelAlias.id, versionAlias.id)
     .limit(1)
   cloudlog({ requestId: c.get('requestId'), message: 'channelDevice Query:', channelDeviceQuery: channelDevice.toSQL() })
 
@@ -482,7 +475,7 @@ export function requestInfosChannelPostgres(
     .innerJoin(versionAlias, activeChannelVersionJoin(channelAlias.version, versionAlias))
 
   const channelQuery = (includeManifest
-    ? baseQuery.leftJoin(schema.manifest, eq(schema.manifest.app_version_id, versionAlias.id))
+    ? baseQuery.leftJoin(schema.app_version_manifest_cache, eq(schema.app_version_manifest_cache.app_version_id, versionAlias.id))
     : baseQuery)
     .where(
       !defaultChannel
@@ -496,7 +489,6 @@ export function requestInfosChannelPostgres(
             eq(channelAlias.name, defaultChannel),
           ),
     )
-    .groupBy(channelAlias.id, versionAlias.id)
     .limit(1)
   cloudlog({ requestId: c.get('requestId'), message: 'channel Query:', channelQuery: channelQuery.toSQL() })
   const channel = channelQuery.then(data => data.at(0))

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -401,27 +401,7 @@ function getSchemaUpdatesAlias(includeMetadata = false) {
     allow_device_self_set: channelAlias.allow_device_self_set,
     public: channelAlias.public,
   }
-  const manifestFallbackSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`(
-    SELECT COALESCE(
-      jsonb_agg(
-        jsonb_build_object(
-          'file_name', ${schema.manifest.file_name},
-          'file_hash', ${schema.manifest.file_hash},
-          's3_path', ${schema.manifest.s3_path}
-        )
-        ORDER BY ${schema.manifest.id}
-      ),
-      '[]'::jsonb
-    )
-    FROM ${schema.manifest}
-    WHERE ${schema.manifest.app_version_id} = ${versionAlias.id}
-  )`
-  const manifestSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`CASE
-    WHEN ${schema.app_version_manifest_cache.entries} IS NOT NULL
-      AND jsonb_array_length(${schema.app_version_manifest_cache.entries}) > 0
-    THEN ${schema.app_version_manifest_cache.entries}
-    ELSE ${manifestFallbackSelect}
-  END`
+  const manifestSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[] | null>`${schema.app_version_manifest_cache.entries}`
   return { versionSelect, channelDevicesAlias, channelAlias, channelSelect, manifestSelect, versionAlias }
 }
 

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -401,7 +401,27 @@ function getSchemaUpdatesAlias(includeMetadata = false) {
     allow_device_self_set: channelAlias.allow_device_self_set,
     public: channelAlias.public,
   }
-  const manifestSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`COALESCE(${schema.app_version_manifest_cache.entries}, '[]'::jsonb)`
+  const manifestFallbackSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`(
+    SELECT COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'file_name', ${schema.manifest.file_name},
+          'file_hash', ${schema.manifest.file_hash},
+          's3_path', ${schema.manifest.s3_path}
+        )
+        ORDER BY ${schema.manifest.id}
+      ),
+      '[]'::jsonb
+    )
+    FROM ${schema.manifest}
+    WHERE ${schema.manifest.app_version_id} = ${versionAlias.id}
+  )`
+  const manifestSelect = sql<{ file_name: string, file_hash: string, s3_path: string }[]>`CASE
+    WHEN ${schema.app_version_manifest_cache.entries} IS NOT NULL
+      AND jsonb_array_length(${schema.app_version_manifest_cache.entries}) > 0
+    THEN ${schema.app_version_manifest_cache.entries}
+    ELSE ${manifestFallbackSelect}
+  END`
   return { versionSelect, channelDevicesAlias, channelAlias, channelSelect, manifestSelect, versionAlias }
 }
 

--- a/supabase/functions/_backend/utils/postgres_schema.ts
+++ b/supabase/functions/_backend/utils/postgres_schema.ts
@@ -2,6 +2,12 @@ import { bigint, boolean, integer, jsonb, pgEnum, pgTable, primaryKey, serial, t
 
 // do_not_change
 
+interface ManifestCacheEntry {
+  file_name: string
+  file_hash: string
+  s3_path: string
+}
+
 export const disableUpdatePgEnum = pgEnum('disable_update', ['major', 'minor', 'patch', 'version_number', 'none'])
 export const keyModePgEnum = pgEnum('key_mode', ['read', 'write', 'all', 'upload'])
 export const userMinRightPgEnum = pgEnum('user_min_right', [
@@ -64,6 +70,13 @@ export const manifest = pgTable('manifest', {
   s3_path: varchar('s3_path').notNull(),
   file_hash: varchar('file_hash').notNull(),
   file_size: bigint('file_size', { mode: 'number' }).default(0),
+})
+
+export const app_version_manifest_cache = pgTable('app_version_manifest_cache', {
+  app_version_id: bigint('app_version_id', { mode: 'number' }).primaryKey().notNull().references(() => app_versions.id, { onDelete: 'cascade' }),
+  created_at: timestamp('created_at').notNull().defaultNow(),
+  updated_at: timestamp('updated_at').notNull().defaultNow(),
+  entries: jsonb('entries').$type<ManifestCacheEntry[]>().notNull(),
 })
 
 export const channels = pgTable('channels', {

--- a/supabase/functions/_backend/utils/postgres_schema.ts
+++ b/supabase/functions/_backend/utils/postgres_schema.ts
@@ -1,12 +1,7 @@
+import type { ManifestCacheEntry } from './manifestCache.ts'
 import { bigint, boolean, integer, jsonb, pgEnum, pgTable, primaryKey, serial, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
 
 // do_not_change
-
-interface ManifestCacheEntry {
-  file_name: string
-  file_hash: string
-  s3_path: string
-}
 
 export const disableUpdatePgEnum = pgEnum('disable_update', ['major', 'minor', 'patch', 'version_number', 'none'])
 export const keyModePgEnum = pgEnum('key_mode', ['read', 'write', 'all', 'upload'])

--- a/supabase/functions/_backend/utils/postgres_schema.ts
+++ b/supabase/functions/_backend/utils/postgres_schema.ts
@@ -265,6 +265,7 @@ export const schema = {
   apps,
   app_versions,
   manifest,
+  app_version_manifest_cache,
   channels,
   channel_devices,
   orgs,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -250,6 +250,35 @@ export type Database = {
           },
         ]
       }
+      app_version_manifest_cache: {
+        Row: {
+          app_version_id: number
+          created_at: string
+          entries: Json
+          updated_at: string
+        }
+        Insert: {
+          app_version_id: number
+          created_at?: string
+          entries?: Json
+          updated_at?: string
+        }
+        Update: {
+          app_version_id?: number
+          created_at?: string
+          entries?: Json
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "app_version_manifest_cache_app_version_id_fkey"
+            columns: ["app_version_id"]
+            isOneToOne: true
+            referencedRelation: "app_versions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       apps: {
         Row: {
           allow_device_custom_id: boolean

--- a/supabase/migrations/20260427132636_add_update_manifest_cache.sql
+++ b/supabase/migrations/20260427132636_add_update_manifest_cache.sql
@@ -1,0 +1,132 @@
+CREATE TABLE IF NOT EXISTS public.app_version_manifest_cache (
+    app_version_id bigint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    entries jsonb DEFAULT '[]'::jsonb NOT NULL,
+    CONSTRAINT app_version_manifest_cache_pkey PRIMARY KEY (app_version_id),
+    CONSTRAINT app_version_manifest_cache_app_version_id_fkey
+    FOREIGN KEY (app_version_id)
+    REFERENCES public.app_versions (id)
+    ON DELETE CASCADE,
+    CONSTRAINT app_version_manifest_cache_entries_is_array
+    CHECK (jsonb_typeof(entries) = 'array')
+);
+
+ALTER TABLE public.app_version_manifest_cache OWNER TO postgres;
+ALTER TABLE ONLY public.app_version_manifest_cache REPLICA IDENTITY FULL;
+
+COMMENT ON TABLE public.app_version_manifest_cache IS
+'Internal precomputed manifest payload used by the /updates hot path
+to avoid aggregating manifest rows per request.';
+COMMENT ON COLUMN public.app_version_manifest_cache.entries IS
+'Compact manifest payload served by /updates. Each entry stores
+file_name, file_hash, and s3_path.';
+
+REVOKE ALL ON TABLE public.app_version_manifest_cache FROM public;
+REVOKE ALL ON TABLE public.app_version_manifest_cache FROM anon;
+REVOKE ALL ON TABLE public.app_version_manifest_cache FROM authenticated;
+GRANT ALL ON TABLE public.app_version_manifest_cache TO service_role;
+
+ALTER TABLE public.app_version_manifest_cache ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = 'planetscale_replicate'
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'planetscale_replicate'
+      AND schemaname = 'public'
+      AND tablename = 'app_version_manifest_cache'
+  ) THEN
+    ALTER PUBLICATION "planetscale_replicate" ADD TABLE ONLY public.app_version_manifest_cache;
+  END IF;
+END;
+$$;
+
+INSERT INTO public.app_version_manifest_cache (app_version_id, entries)
+SELECT
+    m.app_version_id,
+    jsonb_agg(
+        jsonb_build_object(
+            'file_name', m.file_name,
+            'file_hash', m.file_hash,
+            's3_path', m.s3_path
+        )
+        ORDER BY m.id
+    ) AS entries
+FROM public.manifest AS m
+GROUP BY m.app_version_id
+ON CONFLICT (app_version_id) DO UPDATE
+    SET
+        entries = excluded.entries,
+        updated_at = now();
+
+INSERT INTO public.app_version_manifest_cache (app_version_id, entries)
+SELECT
+    av.id,
+    jsonb_agg(
+        jsonb_build_object(
+            'file_name', manifest_entry.file_name,
+            'file_hash', manifest_entry.file_hash,
+            's3_path', manifest_entry.s3_path
+        )
+        ORDER BY manifest_entry.ordinality
+    ) AS entries
+FROM public.app_versions AS av
+CROSS JOIN
+    LATERAL unnest(av.manifest) WITH ORDINALITY
+        AS manifest_entry (file_name, s3_path, file_hash, ordinality)
+WHERE
+    av.manifest IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM public.app_version_manifest_cache AS manifest_cache
+        WHERE manifest_cache.app_version_id = av.id
+    )
+GROUP BY av.id
+ON CONFLICT (app_version_id) DO UPDATE
+    SET
+        entries = excluded.entries,
+        updated_at = now();
+
+UPDATE public.app_versions AS av
+SET manifest_count = coalesce(manifest_cache.manifest_count, 0)
+FROM (
+    SELECT
+        app_version.id,
+        coalesce(
+            jsonb_array_length(manifest_cache.entries),
+            0
+        ) AS manifest_count
+    FROM public.app_versions AS app_version
+    LEFT JOIN public.app_version_manifest_cache AS manifest_cache
+        ON app_version.id = manifest_cache.app_version_id
+) AS manifest_cache
+WHERE
+    av.id = manifest_cache.id
+    AND av.manifest_count IS DISTINCT FROM manifest_cache.manifest_count;
+
+UPDATE public.apps AS app
+SET
+    manifest_bundle_count = app_cache.bundle_count,
+    updated_at = now()
+FROM (
+    SELECT
+        app_inner.app_id,
+        count(cache_inner.app_version_id) FILTER (
+            WHERE app_version.deleted = FALSE
+        )::bigint AS bundle_count
+    FROM public.apps AS app_inner
+    LEFT JOIN public.app_versions AS app_version
+        ON app_inner.app_id = app_version.app_id
+    LEFT JOIN public.app_version_manifest_cache AS cache_inner
+        ON app_version.id = cache_inner.app_version_id
+    GROUP BY app_inner.app_id
+) AS app_cache
+WHERE
+    app.app_id = app_cache.app_id
+    AND app.manifest_bundle_count IS DISTINCT FROM app_cache.bundle_count;

--- a/supabase/migrations/20260427132636_add_update_manifest_cache.sql
+++ b/supabase/migrations/20260427132636_add_update_manifest_cache.sql
@@ -47,6 +47,34 @@ BEGIN
 END;
 $$;
 
+INSERT INTO public.manifest (
+    app_version_id,
+    file_name,
+    s3_path,
+    file_hash,
+    file_size
+)
+SELECT
+    av.id,
+    manifest_entry.file_name,
+    manifest_entry.s3_path,
+    manifest_entry.file_hash,
+    0 AS file_size
+FROM public.app_versions AS av
+CROSS JOIN
+    LATERAL unnest(av.manifest) WITH ORDINALITY
+        AS manifest_entry (file_name, s3_path, file_hash, ordinality)
+WHERE
+    av.manifest IS NOT NULL
+    AND manifest_entry.file_name IS NOT NULL
+    AND manifest_entry.s3_path IS NOT NULL
+    AND manifest_entry.file_hash IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM public.manifest AS manifest_row
+        WHERE manifest_row.app_version_id = av.id
+    );
+
 INSERT INTO public.app_version_manifest_cache (app_version_id, entries)
 SELECT
     m.app_version_id,
@@ -65,33 +93,18 @@ ON CONFLICT (app_version_id) DO UPDATE
         entries = excluded.entries,
         updated_at = now();
 
-INSERT INTO public.app_version_manifest_cache (app_version_id, entries)
-SELECT
-    av.id,
-    jsonb_agg(
-        jsonb_build_object(
-            'file_name', manifest_entry.file_name,
-            'file_hash', manifest_entry.file_hash,
-            's3_path', manifest_entry.s3_path
-        )
-        ORDER BY manifest_entry.ordinality
-    ) AS entries
-FROM public.app_versions AS av
-CROSS JOIN
-    LATERAL unnest(av.manifest) WITH ORDINALITY
-        AS manifest_entry (file_name, s3_path, file_hash, ordinality)
+UPDATE public.app_versions AS av
+SET manifest = NULL
 WHERE
     av.manifest IS NOT NULL
-    AND NOT EXISTS (
-        SELECT 1
-        FROM public.app_version_manifest_cache AS manifest_cache
-        WHERE manifest_cache.app_version_id = av.id
-    )
-GROUP BY av.id
-ON CONFLICT (app_version_id) DO UPDATE
-    SET
-        entries = excluded.entries,
-        updated_at = now();
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM public.app_version_manifest_cache AS manifest_cache
+            WHERE manifest_cache.app_version_id = av.id
+        )
+        OR coalesce(array_length(av.manifest, 1), 0) = 0
+    );
 
 UPDATE public.app_versions AS av
 SET manifest_count = coalesce(manifest_cache.manifest_count, 0)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -558,6 +558,7 @@ BEGIN
     INSERT INTO "public"."apps" ("created_at", "app_id", "icon_url", "name", "last_version", "updated_at", "owner_org", "user_id") VALUES
     (NOW(), 'com.demoadmin.app', '', 'Demo Admin app', '1.0.0', NOW(), '22dbad8a-b885-4309-9b3b-a09f8460fb6d', 'c591b04e-cf29-4945-b9a0-776d0672061a'),
     (NOW(), 'com.demo.app', '', 'Demo app', '1.0.0', NOW(), '046a36ac-e03c-4590-9257-bd6c9dba9ee8', '6aa76066-55ef-4238-ade6-0b32334a4097'),
+    (NOW(), 'com.nonowner.readonly.app', '', 'Non-owner Readonly App', '1.0.0', NOW(), 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', '6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5'),
     (NOW(), 'com.stats.app', '', 'Stats Test App', '1.0.0', NOW(), 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e', '7a1b2c3d-4e5f-4a6b-7c8d-9e0f1a2b3c4d'),
     (NOW(), 'com.rls.app', '', 'RLS Test App', '1.0.0', NOW(), 'c3d4e5f6-a7b8-4c9d-8e0f-1a2b3c4d5e6f', '8b2c3d4e-5f6a-4b7c-8d9e-0f1a2b3c4d5e'),
     (NOW(), 'com.encrypted.app', '', 'Encrypted Test App', '1.0.0', NOW(), 'a7b8c9d0-e1f2-4a3b-9c4d-5e6f7a8b9ca4', 'f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f708193'),

--- a/tests/private-error-cases.test.ts
+++ b/tests/private-error-cases.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { APIKEY_STATS, getEndpointUrl, getSupabaseClient, headers, NON_OWNER_ORG_ID, resetAndSeedAppData, resetAppData, USER_ID } from './test-utils.ts'
+import { APIKEY_STATS, getEndpointUrl, getSupabaseClient, headers, NON_OWNER_ORG_ID, NON_OWNER_READONLY_APP_NAME, resetAndSeedAppData, resetAppData, USER_ID } from './test-utils.ts'
 
 const id = randomUUID()
 const APPNAME = `com.private.error.${id}`
@@ -113,7 +113,8 @@ describe('[POST] /private/create_device - Error Cases', () => {
       method: 'POST',
       headers,
       body: JSON.stringify({
-        app_id: 'com.demoadmin.app', // Use the admin app that test user doesn't have access to
+        // Use an app owned by NON_OWNER_ORG_ID where the test user only has read access.
+        app_id: NON_OWNER_READONLY_APP_NAME,
         org_id: NON_OWNER_ORG_ID,
         device_id: randomUUID(),
         platform: 'android',

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -229,6 +229,7 @@ export const PRODUCT_ID = 'prod_LQIregjtNduh4q'
 export const USER_ADMIN_EMAIL = 'admin@capgo.app'
 export const APP_NAME = 'com.demo'
 export const NON_ACCESS_APP_NAME = 'com.demoadmin.app'
+export const NON_OWNER_READONLY_APP_NAME = 'com.nonowner.readonly.app'
 export const headers = {
   'Content-Type': 'application/json',
   'Authorization': APIKEY_TEST_ALL,

--- a/tests/updates-manifest.test.ts
+++ b/tests/updates-manifest.test.ts
@@ -27,8 +27,8 @@ interface UpdateRes {
 async function insertManifestEntries(appVersionId: number) {
   const supabase = getSupabaseClient()
   // First, delete any existing manifest entries for this version
-  await supabase.from('manifest').delete().eq('app_version_id', appVersionId)
-  await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', appVersionId)
+  await supabase.from('manifest').delete().eq('app_version_id', appVersionId).throwOnError()
+  await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', appVersionId).throwOnError()
   // Insert the manifest entry
   const { error } = await supabase.from('manifest').insert({
     app_version_id: appVersionId,
@@ -62,8 +62,8 @@ async function insertManifestEntries(appVersionId: number) {
 // Helper to remove manifest entries
 async function removeManifestEntries(appVersionId: number) {
   const supabase = getSupabaseClient()
-  await supabase.from('manifest').delete().eq('app_version_id', appVersionId)
-  await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', appVersionId)
+  await supabase.from('manifest').delete().eq('app_version_id', appVersionId).throwOnError()
+  await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', appVersionId).throwOnError()
   await supabase.from('app_versions').update({ manifest_count: 0 }).eq('id', appVersionId)
 }
 
@@ -92,8 +92,8 @@ afterEach(async () => {
 
   if (versionId) {
     // Remove any manifest entries added during the test
-    await supabase.from('manifest').delete().eq('app_version_id', versionId)
-    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', versionId)
+    await supabase.from('manifest').delete().eq('app_version_id', versionId).throwOnError()
+    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', versionId).throwOnError()
 
     // Reset app_versions fields to initial state
     await supabase

--- a/tests/updates-manifest.test.ts
+++ b/tests/updates-manifest.test.ts
@@ -28,6 +28,7 @@ async function insertManifestEntries(appVersionId: number) {
   const supabase = getSupabaseClient()
   // First, delete any existing manifest entries for this version
   await supabase.from('manifest').delete().eq('app_version_id', appVersionId)
+  await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', appVersionId)
   // Insert the manifest entry
   const { error } = await supabase.from('manifest').insert({
     app_version_id: appVersionId,
@@ -38,6 +39,15 @@ async function insertManifestEntries(appVersionId: number) {
   })
   if (error)
     throw new Error(`Failed to insert manifest entry: ${error.message}`)
+
+  const { error: cacheError } = await supabase.from('app_version_manifest_cache').upsert({
+    app_version_id: appVersionId,
+    entries: [manifestData],
+  }, {
+    onConflict: 'app_version_id',
+  })
+  if (cacheError)
+    throw new Error(`Failed to insert manifest cache: ${cacheError.message}`)
 
   // Update the manifest_count on the version
   await supabase.from('app_versions').update({ manifest_count: 1 }).eq('id', appVersionId)
@@ -53,6 +63,7 @@ async function insertManifestEntries(appVersionId: number) {
 async function removeManifestEntries(appVersionId: number) {
   const supabase = getSupabaseClient()
   await supabase.from('manifest').delete().eq('app_version_id', appVersionId)
+  await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', appVersionId)
   await supabase.from('app_versions').update({ manifest_count: 0 }).eq('id', appVersionId)
 }
 
@@ -82,6 +93,7 @@ afterEach(async () => {
   if (versionId) {
     // Remove any manifest entries added during the test
     await supabase.from('manifest').delete().eq('app_version_id', versionId)
+    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', versionId)
 
     // Reset app_versions fields to initial state
     await supabase

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -486,8 +486,8 @@ describe('manifest bundle count gating', () => {
     expect(json.manifest?.some(entry => entry?.file_name === fileName)).toBe(true)
   })
 
-  it('falls back to manifest rows when the cache row is missing', async () => {
-    const fileName = await seedManifestEntry()
+  it('does not rebuild manifest rows when the cache row is missing', async () => {
+    await seedManifestEntry()
     await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', baseVersionId).throwOnError()
 
     const { error } = await supabase.from('apps').update({ manifest_bundle_count: 1 }).eq('app_id', APP_NAME_UPDATE)
@@ -497,7 +497,7 @@ describe('manifest bundle count gating', () => {
     const response = await postUpdate(makeUpdatePayload())
     expect(response.status).toBe(200)
     const json = await response.json<UpdateRes>()
-    expect(json.manifest?.some(entry => entry?.file_name === fileName)).toBe(true)
+    expect(json.manifest).toBeUndefined()
   })
 
   it('skips manifest query when manifest bundle count is zero', async () => {

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -418,7 +418,7 @@ describe('manifest bundle count gating', () => {
       await supabase.from('manifest').delete().in('id', insertedManifestIds)
       insertedManifestIds.length = 0
     }
-    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', baseVersionId)
+    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', baseVersionId).throwOnError()
     await supabase.from('app_versions').update({ manifest_count: 0 }).eq('id', baseVersionId)
     await supabase.from('apps').update({ manifest_bundle_count: 0 }).eq('app_id', APP_NAME_UPDATE)
   })
@@ -483,6 +483,20 @@ describe('manifest bundle count gating', () => {
     expect(response.status).toBe(200)
     const json = await response.json<UpdateRes>()
     expect(json.manifest).toBeDefined()
+    expect(json.manifest?.some(entry => entry?.file_name === fileName)).toBe(true)
+  })
+
+  it('falls back to manifest rows when the cache row is missing', async () => {
+    const fileName = await seedManifestEntry()
+    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', baseVersionId).throwOnError()
+
+    const { error } = await supabase.from('apps').update({ manifest_bundle_count: 1 }).eq('app_id', APP_NAME_UPDATE)
+    if (error)
+      throw error
+
+    const response = await postUpdate(makeUpdatePayload())
+    expect(response.status).toBe(200)
+    const json = await response.json<UpdateRes>()
     expect(json.manifest?.some(entry => entry?.file_name === fileName)).toBe(true)
   })
 

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -415,12 +415,12 @@ describe('manifest bundle count gating', () => {
 
   afterEach(async () => {
     if (insertedManifestIds.length > 0) {
-      await supabase.from('manifest').delete().in('id', insertedManifestIds)
+      await supabase.from('manifest').delete().in('id', insertedManifestIds).throwOnError()
       insertedManifestIds.length = 0
     }
     await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', baseVersionId).throwOnError()
-    await supabase.from('app_versions').update({ manifest_count: 0 }).eq('id', baseVersionId)
-    await supabase.from('apps').update({ manifest_bundle_count: 0 }).eq('app_id', APP_NAME_UPDATE)
+    await supabase.from('app_versions').update({ manifest_count: 0 }).eq('id', baseVersionId).throwOnError()
+    await supabase.from('apps').update({ manifest_bundle_count: 0 }).eq('app_id', APP_NAME_UPDATE).throwOnError()
   })
 
   async function seedManifestEntry() {

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -418,6 +418,8 @@ describe('manifest bundle count gating', () => {
       await supabase.from('manifest').delete().in('id', insertedManifestIds)
       insertedManifestIds.length = 0
     }
+    await supabase.from('app_version_manifest_cache').delete().eq('app_version_id', baseVersionId)
+    await supabase.from('app_versions').update({ manifest_count: 0 }).eq('id', baseVersionId)
     await supabase.from('apps').update({ manifest_bundle_count: 0 }).eq('app_id', APP_NAME_UPDATE)
   })
 
@@ -437,6 +439,29 @@ describe('manifest bundle count gating', () => {
     if (error || !data)
       throw error ?? new Error('Failed to seed manifest entry')
     insertedManifestIds.push(data.id)
+
+    const { error: cacheError } = await supabase
+      .from('app_version_manifest_cache')
+      .upsert({
+        app_version_id: baseVersionId,
+        entries: [{
+          file_name: fileName,
+          file_hash: `hash-${suffix}`,
+          s3_path: `tests/${fileName}`,
+        }],
+      }, {
+        onConflict: 'app_version_id',
+      })
+    if (cacheError)
+      throw cacheError
+
+    const { error: manifestCountError } = await supabase
+      .from('app_versions')
+      .update({ manifest_count: 1 })
+      .eq('id', baseVersionId)
+    if (manifestCountError)
+      throw manifestCountError
+
     return fileName
   }
 


### PR DESCRIPTION
## Summary (AI generated)

- Add `app_version_manifest_cache` to precompute `/updates` manifest payloads per bundle.
- Backfill existing manifest data and keep the cache in sync on upload, soft delete, and demo seeding.
- Replace the `/updates` manifest aggregation join with a one-to-one cache lookup and adjust tests.

## Motivation (AI generated)

`/updates` is a hot path. Rebuilding manifest payloads from `manifest` rows on every request adds avoidable work and makes response time scale with manifest size.

## Business Impact (AI generated)

This reduces work on one of Capgo's most latency-sensitive endpoints, improving update responsiveness for customers while keeping existing manifest tooling and storage accounting intact.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run lint:backend`
- [x] `bun run typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/updates.test.ts tests/updates-manifest.test.ts tests/manifest-rls.test.ts`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent per-version manifest cache and manifest compaction to improve manifest handling.
* **Performance Improvements**
  * Reads now prefer the precomputed cache for faster UI and API responses.
* **Reliability / Bug Fixes**
  * Manifest updates are applied transactionally with synchronized counts and safe fallbacks when cache is missing; demo app creation now includes precomputed manifest payloads.
* **Tests**
  * Test suites and helpers updated to cover cache behavior and count synchronization.
* **Chores**
  * Added a seeded readonly app for test scenarios and a test utility constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->