### PR TITLE
fix(cli): clarify Capgo test banner is temporary

### DIFF
--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -3360,7 +3360,7 @@ async function addCodeChangeStep(orgId: string, apikey: string, appId: string, p
                 '<body>',
                 `<body>
   <div id="capgo-test-banner" style="background: linear-gradient(90deg, #4CAF50, #2196F3); color: white; padding: 15px; text-align: center; font-weight: bold; position: fixed; top: env(safe-area-inset-top, 0); left: env(safe-area-inset-left, 0); right: env(safe-area-inset-right, 0); z-index: 9999; box-shadow: 0 2px 10px rgba(0,0,0,0.1); padding-top: calc(15px + env(safe-area-inset-top, 0));">
-    🚀 Capgo Update Test - This banner shows the update worked!
+    🚀 Capgo Update Test - This is a temporary test banner and should be removed after verification.
   </div>
   <style>
     body { padding-top: calc(60px + env(safe-area-inset-top, 0)) !important; }


### PR DESCRIPTION
### Motivation (AI generated)

- Clarify that the Capgo-injected update test banner is a temporary, test-only UI artifact that should be removed after verification to avoid user confusion.

### Description (AI generated)

- Changed the HTML banner text inserted by the CLI init flow in `cli/src/init/command.ts` so the injected banner reads: "This is a temporary test banner and should be removed after verification.".

### Testing (AI generated)

- Ran `bun install`, `bun run lint`, `bun run cli:build`, `cd cli && bun run test:mcp`, and `bun run test:bundle`, and all automated checks in that sequence completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24d48b03083269145ae4bd5391e82)