### PR TITLE
ci: enforce Supabase migration ordering in PR checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   pull_request:
+  merge_group:
+    types:
+      - checks_requested
   workflow_call: # Allow this workflow to be called by other workflows
 
 permissions: {}
@@ -37,82 +40,8 @@ jobs:
         with:
           bun-version: latest
       - name: Validate migration timestamps
-        if: github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-
-          extract_timestamp() {
-            local file_name="$1"
-            local base_name
-            base_name="$(basename "$file_name")"
-
-            if [[ "$base_name" =~ ^([0-9]{14})_ ]]; then
-              echo "${BASH_REMATCH[1]}"
-            else
-              return 1
-            fi
-          }
-
-          BASE_REF="HEAD^1"
-
-          declare -A base_timestamp_to_file
-          while IFS= read -r file; do
-            ts="$(extract_timestamp "$file" || true)"
-            [ -z "$ts" ] && continue
-            base_timestamp_to_file["$ts"]="$file"
-          done < <(git ls-tree -r --name-only "$BASE_REF" -- 'supabase/migrations/*.sql')
-
-          latest_base_timestamp="00000000000000"
-          for ts in "${!base_timestamp_to_file[@]}"; do
-            if [[ "$ts" > "$latest_base_timestamp" ]]; then
-              latest_base_timestamp="$ts"
-            fi
-          done
-
-          added_files="$(git diff --name-only --diff-filter=A "${BASE_REF}" HEAD -- 'supabase/migrations/*.sql')"
-          duplicate_timestamps=0
-
-          if [ -n "$added_files" ]; then
-            declare -A added_timestamp_count
-            declare -A added_timestamp_files
-
-            while IFS= read -r file; do
-              [ -z "$file" ] && continue
-              ts="$(extract_timestamp "$file" || true)"
-              [ -z "$ts" ] && continue
-
-              if [[ -n "${base_timestamp_to_file["$ts"]+x}" ]]; then
-                echo "❌ Duplicate migration timestamp: ${ts}"
-                echo "  PR file: $file"
-                echo "  Existing file on main: ${base_timestamp_to_file["$ts"]}"
-                duplicate_timestamps=1
-              fi
-
-              if [ -n "${added_timestamp_count["$ts"]+x}" ]; then
-                echo "❌ Duplicate migration timestamp in PR: ${ts}"
-                echo "  Previous file: ${added_timestamp_files["$ts"]}"
-                echo "  Additional file: ${file}"
-                duplicate_timestamps=1
-              else
-                added_timestamp_count["$ts"]=1
-                added_timestamp_files["$ts"]="$file"
-              fi
-
-              if [[ "$ts" < "$latest_base_timestamp" ]]; then
-                echo "❌ Migration timestamp regression detected"
-                echo "  Last migration timestamp on main: ${latest_base_timestamp}"
-                echo "  New migration file: $file"
-                echo "  New migration timestamp: ${ts}"
-                duplicate_timestamps=1
-              fi
-            done <<< "$added_files"
-          fi
-
-          if [ "$duplicate_timestamps" -ne 0 ]; then
-            exit 1
-          fi
-
-          echo "✅ Migration filename timestamps are unique and strictly newer than main."
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        run: bash scripts/check-supabase-migration-order.sh
       - name: Check for typos
         uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
       - name: Show bun version

--- a/scripts/check-supabase-migration-order.sh
+++ b/scripts/check-supabase-migration-order.sh
@@ -87,6 +87,17 @@ if [[ -n "$modified_files" ]]; then
   status=1
 fi
 
+deleted_files="$(git diff --name-only --diff-filter=D "${base_ref}...HEAD" -- 'supabase/migrations/*.sql')"
+if [[ -n "$deleted_files" ]]; then
+  echo '❌ Existing Supabase migrations were deleted in this change.'
+  echo '  Supabase migrations must remain append-only.'
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    echo "  - $file"
+  done <<< "$deleted_files"
+  status=1
+fi
+
 added_files="$(git diff --name-only --diff-filter=A "${base_ref}...HEAD" -- 'supabase/migrations/*.sql')"
 if [[ -n "$added_files" ]]; then
   : > "${added_timestamps_file}"

