### PR TITLE
[codex] Fix scoped API key management authorization

### DIFF
--- a/supabase/functions/_backend/public/apikey/delete.ts
+++ b/supabase/functions/_backend/public/apikey/delete.ts
@@ -18,9 +18,10 @@ app.delete('/:id', middlewareV2(['all']), async (c) => {
   const auth = c.get('auth') as AuthInfo
   const authApikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
 
-  // Only check limited_to_orgs constraint for API key auth (not JWT)
-  if (auth.authType === 'apikey' && authApikey?.limited_to_orgs?.length) {
-    throw quickError(401, 'cannot_delete_apikey', 'You cannot do that as a limited API key', { apikeyId: authApikey.id })
+  const callerHasLimitedScope = (authApikey?.limited_to_orgs?.length ?? 0) > 0
+    || (authApikey?.limited_to_apps?.length ?? 0) > 0
+  if (auth.authType === 'apikey' && callerHasLimitedScope) {
+    throw quickError(401, 'cannot_delete_apikey', 'You cannot do that as a limited API key', { apikeyId: authApikey?.id })
   }
 
   const id = c.req.param('id')

--- a/supabase/functions/_backend/public/apikey/get.ts
+++ b/supabase/functions/_backend/public/apikey/get.ts
@@ -18,9 +18,10 @@ app.get('/', middlewareV2(['all']), async (c) => {
   const auth = c.get('auth') as AuthInfo
   const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
 
-  // Only check limited_to_orgs constraint for API key auth (not JWT)
-  if (auth.authType === 'apikey' && apikey?.limited_to_orgs?.length) {
-    throw quickError(401, 'cannot_list_apikeys', 'You cannot do that as a limited API key', { apikeyId: apikey.id })
+  const callerHasLimitedScope = (apikey?.limited_to_orgs?.length ?? 0) > 0
+    || (apikey?.limited_to_apps?.length ?? 0) > 0
+  if (auth.authType === 'apikey' && callerHasLimitedScope) {
+    throw quickError(401, 'cannot_list_apikeys', 'You cannot do that as a limited API key', { apikeyId: apikey?.id })
   }
 
   // Use supabaseWithAuth which handles both JWT and API key authentication
@@ -42,9 +43,10 @@ app.get('/:id', middlewareV2(['all']), async (c) => {
   const auth = c.get('auth') as AuthInfo
   const authApikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
 
-  // Only check limited_to_orgs constraint for API key auth (not JWT)
-  if (auth.authType === 'apikey' && authApikey?.limited_to_orgs?.length) {
-    throw quickError(401, 'cannot_get_apikey', 'You cannot do that as a limited API key', { apikeyId: authApikey.id })
+  const callerHasLimitedScope = (authApikey?.limited_to_orgs?.length ?? 0) > 0
+    || (authApikey?.limited_to_apps?.length ?? 0) > 0
+  if (auth.authType === 'apikey' && callerHasLimitedScope) {
+    throw quickError(401, 'cannot_get_apikey', 'You cannot do that as a limited API key', { apikeyId: authApikey?.id })
   }
 
   const id = c.req.param('id')

--- a/supabase/functions/_backend/public/apikey/post.ts
+++ b/supabase/functions/_backend/public/apikey/post.ts
@@ -34,11 +34,7 @@ app.post('/', middlewareV2(['all']), async (c) => {
   // Limit API key creation for constrained caller keys (not JWT).
   const callerHasLimitedScope = (apikey?.limited_to_orgs?.length ?? 0) > 0 || (apikey?.limited_to_apps?.length ?? 0) > 0
   if (auth.authType === 'apikey' && callerHasLimitedScope) {
-    // A limited key cannot create an unlimited key (privilege escalation)
-    const newKeyIsUnlimited = (limitedToOrgs.length === 0 && limitedToApps.length === 0)
-    if (newKeyIsUnlimited) {
-      throw simpleError('cannot_create_apikey', 'You cannot create an unlimited API key with a limited API key', { keyId: apikey?.id })
-    }
+    throw simpleError('cannot_create_apikey', 'You cannot create API keys with a limited API key', { keyId: apikey?.id })
   }
   const expiresAt = body.expires_at ?? null
   const isHashed = body.hashed === true

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -93,9 +93,8 @@ describe('[POST] /apikey operations', () => {
       method: 'POST',
       headers: limitedHeaders,
       body: JSON.stringify({
-        name: 'blocked-unrestricted-creation',
-        limited_to_orgs: [],
-        limited_to_apps: [],
+        name: 'blocked-limited-creation',
+        limited_to_apps: [APPNAME],
       }),
     })
     const escalationData = await escalationResponse.json() as { error: string }
@@ -106,6 +105,86 @@ describe('[POST] /apikey operations', () => {
       method: 'DELETE',
       headers,
     })
+  })
+
+  it('app-limited key cannot manage sibling API keys', async () => {
+    const createdKeyIds: number[] = []
+
+    try {
+      const limitedResponse = await fetch(`${BASE_URL}/apikey`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: 'app-limited-management-blocked',
+          mode: 'all',
+          limited_to_apps: [APPNAME],
+        }),
+      })
+      expect(limitedResponse.status).toBe(200)
+      const limitedData = await limitedResponse.json<{ id: number, key: string }>()
+      createdKeyIds.push(limitedData.id)
+
+      const siblingResponse = await fetch(`${BASE_URL}/apikey`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: 'sibling-management-target',
+          mode: 'all',
+        }),
+      })
+      expect(siblingResponse.status).toBe(200)
+      const siblingData = await siblingResponse.json<{ id: number }>()
+      createdKeyIds.push(siblingData.id)
+
+      const limitedHeaders = {
+        'Content-Type': 'application/json',
+        'capgkey': limitedData.key,
+      }
+
+      const listResponse = await fetch(`${BASE_URL}/apikey`, {
+        method: 'GET',
+        headers: limitedHeaders,
+      })
+      expect(listResponse.status).toBe(401)
+      await expect(listResponse.json()).resolves.toHaveProperty('error', 'cannot_list_apikeys')
+
+      const getResponse = await fetch(`${BASE_URL}/apikey/${siblingData.id}`, {
+        method: 'GET',
+        headers: limitedHeaders,
+      })
+      expect(getResponse.status).toBe(401)
+      await expect(getResponse.json()).resolves.toHaveProperty('error', 'cannot_get_apikey')
+
+      const updateResponse = await fetch(`${BASE_URL}/apikey/${siblingData.id}`, {
+        method: 'PUT',
+        headers: limitedHeaders,
+        body: JSON.stringify({
+          name: 'sibling-renamed-by-limited-key',
+        }),
+      })
+      expect(updateResponse.status).toBe(401)
+      await expect(updateResponse.json()).resolves.toHaveProperty('error', 'cannot_update_apikey')
+
+      const deleteResponse = await fetch(`${BASE_URL}/apikey/${siblingData.id}`, {
+        method: 'DELETE',
+        headers: limitedHeaders,
+      })
+      expect(deleteResponse.status).toBe(401)
+      await expect(deleteResponse.json()).resolves.toHaveProperty('error', 'cannot_delete_apikey')
+
+      const verifyResponse = await fetch(`${BASE_URL}/apikey/${siblingData.id}`, { headers })
+      expect(verifyResponse.status).toBe(200)
+      const verifyData = await verifyResponse.json<{ name: string }>()
+      expect(verifyData.name).toBe('sibling-management-target')
+    }
+    finally {
+      for (const keyId of createdKeyIds.reverse()) {
+        await fetch(`${BASE_URL}/apikey/${keyId}`, {
+          method: 'DELETE',
+          headers,
+        })
+      }
+    }
   })
 
   it('create api key with missing name', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Block app-scoped and org-scoped API keys from API key management reads and deletes.
- Block constrained API keys from creating additional API keys.
- Add a regression test covering app-limited key attempts to list, read, update, and delete sibling API keys.

## Motivation (AI generated)

Scoped API keys should not be able to manage account-level sibling API keys outside their declared scope.

## Business Impact (AI generated)

This closes an authorization bypass that could let a compromised scoped key tamper with credentials for unrelated apps or workflows.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx eslint tests/apikeys.test.ts`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/apikeys.test.ts`

Generated with AI