### PR TITLE
fix(ui): fix unreadable text in API key created modal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "capgo-app",
@@ -139,7 +138,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "7.94.6",
+      "version": "7.94.9",
       "bin": {
         "capgo": "dist/index.js",
       },

--- a/src/pages/settings/organization/ApiKeys.[id].vue
+++ b/src/pages/settings/organization/ApiKeys.[id].vue
@@ -1019,7 +1019,7 @@ async function syncAppBindings() {
       defer
     >
       <div class="space-y-4">
-        <p class="text-sm text-slate-600 dark:text-slate-300">
+        <p class="text-sm text-slate-600">
           {{
             createdKeyDialogMode === 'partial-failure-hashed'
               ? t('api-key-create-partial-failure-warning-hashed')
@@ -1029,17 +1029,17 @@ async function syncAppBindings() {
           }}
         </p>
 
-        <div class="p-4 border rounded-lg border-blue-200 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20">
-          <p class="mb-2 text-sm font-semibold text-blue-800 dark:text-blue-200">
+        <div class="p-4 border rounded-lg border-blue-200 bg-blue-50">
+          <p class="mb-2 text-sm font-semibold text-blue-800">
             {{ t('your-api-key') }}
           </p>
 
-          <div class="flex flex-col gap-3 p-3 border rounded-lg border-blue-200 bg-white dark:border-blue-700 dark:bg-gray-800 sm:flex-row sm:items-start sm:justify-between">
-            <code class="flex-1 text-sm break-all whitespace-pre-wrap text-slate-800 dark:text-white">{{ createdPlainKey }}</code>
+          <div class="flex flex-col gap-3 p-3 border rounded-lg border-blue-200 bg-white sm:flex-row sm:items-start sm:justify-between">
+            <code class="flex-1 text-sm break-all whitespace-pre-wrap text-slate-800">{{ createdPlainKey }}</code>
 
             <button
               type="button"
-              class="d-btn d-btn-sm d-btn-outline border-blue-300 text-blue-700 hover:bg-blue-100 dark:border-blue-600 dark:text-blue-200 dark:hover:bg-blue-900/30"
+              class="d-btn d-btn-sm d-btn-outline border-blue-300 text-blue-700 hover:bg-blue-100"
               @click="copyCreatedKey"
             >
               <IconClipboard class="w-4 h-4" />


### PR DESCRIPTION
## Summary

- `DialogV2` force toujours le mode clair (`bg-white` + `data-theme="capgolight"`) sur son conteneur
- Le contenu Teleport dans `ApiKeys.[id].vue` utilisait des variantes `dark:` Tailwind (ex. `dark:text-blue-200`, `dark:text-white`, `dark:text-slate-300`) conçues pour des fonds sombres
- En mode sombre, ces couleurs claires s'affichaient sur le fond blanc du dialog → contraste quasi-nul, texte illisible
- **Fix :** suppression de toutes les variantes `dark:` du bloc Teleport `org-apikey-created`

## Test plan

- [ ] Passer le navigateur en mode sombre et créer une API key → le texte de la clé et les labels sont lisibles sur fond blanc
- [ ] Vérifier en mode clair : aucune régression visuelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the API key creation confirmation modal styling to apply light-mode colors exclusively, with adjustments to text, containers, labels, and buttons throughout the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->