### PR TITLE
fix(auth): rate limit email otp by account

### DIFF
--- a/supabase/functions/_backend/private/verify_email_otp.ts
+++ b/supabase/functions/_backend/private/verify_email_otp.ts
@@ -1,7 +1,9 @@
 import { type } from 'arktype'
 import { safeParseSchema } from '../utils/ark_validation.ts'
-import { createHono, getClaimsFromJWT, middlewareAuth, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
+import { createHono, getClaimsFromJWT, middlewareAuth, parseBody, quickError, simpleError, simpleRateLimit, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { clearFailedAccountAuth, isAccountRateLimited, recordFailedAccountAuth } from '../utils/rate_limit.ts'
+import { buildRateLimitInfo } from '../utils/rateLimitInfo.ts'
 import { emptySupabase, supabaseAdmin } from '../utils/supabase.ts'
 import { version } from '../utils/version.ts'
 
@@ -51,6 +53,11 @@ app.post('/', middlewareAuth, async (c) => {
     return quickError(401, 'invalid_auth_type', 'JWT authentication required')
   }
 
+  const accountRateLimitStatus = await isAccountRateLimited(c, auth.userId)
+  if (accountRateLimitStatus.limited) {
+    return simpleRateLimit({ reason: 'too_many_failed_account_auth_attempts', ...buildRateLimitInfo(accountRateLimitStatus.resetAt) })
+  }
+
   const authorization = c.get('authorization')
   if (!authorization) {
     return quickError(401, 'no_authorization', 'No authorization header provided')
@@ -83,16 +90,21 @@ app.post('/', middlewareAuth, async (c) => {
   }
 
   if (verifyError || !verifyData?.session?.access_token) {
+    await recordFailedAccountAuth(c, auth.userId)
     cloudlog({ requestId: c.get('requestId'), context: 'verify_email_otp - verifyOtp failed', error: verifyError?.message })
     return quickError(401, 'invalid_otp', 'Invalid or expired OTP')
   }
 
   if (verifyData.user?.id && verifyData.user.id !== auth.userId) {
+    await recordFailedAccountAuth(c, auth.userId)
     return quickError(403, 'otp_user_mismatch', 'OTP does not match current user')
   }
   if (!verifyData.user?.id) {
+    await recordFailedAccountAuth(c, auth.userId)
     return quickError(500, 'no_user', 'No user associated with OTP')
   }
+
+  await clearFailedAccountAuth(c, auth.userId)
 
   const otpVerifiedAt = new Date().toISOString()
   const { error: recordError } = await supabaseAdmin(c).rpc('record_email_otp_verified', {

--- a/supabase/functions/_backend/utils/rate_limit.ts
+++ b/supabase/functions/_backend/utils/rate_limit.ts
@@ -10,6 +10,9 @@ const API_KEY_RATE_LIMIT_TTL = 60 // 1 minute window for API key rate limiting
 // Default limits - set high to catch only severe abuse, not normal usage
 const DEFAULT_FAILED_AUTH_LIMIT = 20 // 20 failed attempts before blocking (catches brute force, allows mistakes)
 const DEFAULT_API_KEY_RATE_LIMIT = 2000 // 2000 requests per minute per API key (catches infinite loops)
+const FAILED_AUTH_PATH = '/rate-limit/failed-auth'
+const FAILED_ACCOUNT_AUTH_PATH = '/rate-limit/failed-auth-account'
+const API_KEY_RATE_LIMIT_PATH = '/rate-limit/apikey'
 
 interface RateLimitData {
   count: number
@@ -49,6 +52,35 @@ export function getClientIP(c: Context): string {
   return 'unknown'
 }
 
+function bytesToHex(bytes: Uint8Array) {
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+async function hashIdentifier(identifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(identifier))
+  return bytesToHex(new Uint8Array(digest))
+}
+
+export function normalizeRateLimitAccountIdentifier(identifier: string): string {
+  return identifier.trim().toLowerCase()
+}
+
+async function getAccountRateLimitKey(identifier: string): Promise<string | null> {
+  const normalized = normalizeRateLimitAccountIdentifier(identifier)
+  if (!normalized)
+    return null
+
+  return await hashIdentifier(normalized)
+}
+
+function getRateLimitWindowSeconds(resetAt: number, now: number): number {
+  return Math.max(1, Math.ceil((resetAt - now) / 1000))
+}
+
+function buildResetAt() {
+  return Date.now() + FAILED_AUTH_TTL * 1000
+}
+
 /**
  * Check if an IP is rate limited due to failed authentication attempts.
  * Returns true if the IP should be blocked.
@@ -66,7 +98,7 @@ export async function isIPRateLimited(c: Context): Promise<RateLimitStatus> {
   }
 
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest('/rate-limit/failed-auth', { ip })
+  const cacheKey = cacheHelper.buildRequest(FAILED_AUTH_PATH, { ip })
   const data = await cacheHelper.matchJson<RateLimitData>(cacheKey)
 
   // If no data or cache unavailable, fail open (don't block)
@@ -105,15 +137,16 @@ export async function recordFailedAuth(c: Context): Promise<void> {
   }
 
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest('/rate-limit/failed-auth', { ip })
+  const cacheKey = cacheHelper.buildRequest(FAILED_AUTH_PATH, { ip })
   const existingData = await cacheHelper.matchJson<RateLimitData>(cacheKey)
+  const resetAt = buildResetAt()
 
   const newData: RateLimitData = {
     count: (existingData?.count ?? 0) + 1,
-    resetAt: Date.now() + FAILED_AUTH_TTL * 1000,
+    resetAt,
   }
 
-  await cacheHelper.putJson(cacheKey, newData, FAILED_AUTH_TTL)
+  await cacheHelper.putJson(cacheKey, newData, getRateLimitWindowSeconds(resetAt, Date.now()))
 
   cloudlog({
     requestId: c.get('requestId'),
@@ -133,10 +166,95 @@ export async function clearFailedAuth(c: Context): Promise<void> {
     return
 
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest('/rate-limit/failed-auth', { ip })
+  const cacheKey = cacheHelper.buildRequest(FAILED_AUTH_PATH, { ip })
 
   // Set count to 0 to effectively clear the rate limit
   // Use 60s TTL for cache consistency across Cloudflare edge nodes
+  await cacheHelper.putJson(cacheKey, { count: 0 }, 60)
+}
+
+/**
+ * Check if a specific account is rate limited due to failed authentication attempts.
+ * The account identifier is hashed before it is used as a cache key to avoid storing
+ * raw email addresses or user IDs in Cache API URLs.
+ */
+export async function isAccountRateLimited(c: Context, accountIdentifier: string): Promise<RateLimitStatus> {
+  const accountKey = await getAccountRateLimitKey(accountIdentifier)
+  if (!accountKey) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Account rate limit check skipped: empty account identifier',
+    })
+    return { limited: false }
+  }
+
+  const cacheHelper = new CacheHelper(c)
+  const cacheKey = cacheHelper.buildRequest(FAILED_ACCOUNT_AUTH_PATH, { account: accountKey })
+  const data = await cacheHelper.matchJson<RateLimitData>(cacheKey)
+
+  if (!data)
+    return { limited: false }
+
+  const limit = getFailedAuthLimit(c)
+  const isLimited = data.count >= limit
+
+  if (isLimited) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Account rate limited due to failed auth attempts',
+      accountKey,
+      count: data.count,
+      limit,
+    })
+  }
+
+  return { limited: isLimited, resetAt: data.resetAt }
+}
+
+/**
+ * Record a failed authentication attempt for a specific account.
+ */
+export async function recordFailedAccountAuth(c: Context, accountIdentifier: string): Promise<void> {
+  const accountKey = await getAccountRateLimitKey(accountIdentifier)
+  if (!accountKey) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Failed account auth not recorded: empty account identifier',
+    })
+    return
+  }
+
+  const cacheHelper = new CacheHelper(c)
+  const cacheKey = cacheHelper.buildRequest(FAILED_ACCOUNT_AUTH_PATH, { account: accountKey })
+  const existingData = await cacheHelper.matchJson<RateLimitData>(cacheKey)
+  const resetAt = buildResetAt()
+
+  const newData: RateLimitData = {
+    count: (existingData?.count ?? 0) + 1,
+    resetAt,
+  }
+
+  await cacheHelper.putJson(cacheKey, newData, getRateLimitWindowSeconds(resetAt, Date.now()))
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Recorded failed account auth attempt',
+    accountKey,
+    count: newData.count,
+  })
+}
+
+/**
+ * Clear failed authentication attempts for a specific account after successful authentication.
+ */
+export async function clearFailedAccountAuth(c: Context, accountIdentifier: string): Promise<void> {
+  const accountKey = await getAccountRateLimitKey(accountIdentifier)
+  if (!accountKey)
+    return
+
+  const cacheHelper = new CacheHelper(c)
+  const cacheKey = cacheHelper.buildRequest(FAILED_ACCOUNT_AUTH_PATH, { account: accountKey })
+
   await cacheHelper.putJson(cacheKey, { count: 0 }, 60)
 }
 
