### PR TITLE
fix(api): keep anon CLI app-list helper grants

### DIFF
--- a/supabase/migrations/20260427175506_temporary_cli_apps_list_anon_helper_grants.sql
+++ b/supabase/migrations/20260427175506_temporary_cli_apps_list_anon_helper_grants.sql
@@ -2,9 +2,42 @@
 --
 -- The currently published CLI still does legacy anonymous PostgREST auth checks
 -- before issuing a direct `GET /rest/v1/apps` request with the `capgkey`
--- header. The `apps` RLS path resolves API-key identity through the helper
--- functions below, so anonymous execute on them remains required until the CLI
--- repo switches `app list` to the RBAC-aware wrappers.
+-- header. The `public.apps` SELECT policy for `anon` / `authenticated` is:
+--
+--   public.check_min_rights(
+--     'read'::public.user_min_right,
+--     public.get_identity_org_appid(
+--       '{read,upload,write,all}'::public.key_mode[],
+--       owner_org,
+--       app_id
+--     ),
+--     owner_org,
+--     app_id,
+--     NULL::bigint
+--   )
+--
+-- That policy makes each helper below part of the anonymous table read:
+-- - public.get_apikey_header()
+--   Extracts `capgkey` from `request.headers` so RLS helpers can see the API
+--   key on an anonymous PostgREST request.
+-- - public.is_apikey_expired(timestamp with time zone)
+--   Called by `get_identity_org_appid()` and by the RBAC API-key branch inside
+--   `check_min_rights()` to reject expired keys before identity or permission
+--   checks continue.
+-- - public.get_identity_org_appid(public.key_mode[], uuid, character varying)
+--   Called directly by the `public.apps` SELECT policy to convert the
+--   anonymous request plus `capgkey` into the API-key owner identity after
+--   mode, org, and app-scope checks pass.
+-- - public.check_min_rights(public.user_min_right, uuid, uuid, character
+--   varying, bigint)
+--   Called directly by the `public.apps` SELECT policy to enforce `read`
+--   permission for that derived identity. On RBAC orgs it also re-reads the
+--   API key to evaluate direct API-key principal grants and org/app
+--   restrictions.
+--
+-- Until the CLI switches `app list` to the RBAC-aware wrappers, removing any
+-- of these anon grants breaks the anonymous `public.apps` read even when the
+-- key itself is valid.
 
 GRANT EXECUTE ON FUNCTION public.get_apikey_header() TO anon;
 GRANT EXECUTE ON FUNCTION public.is_apikey_expired(timestamp with time zone) TO anon;

--- a/supabase/migrations/20260427175506_temporary_cli_apps_list_anon_helper_grants.sql
+++ b/supabase/migrations/20260427175506_temporary_cli_apps_list_anon_helper_grants.sql
@@ -1,0 +1,12 @@
+-- Temporary compatibility fix for the published CLI `app list` flow.
+--
+-- The currently published CLI still does legacy anonymous PostgREST auth checks
+-- before issuing a direct `GET /rest/v1/apps` request with the `capgkey`
+-- header. The `apps` RLS path resolves API-key identity through the helper
+-- functions below, so anonymous execute on them remains required until the CLI
+-- repo switches `app list` to the RBAC-aware wrappers.
+
+GRANT EXECUTE ON FUNCTION public.get_apikey_header() TO anon;
+GRANT EXECUTE ON FUNCTION public.is_apikey_expired(timestamp with time zone) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_identity_org_appid(public.key_mode[], uuid, character varying) TO anon;
+GRANT EXECUTE ON FUNCTION public.check_min_rights(public.user_min_right, uuid, uuid, character varying, bigint) TO anon;

--- a/supabase/migrations/20260427175506_temporary_cli_apps_list_anon_helper_grants.sql
+++ b/supabase/migrations/20260427175506_temporary_cli_apps_list_anon_helper_grants.sql
@@ -1,4 +1,9 @@
 -- Temporary compatibility fix for the published CLI `app list` flow.
+-- Sunset: remove these grants in cleanup migration
+-- `remove_temporary_cli_apps_anon_helper_grants` once the published CLI
+-- switches `app list` to the RBAC-aware wrappers from
+-- `20260427144323_cli_rbac_permission_wrappers.sql`
+-- (`get_accessible_apps_for_apikey_v2()` / `cli_check_permission()`).
 --
 -- The currently published CLI still does legacy anonymous PostgREST auth checks
 -- before issuing a direct `GET /rest/v1/apps` request with the `capgkey`

