### PR TITLE
Annotate test-only Capgo update banner in init command

### DIFF
--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -3355,6 +3355,7 @@ async function addCodeChangeStep(orgId: string, apikey: string, appId: string, p
 
           if (filePath.endsWith('.html')) {
             // Add a visible banner to HTML files
+            // This banner is test-only and must be removed by the app team after update verification.
             if (content.includes('<body>') && !content.includes('capgo-test-banner')) {
               newContent = content.replace(
                 '<body>',


### PR DESCRIPTION
### Motivation
- Clarify that the visible banner injected into app files to test Capgo updates is temporary and must be removed by the app team after verifying the update.

### Description
- Add an inline comment in `cli/src/init/command.ts` immediately above the HTML banner injection to mark the banner as test-only and to instruct removal after verification; the banner injection logic is otherwise unchanged.

### Testing
- Ran the project's automated checks using `yarn test` and `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24d48b03083269145ae4bd5391e82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that test banners automatically injected during OTA for HTML files are temporary and must be removed after verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->