### PR TITLE
fix(ci): split capgo and cli release workflows

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,12 +7,12 @@ concurrency:
 on:
   push:
     tags:
-      - 'capgo-*'
+      - "capgo-*"
 
 permissions: {}
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # Tests already passed before tag was created, so just build and deploy
@@ -133,7 +133,7 @@ jobs:
 
             🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
           make_latest: true
-          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           prerelease: ${{ contains(github.ref, '-alpha.') }}
 
   deploy_api:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - "capgo-*"
+      - "capgo-[0-9]*"
 
 permissions: {}
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - 'v*'
+      - 'capgo-*'
 
 permissions: {}
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions: {}
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -22,6 +22,7 @@ jobs:
       capgo_release_as: ${{ steps.capgo.outputs.release_as }}
       run_cli: ${{ steps.cli.outputs.should_release }}
       cli_release_as: ${{ steps.cli.outputs.release_as }}
+      has_migration_changes: ${{ steps.migration_scope.outputs.has_migration_changes }}
       run_any: ${{ steps.capgo.outputs.should_release == 'true' || steps.cli.outputs.should_release == 'true' }}
     steps:
       - name: Checkout
@@ -36,6 +37,14 @@ jobs:
       - name: Resolve CLI release scope
         id: cli
         run: bun scripts/release-scope.ts cli "${{ github.event.before }}" "${{ github.sha }}" >> "$GITHUB_OUTPUT"
+      - name: Resolve migration scope
+        id: migration_scope
+        run: |
+          if git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -q '^supabase/migrations/'; then
+            echo "has_migration_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_migration_changes=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # Run only the relevant test scope before creating tags
   test:
@@ -132,7 +141,7 @@ jobs:
 
   sync_schema_types:
     needs: [changes, bump-version]
