### PR TITLE
[codex] fix plugin on-prem misclassification

### DIFF
--- a/cloudflare_workers/snippet/index.js
+++ b/cloudflare_workers/snippet/index.js
@@ -204,6 +204,21 @@ function isPlanUpgradeResponse(status, responseBody) {
   return status === 429 && responseBody && responseBody.error === 'need_plan_upgrade'
 }
 
+async function buildOnPremResponse(hostname, appId, endpoint, method, responseBody, status, responseHeaders) {
+  // Cache only after every configured fallback agrees this is an on-prem app.
+  await setOnPremCache(hostname, appId, endpoint, method, responseBody, status, responseHeaders)
+
+  const newHeaders = new Headers(responseHeaders)
+  newHeaders.set('Content-Type', 'application/json')
+  newHeaders.set('X-Onprem-Cached', 'false')
+  newHeaders.set('X-Onprem-App-Id', appId)
+
+  return new Response(JSON.stringify(responseBody), {
+    status,
+    headers: newHeaders,
+  })
+}
+
 async function setPlanUpgradeCache(hostname, appId, endpoint, method, responseBody, status, responseHeaders) {
   try {
     const cacheTtl = getCacheTtlSeconds(responseHeaders)
@@ -662,11 +677,20 @@ export default {
     const pathWithQuery = url.pathname + url.search
 
     const fallbackUrls = zoneFallbackUrls[zone] || [WORKER_URL.EUROPE]
+    const requestBody = method === 'POST' || method === 'PUT'
+      ? await request.clone().arrayBuffer()
+      : undefined
+    let pendingOnPrem = null
+    let onPremConfirmations = 0
+    let successfulFallbacks = 0
+    let fallbackFailure = false
 
-    for (const workerUrl of fallbackUrls) {
+    for (let index = 0; index < fallbackUrls.length; index++) {
+      const workerUrl = fallbackUrls[index]
       // Skip unhealthy workers (circuit is open)
       const healthy = await isHealthy(hostname, colo, workerUrl)
       if (!healthy) {
+        fallbackFailure = true
         console.log(`Skipping ${workerUrl} (circuit open for ${colo})`)
         continue
       }
@@ -678,7 +702,7 @@ export default {
         const response = await fetch(`${workerUrl}${pathWithQuery}`, {
           method: request.method,
           headers: request.headers,
-          body: request.body,
+          body: requestBody ? requestBody.slice(0) : undefined,
           signal: abortController.signal,
         })
 
@@ -686,6 +710,7 @@ export default {
 
         // Check for server errors (5xx) - infrastructure problem
         if (response.status >= 500) {
+          fallbackFailure = true
           console.log(`${workerUrl} returned ${response.status}, marking unhealthy`)
           await markUnhealthy(hostname, colo, workerUrl)
           continue // try fallback
@@ -693,6 +718,7 @@ export default {
 
         // Success (2xx, 3xx, 4xx) - worker is healthy
         await markHealthy(hostname, colo, workerUrl)
+        successfulFallbacks += 1
         console.log(`Request served by ${workerUrl}`)
 
         // Check if this is an on-prem response that should be cached
@@ -702,19 +728,18 @@ export default {
             const responseBody = await responseClone.json()
 
             if (isOnPremResponse(response.status, responseBody)) {
-              // Cache the on-prem response (fire-and-forget, errors handled internally)
-              setOnPremCache(hostname, appId, endpoint, method, responseBody, response.status, response.headers)
-
-              // Return a new response, preserving original headers and adding on-prem headers
-              const newHeaders = new Headers(response.headers)
-              newHeaders.set('Content-Type', 'application/json')
-              newHeaders.set('X-Onprem-Cached', 'false')
-              newHeaders.set('X-Onprem-App-Id', appId)
-
-              return new Response(JSON.stringify(responseBody), {
+              onPremConfirmations += 1
+              pendingOnPrem = {
+                responseBody,
                 status: response.status,
-                headers: newHeaders,
-              })
+                headers: response.headers,
+                workerUrl,
+              }
+              if (index < fallbackUrls.length - 1) {
+                console.log(`${workerUrl} returned on-prem for ${appId}; trying fallback worker before finalizing`)
+                continue
+              }
+              continue
             }
 
             if (isPlanUpgradeResponse(response.status, responseBody)) {
@@ -741,14 +766,27 @@ export default {
       }
       catch (error) {
         // Network failure or timeout - mark unhealthy
+        fallbackFailure = true
         console.log(`${workerUrl} failed: ${error.message}, marking unhealthy`)
         await markUnhealthy(hostname, colo, workerUrl)
         // continue to next fallback
       }
     }
 
-    // All workers failed or are unhealthy - try the original request as last resort
-    console.log('All workers failed, falling back to original request')
+    // Skipped/failed fallback workers are not counted as agreement because a partial outage can reflect stale replicas.
+    if (pendingOnPrem && !fallbackFailure && successfulFallbacks > 0 && onPremConfirmations === successfulFallbacks) {
+      console.log(`All ${onPremConfirmations}/${successfulFallbacks} successful fallback workers returned on-prem for ${appId}`)
+      return await buildOnPremResponse(hostname, appId, endpoint, method, pendingOnPrem.responseBody, pendingOnPrem.status, pendingOnPrem.headers)
+    }
+    if (pendingOnPrem) {
+      const failureLog = fallbackFailure ? '; at least one configured fallback failed or was skipped' : ''
+      console.log(`Only ${onPremConfirmations}/${successfulFallbacks} successful fallback workers returned on-prem for ${appId}${failureLog}; falling back to original request`)
+    }
+    else {
+      console.log('All workers failed, falling back to original request')
+    }
+
+    // No worker produced a usable non-on-prem response, so try the original request as last resort.
     return fetch(request)
   },
 }

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -535,12 +535,22 @@ export function requestInfosPostgres(
     })
 }
 
+export interface AppOwnerPostgresResult {
+  owner_org: string
+  orgs: { created_by: string, id: string, management_email: string }
+  plan_valid: boolean
+  channel_device_count: number
+  manifest_bundle_count: number
+  expose_metadata: boolean
+  allow_device_custom_id: boolean
+}
+
 export async function getAppOwnerPostgres(
   c: Context,
   appId: string,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
   actions: ('mau' | 'storage' | 'bandwidth')[] = [],
-): Promise<{ owner_org: string, orgs: { created_by: string, id: string, management_email: string }, plan_valid: boolean, channel_device_count: number, manifest_bundle_count: number, expose_metadata: boolean, allow_device_custom_id: boolean } | null> {
+): Promise<AppOwnerPostgresResult | null> {
   try {
     if (actions.length === 0)
       return null
@@ -563,11 +573,31 @@ export async function getAppOwnerPostgres(
       })
       .from(schema.apps)
       .where(eq(schema.apps.app_id, appId))
-      .innerJoin(orgAlias, eq(schema.apps.owner_org, orgAlias.id))
+      .leftJoin(orgAlias, eq(schema.apps.owner_org, orgAlias.id))
       .limit(1)
       .then(data => data[0])
 
-    return appOwner
+    if (!appOwner)
+      return null
+
+    if (!appOwner.orgs?.id || !appOwner.orgs.created_by || !appOwner.orgs.management_email) {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'App owner org missing on read replica; preserving cloud app classification from apps row',
+        appId,
+        ownerOrg: appOwner.owner_org,
+      })
+      return {
+        ...appOwner,
+        orgs: {
+          created_by: appOwner.orgs?.created_by ?? '',
+          id: appOwner.owner_org,
+          management_email: appOwner.orgs?.management_email ?? '',
+        },
+      }
+    }
+
+    return appOwner as AppOwnerPostgresResult
   }
   catch (e: unknown) {
     logPgError(c, 'getAppOwnerPostgres', e)

--- a/tests/cloudflare-snippet.unit.test.ts
+++ b/tests/cloudflare-snippet.unit.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import snippet from '../cloudflare_workers/snippet/index.js'
+
+function buildRequest(path: string, body: Record<string, unknown>, colo = 'SFO') {
+  const request = new Request(`https://api.capgo.app${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  Object.defineProperty(request, 'cf', {
+    value: { colo },
+  })
+  return request
+}
+
+function buildCache() {
+  const store = new Map<string, Response>()
+  return {
+    match: vi.fn(async (key: RequestInfo | URL) => {
+      const url = key instanceof Request ? key.url : String(key)
+      return store.get(url)?.clone()
+    }),
+    put: vi.fn(async (key: RequestInfo | URL, response: Response) => {
+      const url = key instanceof Request ? key.url : String(key)
+      store.set(url, response.clone())
+    }),
+    delete: vi.fn(async (key: RequestInfo | URL) => {
+      const url = key instanceof Request ? key.url : String(key)
+      return store.delete(url)
+    }),
+  }
+}
+
+describe('cloudflare plugin snippet on-prem fallback', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('tries a fallback worker before returning a regional on-prem response', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const cache = buildCache()
+    vi.stubGlobal('caches', { default: cache })
+
+    const body = {
+      app_id: 'com.cloud.valid',
+      device_id: '11111111-1111-4111-8111-111111111111',
+      version_name: '0.0.0',
+    }
+    const fetchMock = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+      const target = new URL(String(url))
+      if (target.origin === 'https://plugin.na.capgo.app') {
+        return new Response(JSON.stringify({ error: 'on_premise_app', message: 'On-premise app detected' }), {
+          status: 429,
+          headers: { 'Cache-Control': 'public, max-age=60' },
+        })
+      }
+      if (target.origin === 'https://plugin.eu.capgo.app') {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 })
+      }
+      throw new Error(`Unexpected fetch target ${target.href}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await snippet.fetch(buildRequest('/updates', body))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ status: 'ok' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(String(fetchMock.mock.calls[0][0])).toContain('https://plugin.na.capgo.app/updates')
+    expect(String(fetchMock.mock.calls[1][0])).toContain('https://plugin.eu.capgo.app/updates')
+    await expect(new Response(fetchMock.mock.calls[0][1]?.body).json()).resolves.toEqual(body)
+    await expect(new Response(fetchMock.mock.calls[1][1]?.body).json()).resolves.toEqual(body)
+    expect(cache.put).not.toHaveBeenCalled()
+  })
+
+  it('caches on-prem only after all fallback workers agree', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const cache = buildCache()
+    vi.stubGlobal('caches', { default: cache })
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: 'on_premise_app', message: 'On-premise app detected' }), {
+        status: 429,
+        headers: { 'Cache-Control': 'public, max-age=60' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await snippet.fetch(buildRequest('/updates', { app_id: 'com.external.app' }))
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('X-Onprem-Cached')).toBe('false')
+    expect(response.headers.get('X-Onprem-App-Id')).toBe('com.external.app')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(cache.put).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not finalize on-prem when fallback workers do not confirm it', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const cache = buildCache()
+    vi.stubGlobal('caches', { default: cache })
+
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      if (url instanceof Request) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 })
+      }
+
+      const target = new URL(String(url))
+      if (target.origin === 'https://plugin.na.capgo.app') {
+        return new Response(JSON.stringify({ error: 'on_premise_app', message: 'On-premise app detected' }), {
+          status: 429,
+          headers: { 'Cache-Control': 'public, max-age=60' },
+        })
+      }
+      if (target.origin === 'https://plugin.eu.capgo.app')
+        throw new Error('fallback unavailable')
+      throw new Error(`Unexpected fetch target ${target.href}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await snippet.fetch(buildRequest('/updates', { app_id: 'com.cloud.valid' }))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ status: 'ok' })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const putKeys = cache.put.mock.calls.map(([key]) => key instanceof Request ? key.url : String(key))
+    expect(putKeys.some(key => key.includes('/__internal__/onprem-cache-v2/'))).toBe(false)
+  })
+
+  it('requires every configured fallback worker to confirm on-prem', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const cache = buildCache()
+    vi.stubGlobal('caches', { default: cache })
+
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      if (url instanceof Request) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 })
+      }
+
+      const target = new URL(String(url))
+      if (target.origin === 'https://plugin.sa.capgo.app' || target.origin === 'https://plugin.na.capgo.app') {
+        return new Response(JSON.stringify({ error: 'on_premise_app', message: 'On-premise app detected' }), {
+          status: 429,
+          headers: { 'Cache-Control': 'public, max-age=60' },
+        })
+      }
+      if (target.origin === 'https://plugin.eu.capgo.app')
+        throw new Error('fallback unavailable')
+      throw new Error(`Unexpected fetch target ${target.href}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await snippet.fetch(buildRequest('/updates', { app_id: 'com.cloud.valid' }, 'GRU'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ status: 'ok' })
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    const putKeys = cache.put.mock.calls.map(([key]) => key instanceof Request ? key.url : String(key))
+    expect(putKeys.some(key => key.includes('/__internal__/onprem-cache-v2/'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Fix GHSA-jxpf-8j7v-2vcf by preventing one regional plugin replica miss from being treated as a final on-prem classification.
- Retry configured plugin fallback workers before returning or caching an on-prem response.
- Keep cloud classification when the app row is present but the replicated org join is temporarily missing.
- Add unit coverage for fallback retry and delayed on-prem caching.

## Motivation (AI generated)

Valid cloud apps can be misrouted as on-prem when a plugin-plane read replica returns an incomplete owner lookup. The hot plugin endpoints need to avoid primary DB fallback while still resisting transient regional replica misses.

## Business Impact (AI generated)

This protects OTA update checks, channel self operations, and stats ingestion for legitimate cloud apps, reducing false denials and support risk without adding primary-database traffic to the plugin hot path.

## Test Plan (AI generated)

- [x] bunx eslint cloudflare_workers/snippet/index.js tests/cloudflare-snippet.unit.test.ts supabase/functions/_backend/utils/pg.ts
- [x] bun run lint:backend
- [x] bunx vitest run tests/cloudflare-snippet.unit.test.ts
- [x] bun typecheck
- [x] bun run test:plugin

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-prem regional fallback: request bodies are buffered for reliable retries, on-prem responses are normalized and only cached/returned after required confirmations; partial or missing agreement falls back to origin and avoids premature caching. Safer handling when organization info is incomplete on read replicas, preserving app data and logging gaps.

* **Tests**
  * Added unit tests covering on-prem fallback flows, request forwarding, header normalization, and caching outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->