### PR TITLE
fix(frontend): hide API Keys tab for non-RBAC orgs and fix missing i18n keys

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -267,6 +267,7 @@
   "api-keys-legacy-title": "Legacy API Keys",
   "api-keys-legacy-description": "Legacy API keys continue to function, but new legacy keys can no longer be created. They still rely on mode and explicit organization/application scopes.",
   "api-keys-are-used-for-cli-and-public-api": "API keys are used for CLI and public API",
+  "api-keys-unavailable": "API keys are not available for your organization.",
   "app": "app",
   "app-access-control": "Access Control",
   "app-access-control-description": "Manage who can access this app and what they can do",

--- a/src/layouts/settings.vue
+++ b/src/layouts/settings.vue
@@ -125,7 +125,7 @@ watchEffect(() => {
   if (!needsGroups && hasGroups)
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/groups')
 
-  const needsApiKeys = true
+  const needsApiKeys = hasOrgRbacEnabled
   const hasApiKeys = organizationTabs.value.find(tab => tab.key === '/settings/organization/api-keys')
   if (needsApiKeys && !hasApiKeys) {
     const base = baseOrgTabs.find(t => t.key === '/settings/organization/api-keys')
@@ -143,6 +143,9 @@ watchEffect(() => {
     else if (base)
       organizationTabs.value.push({ ...base })
   }
+  if (!needsApiKeys && hasApiKeys)
+    organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/api-keys')
+
   // ensure usage/plans tabs based on permissions (keeps icons from base)
   const needsUsage = billingEnabled && canReadBilling.value
   const hasUsage = organizationTabs.value.find(tab => tab.key === '/settings/organization/usage')

--- a/src/pages/settings/organization/ApiKeys.[id].vue
+++ b/src/pages/settings/organization/ApiKeys.[id].vue
@@ -1002,7 +1002,7 @@ async function syncAppBindings() {
               @click="isCreateMode ? createKey() : saveKey()"
             >
               <span v-if="isSubmitting" class="d-loading d-loading-spinner d-loading-xs" />
-              {{ isCreateMode ? t('create') : t('save') }}
+              {{ isCreateMode ? t('create') : t('save-changes') }}
             </button>
           </div>
         </template>


### PR DESCRIPTION
## Summary (AI generated)

- Hide the "API Keys" settings tab for organizations without RBAC enabled (`use_new_rbac`), using the same gating pattern already in place for the "Groups" tab
- Add the missing `api-keys-unavailable` translation key to `messages/en.json` as a fallback for direct URL access
- Replace the missing `t('save')` call with the existing `t('save-changes')` key in the API key edit form

## Motivation (AI generated)

Users in non-RBAC organizations could navigate to the API Keys settings page and see a broken "unavailable" message (rendered as the raw i18n key `api-keys-unavailable`). The tab should not be visible at all for these orgs, consistent with how the Groups tab is already hidden.

## Business Impact (AI generated)

Prevents confusion for users on non-RBAC orgs who would see a broken/empty page. Improves UI consistency across the settings navigation.

## Test Plan (AI generated)

- [ ] Switch to a non-RBAC org → verify the "API Keys" tab is not visible in settings navigation
- [ ] Switch to an RBAC-enabled org → verify the "API Keys" tab appears and works normally
- [ ] Navigate directly to `/settings/organization/api-keys` on a non-RBAC org → verify the fallback message renders correctly
- [ ] Edit an existing API key → verify the save button shows "Save Changes" instead of raw `save`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a message indicating when API keys are unavailable for your organization.

* **Bug Fixes**
  * Fixed API keys tab visibility to only display when organization RBAC is enabled.

* **UI Updates**
  * Updated API keys editor button label from "Save" to "Save Changes".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->