### PR TITLE
[codex] Fix plugin owner resolver on replica metadata gaps

### DIFF
--- a/supabase/functions/_backend/utils/notifications.ts
+++ b/supabase/functions/_backend/utils/notifications.ts
@@ -170,9 +170,14 @@ export async function sendNotifOrg(
   orgId: string,
   uniqId: string,
   cron: string,
-  managementEmail: string,
+  managementEmail: string | null | undefined,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
 ) {
+  if (!managementEmail) {
+    cloudlog({ requestId: c.get('requestId'), message: 'notif skipped missing management email', event: eventName, orgId })
+    return false
+  }
+
   // Check if notification has already been sent (read from replica)
   const notif = await getNotification(c, drizzleClient, orgId, eventName, uniqId)
   if (notif === undefined) {
@@ -334,7 +339,7 @@ export async function sendNotifOrgCached(
   orgId: string,
   uniqId: string,
   cron: string,
-  managementEmail: string,
+  managementEmail: string | null | undefined,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
 ): Promise<boolean> {
   // Check cache first - if we recently checked and it wasn't sendable, skip DB query

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -553,6 +553,12 @@ type AppOwnerPostgresRow = Omit<AppOwnerPostgresResult, 'orgs'> & {
   orgs: AppOwnerPostgresResult['orgs'] | null
 }
 
+function isReplicaMetadataGapError(error: unknown): boolean {
+  const pgError = error as { code?: string }
+  return pgError.code === '42703' // undefined_column
+    || pgError.code === '42P01' // undefined_table
+}
+
 function normalizeAppOwnerPostgresResult(c: Context, appId: string, appOwner: AppOwnerPostgresRow): AppOwnerPostgresResult {
   const orgs = appOwner.orgs?.id
     ? {
@@ -664,7 +670,9 @@ export async function getAppOwnerPostgres(
   }
   catch (e: unknown) {
     logPgError(c, 'getAppOwnerPostgres', e)
-    return getAppOwnerPostgresAppOnlyFallback(c, appId, drizzleClient)
+    if (isReplicaMetadataGapError(e))
+      return getAppOwnerPostgresAppOnlyFallback(c, appId, drizzleClient)
+    return null
   }
 }
 

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -535,12 +535,102 @@ export function requestInfosPostgres(
     })
 }
 
+interface AppOwnerPostgresResult {
+  owner_org: string
+  orgs: {
+    created_by: string | null
+    id: string
+    management_email: string | null
+  }
+  plan_valid: boolean
+  channel_device_count: number
+  manifest_bundle_count: number
+  expose_metadata: boolean
+  allow_device_custom_id: boolean
+}
+
+type AppOwnerPostgresRow = Omit<AppOwnerPostgresResult, 'orgs'> & {
+  orgs: AppOwnerPostgresResult['orgs'] | null
+}
+
+function normalizeAppOwnerPostgresResult(c: Context, appId: string, appOwner: AppOwnerPostgresRow): AppOwnerPostgresResult {
+  const orgs = appOwner.orgs?.id
+    ? {
+        created_by: appOwner.orgs.created_by,
+        id: appOwner.orgs.id,
+        management_email: appOwner.orgs.management_email,
+      }
+    : {
+        created_by: appOwner.orgs?.created_by ?? null,
+        id: appOwner.owner_org,
+        management_email: appOwner.orgs?.management_email ?? null,
+      }
+
+  if (!appOwner.orgs?.id) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'App owner org metadata missing on replica, preserving cloud app classification',
+      app_id: appId,
+      owner_org: appOwner.owner_org,
+    })
+  }
+
+  return {
+    ...appOwner,
+    orgs,
+  }
+}
+
+async function getAppOwnerPostgresAppOnlyFallback(
+  c: Context,
+  appId: string,
+  drizzleClient: ReturnType<typeof getDrizzleClient>,
+): Promise<AppOwnerPostgresResult | null> {
+  try {
+    const app = await drizzleClient
+      .select({
+        owner_org: schema.apps.owner_org,
+        channel_device_count: schema.apps.channel_device_count,
+        manifest_bundle_count: schema.apps.manifest_bundle_count,
+        expose_metadata: schema.apps.expose_metadata,
+        allow_device_custom_id: schema.apps.allow_device_custom_id,
+      })
+      .from(schema.apps)
+      .where(eq(schema.apps.app_id, appId))
+      .limit(1)
+      .then(data => data[0])
+
+    if (!app)
+      return null
+
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'App owner resolved from app row after metadata lookup failed',
+      app_id: appId,
+      owner_org: app.owner_org,
+    })
+
+    // Plugin endpoints can only use the replica here. If auxiliary org/plan
+    // metadata is unavailable, keep an existing app in the cloud path instead
+    // of poisoning the on-prem caches.
+    return normalizeAppOwnerPostgresResult(c, appId, {
+      ...app,
+      plan_valid: true,
+      orgs: null,
+    })
+  }
+  catch (fallbackError: unknown) {
+    logPgError(c, 'getAppOwnerPostgres fallback', fallbackError)
+    return null
+  }
+}
+
 export async function getAppOwnerPostgres(
   c: Context,
   appId: string,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
   actions: ('mau' | 'storage' | 'bandwidth')[] = [],
-): Promise<{ owner_org: string, orgs: { created_by: string, id: string, management_email: string }, plan_valid: boolean, channel_device_count: number, manifest_bundle_count: number, expose_metadata: boolean, allow_device_custom_id: boolean } | null> {
+): Promise<AppOwnerPostgresResult | null> {
   try {
     if (actions.length === 0)
       return null
@@ -563,15 +653,18 @@ export async function getAppOwnerPostgres(
       })
       .from(schema.apps)
       .where(eq(schema.apps.app_id, appId))
-      .innerJoin(orgAlias, eq(schema.apps.owner_org, orgAlias.id))
+      .leftJoin(orgAlias, eq(schema.apps.owner_org, orgAlias.id))
       .limit(1)
       .then(data => data[0])
 
-    return appOwner
+    if (!appOwner)
+      return null
+
+    return normalizeAppOwnerPostgresResult(c, appId, appOwner)
   }
   catch (e: unknown) {
     logPgError(c, 'getAppOwnerPostgres', e)
-    return null
+    return getAppOwnerPostgresAppOnlyFallback(c, appId, drizzleClient)
   }
 }
 

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -560,6 +560,7 @@ function isReplicaMetadataGapError(error: unknown): boolean {
 }
 
 function normalizeAppOwnerPostgresResult(c: Context, appId: string, appOwner: AppOwnerPostgresRow): AppOwnerPostgresResult {
+  const orgMetadataMissing = !appOwner.orgs?.id
   const orgs = appOwner.orgs?.id
     ? {
         created_by: appOwner.orgs.created_by,
@@ -572,10 +573,10 @@ function normalizeAppOwnerPostgresResult(c: Context, appId: string, appOwner: Ap
         management_email: appOwner.orgs?.management_email ?? null,
       }
 
-  if (!appOwner.orgs?.id) {
+  if (orgMetadataMissing) {
     cloudlog({
       requestId: c.get('requestId'),
-      message: 'App owner org metadata missing on replica, preserving cloud app classification',
+      message: 'App owner org metadata missing on replica, preserving app ownership',
       app_id: appId,
       owner_org: appOwner.owner_org,
     })
@@ -583,6 +584,9 @@ function normalizeAppOwnerPostgresResult(c: Context, appId: string, appOwner: Ap
 
   return {
     ...appOwner,
+    // Keep app ownership visible, but do not mark the plan valid when org
+    // metadata is missing and the plan cannot be verified.
+    plan_valid: orgMetadataMissing ? false : appOwner.plan_valid,
     orgs,
   }
 }
@@ -617,11 +621,11 @@ async function getAppOwnerPostgresAppOnlyFallback(
     })
 
     // Plugin endpoints can only use the replica here. If auxiliary org/plan
-    // metadata is unavailable, keep an existing app in the cloud path instead
-    // of poisoning the on-prem caches.
+    // metadata is unavailable, keep app ownership visible but fail plan checks
+    // closed until metadata is queryable again.
     return normalizeAppOwnerPostgresResult(c, appId, {
       ...app,
-      plan_valid: true,
+      plan_valid: false,
       orgs: null,
     })
   }

--- a/tests/pg-app-owner.unit.test.ts
+++ b/tests/pg-app-owner.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+  } as any
+}
+
+function createQueryChain(result: any[] | Error) {
+  const chain: any = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    then: vi.fn((resolve: (rows: any[]) => unknown) => {
+      if (result instanceof Error)
+        return Promise.reject(result)
+      return Promise.resolve(resolve(result))
+    }),
+  }
+
+  return chain
+}
+
+function createDrizzleClient(results: Array<any[] | Error>) {
+  const chains = results.map(createQueryChain)
+  let index = 0
+  const drizzleClient = {
+    select: vi.fn(() => chains[index++]),
+  }
+
+  return { drizzleClient, chains }
+}
+
+describe('getAppOwnerPostgres', () => {
+  it('keeps cloud app ownership when org metadata is missing from the replica', async () => {
+    const { drizzleClient, chains } = createDrizzleClient([
+      [
+        {
+          owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+          plan_valid: true,
+          channel_device_count: 0,
+          manifest_bundle_count: 0,
+          expose_metadata: false,
+          allow_device_custom_id: true,
+          orgs: null,
+        },
+      ],
+    ])
+
+    const { getAppOwnerPostgres } = await import('../supabase/functions/_backend/utils/pg.ts')
+
+    const appOwner = await getAppOwnerPostgres(
+      createContext(),
+      'com.test.replica-gap',
+      drizzleClient as any,
+      ['mau', 'bandwidth'],
+    )
+
+    expect(chains[0].leftJoin).toHaveBeenCalledTimes(1)
+    expect(chains[0].innerJoin).not.toHaveBeenCalled()
+    expect(appOwner).toMatchObject({
+      owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+      plan_valid: true,
+      orgs: {
+        created_by: null,
+        id: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+        management_email: null,
+      },
+    })
+  })
+
+  it('falls back to the app row when replica metadata lookup errors', async () => {
+    const { drizzleClient, chains } = createDrizzleClient([
+      new Error('missing replicated org metadata'),
+      [
+        {
+          owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+          channel_device_count: 2,
+          manifest_bundle_count: 3,
+          expose_metadata: true,
+          allow_device_custom_id: false,
+        },
+      ],
+    ])
+
+    const { getAppOwnerPostgres } = await import('../supabase/functions/_backend/utils/pg.ts')
+
+    const appOwner = await getAppOwnerPostgres(
+      createContext(),
+      'com.test.replica-metadata-error',
+      drizzleClient as any,
+      ['mau', 'bandwidth'],
+    )
+
+    expect(drizzleClient.select).toHaveBeenCalledTimes(2)
+    expect(chains[0].leftJoin).toHaveBeenCalledTimes(1)
+    expect(chains[1].leftJoin).not.toHaveBeenCalled()
+    expect(appOwner).toMatchObject({
+      owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+      plan_valid: true,
+      channel_device_count: 2,
+      manifest_bundle_count: 3,
+      expose_metadata: true,
+      allow_device_custom_id: false,
+      orgs: {
+        id: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+        management_email: null,
+      },
+    })
+  })
+})

