### PR TITLE
fix(api): cache replication lag header

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -525,6 +525,7 @@ async function runChannelSelfWithPgClient(
   record: () => Promise<void>,
 ) {
   await setReplicationLagHeader(c, pgClient)
+
   try {
     return await run(getDrizzleClient(pgClient as any))
   }

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -6,14 +6,16 @@ import { getRuntimeKey } from 'hono/adapter'
 // @ts-types="npm:@types/pg"
 import { Pool } from 'pg'
 import { backgroundTask, existInEnv, getEnv } from '../utils/utils.ts'
+import { CacheHelper } from './cache.ts'
 import { DISPOSABLE_EMAIL_DOMAINS, PERSONAL_EMAIL_DOMAINS } from './emailClassification.ts'
 import { getClientDbRegionSB } from './geolocation.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import * as schema from './postgres_schema.ts'
 import { withOptionalManifestSelect } from './queryHelpers.ts'
 
-// Replication lag threshold
-const REPLICATION_LAG_THRESHOLD_SECONDS = 180 // 3 minutes threshold
+const REPLICATION_LAG_THRESHOLD_SECONDS = 180
+const REPLICATION_LAG_CACHE_TTL_SECONDS = 60
+const REPLICATION_LAG_CACHE_TTL_MS = REPLICATION_LAG_CACHE_TTL_SECONDS * 1000
 
 type ReplicationStatus = 'ok' | 'lagging' | 'unknown'
 
@@ -21,6 +23,13 @@ interface ReplicationLagStatus {
   status: ReplicationStatus
   max_lag_seconds: number | null
 }
+
+interface ReplicationLagCacheEntry extends ReplicationLagStatus {
+  expiresAt: number
+}
+
+const replicationLagMemoryCache = new Map<string, ReplicationLagCacheEntry>()
+const replicationLagInflight = new Map<string, Promise<ReplicationLagStatus>>()
 
 const PLAN_EXCEEDED_COLUMNS: Record<'mau' | 'storage' | 'bandwidth', string> = {
   mau: 'mau_exceeded',
@@ -88,6 +97,38 @@ function fixSupabaseHost(host: string): string {
   return host
 }
 
+function getReplicationLagCacheKey(c: Context): string {
+  return String(c.get('databaseSource') ?? c.res.headers.get('X-Database-Source') ?? 'unknown')
+}
+
+function getFreshReplicationLagMemoryEntry(cacheKey: string, now = Date.now()): ReplicationLagStatus | null {
+  const cached = replicationLagMemoryCache.get(cacheKey)
+  if (!cached)
+    return null
+  if (cached.expiresAt <= now) {
+    replicationLagMemoryCache.delete(cacheKey)
+    return null
+  }
+  return {
+    status: cached.status,
+    max_lag_seconds: cached.max_lag_seconds,
+  }
+}
+
+function setReplicationLagMemoryEntry(cacheKey: string, status: ReplicationLagStatus, expiresAt = Date.now() + REPLICATION_LAG_CACHE_TTL_MS) {
+  replicationLagMemoryCache.set(cacheKey, {
+    ...status,
+    expiresAt,
+  })
+}
+
+function toReplicationLagSeconds(value: unknown): number | null {
+  if (value === null || value === undefined)
+    return null
+  const lagSeconds = Number(value)
+  return Number.isFinite(lagSeconds) ? lagSeconds : null
+}
+
 /**
  * Query replication lag from the REPLICA database using pg_stat_subscription.
  * Uses the existing pool - no new connections.
@@ -102,9 +143,7 @@ async function queryReplicaLag(c: Context, pool: Pool): Promise<ReplicationLagSt
     `
 
     const result = await pool.query(query)
-    const lagSeconds = result.rows[0]?.lag_seconds
-      ? Number(result.rows[0].lag_seconds)
-      : null
+    const lagSeconds = toReplicationLagSeconds(result.rows[0]?.lag_seconds)
 
     let status: ReplicationStatus = 'unknown'
     if (lagSeconds !== null) {
@@ -127,12 +166,53 @@ async function queryReplicaLag(c: Context, pool: Pool): Promise<ReplicationLagSt
   }
 }
 
+async function getCachedReplicaLag(c: Context, pool: Pool): Promise<ReplicationLagStatus> {
+  const cacheKey = getReplicationLagCacheKey(c)
+  const memoryEntry = getFreshReplicationLagMemoryEntry(cacheKey)
+  if (memoryEntry)
+    return memoryEntry
+
+  const existingQuery = replicationLagInflight.get(cacheKey)
+  if (existingQuery)
+    return existingQuery
+
+  const cacheHelper = new CacheHelper(c)
+  const cacheRequest = cacheHelper.buildRequest('/cache/replication-lag', { source: cacheKey })
+  const cachedEntry = await cacheHelper.matchJson<ReplicationLagCacheEntry>(cacheRequest)
+
+  if (cachedEntry && cachedEntry.expiresAt > Date.now()) {
+    const cachedStatus = {
+      status: cachedEntry.status,
+      max_lag_seconds: cachedEntry.max_lag_seconds,
+    }
+    setReplicationLagMemoryEntry(cacheKey, cachedStatus, cachedEntry.expiresAt)
+    return cachedStatus
+  }
+
+  const existingQueryAfterCache = replicationLagInflight.get(cacheKey)
+  if (existingQueryAfterCache)
+    return existingQueryAfterCache
+
+  const query = queryReplicaLag(c, pool)
+    .then(async (status) => {
+      const expiresAt = Date.now() + REPLICATION_LAG_CACHE_TTL_MS
+      setReplicationLagMemoryEntry(cacheKey, status, expiresAt)
+      await cacheHelper.putJson(cacheRequest, { ...status, expiresAt }, REPLICATION_LAG_CACHE_TTL_SECONDS)
+      return status
+    })
+    .finally(() => {
+      replicationLagInflight.delete(cacheKey)
+    })
+
+  replicationLagInflight.set(cacheKey, query)
+  return query
+}
+
 /**
- * Set replication lag header on the response.
- * Uses the provided pool to query pg_stat_subscription on the replica.
+ * Set replication lag headers on hot plugin responses using a 60-second cache.
  */
 export async function setReplicationLagHeader(c: Context, pool: Pool): Promise<void> {
-  const status = await queryReplicaLag(c, pool)
+  const status = await getCachedReplicaLag(c, pool)
   safeSetResponseHeader(c, 'X-Replication-Lag', status.status)
   if (status.max_lag_seconds !== null) {
     safeSetResponseHeader(c, 'X-Replication-Lag-Seconds', String(Math.round(status.max_lag_seconds)))

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -419,7 +419,6 @@ export async function updateWithPG(
 export async function update(c: Context, body: AppInfos) {
   const pgClient = getPgClient(c, true)
 
-  // Set replication lag header (uses cached status, non-blocking)
   await setReplicationLagHeader(c, pgClient)
 
   const drizzlePg = pgClient ? getDrizzleClient(pgClient) : (null as any)

--- a/tests/replication-lag-cache.unit.test.ts
+++ b/tests/replication-lag-cache.unit.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setReplicationLagHeader } from '../supabase/functions/_backend/utils/pg.ts'
+
+function makeContext(databaseSource: string) {
+  const headers = new Headers()
+  return {
+    context: {
+      req: { url: 'https://api.capgo.test/updates' },
+      res: new Response(null),
+      get: (key: string) => {
+        if (key === 'databaseSource')
+          return databaseSource
+        if (key === 'requestId')
+          return `req-${databaseSource}`
+        return undefined
+      },
+      header: (name: string, value: string) => {
+        headers.set(name, value)
+      },
+    },
+    headers,
+  }
+}
+
+describe('replication lag header cache', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reuses replication lag for one minute before querying again', async () => {
+    vi.stubGlobal('caches', undefined)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T12:00:00Z'))
+
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [{ lag_seconds: '12.4' }] })
+        .mockResolvedValueOnce({ rows: [{ lag_seconds: '25.1' }] }),
+    }
+    const source = `replica-cache-${crypto.randomUUID()}`
+
+    const first = makeContext(source)
+    await setReplicationLagHeader(first.context as any, pool as any)
+    expect(first.headers.get('X-Replication-Lag')).toBe('ok')
+    expect(first.headers.get('X-Replication-Lag-Seconds')).toBe('12')
+
+    const second = makeContext(source)
+    await setReplicationLagHeader(second.context as any, pool as any)
+    expect(second.headers.get('X-Replication-Lag-Seconds')).toBe('12')
+    expect(pool.query).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(new Date('2026-05-01T12:01:01Z'))
+
+    const third = makeContext(source)
+    await setReplicationLagHeader(third.context as any, pool as any)
+    expect(third.headers.get('X-Replication-Lag-Seconds')).toBe('25')
+    expect(pool.query).toHaveBeenCalledTimes(2)
+  })
+
+  it('emits cached zero-second lag values', async () => {
+    vi.stubGlobal('caches', undefined)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T12:00:00Z'))
+
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ lag_seconds: '0' }] }),
+    }
+    const source = `replica-zero-${crypto.randomUUID()}`
+
+    const first = makeContext(source)
+    await setReplicationLagHeader(first.context as any, pool as any)
+    expect(first.headers.get('X-Replication-Lag')).toBe('ok')
+    expect(first.headers.get('X-Replication-Lag-Seconds')).toBe('0')
+
+    const second = makeContext(source)
+    await setReplicationLagHeader(second.context as any, pool as any)
+    expect(second.headers.get('X-Replication-Lag-Seconds')).toBe('0')
+    expect(pool.query).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Cache `X-Replication-Lag` and `X-Replication-Lag-Seconds` values for 60 seconds per replica source.
- Add an in-memory in-flight guard so request bursts share one lag query instead of each hitting `pg_stat_subscription`.
- Add unit coverage for cache reuse, cache expiry, and zero-second lag headers.

## Motivation (AI generated)

The hot plugin paths were querying `pg_stat_subscription` on each `/updates` and `/channel_self` request just to emit diagnostic replication headers. That caused unnecessary repeated work on replicas and showed up as high CPU usage.

## Business Impact (AI generated)

This reduces database CPU pressure on high-traffic plugin endpoints while preserving the replication lag headers used for diagnostics. Lower replica load improves update-check latency and service stability.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bunx eslint tests/replication-lag-cache.unit.test.ts`
- [x] `bunx vitest run tests/replication-lag-cache.unit.test.ts`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`

Generated with AI