--- a/scripts/check-supabase-migration-order.sh
+++ b/scripts/check-supabase-migration-order.sh
@@ -24,12 +24,12 @@ resolve_target_branch() {
     if [[ "${GITHUB_REF_NAME}" == gh-readonly-queue/* ]]; then
       local queued_ref
       queued_ref="${GITHUB_REF_NAME#gh-readonly-queue/}"
-      echo "${queued_ref%%/pr-*}"
+      echo "${queued_ref%/pr-*}"
       return
     fi
 
     if [[ "${GITHUB_REF_NAME}" == */pr-* ]]; then
-      echo "${GITHUB_REF_NAME%%/pr-*}"
+      echo "${GITHUB_REF_NAME%/pr-*}"
       return
     fi
   fi

--- a/scripts/check-supabase-migration-order.sh
+++ b/scripts/check-supabase-migration-order.sh
@@ -131,7 +131,7 @@ if [[ -n "$added_files" ]]; then
       printf '%s\t%s\n' "$ts" "$file" >> "${added_timestamps_file}"
     fi
 
-    if [[ "$ts" < "$latest_base_timestamp" ]]; then
+    if (( 10#$ts < 10#$latest_base_timestamp )); then
       echo '❌ Migration timestamp regression detected'
       echo "  Latest timestamp on ${base_ref}: ${latest_base_timestamp}"
       echo "  New file: $file"

--- a/scripts/check-supabase-migration-order.sh
+++ b/scripts/check-supabase-migration-order.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+extract_timestamp() {
+  local file_name="$1"
+  local base_name
+  base_name="$(basename "$file_name")"
+
+  if [[ "$base_name" =~ ^([0-9]{14})_.+\.sql$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+resolve_target_branch() {
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    echo "${GITHUB_BASE_REF}"
+    return
+  fi
+
+  if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    if [[ "${GITHUB_REF_NAME}" == gh-readonly-queue/* ]]; then
+      local queued_ref
+      queued_ref="${GITHUB_REF_NAME#gh-readonly-queue/}"
+      echo "${queued_ref%%/pr-*}"
+      return
+    fi
+
+    if [[ "${GITHUB_REF_NAME}" == */pr-* ]]; then
+      echo "${GITHUB_REF_NAME%%/pr-*}"
+      return
+    fi
+  fi
+
+  if [[ -n "${GITHUB_EVENT_PATH:-}" ]] && command -v jq >/dev/null 2>&1; then
+    local branch
+    branch="$(jq -r '.pull_request.base.ref // .merge_group.base_ref // .repository.default_branch // empty' "${GITHUB_EVENT_PATH}")"
+    if [[ -n "$branch" && "$branch" != "null" ]]; then
+      echo "$branch"
+      return
+    fi
+  fi
+
+  echo 'main'
+}
+
+target_branch="$(resolve_target_branch)"
+base_ref="origin/${target_branch}"
+tmp_dir="$(mktemp -d)"
+base_timestamps_file="${tmp_dir}/base_timestamps.tsv"
+added_timestamps_file="${tmp_dir}/added_timestamps.tsv"
+
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+echo "Checking Supabase migrations against ${base_ref}"
+git fetch --no-tags origin "${target_branch}"
+
+: > "${base_timestamps_file}"
+while IFS= read -r file; do
+  [[ "$file" != supabase/migrations/*.sql ]] && continue
+  ts="$(extract_timestamp "$file" || true)"
+  [[ -z "$ts" ]] && continue
+  printf '%s\t%s\n' "$ts" "$file" >> "${base_timestamps_file}"
+done < <(git ls-tree -r --name-only "${base_ref}" -- supabase/migrations)
+
+latest_base_timestamp='00000000000000'
+if [[ -s "${base_timestamps_file}" ]]; then
+  latest_base_timestamp="$(awk -F '\t' '
+    BEGIN { max = "00000000000000" }
+    $1 > max { max = $1 }
+    END { print max }
+  ' "${base_timestamps_file}")"
+fi
+
+status=0
+
+modified_files="$(git diff --name-only --diff-filter=MR "${base_ref}...HEAD" -- 'supabase/migrations/*.sql')"
+if [[ -n "$modified_files" ]]; then
+  echo '❌ Existing Supabase migrations were modified in this change.'
+  echo '  Create a new migration instead of editing committed migration files.'
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    echo "  - $file"
+  done <<< "$modified_files"
+  status=1
+fi
+
+added_files="$(git diff --name-only --diff-filter=A "${base_ref}...HEAD" -- 'supabase/migrations/*.sql')"
+if [[ -n "$added_files" ]]; then
+  : > "${added_timestamps_file}"
+
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+
+    ts="$(extract_timestamp "$file" || true)"
+    if [[ -z "$ts" ]]; then
+      echo "❌ Invalid Supabase migration filename: $file"
+      echo '  Expected format: YYYYMMDDHHMMSS_description.sql'
+      status=1
+      continue
+    fi
+
+    existing_base_file="$(awk -F '\t' -v ts="$ts" '$1 == ts { print $2; exit }' "${base_timestamps_file}")"
+    if [[ -n "$existing_base_file" ]]; then
+      echo "❌ Duplicate migration timestamp: ${ts}"
+      echo "  New file: $file"
+      echo "  Existing file: ${existing_base_file}"
+      status=1
+    fi
+
+    existing_added_file="$(awk -F '\t' -v ts="$ts" '$1 == ts { print $2; exit }' "${added_timestamps_file}")"
+    if [[ -n "$existing_added_file" ]]; then
+      echo "❌ Duplicate migration timestamp in this change: ${ts}"
+      echo "  First file: ${existing_added_file}"
+      echo "  Second file: $file"
+      status=1
+    else
+      printf '%s\t%s\n' "$ts" "$file" >> "${added_timestamps_file}"
+    fi
+
+    if [[ "$ts" < "$latest_base_timestamp" ]]; then
+      echo '❌ Migration timestamp regression detected'
+      echo "  Latest timestamp on ${base_ref}: ${latest_base_timestamp}"
+      echo "  New file: $file"
+      echo "  New timestamp: ${ts}"
+      status=1
+    fi
+  done <<< "$added_files"
+fi
+
+if [[ "$status" -ne 0 ]]; then
+  exit 1
+fi
+
+echo '✅ Supabase migration filenames are unique and newer than the target branch.'


### PR DESCRIPTION
## Summary (AI generated)

- add a dedicated CI script to validate Supabase migration filenames against the current target branch
- fail PRs that reuse timestamps, backdate new migrations, modify committed migrations, or use invalid migration filenames
- run the same migration-order check for both `pull_request` and `merge_group` events so merge queue validations catch stale migration order before deploy

## Motivation (AI generated)

Supabase migrations are applied in timestamp order. When multiple pull requests merge close together, a branch can still pass local validation while carrying a migration timestamp that is older than the newest migration already on `main`, which later breaks deployment ordering. This change makes CI compare new migrations against the live target branch instead of only the local merge parent.

## Business Impact (AI generated)

This reduces failed production or alpha deploys caused by out-of-order Supabase migrations, which lowers release friction and avoids wasting maintainer time on avoidable migration-order incidents.

## Test Plan (AI generated)

- [x] Run `GITHUB_BASE_REF=main bash scripts/check-supabase-migration-order.sh`
- [x] Verify the script passes for a newer migration timestamp in a temporary repository
- [x] Verify the script fails for a stale migration timestamp after the base branch advances in a temporary repository
- [ ] Wait for GitHub Actions checks on this PR to pass

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs enhanced migration validations on pull requests and merge groups: enforces migration filename format, prevents edits or deletions of existing migrations, rejects duplicate or out-of-order timestamps (including against the target branch), and blocks merge on validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->