--- a/tests/pg-app-owner.unit.test.ts
+++ b/tests/pg-app-owner.unit.test.ts
@@ -62,7 +62,7 @@ describe('getAppOwnerPostgres', () => {
     expect(chains[0].innerJoin).not.toHaveBeenCalled()
     expect(appOwner).toMatchObject({
       owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
-      plan_valid: true,
+      plan_valid: false,
       orgs: {
         created_by: null,
         id: '623c5839-8c68-4ace-803e-c695d9d28a2b',
@@ -102,7 +102,7 @@ describe('getAppOwnerPostgres', () => {
     expect(chains[1].leftJoin).not.toHaveBeenCalled()
     expect(appOwner).toMatchObject({
       owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
-      plan_valid: true,
+      plan_valid: false,
       channel_device_count: 2,
       manifest_bundle_count: 3,
       expose_metadata: true,

--- a/tests/pg-app-owner.unit.test.ts
+++ b/tests/pg-app-owner.unit.test.ts
@@ -34,7 +34,7 @@ function createDrizzleClient(results: Array<any[] | Error>) {
 }
 
 describe('getAppOwnerPostgres', () => {
-  it('keeps cloud app ownership when org metadata is missing from the replica', async () => {
+  it.concurrent('keeps cloud app ownership when org metadata is missing from the replica', async () => {
     const { drizzleClient, chains } = createDrizzleClient([
       [
         {
@@ -71,9 +71,12 @@ describe('getAppOwnerPostgres', () => {
     })
   })
 
-  it('falls back to the app row when replica metadata lookup errors', async () => {
+  it.concurrent('falls back to the app row when replica metadata lookup errors', async () => {
+    const replicaMetadataError = Object.assign(new Error('missing replicated org metadata'), {
+      code: '42P01',
+    })
     const { drizzleClient, chains } = createDrizzleClient([
-      new Error('missing replicated org metadata'),
+      replicaMetadataError,
       [
         {
           owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
@@ -109,5 +112,32 @@ describe('getAppOwnerPostgres', () => {
         management_email: null,
       },
     })
+  })
+
+  it.concurrent('does not use the app row fallback for generic query errors', async () => {
+    const { drizzleClient } = createDrizzleClient([
+      new Error('connection timeout'),
+      [
+        {
+          owner_org: '623c5839-8c68-4ace-803e-c695d9d28a2b',
+          channel_device_count: 2,
+          manifest_bundle_count: 3,
+          expose_metadata: true,
+          allow_device_custom_id: false,
+        },
+      ],
+    ])
+
+    const { getAppOwnerPostgres } = await import('../supabase/functions/_backend/utils/pg.ts')
+
+    const appOwner = await getAppOwnerPostgres(
+      createContext(),
+      'com.test.generic-error',
+      drizzleClient as any,
+      ['mau', 'bandwidth'],
+    )
+
+    expect(drizzleClient.select).toHaveBeenCalledTimes(1)
+    expect(appOwner).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Preserve cloud app classification when replicated org metadata is temporarily unavailable.
- Add an app-row fallback for owner resolution failures without querying the primary database.
- Skip notification sends when replica metadata cannot provide a management email.
- Add unit coverage for missing org metadata and metadata lookup fallback behavior.

## Motivation (AI generated)

Plugin endpoints depend on replica-safe reads. A valid app row should not be classified as on-prem just because auxiliary org or plan metadata is missing or unavailable on the plugin replica.

## Business Impact (AI generated)

This prevents legitimate cloud apps from being denied update checks, channel self-service calls, or normal stats routing because of replica metadata gaps, while keeping the hot plugin path on replica reads.

## Test Plan (AI generated)

- [x] bun run lint:backend
- [x] bunx eslint tests/pg-app-owner.unit.test.ts
- [x] bunx vitest run tests/pg-app-owner.unit.test.ts
- [x] bun run typecheck
- [x] bun run test:plugin

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification sending now skips and logs when management email is missing to avoid incomplete attempts.
  * App ownership lookup now falls back when replica metadata is missing, preserving ownership and marking plan metadata as unverified.

* **Tests**
  * Added unit tests covering app ownership retrieval and replica metadata/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->