### PR TITLE
[codex] Move replication simulation into replication tab

### DIFF
--- a/src/constants/adminTabs.ts
+++ b/src/constants/adminTabs.ts
@@ -1,7 +1,6 @@
 import type { Tab } from '~/components/comp_def'
 import IconArrowPath from '~icons/heroicons/arrow-path'
 import IconBanknotes from '~icons/heroicons/banknotes'
-import IconBeaker from '~icons/heroicons/beaker'
 import IconChart from '~icons/heroicons/chart-bar'
 import IconCircleStack from '~icons/heroicons/circle-stack'
 import IconCurrencyDollar from '~icons/heroicons/currency-dollar'
@@ -12,7 +11,6 @@ export const adminTabs: Tab[] = [
   { label: 'overview', icon: IconChart, key: '' },
   { label: 'updates', icon: IconArrowPath, key: '/updates' },
   { label: 'replication', icon: IconCircleStack, key: '/replication' },
-  { label: 'admin-debug', icon: IconBeaker, key: '/debug' },
   { label: 'plugins', icon: IconPuzzle, key: '/plugins' },
   { label: 'users', icon: IconUsers, key: '/users' },
   { label: 'revenue', icon: IconBanknotes, key: '/revenue' },

--- a/src/pages/admin/dashboard/replication.vue
+++ b/src/pages/admin/dashboard/replication.vue
@@ -7,10 +7,12 @@ meta:
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import BeakerIcon from '~icons/heroicons/beaker'
 import AdminStatsCard from '~/components/admin/AdminStatsCard.vue'
 import Spinner from '~/components/Spinner.vue'
 import { formatLocalDateTime } from '~/services/date'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
+import { showUploadReplicationToast } from '~/services/updateReplicationToast'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
 
@@ -146,6 +148,15 @@ async function loadReplicationStatus() {
   }
 }
 
+function triggerFakeReplicationToast() {
+  showUploadReplicationToast({
+    eventLabel: 'Upload was uploaded',
+    route: '/admin/dashboard/replication',
+    actionLabel: t('view'),
+    onAction: () => router.push('/admin/dashboard/replication'),
+  })
+}
+
 onMounted(async () => {
   if (!mainStore.isAdmin) {
     console.error('Non-admin user attempted to access admin replication dashboard')
@@ -174,13 +185,24 @@ displayStore.defaultBack = '/dashboard'
               Logical replication slot lag monitoring
             </p>
           </div>
-          <button
-            class="d-btn d-btn-outline d-btn-sm"
-            :disabled="isLoading"
-            @click="loadReplicationStatus"
-          >
-            {{ isLoading ? 'Refreshing...' : 'Refresh' }}
-          </button>
+          <div class="flex flex-wrap gap-2">
+            <button
+              class="d-btn d-btn-primary d-btn-sm"
+              type="button"
+              @click="triggerFakeReplicationToast"
+            >
+              <BeakerIcon class="h-4 w-4" aria-hidden="true" />
+              {{ t('admin-debug') }}
+            </button>
+            <button
+              class="d-btn d-btn-outline d-btn-sm"
+              type="button"
+              :disabled="isLoading"
+              @click="loadReplicationStatus"
+            >
+              {{ isLoading ? 'Refreshing...' : 'Refresh' }}
+            </button>
+          </div>
         </div>
 
         <div v-if="errorMessage && !data" class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-200">


### PR DESCRIPTION
## Summary (AI generated)

- Removed the standalone admin debug tab from the admin dashboard tab list.
- Added the replication simulation action as a button in the Replication admin page header.

## Motivation (AI generated)

Replication simulation belongs next to the replication status controls instead of occupying its own admin tab.

## Business Impact (AI generated)

This keeps the admin dashboard navigation focused while preserving the replication toast simulation tool for internal validation.

## Test Plan (AI generated)

- [x] Run `bun lint`
- [x] Run `bun typecheck`

Generated with AI