### PR TITLE
fix(auth): rate limit password compliance by account

### DIFF
--- a/supabase/functions/_backend/private/validate_password_compliance.ts
+++ b/supabase/functions/_backend/private/validate_password_compliance.ts
@@ -8,7 +8,7 @@ import { safeParseSchema } from '../utils/ark_validation.ts'
 import { parseBody, quickError, simpleError, simpleRateLimit, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { getEffectivePasswordMinLength, getPasswordPolicyValidationErrors } from '../utils/password_policy.ts'
-import { isIPRateLimited, recordFailedAuth } from '../utils/rate_limit.ts'
+import { clearFailedAccountAuth, isAccountRateLimited, isIPRateLimited, recordFailedAccountAuth, recordFailedAuth } from '../utils/rate_limit.ts'
 import { buildRateLimitInfo } from '../utils/rateLimitInfo.ts'
 import { emptySupabase, supabaseClient, supabaseAdmin as useSupabaseAdmin } from '../utils/supabase.ts'
 import { getEnv } from '../utils/utils.ts'
@@ -149,6 +149,11 @@ app.post('/', async (c) => {
   }
 
   const body = validationResult.data
+  const accountRateLimitStatus = await isAccountRateLimited(c, body.email)
+  if (accountRateLimitStatus.limited) {
+    return simpleRateLimit({ reason: 'too_many_failed_account_auth_attempts', ...buildRateLimitInfo(accountRateLimitStatus.resetAt) })
+  }
+
   const { password: _password, captcha_token: _captchaToken, ...bodyWithoutPassword } = body
   cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance raw body', rawBody: bodyWithoutPassword })
 
@@ -165,16 +170,27 @@ app.post('/', async (c) => {
   })
 
   if (signInError || !signInData.user || !signInData.session) {
+    const errorCode = signInError?.code
+    const authErrorStatus = (signInError as { status?: unknown } | null)?.status
+    const errorStatus = typeof authErrorStatus === 'number' ? authErrorStatus : undefined
+    const errorMessage = signInError?.message ?? 'Authentication failed'
+    const missingAuthenticatedSession = !signInError && (!signInData.user || !signInData.session)
+    cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance - login failed', error: errorMessage, errorCode: errorCode ?? 'auth_failed', errorStatus })
     await recordFailedAuth(c)
-    const errorMessage = signInError?.message ?? 'Unknown error'
-    cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance - login failed', error: errorMessage })
 
-    if (errorMessage.toLowerCase().includes('captcha')) {
+    if (errorCode === 'captcha_failed') {
       return quickError(401, 'captcha_failed', 'Captcha verification failed')
+    }
+
+    if (errorCode === 'invalid_credentials' || (!errorCode && errorStatus === 400) || missingAuthenticatedSession) {
+      await recordFailedAccountAuth(c, body.email)
+      return quickError(401, 'invalid_credentials', 'Invalid email or password')
     }
 
     return quickError(401, 'invalid_credentials', 'Invalid email or password')
   }
+
+  await clearFailedAccountAuth(c, body.email)
 
   const userId = signInData.user.id
   const userClient = supabaseClient(c, `Bearer ${signInData.session.access_token}`)

--- a/tests/account-rate-limit.unit.test.ts
+++ b/tests/account-rate-limit.unit.test.ts
@@ -1,9 +1,11 @@
 import type { Context } from 'hono'
 import { Hono } from 'hono/tiny'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { app as validatePasswordComplianceApp } from '../supabase/functions/_backend/private/validate_password_compliance.ts'
 import {
   clearFailedAccountAuth,
   isAccountRateLimited,
+  isIPRateLimited,
   normalizeRateLimitAccountIdentifier,
   recordFailedAccountAuth,
 } from '../supabase/functions/_backend/utils/rate_limit.ts'
@@ -103,5 +105,50 @@ describe('account failed-auth rate limiting', () => {
       '198.51.100.5',
     )
     expect(afterClear.limited).toBe(false)
+  })
+
+  it('blocks password compliance verification by account across different client IPs', async () => {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      await withContext(c => recordFailedAccountAuth(c, 'password-policy@example.com'), `198.51.100.${attempt + 1}`)
+    }
+
+    const app = new Hono()
+    app.route('/validate_password_compliance', validatePasswordComplianceApp)
+    app.onError((error, _c) => {
+      const errorDetails = error as unknown as {
+        cause?: { error?: string, moreInfo?: { reason?: string } }
+        status?: unknown
+      }
+      const status = typeof errorDetails.status === 'number' ? errorDetails.status : 500
+      const cause = errorDetails.cause
+      return new Response(JSON.stringify({ error: cause?.error, reason: cause?.moreInfo?.reason }), {
+        headers: { 'Content-Type': 'application/json' },
+        status,
+      })
+    })
+
+    const response = await app.request('http://rate-limit.test/validate_password_compliance', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'cf-connecting-ip': '203.0.113.20',
+      },
+      body: JSON.stringify({
+        email: 'password-policy@example.com',
+        password: 'WrongPassword123!',
+        org_id: '00000000-0000-4000-8000-000000000000',
+      }),
+    })
+
+    expect(response.status).toBe(429)
+    const responseBody = await response.json() as { error?: string, reason?: string }
+    expect(responseBody.error).toBe('too_many_requests')
+    expect(responseBody.reason).toBe('too_many_failed_account_auth_attempts')
+
+    const freshIpStatus = await withContext(
+      c => isIPRateLimited(c),
+      '203.0.113.20',
+    )
+    expect(freshIpStatus.limited).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Added account-keyed failed-auth rate limiting to the existing password policy compliance verification endpoint.
- Records failed password verification attempts by normalized account identifier while keeping the existing Supabase `signInWithPassword` flow.
- Added unit coverage proving the endpoint blocks by account even when client IP changes.

## Motivation (AI generated)

The password policy remediation endpoint verifies the current password through Supabase Auth, but the endpoint also needs Capgo's account-keyed limiter so rotating origins cannot repeatedly target one account.

## Business Impact (AI generated)

This closes the remaining account-targeted brute-force path for password-policy remediation while preserving the existing user flow and Supabase Auth behavior.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx eslint tests/account-rate-limit.unit.test.ts`
- [x] `bunx vitest run tests/account-rate-limit.unit.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/password-policy.test.ts --testTimeout=60000`
- [x] `bun typecheck` via commit hook

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account-scoped rate limiting added to protect against brute-force login attempts.
  * Successful authentication now clears account-specific failed-attempt tracking.

* **Bug Fixes / Behavior Changes**
  * Authentication failures return more specific error codes/statuses and are logged; captcha failures are detected more reliably.
  * Failed-auth recording now targets account-level failures in appropriate cases.

* **Tests**
  * New unit test verifies account-level rate limiting blocks compliance checks even when the client IP is not rate limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->