### PR TITLE
test: stabilize cloudflare queue processing specs

### DIFF
--- a/tests/notifications-send-once.unit.test.ts
+++ b/tests/notifications-send-once.unit.test.ts
@@ -53,12 +53,13 @@ function createWriteClient(options?: { deleteError?: Error }) {
   }
 }
 
-describe('sendNotifOrgOnce', () => {
+describe.sequential('sendNotifOrgOnce', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
+    vi.resetModules()
   })
 
-  it.concurrent('deletes the recipient claim when Bento throws', async () => {
+  it('deletes the recipient claim when Bento throws', async () => {
     trackBentoEventMock.mockRejectedValue(new Error('bento exploded'))
     const { client, deleteMock, whereMock } = createWriteClient()
 
@@ -85,7 +86,7 @@ describe('sendNotifOrgOnce', () => {
     )
   })
 
-  it.concurrent('surfaces cleanup failure when the recipient claim cannot be deleted', async () => {
+  it('surfaces cleanup failure when the recipient claim cannot be deleted', async () => {
     trackBentoEventMock.mockResolvedValue(false)
     const { client } = createWriteClient({ deleteError: new Error('delete exploded') })
 

--- a/tests/queue_load.test.ts
+++ b/tests/queue_load.test.ts
@@ -21,6 +21,21 @@ beforeEach(async () => {
   await pool.query(`DELETE FROM pgmq.a_${queueName}`)
 })
 
+async function waitForQueueCount(queueName: string, expectedCount: number, timeoutMs = 10000) {
+  const start = Date.now()
+
+  while (Date.now() - start < timeoutMs) {
+    const { rows } = await pool.query(`SELECT count(*) as count FROM pgmq.q_${queueName}`)
+    if (Number(rows[0]?.count ?? -1) === expectedCount)
+      return
+
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+
+  const { rows } = await pool.query(`SELECT count(*) as count FROM pgmq.q_${queueName}`)
+  throw new Error(`Timed out waiting for queue ${queueName} to reach ${expectedCount} messages (last count: ${rows[0]?.count ?? 'unknown'})`)
+}
+
 async function fetchQueueSync(queueName: string, maxRetries = 4) {
   let lastError: Error | null = null
 
@@ -131,13 +146,7 @@ describe('queue Load Test', () => {
 
     // Process the queue
     await fetchQueueSync(queueName)
-
-    // Wait for processing to complete
-    await new Promise(resolve => setTimeout(resolve, 2000))
-
-    // Verify queue is empty after processing
-    const { rows: finalRows } = await pool.query(`SELECT count(*) as count FROM pgmq.q_${queueName}`)
-    expect(finalRows[0].count).toBe('0')
+    await waitForQueueCount(queueName, 0)
   })
 
   it('should handle stress test with rapid queue processing', { timeout: 30000 }, async () => {

--- a/tests/webhook-queue-processing.test.ts
+++ b/tests/webhook-queue-processing.test.ts
@@ -61,27 +61,27 @@ async function fetchQueueSync(queueName: string, maxRetries = 4) {
   throw new Error(`queue_consumer/sync failed for ${queueName}`)
 }
 
-async function waitForDeliveryRecord(webhookId: string, timeoutMs = 10000) {
+async function waitForDeliveryRecord(webhookId: string, recordId: string, timeoutMs = 10000) {
   const start = Date.now()
 
   while (Date.now() - start < timeoutMs) {
-    const { data, error } = await (getSupabaseClient() as any)
-      .from('webhook_deliveries')
-      .select('*')
-      .eq('webhook_id', webhookId)
-      .order('created_at', { ascending: false })
-      .limit(1)
+    const { rows } = await pool.query(
+      `SELECT *
+       FROM public.webhook_deliveries
+       WHERE webhook_id = $1
+         AND request_payload->'data'->>'record_id' = $2
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [webhookId, recordId],
+    )
 
-    if (error)
-      throw error
-
-    if (data?.[0])
-      return data[0]
+    if (rows[0])
+      return rows[0]
 
     await new Promise(resolve => setTimeout(resolve, 250))
   }
 
-  throw new Error(`Timed out waiting for delivery record for webhook ${webhookId}`)
+  throw new Error(`Timed out waiting for delivery record for webhook ${webhookId} and record ${recordId}`)
 }
 
 async function waitForWebhookDeliveryQueueMessage(deliveryId: string, timeoutMs = 10000) {
@@ -186,6 +186,7 @@ describe('webhook queue processing', () => {
     if (!createdWebhookId)
       throw new Error('Webhook was not created in setup')
 
+    const recordId = `app_${randomUUID()}`
     const queueMessage = {
       function_name: 'webhook_dispatcher',
       function_type: 'cloudflare',
@@ -194,7 +195,7 @@ describe('webhook queue processing', () => {
         table_name: 'apps',
         operation: 'UPDATE',
         org_id: WEBHOOK_QUEUE_TEST_ORG_ID,
-        record_id: `app_${randomUUID()}`,
+        record_id: recordId,
         old_record: { name: 'Before' },
         new_record: { name: 'After' },
         changed_fields: ['name'],
@@ -206,12 +207,11 @@ describe('webhook queue processing', () => {
     await pool.query('SELECT pgmq.send($1, $2::jsonb)', ['webhook_dispatcher', JSON.stringify(queueMessage)])
 
     await fetchQueueSync('webhook_dispatcher')
-    const createdDelivery = await waitForDeliveryRecord(createdWebhookId)
+    const createdDelivery = await waitForDeliveryRecord(createdWebhookId, recordId)
+    await waitForWebhookDeliveryQueueMessage(createdDelivery.id)
 
     expect(createdDelivery.event_type).toBe('apps.UPDATE')
     expect(createdDelivery.status).toBe('pending')
-
-    await waitForWebhookDeliveryQueueMessage(createdDelivery.id)
     await fetchQueueSync('webhook_delivery')
     const completedDelivery = await waitForDeliveryCompletion(createdDelivery.id)
 


### PR DESCRIPTION
## Summary (AI generated)

- stabilize `notifications-send-once` by removing unsafe concurrent mock mutation in that suite
- harden `queue_load` against async queue drain timing by polling queue state instead of sleeping
- make `webhook-queue-processing` wait for the exact delivery record tied to the current test payload before asserting state

## Motivation (AI generated)

The Cloudflare backend workflow on `main` was failing in queue/webhook processing, and two related tests were also reporting flake retries. These specs were relying on timing shortcuts and shared concurrent mocks, which made CI sensitive to scheduling noise.

## Business Impact (AI generated)

This restores release confidence on `main` by removing false-negative backend failures in GitHub Actions. A stable test lane matters directly for shipping Capgo backend and CLI changes without blocking tags, releases, or deploy follow-up automation.

## Test Plan (AI generated)

- [x] `bun run supabase:with-env -- bunx vitest run tests/notifications-send-once.unit.test.ts tests/queue_load.test.ts tests/webhook-queue-processing.test.ts --config vitest.config.cloudflare.ts`
- [x] `bun run supabase:with-env -- bun run test:cloudflare:backend`

Generated with AI
