### PR TITLE
fix(ci): allow reusable tests workflow PR read scope

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       actions: write
+      # The reusable tests workflow declares PR read access for its path filter job.
+      pull-requests: read
 
   # Only bump version and create tag if all tests pass
   bump-version:


### PR DESCRIPTION
## Summary (AI generated)

- add `pull-requests: read` to the `bump_version.yml` reusable test workflow call
- align the caller permissions with `.github/workflows/tests.yml` so GitHub can validate the nested workflow

## Motivation (AI generated)

The monorepo test workflow now declares `pull-requests: read` for its path filter job. `bump_version.yml` calls that workflow on pushes to `main` and `development`, but its job-level permissions did not allow that scope, so GitHub rejected the workflow file before CI could start.

## Business Impact (AI generated)

This restores release automation on `main` and `development`. Without it, version bumping and follow-up release steps stop at workflow validation instead of running after merges.

## Test Plan (AI generated)

- [x] Parse `.github/workflows/bump_version.yml` and `.github/workflows/tests.yml` locally after the change
- [x] Let the commit hook run successfully during commit creation
- [ ] Verify GitHub Actions validates and runs the PR checks

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to ensure proper access control and alignment with testing infrastructure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->