### PR TITLE
[codex] fix deleted bundle storage cleanup

### DIFF
--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -3,7 +3,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
-import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
+import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { manifest } from '../utils/postgres_schema.ts'
@@ -291,18 +291,22 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
 export async function deleteIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   cloudlog({ requestId: c.get('requestId'), message: 'Delete', r2_path: record.r2_path })
 
-  const v2Path = await getPath(c, record)
-  if (!v2Path) {
-    cloudlog({ requestId: c.get('requestId'), message: 'No r2 path' })
-    return c.json(BRES)
-  }
+  if (record.r2_path) {
+    let deleted = false
+    try {
+      deleted = await s3.deleteObject(c, record.r2_path)
+    }
+    catch (error) {
+      cloudlog({ requestId: c.get('requestId'), message: 'Cannot delete s3 (v2)', error })
+      throw simpleError('cannot_delete_s3', 'Cannot delete S3 object for deleted version', { id: record.id, r2_path: record.r2_path }, error)
+    }
 
-  try {
-    await s3.deleteObject(c, v2Path)
+    if (!deleted) {
+      throw simpleError('cannot_delete_s3', 'Cannot delete S3 object for deleted version', { id: record.id, r2_path: record.r2_path })
+    }
   }
-  catch (error) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot delete s3 (v2)', error })
-    return c.json(BRES)
+  else {
+    cloudlog({ requestId: c.get('requestId'), message: 'No r2 path for deleted version', id: record.id })
   }
 
   const { data, error: dbError } = await supabaseAdmin(c)
@@ -322,8 +326,10 @@ export async function deleteIt(c: Context, record: Database['public']['Tables'][
     .from('app_versions_meta')
     .update({ size: 0 })
     .eq('id', record.id)
-  if (errorUpdate)
+  if (errorUpdate) {
     cloudlog({ requestId: c.get('requestId'), message: 'error', error: errorUpdate })
+    throw simpleError('cannot_update_version_meta', 'Cannot update version metadata for deleted version', { id: record.id }, errorUpdate)
+  }
 
   await deleteManifest(c, record)
 
@@ -341,13 +347,14 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
     cloudlog({ requestId: c.get('requestId'), message: 'no app_id', record })
     return c.json(BRES)
   }
+  // check if version was soft-deleted (deleted_at was set)
+  if (record.deleted_at && record.deleted_at !== oldRecord.deleted_at)
+    return deleteIt(c, record)
+
   if (!record.r2_path && !record.manifest) {
     cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', record })
     return c.json(BRES)
   }
-  // check if version was soft-deleted (deleted_at was set)
-  if (record.deleted_at && record.deleted_at !== oldRecord.deleted_at)
-    return deleteIt(c, record)
 
   cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted' })
   return updateIt(c, record)

--- a/supabase/migrations/20260501162433_fix_storage_cleanup_counts.sql
+++ b/supabase/migrations/20260501162433_fix_storage_cleanup_counts.sql
@@ -1,0 +1,52 @@
+-- Keep deleted bundle metadata out of the admin storage trend.
+-- Physical R2 cleanup is asynchronous, but this metric is used for active bundle storage.
+CREATE OR REPLACE FUNCTION "public"."total_bundle_storage_bytes"() RETURNS bigint
+    LANGUAGE "sql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  SELECT (
+    -- Sum bundle sizes only for active app versions.
+    COALESCE(
+      (
+        SELECT SUM(avm.size)
+        FROM public.app_versions_meta avm
+        INNER JOIN public.app_versions av ON av.id = avm.id
+        WHERE av.deleted = false
+      ),
+      0
+    ) +
+    -- Sum manifest file sizes only for active app versions.
+    COALESCE(
+      (
+        SELECT SUM(m.file_size)
+        FROM public.manifest m
+        WHERE EXISTS (
+          SELECT 1
+          FROM public.app_versions av
+          WHERE av.id = m.app_version_id
+            AND av.deleted = false
+        )
+      ),
+      0
+    )
+  )::bigint;
+$$;
+
+ALTER FUNCTION "public"."total_bundle_storage_bytes"() OWNER TO "postgres";
+
+COMMENT ON FUNCTION "public"."total_bundle_storage_bytes"() IS 'Returns active bundle storage in bytes including bundle sizes (app_versions_meta.size) and manifest file sizes for non-deleted app versions.';
+
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM "anon";
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM "authenticated";
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM "service_role";
+GRANT EXECUTE ON FUNCTION "public"."total_bundle_storage_bytes"() TO "service_role";
+
+-- The high-frequency queue previously used the default 950-message batch for every
+-- queue, which can fan out hundreds of S3 deletes at once during retention cleanup.
+UPDATE public.cron_tasks
+SET
+  batch_size = 100,
+  updated_at = now()
+WHERE name = 'high_frequency_queues'
+  AND (batch_size IS NULL OR batch_size > 100);

--- a/supabase/tests/52_test_total_bundle_storage_bytes.sql
+++ b/supabase/tests/52_test_total_bundle_storage_bytes.sql
@@ -1,0 +1,54 @@
+BEGIN;
+
+SELECT plan(1);
+
+CREATE OR REPLACE FUNCTION my_tests() RETURNS SETOF TEXT AS $$
+DECLARE
+  test_app_id text := 'com.test.total-bundle-storage';
+  test_owner_org uuid;
+  active_version_id bigint;
+  deleted_version_id bigint;
+  before_bytes bigint;
+BEGIN
+  SELECT owner_org
+  INTO test_owner_org
+  FROM public.apps
+  LIMIT 1;
+
+  before_bytes := public.total_bundle_storage_bytes();
+
+  INSERT INTO public.apps (app_id, name, icon_url, owner_org)
+  VALUES (test_app_id, 'Total bundle storage test', 'https://example.com/icon.png', test_owner_org);
+
+  INSERT INTO public.app_versions (app_id, name, storage_provider, owner_org, deleted)
+  VALUES (test_app_id, '1.0.0-active', 'r2', test_owner_org, false)
+  RETURNING id INTO active_version_id;
+
+  INSERT INTO public.app_versions (app_id, name, storage_provider, owner_org, deleted, deleted_at)
+  VALUES (test_app_id, '1.0.0-deleted', 'r2', test_owner_org, true, now())
+  RETURNING id INTO deleted_version_id;
+
+  INSERT INTO public.app_versions_meta (app_id, checksum, size, id, owner_org)
+  VALUES
+    (test_app_id, 'active-checksum', 100, active_version_id, test_owner_org),
+    (test_app_id, 'deleted-checksum', 1000, deleted_version_id, test_owner_org);
+
+  INSERT INTO public.manifest (app_version_id, file_name, s3_path, file_hash, file_size)
+  VALUES
+    (active_version_id, 'active.js', 'orgs/test/active.js', 'active-hash', 200),
+    (deleted_version_id, 'deleted.js', 'orgs/test/deleted.js', 'deleted-hash', 2000);
+
+  RETURN NEXT IS(
+    public.total_bundle_storage_bytes(),
+    before_bytes + 300,
+    'total_bundle_storage_bytes should exclude deleted version bundle and manifest bytes'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT my_tests();
+
+SELECT *
+FROM finish();
+
+ROLLBACK;

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  appVersionsMetaSelectEq,
+  appVersionsMetaUpdate,
+  appVersionsMetaUpdateEq,
+  closeClient,
+  createStatsMeta,
+  deleteObject,
+  getDrizzleClient,
+  getPgClient,
+  supabaseAdmin,
+} = vi.hoisted(() => {
+  const appVersionsMetaSelectEq = vi.fn()
+  const appVersionsMetaSelect = vi.fn(() => ({ eq: appVersionsMetaSelectEq }))
+  const appVersionsMetaUpdateEq = vi.fn()
+  const appVersionsMetaUpdate = vi.fn(() => ({ eq: appVersionsMetaUpdateEq }))
+  const supabaseFrom = vi.fn((table: string) => {
+    if (table === 'app_versions_meta') {
+      return {
+        select: appVersionsMetaSelect,
+        update: appVersionsMetaUpdate,
+      }
+    }
+    return {}
+  })
+
+  return {
+    appVersionsMetaSelectEq,
+    appVersionsMetaUpdate,
+    appVersionsMetaUpdateEq,
+    closeClient: vi.fn(),
+    createStatsMeta: vi.fn(),
+    deleteObject: vi.fn(),
+    getDrizzleClient: vi.fn(() => ({
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(async () => []),
+        })),
+      })),
+    })),
+    getPgClient: vi.fn(() => ({})),
+    supabaseAdmin: vi.fn(() => ({ from: supabaseFrom })),
+    supabaseFrom,
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/s3.ts', () => ({
+  getPath: vi.fn(),
+  s3: {
+    deleteObject,
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/stats.ts', () => ({
+  createStatsMeta,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient,
+  getDrizzleClient,
+  getPgClient,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+  cloudlogErr: vi.fn(),
+}))
+
+const { deleteIt } = await import('../supabase/functions/_backend/triggers/on_version_update.ts')
+
+function createContext() {
+  return {
+    get: vi.fn(() => undefined),
+    json: vi.fn((body: unknown, status = 200) => new Response(JSON.stringify(body), { status })),
+  } as any
+}
+
+function createVersion(overrides: Record<string, unknown> = {}) {
+  return {
+    app_id: 'com.cleanup.test',
+    id: 123,
+    manifest: null,
+    name: '1.0.0',
+    r2_path: 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
+    storage_provider: 'r2',
+    ...overrides,
+  } as any
+}
+
+describe('on_version_update deleted version cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deleteObject.mockResolvedValue(true)
+    createStatsMeta.mockResolvedValue({ error: null })
+    appVersionsMetaSelectEq.mockReturnValue({
+      single: vi.fn(async () => ({ data: { size: 1234 }, error: null })),
+    })
+    appVersionsMetaUpdateEq.mockResolvedValue({ error: null })
+  })
+
+  it('deletes the bundle directly and clears stored size for soft-deleted versions', async () => {
+    const response = await deleteIt(createContext(), createVersion())
+
+    expect(response.status).toBe(200)
+    expect(deleteObject).toHaveBeenCalledWith(expect.anything(), 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip')
+    expect(appVersionsMetaUpdate).toHaveBeenCalledWith({ size: 0 })
+    expect(appVersionsMetaUpdateEq).toHaveBeenCalledWith('id', 123)
+    expect(createStatsMeta).toHaveBeenCalledWith(expect.anything(), 'com.cleanup.test', 123, -1234)
+  })
+
+  it('still clears stale metadata when the deleted version has no bundle path', async () => {
+    const response = await deleteIt(createContext(), createVersion({ r2_path: null }))
+
+    expect(response.status).toBe(200)
+    expect(deleteObject).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpdate).toHaveBeenCalledWith({ size: 0 })
+    expect(createStatsMeta).toHaveBeenCalledWith(expect.anything(), 'com.cleanup.test', 123, -1234)
+  })
+
+  it('keeps the queue retryable when R2 deletion fails', async () => {
+    deleteObject.mockResolvedValue(false)
+
+    await expect(deleteIt(createContext(), createVersion())).rejects.toThrow('Cannot delete S3 object for deleted version')
+    expect(appVersionsMetaUpdate).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Exclude deleted app versions from the admin bundle storage snapshot RPC.
- Make soft-deleted version cleanup delete R2 directly and keep failed deletes retryable.
- Cap the high-frequency queue batch size to reduce retention cleanup fanout.
- Add focused trigger unit coverage and pgTAP coverage for active storage counting.

## Motivation (AI generated)

The Storage Trend chart was inflated by deleted version metadata after large cleanup batches failed and archived `on_version_update` messages. Cleanup also skipped stale metadata when a deleted version no longer had a bundle path.

## Business Impact (AI generated)

This makes admin storage reporting reflect active bundle storage again and reduces the chance that cleanup backlog inflates storage, plan, or operational signals.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bunx eslint tests/on-version-update-cleanup.unit.test.ts`
- [x] `bun typecheck`
- [x] `bunx vitest run tests/on-version-update-cleanup.unit.test.ts tests/queue-consumer-message-shape.unit.test.ts`
- [x] `bun scripts/supabase-worktree.ts test db supabase/tests/52_test_total_bundle_storage_bytes.sql`

Generated with AI