### PR TITLE
[codex] Fix /updates private defaultChannel oracle

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -494,6 +494,11 @@ export function requestInfosChannelPostgres(
         : and(
             eq(channelAlias.app_id, app_id),
             eq(channelAlias.name, defaultChannel),
+            eq(platformQuery, true),
+            or(
+              eq(channelAlias.public, true),
+              eq(channelAlias.allow_device_self_set, true),
+            ),
           ),
     )
     .groupBy(channelAlias.id, versionAlias.id)

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -1039,6 +1039,8 @@ describe('update scenarios', () => {
       const json = await response.json<UpdateRes>()
       expect(json.error).toBe('no_channel')
       expect(json.version).toBeUndefined()
+      expect(json.old).toBeUndefined()
+      expect(json.major).toBeUndefined()
     }
     finally {
       await updateChannel('production', {

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -572,6 +572,7 @@ describe('[POST] /updates parallel tests', () => {
       .throwOnError()
 
     const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.platform = 'android'
     baseData.defaultChannel = channelName
     baseData.version_build = '0.0.1'
     baseData.version_name = '0.0.1'
@@ -584,6 +585,55 @@ describe('[POST] /updates parallel tests', () => {
     expect(json.version).toBeUndefined()
     expect(json.old).toBeUndefined()
     expect(json.major).toBeUndefined()
+  })
+
+  it('allows private self-settable platform-compatible defaultChannel', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `9.7.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `private-selfset-${randomUUID().slice(0, 8)}`
+
+    const version = await createAppVersions(versionName, APP_NAME_UPDATE)
+    await supabase
+      .from('app_versions')
+      .update({ external_url: `https://example.com/${channelName}.zip` })
+      .eq('id', version.id)
+      .throwOnError()
+
+    await supabase
+      .from('channels')
+      .insert({
+        name: channelName,
+        app_id: APP_NAME_UPDATE,
+        version: version.id,
+        owner_org: ORG_ID,
+        created_by: USER_ID,
+        public: false,
+        disable_auto_update_under_native: false,
+        disable_auto_update: 'none',
+        allow_device_self_set: true,
+        allow_emulator: true,
+        allow_device: true,
+        allow_dev: true,
+        allow_prod: true,
+        ios: false,
+        android: true,
+        electron: false,
+      })
+      .throwOnError()
+
+    const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.platform = 'android'
+    baseData.defaultChannel = channelName
+    baseData.version_build = '0.0.1'
+    baseData.version_name = '0.0.1'
+
+    const response = await postUpdate(baseData)
+    expect(response.status).toBe(200)
+
+    const json = await response.json<UpdateRes>()
+    expect(() => updateNewScheme.parse(json)).not.toThrow()
+    expect(json.version).toBe(versionName)
+    expect(json.error).toBeUndefined()
   })
 
   it('hides platform-incompatible private defaultChannel before platform checks', async () => {
@@ -621,6 +671,7 @@ describe('[POST] /updates parallel tests', () => {
       .throwOnError()
 
     const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.platform = 'android'
     baseData.defaultChannel = channelName
     baseData.version_build = '0.0.1'
     baseData.version_name = '0.0.1'

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -683,6 +683,7 @@ describe('[POST] /updates parallel tests', () => {
     expect(json.error).toBe('no_channel')
     expect(json.version).toBeUndefined()
     expect(json.old).toBeUndefined()
+    expect(json.major).toBeUndefined()
   })
 })
 

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -14,6 +14,8 @@ interface UpdateRes {
   version?: string
   message?: string
   manifest?: { file_name: string | null, file_hash?: string | null, download_url?: string | null }[]
+  old?: string
+  major?: boolean
 }
 
 const updateNewScheme = z.object({
@@ -524,8 +526,8 @@ describe('[POST] /updates parallel tests', () => {
     const uuid = randomUUID().toLowerCase()
 
     const baseData = getBaseData(APP_NAME_UPDATE)
-    baseData.device_id = uuid;
-    (baseData as any).defaultChannel = 'beta'
+    baseData.device_id = uuid
+    baseData.defaultChannel = 'beta'
 
     const response = await postUpdate(baseData)
     expect(response.status).toBe(200)
@@ -533,6 +535,103 @@ describe('[POST] /updates parallel tests', () => {
     const json = await response.json<UpdateRes>()
     expect(() => updateNewScheme.parse(json)).not.toThrow()
     expect(json.version).toBe('1.361.0')
+  })
+
+  it('hides private defaultChannel before major upgrade checks', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `9.9.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `private-noself-${randomUUID().slice(0, 8)}`
+
+    const version = await createAppVersions(versionName, APP_NAME_UPDATE)
+    await supabase
+      .from('app_versions')
+      .update({ external_url: `https://example.com/${channelName}.zip` })
+      .eq('id', version.id)
+      .throwOnError()
+
+    await supabase
+      .from('channels')
+      .insert({
+        name: channelName,
+        app_id: APP_NAME_UPDATE,
+        version: version.id,
+        owner_org: ORG_ID,
+        created_by: USER_ID,
+        public: false,
+        disable_auto_update_under_native: false,
+        disable_auto_update: 'major',
+        allow_device_self_set: false,
+        allow_emulator: true,
+        allow_device: true,
+        allow_dev: true,
+        allow_prod: true,
+        ios: true,
+        android: true,
+        electron: true,
+      })
+      .throwOnError()
+
+    const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.defaultChannel = channelName
+    baseData.version_build = '0.0.1'
+    baseData.version_name = '0.0.1'
+
+    const response = await postUpdate(baseData)
+    expect(response.status).toBe(200)
+
+    const json = await response.json<UpdateRes>()
+    expect(json.error).toBe('no_channel')
+    expect(json.version).toBeUndefined()
+    expect(json.old).toBeUndefined()
+    expect(json.major).toBeUndefined()
+  })
+
+  it('hides platform-incompatible private defaultChannel before platform checks', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `9.8.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `private-iosonly-${randomUUID().slice(0, 8)}`
+
+    const version = await createAppVersions(versionName, APP_NAME_UPDATE)
+    await supabase
+      .from('app_versions')
+      .update({ external_url: `https://example.com/${channelName}.zip` })
+      .eq('id', version.id)
+      .throwOnError()
+
+    await supabase
+      .from('channels')
+      .insert({
+        name: channelName,
+        app_id: APP_NAME_UPDATE,
+        version: version.id,
+        owner_org: ORG_ID,
+        created_by: USER_ID,
+        public: false,
+        disable_auto_update_under_native: false,
+        disable_auto_update: 'none',
+        allow_device_self_set: true,
+        allow_emulator: true,
+        allow_device: true,
+        allow_dev: true,
+        allow_prod: true,
+        ios: true,
+        android: false,
+        electron: false,
+      })
+      .throwOnError()
+
+    const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.defaultChannel = channelName
+    baseData.version_build = '0.0.1'
+    baseData.version_name = '0.0.1'
+
+    const response = await postUpdate(baseData)
+    expect(response.status).toBe(200)
+
+    const json = await response.json<UpdateRes>()
+    expect(json.error).toBe('no_channel')
+    expect(json.version).toBeUndefined()
+    expect(json.old).toBeUndefined()
   })
 })
 
@@ -864,14 +963,14 @@ describe('update scenarios', () => {
     }
   })
 
-  it('cannot update via private channel', async () => {
+  it('hides private channel that does not allow self-assignment', async () => {
     // First reset the channel to ensure it's working properly
     await updateChannel('production', {
       public: true,
       allow_device_self_set: true,
     })
 
-    // Now set both conditions for the error
+    // Now set both conditions that make the channel private.
     await updateChannel('production', {
       public: false,
       allow_device_self_set: false,
@@ -879,15 +978,15 @@ describe('update scenarios', () => {
 
     const baseData = getBaseData(APP_NAME_UPDATE)
     baseData.version_name = '1.1.0'
-    // Need to specify defaultChannel so the non-public channel can be found
-    ;(baseData as any).defaultChannel = 'production'
+    // A caller-supplied defaultChannel must not reveal that this private channel exists.
+    baseData.defaultChannel = 'production'
 
     try {
       const response = await postUpdate(baseData)
       expect(response.status).toBe(200)
       const json = await response.json<UpdateRes>()
-      expect(json.error).toBe('cannot_update_via_private_channel')
-      expect(json.message).toContain('Cannot update via a private channel')
+      expect(json.error).toBe('no_channel')
+      expect(json.version).toBeUndefined()
     }
     finally {
       await updateChannel('production', {
@@ -937,7 +1036,7 @@ describe('update scenarios', () => {
       const baseData = getBaseData(APP_NAME_UPDATE)
       baseData.device_id = uuid
       baseData.version_name = '1.1.0'
-      ;(baseData as any).defaultChannel = 'production'
+      baseData.defaultChannel = 'production'
 
       const response = await postUpdate(baseData)
       expect(response.status).toBe(200)


### PR DESCRIPTION
## Summary (AI generated)

- Restrict `/updates` named channel resolution to platform-compatible public or self-settable channels.
- Add regression coverage for private no-self-set and platform-incompatible `defaultChannel` probes returning `no_channel` without version metadata.

## Motivation (AI generated)

GHSA-pgmr-gw53-7f77 reported that unauthenticated callers could resolve private channel names through `defaultChannel` before privacy and platform checks ran.

## Business Impact (AI generated)

This protects private rollout metadata from unauthenticated enumeration while preserving valid public and self-settable channel update flows.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bunx eslint tests/updates.test.ts`
- [x] `bun run test:updates`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel matching so update checks respect platform compatibility and allow-device-self-set flags; private or incompatible channels are now consistently hidden, returning standardized "no_channel" responses when applicable.

* **Tests**
  * Expanded tests for private/self-settable and platform-incompatible channel scenarios; added optional response fields to validate version/old/major behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->