### PR TITLE
[codex] Support pnpm workspace native build deps

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1197,6 +1197,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | Param          | Type          | Description          |
 | -------------- | ------------- | -------------------- |
 | **--path** | <code>string</code> | Path to the project directory to build (default: current directory) |
+| **--node-modules** | <code>string</code> | Paths to node_modules directories for monorepos (comma-separated) |
 | **--platform** | <code>string</code> | Target platform: ios or android (required) |
 | **--build-mode** | <code>string</code> | Build mode: debug or release (default: release) |
 | **--build-certificate-base64** | <code>string</code> | iOS: Base64-encoded .p12 certificate |

--- a/cli/skills/native-builds/SKILL.md
+++ b/cli/skills/native-builds/SKILL.md
@@ -85,6 +85,7 @@ interface BuildLogger {
   - Before requesting a build, save credentials with `build credentials save`.
 - Core options:
   - `--path <path>`
+  - `--node-modules <nodeModules>`: paths to `node_modules` directories for monorepos, comma-separated.
   - `--platform <platform>`: `ios` or `android`, required.
   - `--build-mode <buildMode>`: `debug` or `release`.
   - `-a, --apikey <apikey>`

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -678,6 +678,10 @@ interface NativeDependencies {
   usesCocoaPods: boolean
 }
 
+interface ZipDirectoryOptions {
+  nodeModules?: string
+}
+
 async function extractNativeDependencies(
   projectDir: string,
   platform: 'ios' | 'android',
@@ -937,8 +941,94 @@ function addDirectoryToZip(
 
       // Check if we should include this file
       if (shouldIncludeFile(itemZipPath, platform, nativeDeps, platformDir)) {
-        zip.addLocalFile(itemPath, zipPath || undefined)
+        addFileToZip(zip, itemPath, itemZipPath)
       }
+    }
+  }
+}
+
+function addFileToZip(zip: AdmZip, filePath: string, zipEntryPath: string) {
+  const normalizedEntryPath = zipEntryPath.replace(/\\/g, '/')
+  if (zip.getEntry(normalizedEntryPath))
+    return
+
+  const lastSlashIndex = normalizedEntryPath.lastIndexOf('/')
+  const zipFolder = lastSlashIndex === -1 ? undefined : normalizedEntryPath.slice(0, lastSlashIndex)
+  zip.addLocalFile(filePath, zipFolder)
+}
+
+function parseNodeModulesPaths(nodeModules: string | undefined): string[] {
+  if (!nodeModules)
+    return []
+
+  const paths = nodeModules
+    .split(',')
+    .map(nodeModulesPath => nodeModulesPath.trim())
+    .filter(Boolean)
+    .map(nodeModulesPath => resolve(nodeModulesPath))
+
+  return [...new Set(paths)]
+}
+
+function getNativePackagePaths(platform: 'ios' | 'android', nativeDeps: NativeDependencies): Set<string> {
+  const packages = new Set([...nativeDeps.packages, ...nativeDeps.cordovaPackages])
+  packages.add(platform === 'ios' ? '@capacitor/ios' : '@capacitor/android')
+  return packages
+}
+
+function findPackageInNodeModules(nodeModulesPath: string, packagePath: string): string | undefined {
+  const directPackageDir = join(nodeModulesPath, ...packagePath.split('/'))
+  if (existsSync(directPackageDir))
+    return directPackageDir
+
+  const pnpmStoreDir = join(nodeModulesPath, '.pnpm')
+  if (!existsSync(pnpmStoreDir))
+    return undefined
+
+  const encodedPackageName = packagePath.replace('/', '+')
+  const pnpmEntries = readdirSync(pnpmStoreDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(name => name.startsWith(`${encodedPackageName}@`))
+    .sort()
+
+  for (const entry of pnpmEntries) {
+    const packageDir = join(pnpmStoreDir, entry, 'node_modules', ...packagePath.split('/'))
+    if (existsSync(packageDir))
+      return packageDir
+  }
+
+  return undefined
+}
+
+function addNativePackagesFromNodeModules(
+  zip: AdmZip,
+  nodeModulesPaths: string[],
+  platform: 'ios' | 'android',
+  nativeDeps: NativeDependencies,
+  platformDir: string,
+) {
+  if (nodeModulesPaths.length === 0)
+    return
+
+  const missingPaths = nodeModulesPaths.filter(nodeModulesPath => !existsSync(nodeModulesPath))
+  if (missingPaths.length > 0)
+    throw new Error(`Missing node_modules folder at ${missingPaths.join(', ')}`)
+
+  for (const nodeModulesPath of nodeModulesPaths) {
+    for (const packagePath of getNativePackagePaths(platform, nativeDeps)) {
+      const packageDir = findPackageInNodeModules(nodeModulesPath, packagePath)
+      if (!packageDir)
+        continue
+
+      addDirectoryToZip(
+        zip,
+        packageDir,
+        `node_modules/${packagePath}`,
+        platform,
+        nativeDeps,
+        platformDir,
+      )
     }
   }
 }
@@ -949,7 +1039,7 @@ function addDirectoryToZip(
  * - node_modules with native code (from Podfile/settings.gradle)
  * - capacitor.config.*, package.json, package-lock.json
  */
-export async function zipDirectory(projectDir: string, outputPath: string, platform: 'ios' | 'android', capConfig: any): Promise<void> {
+export async function zipDirectory(projectDir: string, outputPath: string, platform: 'ios' | 'android', capConfig: any, options: ZipDirectoryOptions = {}): Promise<void> {
   const platformDir = getPlatformDirFromCapacitorConfig(capConfig, platform)
 
   // Extract which node_modules have native code for this platform
@@ -959,6 +1049,7 @@ export async function zipDirectory(projectDir: string, outputPath: string, platf
 
   // Add files with filtering
   addDirectoryToZip(zip, projectDir, '', platform, nativeDeps, platformDir)
+  addNativePackagesFromNodeModules(zip, parseNodeModulesPaths(options.nodeModules), platform, nativeDeps, platformDir)
 
   // Rewrite pnpm store paths (node_modules/.pnpm/…/node_modules/@scope/pkg)
   // to standard flat paths (node_modules/@scope/pkg).
@@ -1476,7 +1567,9 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       // Zip the project directory
       log.info(`Zipping ${options.platform} project from ${projectDir}...`)
 
-      await zipDirectory(projectDir, zipPath, options.platform, config?.config)
+      await zipDirectory(projectDir, zipPath, options.platform, config?.config, {
+        nodeModules: options.nodeModules,
+      })
 
       const zipStats = await stat(zipPath)
       const sizeMB = (zipStats.size / 1024 / 1024).toFixed(2)

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -992,6 +992,10 @@ function findPackageInNodeModules(nodeModulesPath: string, packagePath: string):
     .filter(name => name.startsWith(`${encodedPackageName}@`))
     .sort()
 
+  if (pnpmEntries.length > 1) {
+    throw new Error(`Multiple pnpm store entries found for ${packagePath} in ${pnpmStoreDir}; provide the app-specific node_modules path so the native build archive can use the exact resolved package.`)
+  }
+
   for (const entry of pnpmEntries) {
     const packageDir = join(pnpmStoreDir, entry, 'node_modules', ...packagePath.split('/'))
     if (existsSync(packageDir))

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -772,6 +772,7 @@ The build will be processed and sent directly to app stores.
 Example: npx @capgo/cli@latest build request com.example.app --platform ios --path .`)
   .action(requestBuildCommand)
   .option('--path <path>', `Path to the project directory to build (default: current directory)`)
+  .option('--node-modules <nodeModules>', optionDescriptions.nodeModules)
   .option('--platform <platform>', `Target platform: ios or android (required)`)
   .option('--build-mode <buildMode>', `Build mode: debug or release (default: release)`)
   // iOS credential CLI options (can also be set via env vars or saved credentials)

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -523,12 +523,14 @@ export async function startMcpServer(): Promise<void> {
       appId: z.string().describe('App ID to build'),
       platform: z.enum(['ios', 'android']).describe('Target platform'),
       path: z.string().optional().describe('Path to project directory'),
+      nodeModules: z.string().optional().describe('Paths to node_modules directories for monorepos (comma-separated)'),
     },
-    async ({ appId, platform, path }) => {
+    async ({ appId, platform, path, nodeModules }) => {
       const result = await sdk.requestBuild({
         appId,
         platform,
         path,
+        nodeModules,
         // Credentials should be pre-saved using the CLI
       })
       if (!result.success) {

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -3,7 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import pack from '../../package.json'
-import { addAppOptionsSchema, cleanupOptionsSchema, getStatsOptionsSchema, starAllRepositoriesOptionsSchema, starRepoOptionsSchema, updateAppOptionsSchema, updateChannelOptionsSchema, uploadOptionsSchema } from '../schemas/sdk'
+import { addAppOptionsSchema, cleanupOptionsSchema, getStatsOptionsSchema, requestBuildOptionsSchema, starAllRepositoriesOptionsSchema, starRepoOptionsSchema, updateAppOptionsSchema, updateChannelOptionsSchema, uploadOptionsSchema } from '../schemas/sdk'
 import { CapgoSDK } from '../sdk'
 import { findSavedKey } from '../utils'
 
@@ -519,12 +519,7 @@ export async function startMcpServer(): Promise<void> {
   server.tool(
     'capgo_request_build',
     'Request a native iOS/Android build from Capgo Cloud',
-    {
-      appId: z.string().describe('App ID to build'),
-      platform: z.enum(['ios', 'android']).describe('Target platform'),
-      path: z.string().optional().describe('Path to project directory'),
-      nodeModules: z.string().optional().describe('Paths to node_modules directories for monorepos (comma-separated)'),
-    },
+    requestBuildOptionsSchema.pick({ appId: true, platform: true, path: true, nodeModules: true }).shape,
     async ({ appId, platform, path, nodeModules }) => {
       const result = await sdk.requestBuild({
         appId,

--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -31,6 +31,7 @@ export type BuildCredentials = z.infer<typeof buildCredentialsSchema>
 
 export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   path: z.string().optional(),
+  nodeModules: z.string().optional(),
   platform: z.enum(['ios', 'android']),
   buildMode: z.enum(['debug', 'release']).optional(),
   userId: z.string().optional(),

--- a/cli/src/schemas/sdk.ts
+++ b/cli/src/schemas/sdk.ts
@@ -338,6 +338,7 @@ export type ZipBundleOptions = z.infer<typeof zipBundleOptionsSchema>
 export const requestBuildOptionsSchema = z.object({
   appId: z.string(),
   path: z.string().optional(),
+  nodeModules: z.string().optional(),
   platform: z.enum(['ios', 'android']),
   credentials: buildCredentialsSchema.optional(),
   userId: z.string().optional(),

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -680,6 +680,7 @@ export class CapgoSDK {
         supaHost: options.supaHost || this.supaHost,
         supaAnon: options.supaAnon || this.supaAnon,
         path: options.path,
+        nodeModules: options.nodeModules,
         platform: options.platform,
         userId: options.userId,
         // Flatten BuildCredentials to individual fields

--- a/cli/test/test-build-zip-filter.mjs
+++ b/cli/test/test-build-zip-filter.mjs
@@ -410,4 +410,79 @@ await t('generated build zip includes Cordova plugin files referenced from capac
   }
 })
 
+await t('generated build zip can pull native pnpm workspace packages from an explicit node_modules root', async () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
+  const workspaceRoot = join(testRoot, 'typescript')
+  const projectRoot = join(workspaceRoot, 'apps', 'pay-tablet')
+  const zipPath = join(testRoot, 'build.zip')
+  const keepAwakePath = join(
+    workspaceRoot,
+    'node_modules',
+    '.pnpm',
+    '@capacitor-community+keep-awake@8.0.0_@capacitor+core@8.2.0',
+    'node_modules',
+    '@capacitor-community',
+    'keep-awake',
+  )
+
+  try {
+    writeFile(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@capacitor-community/keep-awake': '^8.0.0',
+        },
+      }, null, 2),
+    )
+
+    writeFile(
+      join(projectRoot, 'capacitor.config.json'),
+      JSON.stringify({
+        ios: {
+          path: 'ios',
+        },
+        appId: 'com.example.pay',
+        appName: 'Pay Tablet',
+      }, null, 2),
+    )
+
+    writeFile(
+      join(projectRoot, 'ios', 'App', 'Podfile'),
+      "platform :ios, '14.0'\npod 'CapacitorCommunityKeepAwake', :path => '../../node_modules/@capacitor-community/keep-awake'\n",
+    )
+
+    writeFile(
+      join(keepAwakePath, 'package.json'),
+      JSON.stringify({ name: '@capacitor-community/keep-awake', version: '8.0.0' }, null, 2),
+    )
+    writeFile(
+      join(keepAwakePath, 'KeepAwake.podspec'),
+      "Pod::Spec.new do |s|\n  s.name = 'KeepAwake'\nend",
+    )
+    writeFile(
+      join(keepAwakePath, 'ios', 'KeepAwakePlugin.swift'),
+      '// iOS source file',
+    )
+
+    await zipDirectory(projectRoot, zipPath, 'ios', {
+      ios: {
+        path: 'ios',
+      },
+    }, {
+      nodeModules: join(workspaceRoot, 'node_modules'),
+    })
+
+    const zip = new AdmZip(zipPath)
+    const entries = zip.getEntries().map(entry => entry.entryName).sort()
+
+    assert.ok(entries.includes('node_modules/@capacitor-community/keep-awake/package.json'), 'missing workspace plugin package.json in zip')
+    assert.ok(entries.includes('node_modules/@capacitor-community/keep-awake/KeepAwake.podspec'), 'missing workspace plugin podspec in zip')
+    assert.ok(entries.includes('node_modules/@capacitor-community/keep-awake/ios/KeepAwakePlugin.swift'), 'missing workspace plugin ios code in zip')
+    assert.ok(entries.includes('ios/App/Podfile'), 'native platform folder not included')
+  }
+  finally {
+    rmSync(testRoot, { recursive: true, force: true })
+  }
+})
+
 process.stdout.write('OK\n')

--- a/cli/test/test-build-zip-filter.mjs
+++ b/cli/test/test-build-zip-filter.mjs
@@ -485,4 +485,68 @@ await t('generated build zip can pull native pnpm workspace packages from an exp
   }
 })
 
+await t('generated build zip rejects ambiguous pnpm workspace package versions', async () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
+  const workspaceRoot = join(testRoot, 'typescript')
+  const projectRoot = join(workspaceRoot, 'apps', 'pay-tablet')
+  const zipPath = join(testRoot, 'build.zip')
+
+  try {
+    writeFile(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@capacitor-community/keep-awake': '^8.0.0',
+        },
+      }, null, 2),
+    )
+
+    writeFile(
+      join(projectRoot, 'capacitor.config.json'),
+      JSON.stringify({
+        ios: {
+          path: 'ios',
+        },
+        appId: 'com.example.pay',
+        appName: 'Pay Tablet',
+      }, null, 2),
+    )
+
+    writeFile(
+      join(projectRoot, 'ios', 'App', 'Podfile'),
+      "platform :ios, '14.0'\npod 'CapacitorCommunityKeepAwake', :path => '../../node_modules/@capacitor-community/keep-awake'\n",
+    )
+
+    for (const version of ['8.0.0', '8.1.0']) {
+      writeFile(
+        join(
+          workspaceRoot,
+          'node_modules',
+          '.pnpm',
+          `@capacitor-community+keep-awake@${version}_@capacitor+core@8.2.0`,
+          'node_modules',
+          '@capacitor-community',
+          'keep-awake',
+          'package.json',
+        ),
+        JSON.stringify({ name: '@capacitor-community/keep-awake', version }, null, 2),
+      )
+    }
+
+    await assert.rejects(
+      () => zipDirectory(projectRoot, zipPath, 'ios', {
+        ios: {
+          path: 'ios',
+        },
+      }, {
+        nodeModules: join(workspaceRoot, 'node_modules'),
+      }),
+      /Multiple pnpm store entries found for @capacitor-community\/keep-awake/,
+    )
+  }
+  finally {
+    rmSync(testRoot, { recursive: true, force: true })
+  }
+})
+
 process.stdout.write('OK\n')

--- a/cli/webdocs/build.mdx
+++ b/cli/webdocs/build.mdx
@@ -59,6 +59,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | Param          | Type          | Description          |
 | -------------- | ------------- | -------------------- |
 | **--path** | <code>string</code> | Path to the project directory to build (default: current directory) |
+| **--node-modules** | <code>string</code> | Paths to node_modules directories for monorepos (comma-separated) |
 | **--platform** | <code>string</code> | Target platform: ios or android (required) |
 | **--build-mode** | <code>string</code> | Build mode: debug or release (default: release) |
 | **--build-certificate-base64** | <code>string</code> | iOS: Base64-encoded .p12 certificate |
@@ -276,4 +277,3 @@ Example:
 | **--appId** | <code>string</code> | App ID (auto-detected from capacitor.config if omitted) |
 | **--platform** | <code>string</code> | Platform (only ios is supported) |
 | **--local** | <code>boolean</code> | Migrate from local .capgo-credentials.json instead of global |
-


### PR DESCRIPTION
## Summary (AI generated)

- Added `--node-modules` support to `build request` so native build packaging can use explicit monorepo dependency roots.
- Materialized native packages from pnpm `.pnpm` virtual stores into flat `node_modules/<package>` paths inside the build archive.
- Added regression coverage for a pnpm workspace iOS plugin dependency and updated CLI docs/skill metadata.

## Motivation (AI generated)

Customers using pnpm workspace monorepos can have app-local native dependency symlinks that point outside the Capacitor app directory. `bundle upload` already accepts `--node-modules`, but `build request` did not, so native cloud builds could upload an archive missing the real plugin package content.

## Business Impact (AI generated)

This unblocks native cloud builds for pnpm workspace customers and reduces failed iOS build requests caused by unresolved monorepo symlinks on Capgo runners.

## Test Plan (AI generated)

- [x] Confirmed the new pnpm workspace regression test fails before the implementation.
- [x] Ran `bun run test:build-zip-filter`.
- [x] Ran `bun run lint`.
- [x] Ran `bun run build`.
- [x] Ran `bun run test:mcp`.
- [x] Ran `bun run test:bundle`.

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--node-modules` option to the `build request` command, letting users supply comma-separated alternate node_modules paths (including pnpm-style layouts) so native dependencies from monorepos are bundled into build archives.

* **Documentation**
  * CLI docs and build guide updated to describe the new `--node-modules` flag and usage examples for monorepo setups.

* **Tests**
  * New integration tests validating archive creation and pnpm workspace resolution when alternate node_modules roots are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->