--- a/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
+++ b/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(14);
+SELECT plan(19);
 
 SELECT
     is(
@@ -34,6 +34,56 @@ SELECT
         false,
         'anon role has no execute privilege on'
         || ' get_org_perm_for_apikey(text, text)'
+    );
+
+-- Published CLI v7.x still performs anonymous PostgREST helper calls before a
+-- direct `GET /rest/v1/apps` query with the `capgkey` header. Keep these anon
+-- grants covered until the CLI switches to the RBAC-aware wrappers.
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.get_apikey_header()'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'anon role keeps execute privilege on get_apikey_header()'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.is_apikey_expired(timestamp with time zone)'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'anon role keeps execute privilege on'
+        || ' is_apikey_expired(timestamp with time zone)'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.get_identity_org_appid(public.key_mode[], uuid, character varying)'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'anon role keeps execute privilege on'
+        || ' get_identity_org_appid(public.key_mode[], uuid, character varying)'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.check_min_rights(public.user_min_right, uuid, uuid, character varying, bigint)'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'anon role keeps execute privilege on'
+        || ' check_min_rights(public.user_min_right, uuid, uuid, character varying, bigint)'
     );
 
 SELECT
@@ -146,6 +196,17 @@ SELECT
         ),
         1::bigint,
         'anon API-key storage access still works through header-based identity'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM public.apps
+            WHERE app_id = 'com.demo.app'
+        ),
+        1::bigint,
+        'anon API-key apps query still works through RLS helper identity'
     );
 
 DO $$

--- a/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
+++ b/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
@@ -36,9 +36,12 @@ SELECT
         || ' get_org_perm_for_apikey(text, text)'
     );
 
--- Published CLI v7.x still performs anonymous PostgREST helper calls before a
--- direct `GET /rest/v1/apps` query with the `capgkey` header. Keep these anon
--- grants covered until the CLI switches to the RBAC-aware wrappers.
+-- Published CLI v7.x still reads `public.apps` through anon PostgREST RLS.
+-- That path calls `get_identity_org_appid()` directly from the apps SELECT
+-- policy, which depends on `get_apikey_header()` and `is_apikey_expired()`,
+-- then calls `check_min_rights()`, which re-checks API-key RBAC scope on RBAC
+-- orgs. Keep those anon grants covered until the CLI switches to the
+-- RBAC-aware wrappers.
 SELECT
     is(
         has_function_privilege(

--- a/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
+++ b/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(19);
+SELECT plan(20);
 
 SELECT
     is(
@@ -216,6 +216,17 @@ DO $$
 BEGIN
     PERFORM set_config('request.headers', '{"capgkey": "invalid-key"}', true);
 END $$;
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM public.apps
+            WHERE app_id = 'com.demo.app'
+        ),
+        0::bigint,
+        'anon with invalid capgkey cannot read apps through helper identity'
+    );
 
 SELECT
     is(


### PR DESCRIPTION
## Summary (AI generated)

- add a temporary migration that preserves anonymous execute on the helper functions used by the published CLI `app list` flow
- document why the legacy CLI still depends on these helper grants
- extend the SQL privilege regression test to keep the anon grants covered and to exercise an anonymous API-key `apps` read

## Motivation (AI generated)

The currently published CLI still authenticates through legacy anonymous PostgREST helper calls and then issues a direct `GET /rest/v1/apps` request with the `capgkey` header. When these helper grants drift or get tightened, CLI users regress from working API-key auth to opaque `Apps not found` / auth failures.

## Business Impact (AI generated)

This restores short-term CLI reliability for existing customers without forcing an immediate CLI upgrade. It reduces support load around broken API-key workflows and buys time to ship the longer-term CLI-side migration to RBAC-aware wrappers.

## Test Plan (AI generated)

- [x] Run `bun run typecheck`
- [ ] Run `bun scripts/supabase-worktree.ts test db`
- [ ] Verify `bunx @capgo/cli app list` succeeds against a local stack after the legacy anon grants are present

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI app list now correctly returns apps for anonymous users using legacy API-key header authentication (temporary backend permission adjustment).
* **Tests**
  * Expanded test coverage for the header-based identity flow and validated app query behavior with valid vs. invalid API-key headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->