### PR TITLE
ci: update action pins for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
+        uses: supabase/setup-cli@v2.0.0
         with:
           version: latest
       - name: Show Supabase CLI version

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1.6.0
+        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
         with:
           version: latest
       - name: Show Supabase CLI version

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -42,7 +42,7 @@ jobs:
         run: bun install
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
+        uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
           run: npx vitest bench --config vitest.config.bench.ts --run

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,16 +24,16 @@ jobs:
       actions: write
     steps:
       - name: Cache Deno dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@v5
         with:
           path: ${{ env.DENO_DIR }}
           key: my_cache_key
       - name: Checkout capgo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Validate migration timestamps
@@ -114,7 +114,7 @@ jobs:
 
           echo "✅ Migration filename timestamps are unique and strictly newer than main."
       - name: Check for typos
-        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
+        uses: crate-ci/typos@v1.45.1
       - name: Show bun version
         run: bun --version
       - name: Show capgo version
@@ -139,7 +139,7 @@ jobs:
       # - name: Lint I18n
       #   run: bunx @inlang/cli lint --project project.inlang
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
+        uses: supabase/setup-cli@v2.0.0
         with:
           # Supabase CLI 2.90.0 regressed our local test-db startup on GitHub
           # Actions runners; pin to the last known-good version until upstream is
@@ -157,7 +157,7 @@ jobs:
         run: supabase test db
       - name: Lint SQL
         run: supabase db lint -s public --fail-on warning
-      - uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1
+      - uses: JarvusInnovations/background-action@v1
         name: Bootstrap Edge server
         with:
           run: supabase functions serve &
@@ -182,7 +182,7 @@ jobs:
           working-directory: .
       - name: Run all backend and CLI tests
         run: bun run test:all
-      - uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1
+      - uses: JarvusInnovations/background-action@v1
         name: Start Cloudflare Workers for testing
         with:
           run: |
@@ -209,16 +209,16 @@ jobs:
       contents: read
     steps:
       - name: Cache Deno dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@v5
         with:
           path: ${{ env.DENO_DIR }}
           key: my_cache_key
       - name: Checkout capgo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -226,7 +226,7 @@ jobs:
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
+        uses: supabase/setup-cli@v2.0.0
         with:
           version: 2.84.2
       - name: Link Supabase templates
@@ -235,7 +235,7 @@ jobs:
         run: bun run test:front
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-artifacts
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,16 +24,16 @@ jobs:
       actions: write
     steps:
       - name: Cache Deno dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.DENO_DIR }}
           key: my_cache_key
       - name: Checkout capgo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - name: Validate migration timestamps
@@ -139,7 +139,7 @@ jobs:
       # - name: Lint I18n
       #   run: bunx @inlang/cli lint --project project.inlang
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
         with:
           # Supabase CLI 2.90.0 regressed our local test-db startup on GitHub
           # Actions runners; pin to the last known-good version until upstream is
@@ -209,16 +209,16 @@ jobs:
       contents: read
     steps:
       - name: Cache Deno dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.DENO_DIR }}
           key: my_cache_key
       - name: Checkout capgo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -226,7 +226,7 @@ jobs:
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
         with:
           version: 2.84.2
       - name: Link Supabase templates
@@ -235,7 +235,7 @@ jobs:
         run: bun run test:front
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: playwright-artifacts
           path: |


### PR DESCRIPTION
## Summary (AI generated)

- update the pinned GitHub Actions used by CI workflows to Node 24-compatible revisions
- keep the existing Supabase CLI binary pin for tests while moving the setup action wrapper to `supabase/setup-cli@v2`
- remove Node 20 deprecation warnings from the Playwright test workflow and related CI jobs

## Motivation (AI generated)

GitHub Actions is deprecating Node 20-based JavaScript actions. These workflows were still pinned to older action revisions, which created deprecation warnings and risked future CI breakage as GitHub runners move to Node 24.

## Business Impact (AI generated)

This keeps Capgo CI stable, reduces noisy warnings in pull requests, and lowers the risk of test or deployment interruptions caused by upstream GitHub Actions runtime changes.

## Test Plan (AI generated)

- [x] Validate the updated workflow YAML parses correctly
- [x] Confirm the touched workflows no longer pin the previous Node 20-era action revisions
- [x] `Run tests`
- [x] `Run Playwright tests`
- [x] `Run benchmarks`
- [x] Review the rerun of the Playwright job after the transient Supabase reset failure and confirm the workflow passes

## Checklist (AI generated)

- [x] Only CI workflow files were changed
- [x] The Supabase CLI runtime version pin used by tests remains unchanged
- [x] The PR is ready for review with passing checks

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflow configurations to use current versions of development tooling.
  * Refreshed continuous integration testing workflows with updated action versions for improved reliability and compatibility with latest standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->