### PR TITLE
[codex] fix SSO provider merge validation

### DIFF
--- a/supabase/functions/_backend/private/sso/provision-user.ts
+++ b/supabase/functions/_backend/private/sso/provision-user.ts
@@ -29,6 +29,13 @@ interface EnsureOrgMembershipResult {
   alreadyMember: boolean
 }
 
+interface SsoProviderRecord {
+  id: string
+  org_id: string
+  provider_id: string | null
+  enforce_sso?: boolean | null
+}
+
 export const app = createHono('', version)
 
 app.use('*', useCors)
@@ -67,7 +74,7 @@ async function findCanonicalAuthUserIdByEmail(pgClient: ReturnType<typeof getPgC
 
 function getTrustedSsoProviders(userProvider: string, userIdentities: any[]): string[] {
   const trustedProviders = new Set<string>()
-  const isTrustedSsoProvider = (provider: string) => provider === 'sso' || provider.startsWith('sso:') || provider === userProvider
+  const isTrustedSsoProvider = (provider: string) => provider === 'sso' || provider.startsWith('sso:')
 
   if (isTrustedSsoProvider(userProvider)) {
     trustedProviders.add(userProvider)
@@ -81,6 +88,51 @@ function getTrustedSsoProviders(userProvider: string, userIdentities: any[]): st
   }
 
   return [...trustedProviders]
+}
+
+function extractProviderId(provider: unknown): string | null {
+  if (typeof provider !== 'string' || !provider.startsWith('sso:')) {
+    return null
+  }
+
+  const providerId = provider.slice('sso:'.length).trim()
+  return providerId.length > 0 ? providerId : null
+}
+
+function getAuthenticatedSsoProviders(userProvider: string | undefined, userProviders: string[], userIdentities: any[]): string[] {
+  const currentProviderId = extractProviderId(userProvider)
+  if (currentProviderId) {
+    return [`sso:${currentProviderId}`]
+  }
+
+  const providers = new Set<string>()
+  const addProvider = (provider: unknown) => {
+    const providerId = extractProviderId(provider)
+    if (providerId) {
+      providers.add(`sso:${providerId}`)
+    }
+  }
+
+  for (const provider of userProviders) {
+    addProvider(provider)
+  }
+  for (const identity of userIdentities) {
+    addProvider(identity?.provider)
+  }
+
+  return [...providers]
+}
+
+function getAuthorizedSsoProviders(provider: SsoProviderRecord, authenticatedProviders: string[]): string[] {
+  const authorizedProviderIds = new Set(
+    [provider.provider_id]
+      .filter((providerId): providerId is string => typeof providerId === 'string' && providerId.length > 0),
+  )
+
+  return authenticatedProviders.filter((authenticatedProvider) => {
+    const providerId = extractProviderId(authenticatedProvider)
+    return !!providerId && authorizedProviderIds.has(providerId)
+  })
 }
 
 async function transferSsoIdentities(pgClient: ReturnType<typeof getPgClient>, originalUserId: string, duplicateUserId: string, trustedProviders: string[]): Promise<number> {
@@ -294,6 +346,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       cloudlog({ requestId, message: 'User has no SSO identity, rejecting provisioning', userId })
       return quickError(403, 'sso_identity_required', 'User must have an SSO identity to be provisioned')
     }
+    const authenticatedSsoProviders = getAuthenticatedSsoProviders(userProvider, userProviders, userIdentities)
 
     const userEmail = userAuth.user.email
     if (!userEmail) {
@@ -310,11 +363,9 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
     // This happens when SSO is enabled for a domain where users already had email/password accounts.
     // Supabase Auth creates a new auth.users record instead of linking — we fix this by merging.
     //
-    // Security note: merging on email match is safe here because we only reach this point after
-    // Supabase has verified the SAML assertion's cryptographic signature from the trusted IdP
-    // (configured by an org admin). The email claim therefore carries the same trust as the IdP's
-    // signing certificate — not standard email verification. This merge must NOT be replicated in
-    // contexts where the email claim is unverified (e.g., OAuth without verified_email, magic links).
+    // Security note: the email match only selects a merge candidate. The merge must not proceed
+    // until the domain's active SSO provider is resolved and matched against the provider that
+    // authenticated this session; a valid SAML signature alone does not prove email-domain control.
     const { data: existingUser, error: existingUserError } = await (admin as any)
       .from('users')
       .select('id')
@@ -357,7 +408,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       // Step 1: Resolve the SSO provider org so we can ensure the original user is a member
       const { data: mergeProvider, error: mergeProviderError } = await (admin as any)
         .from('sso_providers')
-        .select('id, org_id, enforce_sso')
+        .select('id, org_id, provider_id, enforce_sso')
         .eq('domain', userDomain)
         .eq('status', 'active')
         .maybeSingle()
@@ -370,6 +421,12 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       if (!mergeProvider) {
         cloudlogErr({ requestId, message: 'No active SSO provider found during merge', originalUserId, domain: userDomain })
         return quickError(404, 'provider_not_found', 'No active SSO provider found for your email domain')
+      }
+
+      const authorizedSsoProviders = getAuthorizedSsoProviders(mergeProvider, authenticatedSsoProviders)
+      if (authorizedSsoProviders.length === 0) {
+        cloudlog({ requestId, message: 'Authenticating SSO provider does not match email domain provider — aborting merge', userId, originalUserId, domain: userDomain, providerId: mergeProvider.id, externalProviderId: mergeProvider.provider_id, authenticatedProviders: authenticatedSsoProviders })
+        return quickError(403, 'provider_mismatch', 'SSO provider does not match the email domain provider')
       }
 
       try {
@@ -391,7 +448,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
 
       // Step 2: Transfer SSO identity from duplicate user (userId) → original user (originalUserId)
       try {
-        const transferredIdentityCount = await transferSsoIdentities(getSharedPgClient(), originalUserId, userId, trustedSsoProviders)
+        const transferredIdentityCount = await transferSsoIdentities(getSharedPgClient(), originalUserId, userId, authorizedSsoProviders)
         if (transferredIdentityCount === 0) {
           cloudlogErr({ requestId, message: 'No SSO identities were transferred during merge', userId, originalUserId })
           return quickError(500, 'identity_transfer_failed', 'Failed to merge SSO identity with existing account')
@@ -427,7 +484,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       // update this field. Without this, the next SSO login returns provider='email' and
       // the provider check above rejects the user with sso_auth_required.
       const { error: updateProviderError } = await admin.auth.admin.updateUserById(originalUserId, {
-        app_metadata: { provider: userProvider },
+        app_metadata: { provider: authorizedSsoProviders[0] },
       })
       if (updateProviderError) {
         cloudlogErr({ requestId, message: 'Failed to update app_metadata.provider on original user after merge', originalUserId, error: updateProviderError })
@@ -441,7 +498,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
     // Resolve the provider from the user's email domain server-side
     const { data: provider, error: providerError } = await (admin as any)
       .from('sso_providers')
-      .select('id, org_id, domain, status')
+      .select('id, org_id, domain, status, provider_id')
       .eq('domain', userDomain)
       .eq('status', 'active')
       .maybeSingle()
@@ -454,6 +511,12 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
     if (!provider) {
       cloudlog({ requestId, message: 'No active SSO provider found for domain', userId, domain: userDomain })
       return quickError(404, 'provider_not_found', 'No active SSO provider found for your email domain')
+    }
+
+    const authorizedSsoProviders = getAuthorizedSsoProviders(provider, authenticatedSsoProviders)
+    if (authorizedSsoProviders.length === 0) {
+      cloudlog({ requestId, message: 'Authenticating SSO provider does not match email domain provider — rejecting provisioning', userId, domain: userDomain, providerId: provider.id, externalProviderId: provider.provider_id, authenticatedProviders: authenticatedSsoProviders })
+      return quickError(403, 'provider_mismatch', 'SSO provider does not match the email domain provider')
     }
 
     try {

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -697,10 +697,11 @@ describe('[POST] /private/sso/provision-user', () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_missing_profile_${randomUUID()}`
     const providerId = randomUUID()
+    const externalProviderId = randomUUID()
     const domain = `${randomUUID()}.sso.test`
     const email = `missing-profile-${randomUUID()}@${domain}`
     const password = 'testtest'
-    const identityProvider = `sso:${providerId}`
+    const identityProvider = `sso:${externalProviderId}`
     const identityProviderId = `nameid-${randomUUID()}`
     const pool = new Pool({ connectionString: POSTGRES_URL })
 
@@ -747,7 +748,7 @@ describe('[POST] /private/sso/provision-user', () => {
         id: providerId,
         org_id: managedOrgId,
         domain,
-        provider_id: randomUUID(),
+        provider_id: externalProviderId,
         status: 'active',
         enforce_sso: false,
         dns_verification_token: `dns-${randomUUID()}`,
@@ -816,14 +817,122 @@ describe('[POST] /private/sso/provision-user', () => {
     }
   })
 
+  it('rejects first-time SSO provisioning when the authenticating provider does not own the email domain', async () => {
+    const managedOrgId = randomUUID()
+    const managedCustomerId = `cus_sso_provider_mismatch_${randomUUID()}`
+    const providerId = randomUUID()
+    const externalProviderId = randomUUID()
+    const attackerExternalProviderId = randomUUID()
+    const domain = `${randomUUID()}.sso.test`
+    const email = `provider-mismatch-${randomUUID()}@${domain}`
+    const password = 'testtest'
+    const attackerIdentityProvider = `sso:${attackerExternalProviderId}`
+    const attackerIdentityProviderId = `nameid-${randomUUID()}`
+    const pool = new Pool({ connectionString: POSTGRES_URL })
+
+    let createdUserId: string | null = null
+
+    try {
+      const { error: stripeError } = await getSupabaseClient().from('stripe_info').insert({
+        customer_id: managedCustomerId,
+        status: 'succeeded',
+        product_id: 'prod_LQIregjtNduh4q',
+        subscription_id: `sub_sso_provider_mismatch_${randomUUID()}`,
+        trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+        is_good_plan: true,
+      })
+      if (stripeError)
+        throw stripeError
+
+      await pool.query(
+        `
+          insert into public.orgs (id, name, management_email, created_by, customer_id)
+          values ($1, $2, $3, $4, $5)
+        `,
+        [
+          managedOrgId,
+          `SSO Provider Mismatch Org ${managedOrgId}`,
+          `sso-provider-mismatch-${managedOrgId}@capgo.app`,
+          USER_ID,
+          managedCustomerId,
+        ],
+      )
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: managedOrgId,
+        domain,
+        provider_id: externalProviderId,
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
+
+      const { data: createdUser, error: createUserError } = await getSupabaseClient().auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+        app_metadata: {
+          provider: attackerIdentityProvider,
+        },
+        user_metadata: {
+          first_name: 'Provider',
+          last_name: 'Mismatch',
+        },
+      })
+      if (createUserError || !createdUser.user) {
+        throw createUserError ?? new Error('Failed to create mismatched SSO auth user')
+      }
+      createdUserId = createdUser.user.id
+
+      await pool.query(
+        'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
+        [attackerIdentityProvider, attackerIdentityProviderId, email, createdUserId],
+      )
+
+      const ssoAuthHeaders = await getAuthHeadersForCredentials(email, password)
+      const response = await fetchWithRetry(getEndpointUrl('/private/sso/provision-user'), {
+        method: 'POST',
+        headers: ssoAuthHeaders,
+        body: JSON.stringify({}),
+      })
+
+      expect(response.status).toBe(403)
+      const responseBody = await response.json() as { error: string }
+      expect(responseBody.error).toBe('provider_mismatch')
+
+      const { data: membership, error: membershipError } = await getSupabaseClient()
+        .from('org_users')
+        .select('id')
+        .eq('org_id', managedOrgId)
+        .eq('user_id', createdUserId)
+        .maybeSingle()
+
+      expect(membershipError).toBeNull()
+      expect(membership).toBeNull()
+    }
+    finally {
+      await Promise.allSettled([
+        createdUserId ? getSupabaseClient().auth.admin.deleteUser(createdUserId) : Promise.resolve(null),
+        (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
+        getSupabaseClient().from('orgs').delete().eq('id', managedOrgId),
+        getSupabaseClient().from('stripe_info').delete().eq('customer_id', managedCustomerId),
+        pool.end(),
+      ])
+    }
+  })
+
   it('promotes invite-only org memberships during SSO provisioning instead of treating them as completed membership', async () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_invite_promotion_${randomUUID()}`
     const providerId = randomUUID()
+    const externalProviderId = randomUUID()
     const domain = `${randomUUID()}.sso.test`
     const email = `invite-only-user@${domain}`
     const password = 'testtest'
-    const identityProvider = `sso:${providerId}`
+    const identityProvider = `sso:${externalProviderId}`
     const identityProviderId = `nameid-${randomUUID()}`
     const pool = new Pool({ connectionString: POSTGRES_URL })
 
@@ -871,7 +980,7 @@ describe('[POST] /private/sso/provision-user', () => {
         id: providerId,
         org_id: managedOrgId,
         domain,
-        provider_id: randomUUID(),
+        provider_id: externalProviderId,
         status: 'active',
         enforce_sso: false,
         dns_verification_token: `dns-${randomUUID()}`,
@@ -944,12 +1053,15 @@ describe('[POST] /private/sso/provision-user', () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_merge_${randomUUID()}`
     const providerId = randomUUID()
+    const externalProviderId = randomUUID()
     const domain = `${randomUUID()}.sso.test`
     const targetEmail = `merge-user@${domain}`
     const tempSsoEmail = `temp-sso-${randomUUID()}@${domain}`
     const password = 'testtest'
-    const identityProvider = `sso:${providerId}`
+    const identityProvider = `sso:${externalProviderId}`
     const identityProviderId = `nameid-${randomUUID()}`
+    const unrelatedSsoProvider = `sso:${randomUUID()}`
+    const unrelatedSsoProviderId = `nameid-${randomUUID()}`
     const unrelatedProviderId = `github-${randomUUID()}`
     const originalAuthEmail = `stored-original-${randomUUID()}@${domain}`
     const pool = new Pool({ connectionString: POSTGRES_URL })
@@ -1008,7 +1120,7 @@ describe('[POST] /private/sso/provision-user', () => {
         id: providerId,
         org_id: managedOrgId,
         domain,
-        provider_id: randomUUID(),
+        provider_id: externalProviderId,
         status: 'active',
         enforce_sso: false,
         dns_verification_token: `dns-${randomUUID()}`,
@@ -1053,6 +1165,13 @@ describe('[POST] /private/sso/provision-user', () => {
       await pool.query(
         'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
         [identityProvider, identityProviderId, targetEmail, duplicateUser.user.id],
+      )
+      await pool.query(
+        `
+          insert into auth.identities (id, user_id, identity_data, provider, provider_id, created_at, updated_at, last_sign_in_at)
+          values ($1, $2, jsonb_build_object($$sub$$, $3::text, $$email$$, $4::text, $$email_verified$$, true), $5, $3, now(), now(), now())
+        `,
+        [randomUUID(), duplicateUser.user.id, unrelatedSsoProviderId, targetEmail, unrelatedSsoProvider],
       )
       await pool.query(
         `
@@ -1116,6 +1235,174 @@ describe('[POST] /private/sso/provision-user', () => {
         row.provider === 'github'
         && row.provider_id === unrelatedProviderId,
       )).toBe(false)
+      expect(identitiesAfterMerge.rows.some(row =>
+        row.provider === unrelatedSsoProvider
+        && row.provider_id === unrelatedSsoProviderId,
+      )).toBe(false)
+    }
+    finally {
+      await Promise.allSettled([
+        getSupabaseClient().auth.admin.deleteUser(duplicateUser.user.id),
+        getSupabaseClient().auth.admin.deleteUser(originalUser.user.id),
+        (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
+        getSupabaseClient().from('orgs').delete().eq('id', managedOrgId),
+        getSupabaseClient().from('stripe_info').delete().eq('customer_id', managedCustomerId),
+      ])
+      await pool.end()
+    }
+  })
+
+  it('rejects account merge when the authenticating SSO provider does not match the email domain provider', async () => {
+    const managedOrgId = randomUUID()
+    const managedCustomerId = `cus_sso_merge_mismatch_${randomUUID()}`
+    const providerId = randomUUID()
+    const externalProviderId = randomUUID()
+    const attackerExternalProviderId = randomUUID()
+    const domain = `${randomUUID()}.sso.test`
+    const targetEmail = `merge-mismatch-user@${domain}`
+    const tempSsoEmail = `temp-sso-mismatch-${randomUUID()}@${domain}`
+    const password = 'testtest'
+    const attackerIdentityProvider = `sso:${attackerExternalProviderId}`
+    const attackerIdentityProviderId = `nameid-${randomUUID()}`
+    const originalAuthEmail = `stored-original-mismatch-${randomUUID()}@${domain}`
+    const pool = new Pool({ connectionString: POSTGRES_URL })
+
+    const { data: originalUser, error: originalUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: targetEmail,
+      password,
+      email_confirm: true,
+      user_metadata: {
+        first_name: 'Merge',
+        last_name: 'MismatchOriginal',
+      },
+    })
+    if (originalUserError || !originalUser.user) {
+      await pool.end()
+      throw originalUserError ?? new Error('Failed to create original password auth user for provider mismatch test')
+    }
+
+    const { data: duplicateUser, error: duplicateUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: tempSsoEmail,
+      password,
+      email_confirm: true,
+      user_metadata: {
+        first_name: 'Merge',
+        last_name: 'MismatchDuplicate',
+      },
+    })
+    if (duplicateUserError || !duplicateUser.user) {
+      await pool.end()
+      throw duplicateUserError ?? new Error('Failed to create duplicate auth user for provider mismatch test')
+    }
+
+    try {
+      const { error: stripeError } = await getSupabaseClient().from('stripe_info').insert({
+        customer_id: managedCustomerId,
+        status: 'succeeded',
+        product_id: 'prod_LQIregjtNduh4q',
+        subscription_id: `sub_sso_merge_mismatch_${randomUUID()}`,
+        trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+        is_good_plan: true,
+      })
+      if (stripeError)
+        throw stripeError
+
+      await pool.query(
+        `
+          insert into public.orgs (id, name, management_email, created_by, customer_id)
+          values ($1, $2, $3, $4, $5)
+        `,
+        [
+          managedOrgId,
+          `SSO Merge Mismatch Org ${managedOrgId}`,
+          `sso-merge-mismatch-${managedOrgId}@capgo.app`,
+          USER_ID,
+          managedCustomerId,
+        ],
+      )
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: managedOrgId,
+        domain,
+        provider_id: externalProviderId,
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
+
+      const { error: originalPublicUserError } = await getSupabaseClient().from('users').insert({
+        id: originalUser.user.id,
+        email: targetEmail,
+        first_name: 'Merge',
+        last_name: 'MismatchOriginal',
+        country: null,
+        enable_notifications: true,
+        opt_for_newsletters: true,
+      })
+      if (originalPublicUserError)
+        throw originalPublicUserError
+
+      const duplicateAuthHeaders = await getAuthHeadersForCredentials(tempSsoEmail, password)
+
+      const { error: originalAuthUpdateError } = await getSupabaseClient().auth.admin.updateUserById(originalUser.user.id, {
+        email: originalAuthEmail,
+        email_confirm: true,
+      })
+      if (originalAuthUpdateError)
+        throw originalAuthUpdateError
+
+      const { error: duplicateAuthUpdateError } = await getSupabaseClient().auth.admin.updateUserById(duplicateUser.user.id, {
+        email: targetEmail,
+        email_confirm: true,
+        app_metadata: {
+          provider: attackerIdentityProvider,
+        },
+      })
+      if (duplicateAuthUpdateError)
+        throw duplicateAuthUpdateError
+
+      await pool.query(
+        'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
+        [attackerIdentityProvider, attackerIdentityProviderId, targetEmail, duplicateUser.user.id],
+      )
+
+      const response = await fetchWithRetry(getEndpointUrl('/private/sso/provision-user'), {
+        method: 'POST',
+        headers: duplicateAuthHeaders,
+        body: JSON.stringify({}),
+      })
+
+      expect(response.status).toBe(403)
+      const responseBody = await response.json() as { error: string }
+      expect(responseBody.error).toBe('provider_mismatch')
+
+      const { data: duplicateAuthLookup } = await getSupabaseClient().auth.admin.getUserById(duplicateUser.user.id)
+      expect(duplicateAuthLookup.user?.id).toBe(duplicateUser.user.id)
+
+      const { data: mergedMembership, error: mergedMembershipError } = await getSupabaseClient()
+        .from('org_users')
+        .select('id')
+        .eq('org_id', managedOrgId)
+        .eq('user_id', originalUser.user.id)
+        .maybeSingle()
+
+      expect(mergedMembershipError).toBeNull()
+      expect(mergedMembership).toBeNull()
+
+      const identitiesAfterRejectedMerge = await pool.query(
+        'select provider, user_id from auth.identities where provider = $1 and user_id in ($2, $3) order by user_id',
+        [attackerIdentityProvider, originalUser.user.id, duplicateUser.user.id],
+      )
+
+      expect(identitiesAfterRejectedMerge.rows).toEqual([
+        {
+          provider: attackerIdentityProvider,
+          user_id: duplicateUser.user.id,
+        },
+      ])
     }
     finally {
       await Promise.allSettled([
@@ -1133,10 +1420,11 @@ describe('[POST] /private/sso/provision-user', () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_first_login_${randomUUID()}`
     const providerId = randomUUID()
+    const externalProviderId = randomUUID()
     const domain = `${randomUUID()}.sso.test`
     const email = `first-login-user@${domain}`
     const password = 'testtest'
-    const identityProvider = `sso:${providerId}`
+    const identityProvider = `sso:${externalProviderId}`
     const identityProviderId = `nameid-${randomUUID()}`
     const pool = new Pool({ connectionString: POSTGRES_URL })
 
@@ -1184,7 +1472,7 @@ describe('[POST] /private/sso/provision-user', () => {
         id: providerId,
         org_id: managedOrgId,
         domain,
-        provider_id: randomUUID(),
+        provider_id: externalProviderId,
         status: 'active',
         enforce_sso: false,
         dns_verification_token: `dns-${randomUUID()}`,


### PR DESCRIPTION
## Summary (AI generated)

- Hardened SSO provisioning so the authenticated SSO provider must match the active provider registered for the user email domain.
- Restricted SSO account merge identity transfer to the domain-authorized provider only.
- Added regression coverage for provider mismatch provisioning and account merge takeover attempts.

## Motivation (AI generated)

GHSA-jhjh-vp9p-54fg reported that the SSO merge path could trust an asserted email without proving the IdP was authorized for that email domain. This closes that merge and provisioning gap.

## Business Impact (AI generated)

This prevents cross-domain SSO identity assertions from taking over customer accounts, protecting organization data, app access, and admin privileges.

## Test Plan (AI generated)

- [x] bunx eslint supabase/functions/_backend/private/sso/provision-user.ts tests/sso.test.ts
- [x] bun run lint:backend
- [x] bun run supabase:with-env -- bunx vitest run tests/sso.test.ts
- [x] commit hook: bun run cli:build && vue-tsc --noEmit

Generated with AI