-    if: ${{ github.ref == 'refs/heads/main' && needs.changes.outputs.run_capgo == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') }}
+    if: ${{ github.ref == 'refs/heads/main' && needs.changes.outputs.has_migration_changes == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -152,16 +161,6 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_TOKEN }}
         run: |
-          if ! git rev-parse -q --verify HEAD^ >/dev/null 2>&1; then
-            echo "No parent commit for HEAD, skipping schema/types sync."
-            exit 0
-          fi
-
-          if ! git diff --name-only HEAD^ HEAD | grep -q '^supabase/migrations/'; then
-            echo "No migration changes in latest commit, skipping schema/types sync."
-            exit 0
-          fi
-
           if [ -z "${{ secrets.SUPABASE_PROJECT_ID_PROD }}" ]; then
             echo "SUPABASE_PROJECT_ID_PROD is required for schema/types sync" >&2
             exit 1

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -29,9 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Resolve Capgo release scope
         id: capgo
         run: bun scripts/release-scope.ts capgo "${{ github.event.before }}" "${{ github.sha }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - name: Resolve Capgo release scope

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -84,7 +84,9 @@ jobs:
           bun run --cwd cli generate-docs
           bun run --cwd cli generate-docs --folder webdocs
           git add cli/README.md cli/webdocs
-          git commit -m "docs(cli): update generated docs" || true
+          if ! git diff --cached --quiet; then
+            git commit -m "docs(cli): update generated docs"
+          fi
       - name: Create version bumps
         env:
           RUN_CAPGO: ${{ needs.changes.outputs.run_capgo }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       actions: write
+      # The reusable tests workflow declares PR read access for its path filter job.
+      pull-requests: read
 
   # Only bump version and create tag if all tests pass
   bump-version:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Resolve Capgo release scope
@@ -98,9 +98,9 @@ jobs:
 
           if [ "$RUN_CAPGO" = "true" ]; then
             if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-              bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS"
+              bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS" --tag-prefix capgo-
             else
-              bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS" --prerelease alpha
+              bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS" --prerelease alpha --tag-prefix capgo-
             fi
 
             git add supabase/functions/_backend/utils/version.ts
@@ -116,9 +116,9 @@ jobs:
 
           if [ "$RUN_CLI" = "true" ]; then
             if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-              bunx standard-version --skip.changelog --release-as "$CLI_RELEASE_AS" --tag-prefix cli-v --packageFiles cli/package.json --bumpFiles cli/package.json
+              bunx standard-version --skip.changelog --release-as "$CLI_RELEASE_AS" --tag-prefix cli- --packageFiles cli/package.json --bumpFiles cli/package.json
             else
-              bunx standard-version --skip.changelog --release-as "$CLI_RELEASE_AS" --prerelease alpha --tag-prefix cli-v --packageFiles cli/package.json --bumpFiles cli/package.json
+              bunx standard-version --skip.changelog --release-as "$CLI_RELEASE_AS" --prerelease alpha --tag-prefix cli- --packageFiles cli/package.json --bumpFiles cli/package.json
             fi
           fi
       - name: Push to origin

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -22,6 +22,7 @@ jobs:
       capgo_release_as: ${{ steps.capgo.outputs.release_as }}
       run_cli: ${{ steps.cli.outputs.should_release }}
       cli_release_as: ${{ steps.cli.outputs.release_as }}
+      run_any: ${{ steps.capgo.outputs.should_release == 'true' || steps.cli.outputs.should_release == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,7 +42,7 @@ jobs:
   # Run only the relevant test scope before creating tags
   test:
     needs: changes
-    if: ${{ needs.changes.outputs.run_capgo == 'true' || needs.changes.outputs.run_cli == 'true' }}
+    if: ${{ needs.changes.outputs.run_any == 'true' }}
     uses: ./.github/workflows/tests.yml
     with:
       run_capgo: ${{ needs.changes.outputs.run_capgo == 'true' }}
@@ -55,7 +56,7 @@ jobs:
   # Only bump the changed release scopes and create matching tags after tests pass
   bump-version:
     needs: [changes, test]
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') && (needs.changes.outputs.run_capgo == 'true' || needs.changes.outputs.run_cli == 'true') && needs.test.result == 'success' }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') && needs.changes.outputs.run_any == 'true' && needs.test.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Bump versions and create tags
@@ -93,6 +94,8 @@ jobs:
           RUN_CLI: ${{ needs.changes.outputs.run_cli }}
           CLI_RELEASE_AS: ${{ needs.changes.outputs.cli_release_as }}
         run: |
+          set -e
+
           if [ "$RUN_CAPGO" = "true" ]; then
             if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
               bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS"
@@ -120,9 +123,13 @@ jobs:
           fi
       - name: Push to origin
         run: |
+          set -e
+
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           remote_repo="https://${GITHUB_ACTOR}:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          git pull --rebase $remote_repo $CURRENT_BRANCH
+          if ! git pull --rebase $remote_repo $CURRENT_BRANCH; then
+            git pull --rebase=false $remote_repo $CURRENT_BRANCH
+          fi
           git push $remote_repo HEAD:$CURRENT_BRANCH --follow-tags --tags
 
   sync_schema_types:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -12,69 +12,122 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  # Run all tests first before creating any tags
-  test:
+  changes:
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      run_capgo: ${{ steps.capgo.outputs.should_release }}
+      capgo_release_as: ${{ steps.capgo.outputs.release_as }}
+      run_cli: ${{ steps.cli.outputs.should_release }}
+      cli_release_as: ${{ steps.cli.outputs.release_as }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Resolve Capgo release scope
+        id: capgo
+        run: bun scripts/release-scope.ts capgo "${{ github.event.before }}" "${{ github.sha }}" >> "$GITHUB_OUTPUT"
+      - name: Resolve CLI release scope
+        id: cli
+        run: bun scripts/release-scope.ts cli "${{ github.event.before }}" "${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+  # Run only the relevant test scope before creating tags
+  test:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_capgo == 'true' || needs.changes.outputs.run_cli == 'true' }}
     uses: ./.github/workflows/tests.yml
+    with:
+      run_capgo: ${{ needs.changes.outputs.run_capgo == 'true' }}
+      run_cli: ${{ needs.changes.outputs.run_cli == 'true' }}
     permissions:
       contents: read
       actions: write
       # The reusable tests workflow declares PR read access for its path filter job.
       pull-requests: read
 
-  # Only bump version and create tag if all tests pass
+  # Only bump the changed release scopes and create matching tags after tests pass
   bump-version:
-    needs: [test]
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') }}
+    needs: [changes, test]
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') && (needs.changes.outputs.run_capgo == 'true' || needs.changes.outputs.run_cli == 'true') && needs.test.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Bump version and create tag
+    name: Bump versions and create tags
     permissions:
       contents: write
     steps:
       - name: Check out
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install dependencies
+        if: ${{ needs.changes.outputs.run_cli == 'true' }}
+        run: bun install --frozen-lockfile
       - name: Git config
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Create version bump main
-        if: github.ref == 'refs/heads/main'
-        run: bun x standard-version --skip.changelog
-      - name: Create version bump development
-        if: github.ref != 'refs/heads/main'
-        run: bun x standard-version --prerelease alpha --skip.changelog
-      - name: Add release artifacts to commit
+      - name: Generate CLI docs
+        if: ${{ needs.changes.outputs.run_cli == 'true' }}
         run: |
-          git add supabase/functions/_backend/utils/version.ts
-          if ! git diff --cached --quiet; then
-            # Get the current tag before amending (if it exists)
-            CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+          bun run cli:build
+          bun run --cwd cli generate-docs
+          bun run --cwd cli generate-docs --folder webdocs
+          git add cli/README.md cli/webdocs
+          git commit -m "docs(cli): update generated docs" || true
+      - name: Create version bumps
+        env:
+          RUN_CAPGO: ${{ needs.changes.outputs.run_capgo }}
+          CAPGO_RELEASE_AS: ${{ needs.changes.outputs.capgo_release_as }}
+          RUN_CLI: ${{ needs.changes.outputs.run_cli }}
+          CLI_RELEASE_AS: ${{ needs.changes.outputs.cli_release_as }}
+        run: |
+          if [ "$RUN_CAPGO" = "true" ]; then
+            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+              bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS"
+            else
+              bunx standard-version --skip.changelog --release-as "$CAPGO_RELEASE_AS" --prerelease alpha
+            fi
 
-            # Amend the commit
-            git commit --amend --no-edit
+            git add supabase/functions/_backend/utils/version.ts
+            if ! git diff --cached --quiet; then
+              CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+              git commit --amend --no-edit
 
-            # Move the tag to the amended commit
-            if [ -n "$CURRENT_TAG" ]; then
-              git tag -f "$CURRENT_TAG"
+              if [ -n "$CURRENT_TAG" ]; then
+                git tag -f "$CURRENT_TAG"
+              fi
+            fi
+          fi
+
+          if [ "$RUN_CLI" = "true" ]; then
+            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+              bunx standard-version --skip.changelog --release-as "$CLI_RELEASE_AS" --tag-prefix cli-v --packageFiles cli/package.json --bumpFiles cli/package.json
+            else
+              bunx standard-version --skip.changelog --release-as "$CLI_RELEASE_AS" --prerelease alpha --tag-prefix cli-v --packageFiles cli/package.json --bumpFiles cli/package.json
             fi
           fi
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           remote_repo="https://${GITHUB_ACTOR}:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          git pull $remote_repo $CURRENT_BRANCH
+          git pull --rebase $remote_repo $CURRENT_BRANCH
           git push $remote_repo HEAD:$CURRENT_BRANCH --follow-tags --tags
 
   sync_schema_types:
-    needs: bump-version
-    if: ${{ github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') }}
+    needs: [changes, bump-version]
+    if: ${{ github.ref == 'refs/heads/main' && needs.changes.outputs.run_capgo == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):') && !startsWith(github.event.head_commit.message, 'chore(auto-sync):') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -125,9 +125,7 @@ jobs:
 
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           remote_repo="https://${GITHUB_ACTOR}:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          if ! git pull --rebase $remote_repo $CURRENT_BRANCH; then
-            git pull --rebase=false $remote_repo $CURRENT_BRANCH
-          fi
+          git pull --rebase=false $remote_repo $CURRENT_BRANCH
           git push $remote_repo HEAD:$CURRENT_BRANCH --follow-tags --tags
 
   sync_schema_types:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   changes:

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -1,0 +1,70 @@
+name: Build and publish CLI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - 'cli-v*'
+
+permissions: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  publish_cli:
+    runs-on: ubuntu-latest
+    name: Build and publish CLI to npm
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build CLI
+        run: bun run cli:build
+      - name: Generate AI changelog
+        id: changelog
+        uses: mistricky/ccc@v0.2.6
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          model: claude-sonnet-4-5-20250929
+      - name: Publish CLI to npm
+        if: ${{ !contains(github.ref, '-alpha.') }}
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun publish --cwd cli --access public
+      - name: Publish CLI to npm with next tag
+        if: ${{ contains(github.ref, '-alpha.') }}
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun publish --cwd cli --tag next --access public
+      - name: Create GitHub release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: |
+            ## 🆕 Changelog
+
+            ${{ steps.changelog.outputs.result }}
+
+            ---
+
+            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
+          make_latest: false
+          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - "cli-*"
+      - "cli-[0-9]*"
 
 permissions: {}
 

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -24,12 +24,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           filter: blob:none
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
         run: bun run cli:build
       - name: Generate AI changelog
         id: changelog
-        uses: mistricky/ccc@v0.2.6
+        uses: mistricky/ccc@d9358b3eca472c0f41a6c1732bf073c0c54b837e # v0.2.6
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
         run: bun publish --cwd cli --tag next --access public
       - name: Create GitHub release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           body: |
             ## 🆕 Changelog

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - 'cli-v*'
+      - 'cli-*'
 
 permissions: {}
 
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -29,9 +29,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build CLI

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -39,7 +39,7 @@ jobs:
         uses: mistricky/ccc@d9358b3eca472c0f41a6c1732bf073c0c54b837e # v0.2.6
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ github.token }}
           model: claude-sonnet-4-5-20250929
       - name: Publish CLI to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
@@ -64,5 +64,5 @@ jobs:
 
             🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
           make_latest: false
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          token: ${{ github.token }}
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -7,12 +7,12 @@ concurrency:
 on:
   push:
     tags:
-      - 'cli-*'
+      - "cli-*"
 
 permissions: {}
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   publish_cli:
@@ -66,5 +66,5 @@ jobs:
 
             🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
           make_latest: false
-          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,9 +154,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Validate migration timestamps
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: bash scripts/check-supabase-migration-order.sh
@@ -277,9 +275,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Install dependencies
         run: bun install
       - name: Install Playwright browser
@@ -393,9 +389,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -436,9 +430,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Install dependencies
         run: bun install
       - name: Install test_upload dependencies
@@ -470,9 +462,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        if: runner.os != 'Windows'
+        run: bash scripts/setup-bun.sh
+      - name: Setup bun on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/setup-bun.ps1
       - name: Install dependencies
         run: bun install
       - name: Install test_upload dependencies
@@ -621,9 +616,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -669,9 +662,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        run: bash scripts/setup-bun.sh
       - name: Install dependencies
         run: bun install
       - name: Install Supabase CLI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,8 @@ jobs:
             shared:
               - '.github/workflows/**'
               - '.github/scripts/**'
+              - 'scripts/setup-bun.sh'
+              - 'scripts/setup-bun.ps1'
               - '.npmrc'
               - '.typos.toml'
               - 'package.json'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ permissions: {}
 
 env:
   DENO_DIR: my_cache_directory
-  CLICOLOR: '1'
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  CLICOLOR: "1"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   changes:
@@ -388,7 +388,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '21', '22', '23', '24', '25']
+        node-version: ["20", "21", "22", "23", "24", "25"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -520,7 +520,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: '17'
+          java-version: "17"
       - name: Compile VerifyZip.java
         run: javac ./cli/test/VerifyZip.java
       - name: Verify ZIP file integrity for Linux build with Java

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Validate migration timestamps
@@ -277,7 +277,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -393,7 +393,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -436,7 +436,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -470,7 +470,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -621,7 +621,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Setup Node.js
@@ -669,7 +669,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -1,0 +1,139 @@
+import { execFileSync } from 'node:child_process'
+
+type Component = 'capgo' | 'cli'
+type ReleaseAs = 'patch' | 'minor' | 'major'
+
+const componentMatchers: Record<Component, RegExp[]> = {
+  capgo: [
+    /^package\.json$/,
+    /^aliproxy\//,
+    /^android\//,
+    /^assets\//,
+    /^cloudflare_workers\//,
+    /^configs\.json$/,
+    /^deno-env\.d\.ts$/,
+    /^deno\.lock$/,
+    /^formkit\.config\.ts$/,
+    /^formkit\.theme\.ts$/,
+    /^icons\//,
+    /^index\.html$/,
+    /^internal\//,
+    /^ionic\.config\.json$/,
+    /^ios\//,
+    /^jean\.json$/,
+    /^messages\//,
+    /^public\//,
+    /^read_replicate\//,
+    /^scriptable\//,
+    /^shared\//,
+    /^sql\//,
+    /^src\//,
+    /^supabase\//,
+    /^capacitor\.config\.ts$/,
+    /^vite\.config\.mts$/,
+    /^wrangler\.jsonc$/,
+  ],
+  cli: [
+    /^cli\/src\//,
+    /^cli\/package\.json$/,
+    /^cli\/build\.mjs$/,
+    /^cli\/tsconfig\.json$/,
+    /^cli\/\.npmrc$/,
+  ],
+}
+
+function runGit(args: string[]): string {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function getCommitShas(before: string, after: string): string[] {
+  const isZero = before === '' || /^0+$/.test(before)
+
+  if (!isZero) {
+    const commits = runGit(['rev-list', '--reverse', `${before}..${after}`])
+    return commits ? commits.split('\n').filter(Boolean) : []
+  }
+
+  const parents = runGit(['rev-list', '--parents', '-n', '1', after]).split(' ')
+  if (parents.length > 1) {
+    const commits = runGit(['rev-list', '--reverse', `${after}^..${after}`])
+    return commits ? commits.split('\n').filter(Boolean) : []
+  }
+
+  return [after]
+}
+
+function getChangedFiles(commit: string): string[] {
+  const files = runGit(['show', '--format=', '--name-only', commit])
+  return files ? files.split('\n').filter(Boolean) : []
+}
+
+function getCommitMessage(commit: string): { subject: string, body: string } {
+  return {
+    subject: runGit(['log', '-1', '--format=%s', commit]),
+    body: runGit(['log', '-1', '--format=%b', commit]),
+  }
+}
+
+function matchesComponent(component: Component, files: string[]): boolean {
+  return files.some(file => componentMatchers[component].some(pattern => pattern.test(file)))
+}
+
+function getSeverity(subject: string, body: string): number {
+  const conventionalMatch = subject.match(/^([a-z]+)(\([^)]+\))?(!)?:/)
+  const hasBreakingChange = body.includes('BREAKING CHANGE:') || conventionalMatch?.[3] === '!'
+
+  if (hasBreakingChange) {
+    return 3
+  }
+
+  if (conventionalMatch?.[1] === 'feat') {
+    return 2
+  }
+
+  return 1
+}
+
+function toReleaseAs(severity: number): ReleaseAs {
+  if (severity >= 3) {
+    return 'major'
+  }
+
+  if (severity === 2) {
+    return 'minor'
+  }
+
+  return 'patch'
+}
+
+const componentArg = process.argv[2]
+const before = process.argv[3] ?? ''
+const after = process.argv[4] ?? 'HEAD'
+
+if (componentArg !== 'capgo' && componentArg !== 'cli') {
+  console.error('Usage: bun scripts/release-scope.ts <capgo|cli> <before> <after>')
+  process.exit(1)
+}
+
+const component = componentArg as Component
+const commits = getCommitShas(before, after)
+
+let shouldRelease = false
+let highestSeverity = 0
+
+for (const commit of commits) {
+  const files = getChangedFiles(commit)
+  if (!matchesComponent(component, files)) {
+    continue
+  }
+
+  shouldRelease = true
+  const message = getCommitMessage(commit)
+  highestSeverity = Math.max(highestSeverity, getSeverity(message.subject, message.body))
+}
+
+console.log(`should_release=${shouldRelease}`)
+console.log(`release_as=${shouldRelease ? toReleaseAs(highestSeverity) : 'patch'}`)

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -35,6 +35,7 @@ const componentMatchers: Record<Component, RegExp[]> = {
   ],
   cli: [
     /^cli\/src\//,
+    /^cli\/skills\//,
     /^cli\/package\.json$/,
     /^cli\/build\.mjs$/,
     /^cli\/tsconfig\.json$/,

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -37,7 +37,7 @@ const componentMatchers: Record<Component, RegExp[]> = {
   cli: [
     /^bun\.lock$/,
     /^cli\/src\//,
-    /^cli\/skills\//,
+    /^cli\/skills\/(?!.*\.(md|mdx)$)/,
     /^cli\/package\.json$/,
     /^cli\/build\.mjs$/,
     /^cli\/tsconfig\.json$/,
@@ -117,7 +117,7 @@ const before = process.argv[3] ?? ''
 const after = process.argv[4] ?? 'HEAD'
 
 if (componentArg !== 'capgo' && componentArg !== 'cli') {
-  console.error('Usage: bun scripts/release-scope.ts <capgo|cli> <before> <after>')
+  console.error('Usage: bun scripts/release-scope.ts <capgo|cli> [before] [after]')
   process.exit(1)
 }
 

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -37,6 +37,7 @@ const componentMatchers: Record<Component, RegExp[]> = {
   cli: [
     /^bun\.lock$/,
     /^cli\/src\//,
+    /^cli\/skills\/[^/]+\/SKILL\.md$/,
     /^cli\/skills\/(?!.*\.(md|mdx)$)/,
     /^cli\/package\.json$/,
     /^cli\/build\.mjs$/,

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -6,6 +6,7 @@ type ReleaseAs = 'patch' | 'minor' | 'major'
 const componentMatchers: Record<Component, RegExp[]> = {
   capgo: [
     /^package\.json$/,
+    /^bun\.lock$/,
     /^aliproxy\//,
     /^android\//,
     /^assets\//,
@@ -34,6 +35,7 @@ const componentMatchers: Record<Component, RegExp[]> = {
     /^wrangler\.jsonc$/,
   ],
   cli: [
+    /^bun\.lock$/,
     /^cli\/src\//,
     /^cli\/skills\//,
     /^cli\/package\.json$/,

--- a/scripts/setup-bun.ps1
+++ b/scripts/setup-bun.ps1
@@ -1,6 +1,35 @@
 $ErrorActionPreference = 'Stop'
 
-Invoke-RestMethod https://bun.sh/install.ps1 | Invoke-Expression
+$BunVersion = '1.3.11'
+$AssetName = 'bun-windows-x64.zip'
+$AssetSha256 = '066f8694f8b7d8df592452746d18f01710d4053e93030922dbc6e8c34a8c4b9f'
+
+$TempDir = Join-Path $env:RUNNER_TEMP "bun-$BunVersion"
+$ArchivePath = Join-Path $TempDir $AssetName
+$ExtractPath = Join-Path $TempDir 'extract'
+$InstallDir = Join-Path $env:USERPROFILE '.bun\bin'
+
+Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -Path $TempDir -ItemType Directory -Force | Out-Null
+
+$AssetUrl = "https://github.com/oven-sh/bun/releases/download/bun-v$BunVersion/$AssetName"
+Invoke-WebRequest -Uri $AssetUrl -OutFile $ArchivePath
+
+$ActualSha256 = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($ActualSha256 -ne $AssetSha256) {
+  throw "Checksum mismatch for $AssetName. Expected $AssetSha256, got $ActualSha256."
+}
+
+Expand-Archive -Path $ArchivePath -DestinationPath $ExtractPath -Force
+
+$BunExecutable = Get-ChildItem -Path $ExtractPath -Filter 'bun.exe' -File -Recurse | Select-Object -First 1
+if (-not $BunExecutable) {
+  throw "bun.exe not found in $AssetName."
+}
+
+New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
+Copy-Item -Path $BunExecutable.FullName -Destination (Join-Path $InstallDir 'bun.exe') -Force
+
 "$env:USERPROFILE\.bun\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 $env:PATH = "$env:USERPROFILE\.bun\bin;$env:PATH"
 

--- a/scripts/setup-bun.ps1
+++ b/scripts/setup-bun.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+
+Invoke-RestMethod https://bun.sh/install.ps1 | Invoke-Expression
+"$env:USERPROFILE\.bun\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+$env:PATH = "$env:USERPROFILE\.bun\bin;$env:PATH"
+
+bun --version

--- a/scripts/setup-bun.ps1
+++ b/scripts/setup-bun.ps1
@@ -29,6 +29,7 @@ if (-not $BunExecutable) {
 
 New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
 Copy-Item -Path $BunExecutable.FullName -Destination (Join-Path $InstallDir 'bun.exe') -Force
+Copy-Item -Path $BunExecutable.FullName -Destination (Join-Path $InstallDir 'bunx.exe') -Force
 
 "$env:USERPROFILE\.bun\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 $env:PATH = "$env:USERPROFILE\.bun\bin;$env:PATH"

--- a/scripts/setup-bun.ps1
+++ b/scripts/setup-bun.ps1
@@ -8,16 +8,31 @@ $TempDir = Join-Path $env:RUNNER_TEMP "bun-$BunVersion"
 $ArchivePath = Join-Path $TempDir $AssetName
 $ExtractPath = Join-Path $TempDir 'extract'
 $InstallDir = Join-Path $env:USERPROFILE '.bun\bin'
+$MaxDownloadAttempts = 3
 
 Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -Path $TempDir -ItemType Directory -Force | Out-Null
 
 $AssetUrl = "https://github.com/oven-sh/bun/releases/download/bun-v$BunVersion/$AssetName"
-Invoke-WebRequest -Uri $AssetUrl -OutFile $ArchivePath
+for ($Attempt = 1; $Attempt -le $MaxDownloadAttempts; $Attempt++) {
+  try {
+    Invoke-WebRequest -Uri $AssetUrl -OutFile $ArchivePath
 
-$ActualSha256 = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
-if ($ActualSha256 -ne $AssetSha256) {
-  throw "Checksum mismatch for $AssetName. Expected $AssetSha256, got $ActualSha256."
+    $ActualSha256 = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($ActualSha256 -eq $AssetSha256) {
+      break
+    }
+
+    throw "Checksum mismatch for $AssetName. Expected $AssetSha256, got $ActualSha256."
+  }
+  catch {
+    if ($Attempt -eq $MaxDownloadAttempts) {
+      throw
+    }
+
+    Remove-Item -Path $ArchivePath -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds (2 * $Attempt)
+  }
 }
 
 Expand-Archive -Path $ArchivePath -DestinationPath $ExtractPath -Force

--- a/scripts/setup-bun.sh
+++ b/scripts/setup-bun.sh
@@ -53,6 +53,7 @@ if [ -z "$bun_binary_path" ]; then
 fi
 
 install -m 755 "$bun_binary_path" "$HOME/.bun/bin/bun"
+ln -sf "$HOME/.bun/bin/bun" "$HOME/.bun/bin/bunx"
 echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 export PATH="$HOME/.bun/bin:$PATH"
 

--- a/scripts/setup-bun.sh
+++ b/scripts/setup-bun.sh
@@ -2,7 +2,57 @@
 
 set -euo pipefail
 
-curl -fsSL https://bun.sh/install | bash
+BUN_VERSION="1.3.11"
+
+case "$(uname -s):$(uname -m)" in
+  "Darwin:arm64")
+    asset_name="bun-darwin-aarch64.zip"
+    asset_sha256="6f5a3467ed9caec4795bf78cd476507d9f870c7d57b86c945fcb338126772ffc"
+    ;;
+  "Darwin:x86_64")
+    asset_name="bun-darwin-x64.zip"
+    asset_sha256="c4fe2b9247218b0295f24e895aaec8fee62e74452679a9026b67eacbd611a286"
+    ;;
+  "Linux:aarch64" | "Linux:arm64")
+    asset_name="bun-linux-aarch64.zip"
+    asset_sha256="d13944da12a53ecc74bf6a720bd1d04c4555c038dfe422365356a7be47691fdf"
+    ;;
+  "Linux:x86_64")
+    asset_name="bun-linux-x64.zip"
+    asset_sha256="8611ba935af886f05a6f38740a15160326c15e5d5d07adef966130b4493607ed"
+    ;;
+  *)
+    echo "Unsupported Bun platform: $(uname -s) $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+archive_path="$tmp_dir/$asset_name"
+extract_path="$tmp_dir/extract"
+asset_url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${asset_name}"
+
+curl -fsSL "$asset_url" -o "$archive_path"
+
+if command -v shasum >/dev/null 2>&1; then
+  echo "$asset_sha256  $archive_path" | shasum -a 256 -c -
+else
+  echo "$asset_sha256  $archive_path" | sha256sum -c -
+fi
+
+unzip -q "$archive_path" -d "$extract_path"
+
+mkdir -p "$HOME/.bun/bin"
+bun_binary_path="$(find "$extract_path" -type f -name bun | head -n 1)"
+
+if [ -z "$bun_binary_path" ]; then
+  echo "Bun binary not found in $asset_name" >&2
+  exit 1
+fi
+
+install -m 755 "$bun_binary_path" "$HOME/.bun/bin/bun"
 echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 export PATH="$HOME/.bun/bin:$PATH"
 

--- a/scripts/setup-bun.sh
+++ b/scripts/setup-bun.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl -fsSL https://bun.sh/install | bash
+echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+export PATH="$HOME/.bun/bin:$PATH"
+
+bun --version

--- a/tests/app-error-cases.test.ts
+++ b/tests/app-error-cases.test.ts
@@ -2,10 +2,13 @@ import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { BASE_URL, getAuthHeaders, getSupabaseClient, NON_ACCESS_APP_NAME, resetAndSeedAppData, resetAppData, USER_ID } from './test-utils.ts'
 
-const id = randomUUID()
+const id = randomUUID().replace(/-/g, '').slice(0, 12)
 const APPNAME = `com.app.error.${id}`
+const DELETE_APP_ID = `${APPNAME}.delete`
+const NOT_FOUND_APP_ID = `${APPNAME}.notfound`
+const PUT_APP_ID = `${APPNAME}.put`
 const testOrgId = randomUUID()
-const testStripeCustomerId = `cus_app_error_${id.replace(/-/g, '').slice(0, 18)}`
+const testStripeCustomerId = `cus_app_error_${id}`
 let testApiKeyId: number | null = null
 let testHeaders: Record<string, string>
 let authHeaders: Record<string, string>
@@ -45,9 +48,9 @@ beforeAll(async () => {
 afterAll(async () => {
   await resetAppData(APPNAME)
   // Clean up any test apps created during tests
-  await getSupabaseClient().from('apps').delete().eq('app_id', `${APPNAME}.delete`)
-  await getSupabaseClient().from('apps').delete().eq('app_id', `${APPNAME}.put`)
-  await getSupabaseClient().from('apps').delete().eq('app_id', `${APPNAME}.notfound`)
+  await getSupabaseClient().from('apps').delete().eq('app_id', DELETE_APP_ID)
+  await getSupabaseClient().from('apps').delete().eq('app_id', PUT_APP_ID)
+  await getSupabaseClient().from('apps').delete().eq('app_id', NOT_FOUND_APP_ID)
   if (testApiKeyId !== null) {
     await fetch(`${BASE_URL}/apikey/${testApiKeyId}`, {
       method: 'DELETE',
@@ -135,17 +138,17 @@ describe('[GET] /app - Error Cases', () => {
       headers: testHeaders,
       body: JSON.stringify({
         name: `App ${APPNAME}.notfound`,
-        app_id: `${APPNAME}.notfound`,
+        app_id: NOT_FOUND_APP_ID,
         owner_org: testOrgId,
       }),
     })
     expect(createResponse.status).toBe(200)
 
     // Delete the app from database directly
-    await getSupabaseClient().from('apps').delete().eq('app_id', `${APPNAME}.notfound`)
+    await getSupabaseClient().from('apps').delete().eq('app_id', NOT_FOUND_APP_ID)
 
     // Try to get the deleted app
-    const response = await fetch(`${BASE_URL}/app/${APPNAME}.notfound`, {
+    const response = await fetch(`${BASE_URL}/app/${NOT_FOUND_APP_ID}`, {
       method: 'GET',
       headers: testHeaders,
     })
@@ -175,7 +178,7 @@ describe('[PUT] /app - Error Cases', () => {
       headers: testHeaders,
       body: JSON.stringify({
         name: `App ${APPNAME}.put`,
-        app_id: `${APPNAME}.put`,
+        app_id: PUT_APP_ID,
         owner_org: testOrgId,
       }),
     })
@@ -197,7 +200,7 @@ describe('[PUT] /app - Error Cases', () => {
 
   it('should return 400 when update fails', async () => {
     // Try to update with invalid data that would cause a database error
-    const response = await fetch(`${BASE_URL}/app/${APPNAME}.put`, {
+    const response = await fetch(`${BASE_URL}/app/${PUT_APP_ID}`, {
       method: 'PUT',
       headers: testHeaders,
       body: JSON.stringify({
@@ -211,7 +214,7 @@ describe('[PUT] /app - Error Cases', () => {
   })
 
   it('should handle invalid JSON body', async () => {
-    const response = await fetch(`${BASE_URL}/app/${APPNAME}.put`, {
+    const response = await fetch(`${BASE_URL}/app/${PUT_APP_ID}`, {
       method: 'PUT',
       headers: testHeaders,
       body: 'invalid json',
@@ -238,14 +241,14 @@ describe('[DELETE] /app - Error Cases', () => {
       headers: testHeaders,
       body: JSON.stringify({
         name: `App ${APPNAME}.delete`,
-        app_id: `${APPNAME}.delete`,
+        app_id: DELETE_APP_ID,
         owner_org: testOrgId,
       }),
     })
     expect(createResponse.status).toBe(200)
 
     // Try to delete the app (this should work)
-    const response = await fetch(`${BASE_URL}/app/${APPNAME}.delete`, {
+    const response = await fetch(`${BASE_URL}/app/${DELETE_APP_ID}`, {
       method: 'DELETE',
       headers: testHeaders,
     })
@@ -254,7 +257,7 @@ describe('[DELETE] /app - Error Cases', () => {
     expect(response.status).toBe(200)
 
     // Try to delete the same app again (should fail)
-    const response2 = await fetch(`${BASE_URL}/app/${APPNAME}.delete`, {
+    const response2 = await fetch(`${BASE_URL}/app/${DELETE_APP_ID}`, {
       method: 'DELETE',
       headers: testHeaders,
     })

--- a/tests/statistics.test.ts
+++ b/tests/statistics.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest'
-import { APP_NAME_STATS, BASE_URL, getAuthHeadersForCredentials, headersStats, ORG_ID_STATS } from './test-utils.ts'
+import { APP_NAME_STATS, BASE_URL, getAuthHeadersForCredentials, getSupabaseClient, headersStats, ORG_ID_STATS } from './test-utils.ts'
 
 function hasSeededStats(statsData: unknown) {
   if (!Array.isArray(statsData))
@@ -13,18 +13,21 @@ function hasSeededStats(statsData: unknown) {
   )
 }
 
+async function deleteApikeyById(id: number) {
+  await getSupabaseClient()
+    .from('apikeys')
+    .delete()
+    .eq('id', id)
+    .throwOnError()
+}
+
 describe('[GET] /statistics operations with and without subkey', () => {
   const APPNAME = APP_NAME_STATS // Use the seeded stats app
   let subkeyId = 0
 
   afterAll(async () => {
-    if (subkeyId) {
-      const deleteApikey = await fetch(`${BASE_URL}/apikey/${subkeyId}`, {
-        method: 'DELETE',
-        headers: headersStats,
-      })
-      expect(deleteApikey.status).toBe(200)
-    }
+    if (subkeyId)
+      await deleteApikeyById(subkeyId)
   })
 
   it('should get app statistics without subkey', async () => {
@@ -232,11 +235,7 @@ describe('[GET] /statistics operations with and without subkey', () => {
     expect(orgStatsData.error).toBe('no_access_to_organization')
 
     // Clean up
-    const deleteApikey = await fetch(`${BASE_URL}/apikey/${nonAccessibleOrgSubkeyId}`, {
-      method: 'DELETE',
-      headers: headersStats,
-    })
-    expect(deleteApikey.status).toBe(200)
+    await deleteApikeyById(nonAccessibleOrgSubkeyId)
   })
 
   it('should create subkey with non-accessible app and fail to get app statistics', async () => {
@@ -266,10 +265,6 @@ describe('[GET] /statistics operations with and without subkey', () => {
     expect(statsData.error).toBe('no_access_to_app')
 
     // Clean up
-    const deleteApikey = await fetch(`${BASE_URL}/apikey/${nonAccessibleAppSubkeyId}`, {
-      method: 'DELETE',
-      headers: headersStats,
-    })
-    expect(deleteApikey.status).toBe(200)
+    await deleteApikeyById(nonAccessibleAppSubkeyId)
   })
 })

--- a/tests/statistics.test.ts
+++ b/tests/statistics.test.ts
@@ -223,19 +223,21 @@ describe('[GET] /statistics operations with and without subkey', () => {
     const subkeyData = await createSubkey.json() as { id: number }
     const nonAccessibleOrgSubkeyId = subkeyData.id
 
-    const subkeyHeaders = { 'x-limited-key-id': String(nonAccessibleOrgSubkeyId) }
-    const fromDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
-    const toDate = new Date().toISOString().split('T')[0]
-    const getOrgStats = await fetch(`${BASE_URL}/statistics/org/22dbad8a-b885-4309-9b3b-a09f8460fb6d?from=${fromDate}&to=${toDate}`, {
-      method: 'GET',
-      headers: { ...headersStats, ...subkeyHeaders },
-    })
-    expect(getOrgStats.status).toBe(401)
-    const orgStatsData = await getOrgStats.json<{ error: string }>()
-    expect(orgStatsData.error).toBe('no_access_to_organization')
-
-    // Clean up
-    await deleteApikeyById(nonAccessibleOrgSubkeyId)
+    try {
+      const subkeyHeaders = { 'x-limited-key-id': String(nonAccessibleOrgSubkeyId) }
+      const fromDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+      const toDate = new Date().toISOString().split('T')[0]
+      const getOrgStats = await fetch(`${BASE_URL}/statistics/org/22dbad8a-b885-4309-9b3b-a09f8460fb6d?from=${fromDate}&to=${toDate}`, {
+        method: 'GET',
+        headers: { ...headersStats, ...subkeyHeaders },
+      })
+      expect(getOrgStats.status).toBe(401)
+      const orgStatsData = await getOrgStats.json<{ error: string }>()
+      expect(orgStatsData.error).toBe('no_access_to_organization')
+    }
+    finally {
+      await deleteApikeyById(nonAccessibleOrgSubkeyId)
+    }
   })
 
   it('should create subkey with non-accessible app and fail to get app statistics', async () => {
@@ -253,18 +255,20 @@ describe('[GET] /statistics operations with and without subkey', () => {
     const subkeyData = await createSubkey.json() as { id: number }
     const nonAccessibleAppSubkeyId = subkeyData.id
 
-    const subkeyHeaders = { 'x-limited-key-id': String(nonAccessibleAppSubkeyId) }
-    const fromDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
-    const toDate = new Date().toISOString().split('T')[0]
-    const getStats = await fetch(`${BASE_URL}/statistics/app/com.demoadmin.app?from=${fromDate}&to=${toDate}`, {
-      method: 'GET',
-      headers: { ...headersStats, ...subkeyHeaders },
-    })
-    expect(getStats.status).toBe(401)
-    const statsData = await getStats.json<{ error: string }>()
-    expect(statsData.error).toBe('no_access_to_app')
-
-    // Clean up
-    await deleteApikeyById(nonAccessibleAppSubkeyId)
+    try {
+      const subkeyHeaders = { 'x-limited-key-id': String(nonAccessibleAppSubkeyId) }
+      const fromDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+      const toDate = new Date().toISOString().split('T')[0]
+      const getStats = await fetch(`${BASE_URL}/statistics/app/com.demoadmin.app?from=${fromDate}&to=${toDate}`, {
+        method: 'GET',
+        headers: { ...headersStats, ...subkeyHeaders },
+      })
+      expect(getStats.status).toBe(401)
+      const statsData = await getStats.json<{ error: string }>()
+      expect(statsData.error).toBe('no_access_to_app')
+    }
+    finally {
+      await deleteApikeyById(nonAccessibleAppSubkeyId)
+    }
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- split the monorepo release flow into separate Capgo and CLI lanes
- run the reusable test workflow only for the component that actually needs a release on `main` and `development` pushes
- add a release-scope script so workflow-only and docs-only pushes do not bump product versions
- publish CLI releases from `cli-v*` tags and limit Capgo deploys to `v*` tags

## Motivation (AI generated)

After moving the CLI into the monorepo, the repository still had a single root `bump_version.yml` path. That meant Capgo versioning remained global, the CLI had no monorepo-native publish lane, and any future CLI tag would also trigger the Capgo deploy workflow because tag matching was still `*`.

## Business Impact (AI generated)

This keeps release automation aligned with the product that actually changed. Capgo deployments no longer risk being triggered by CLI-only releases, CLI releases can publish independently again, and non-product changes stop creating unnecessary version churn on the main application.

## Test Plan (AI generated)

- [x] Parse the updated workflow YAML locally
- [x] Run the release-scope script against workflow-only changes and a real monorepo merge commit
- [x] Let the local commit hook complete successfully
- [ ] Verify GitHub Actions passes on the PR
- [ ] Verify the new workflow topology is accepted by GitHub Actions

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated CLI publishing with AI-generated changelogs.
  * Release-scope detection to decide which component(s) to release and semver bump.

* **Chores**
  * CI tag triggers restricted to specific patterns and scoped release flows; version bumps gated by detected scope and tests.
  * Standardized runtime setup with added OS-specific Bun install scripts and workflow refinements.

* **Tests**
  * Test cleanup switched to a direct database helper for API key deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->