@@ -147,7 +265,7 @@ export async function clearFailedAuth(c: Context): Promise<void> {
  */
 export async function isAPIKeyRateLimited(c: Context, apiKeyId: number): Promise<RateLimitStatus> {
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest('/rate-limit/apikey', { id: String(apiKeyId) })
+  const cacheKey = cacheHelper.buildRequest(API_KEY_RATE_LIMIT_PATH, { id: String(apiKeyId) })
   const data = await cacheHelper.matchJson<RateLimitData>(cacheKey)
 
   // If no data or cache unavailable, fail open (don't block)
@@ -177,7 +295,7 @@ export async function isAPIKeyRateLimited(c: Context, apiKeyId: number): Promise
  */
 export async function recordAPIKeyUsage(c: Context, apiKeyId: number): Promise<void> {
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest('/rate-limit/apikey', { id: String(apiKeyId) })
+  const cacheKey = cacheHelper.buildRequest(API_KEY_RATE_LIMIT_PATH, { id: String(apiKeyId) })
   const existingData = await cacheHelper.matchJson<RateLimitData>(cacheKey)
 
   const newData: RateLimitData = {

--- a/tests/account-rate-limit.unit.test.ts
+++ b/tests/account-rate-limit.unit.test.ts
@@ -1,0 +1,107 @@
+import type { Context } from 'hono'
+import { Hono } from 'hono/tiny'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearFailedAccountAuth,
+  isAccountRateLimited,
+  normalizeRateLimitAccountIdentifier,
+  recordFailedAccountAuth,
+} from '../supabase/functions/_backend/utils/rate_limit.ts'
+
+type CacheStore = Map<string, Response>
+
+let previousCaches: typeof globalThis.caches | undefined
+
+function installMemoryCache() {
+  const store: CacheStore = new Map()
+  const cache = {
+    match: async (request: Request) => store.get(request.url)?.clone(),
+    put: async (request: Request, response: Response) => {
+      store.set(request.url, response.clone())
+    },
+  }
+
+  previousCaches = globalThis.caches
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: {
+      open: async () => cache,
+    },
+  })
+
+  return store
+}
+
+async function withContext<T>(handler: (c: Context) => Promise<T>, ip: string) {
+  const app = new Hono()
+  app.get('/', async (c) => {
+    c.set('requestId', 'account-rate-limit-test')
+    const result = await handler(c)
+    return c.json(result ?? { ok: true })
+  })
+
+  const response = await app.request('http://rate-limit.test/', {
+    headers: {
+      'cf-connecting-ip': ip,
+    },
+  })
+
+  return await response.json<T>()
+}
+
+describe('account failed-auth rate limiting', () => {
+  beforeEach(() => {
+    installMemoryCache()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: previousCaches,
+    })
+  })
+
+  it('normalizes account identifiers before hashing', () => {
+    expect(normalizeRateLimitAccountIdentifier('  Victim@Example.COM  ')).toBe('victim@example.com')
+  })
+
+  it('limits by account across different client IPs', async () => {
+    for (let attempt = 0; attempt < 19; attempt++) {
+      await withContext(c => recordFailedAccountAuth(c, 'Victim@Example.COM'), `198.51.100.${attempt + 1}`)
+    }
+
+    const beforeLimit = await withContext(
+      c => isAccountRateLimited(c, 'victim@example.com'),
+      '203.0.113.2',
+    )
+    expect(beforeLimit.limited).toBe(false)
+
+    await withContext(c => recordFailedAccountAuth(c, 'victim@example.com'), '203.0.113.3')
+
+    const afterSecondAttempt = await withContext(
+      c => isAccountRateLimited(c, 'VICTIM@example.com'),
+      '203.0.113.4',
+    )
+    expect(afterSecondAttempt.limited).toBe(true)
+  })
+
+  it('clears the account limiter after successful verification', async () => {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      await withContext(c => recordFailedAccountAuth(c, 'clear-me@example.com'), `198.51.100.${attempt + 1}`)
+    }
+
+    const beforeClear = await withContext(
+      c => isAccountRateLimited(c, 'clear-me@example.com'),
+      '198.51.100.3',
+    )
+    expect(beforeClear.limited).toBe(true)
+
+    await withContext(c => clearFailedAccountAuth(c, 'clear-me@example.com'), '198.51.100.4')
+
+    const afterClear = await withContext(
+      c => isAccountRateLimited(c, 'clear-me@example.com'),
+      '198.51.100.5',
+    )
+    expect(afterClear.limited).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Added account-keyed failed-auth rate limiting for the custom email OTP verification endpoint.
- Hashes normalized account identifiers before storing limiter keys.
- Added unit coverage for account-based limiter behavior across changing client IPs.

## Motivation (AI generated)

The custom email OTP verification path was not protected by Supabase password-auth rate limits and could be brute-forced against one account from rotating origins.

## Business Impact (AI generated)

This closes the advisory path that could let an attacker verify an account email they do not control and then abuse account lifecycle actions.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx eslint tests/account-rate-limit.unit.test.ts`
- [x] `bunx vitest run tests/account-rate-limit.unit.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/verify-email-otp.test.ts --testTimeout=60000`
- [x] `bun typecheck` via commit hook

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-account rate limiting for email OTP verification attempts. The system now tracks failed verification attempts per account and enforces limits to prevent unauthorized access. When rate limits are active, users receive reset timing information to know when they can retry authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->