### PR TITLE
fix(groups): redirect after creation, add members modal, fix access table

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "7.95.0",
+      "version": "7.95.2",
       "bin": {
         "capgo": "dist/index.js",
       },

--- a/messages/es.json
+++ b/messages/es.json
@@ -1710,7 +1710,7 @@
   "trial-organizations-list": "Lista de organizaciones en prueba",
   "trial-plan-expired": "Prueba Expirada",
   "try-a-different-search-term": "Intenta con un término de búsqueda diferente",
-  "type": "Escribe",
+  "type": "Tipo",
   "type-app-id-to-confirm": "Escribe la identificación de la aplicación para confirmar",
   "type-device-id": "Ingrese la identificación del dispositivo",
   "type-device-id-msg": "Por favor, ingrese el ID del dispositivo que le gustaría sobrescribir.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1710,7 +1710,7 @@
   "trial-organizations-list": "Liste des organisations en essai",
   "trial-plan-expired": "Essai Expiré",
   "try-a-different-search-term": "Essayez un terme de recherche différent",
-  "type": "Tapez",
+  "type": "Type",
   "type-app-id-to-confirm": "Tapez l'identifiant de l'application pour confirmer",
   "type-device-id": "Entrez l'ID de l'appareil",
   "type-device-id-msg": "Veuillez entrer l'ID de l'appareil que vous souhaitez écraser",

--- a/messages/id.json
+++ b/messages/id.json
@@ -1710,7 +1710,7 @@
   "trial-organizations-list": "Daftar organisasi uji coba",
   "trial-plan-expired": "Masa Percobaan Berakhir",
   "try-a-different-search-term": "Coba istilah pencarian yang berbeda",
-  "type": "Ketik",
+  "type": "Jenis",
   "type-app-id-to-confirm": "Ketik id aplikasi untuk konfirmasi",
   "type-device-id": "Masukkan ID perangkat",
   "type-device-id-msg": "Silakan masukkan ID dari perangkat yang ingin Anda timpa",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1710,7 +1710,7 @@
   "trial-organizations-list": "Elenco organizzazioni in prova",
   "trial-plan-expired": "Prova Scaduta",
   "try-a-different-search-term": "Prova un termine di ricerca diverso",
-  "type": "Digita",
+  "type": "Tipo",
   "type-app-id-to-confirm": "Digita l'id dell'app per confermare",
   "type-device-id": "Inserisci l'ID del dispositivo",
   "type-device-id-msg": "Inserisci l'ID del dispositivo che desideri sovrascrivere",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -1710,7 +1710,7 @@
   "trial-organizations-list": "Lista de organizações em teste",
   "trial-plan-expired": "Teste Expirado",
   "try-a-different-search-term": "Tente um termo de pesquisa diferente",
-  "type": "Digite",
+  "type": "Tipo",
   "type-app-id-to-confirm": "Digite o id do aplicativo para confirmar",
   "type-device-id": "Insira o ID do dispositivo",
   "type-device-id-msg": "Por favor, insira o ID do dispositivo que você gostaria de sobrescrever.",

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -293,7 +293,7 @@ watch(
       pendingReset.value = false
       pendingAdd.value = false
     }
-    if (previousLoading && !loading)
+    if (!loading)
       hasLoadingCycleCompleted.value = true
   },
   { immediate: true },

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -288,13 +288,12 @@ watch(
 
 watch(
   () => props.isLoading,
-  (loading, previousLoading) => {
+  (loading, _previousLoading) => {
     if (!loading) {
       pendingReset.value = false
       pendingAdd.value = false
-    }
-    if (!loading)
       hasLoadingCycleCompleted.value = true
+    }
   },
   { immediate: true },
 )

--- a/src/components/tables/AccessTable.vue
+++ b/src/components/tables/AccessTable.vue
@@ -514,8 +514,14 @@ const dynamicColumns = computed<TableColumn[]>(() => {
   const baseColumns: TableColumn[] = [
     {
       key: 'principal_name',
-      label: t('email'),
+      label: t('name'),
       sortable: true,
+    },
+    {
+      key: 'principal_type',
+      label: t('type'),
+      sortable: true,
+      displayFunction: (row: Element) => row.principal_type === 'group' ? t('group') : t('user'),
     },
     {
       key: 'role_name',

--- a/src/pages/settings/organization/Groups.[id].vue
+++ b/src/pages/settings/organization/Groups.[id].vue
@@ -355,10 +355,14 @@ async function fetchOrgMembers() {
 }
 
 async function fetchGroupMembers() {
+  const id = group.value?.id
+  if (!id)
+    return
+
   const { data, error } = await supabase
     .from('group_members')
     .select('user_id')
-    .eq('group_id', groupId.value)
+    .eq('group_id', id)
 
   if (error)
     throw error
@@ -451,7 +455,10 @@ async function createGroup() {
     }
 
     toast.success(t('group-created'))
-    await router.replace(`/settings/organization/groups/${data.id}`)
+    await fetchOrgMembers()
+    openAddMembersModal()
+    await dialogStore.onDialogDismiss()
+    await router.replace('/settings/organization/groups')
   }
   catch (error) {
     console.error('Error creating group:', error)
@@ -948,7 +955,7 @@ async function removeMemberFromGroup(userId: string) {
     <div class="w-full space-y-3">
       <SearchInput
         v-model="modalMemberSearch"
-        :placeholder="t('search')"
+        :placeholder="t('search-members')"
         class="d-input-sm"
       />
       <div v-if="availableMembersToAdd.length === 0" class="py-4 text-sm text-center text-slate-500">

--- a/src/pages/settings/organization/Groups.[id].vue
+++ b/src/pages/settings/organization/Groups.[id].vue
@@ -453,20 +453,26 @@ async function createGroup() {
       console.error('Error syncing app bindings:', bindingError)
       toast.warning(t('error-syncing-app-bindings'))
     }
-
-    toast.success(t('group-created'))
-    await fetchOrgMembers()
-    openAddMembersModal()
-    await dialogStore.onDialogDismiss()
-    await router.replace('/settings/organization/groups')
   }
   catch (error) {
     console.error('Error creating group:', error)
     toast.error(t('error-creating-group'))
+    return
   }
   finally {
     isSubmitting.value = false
   }
+
+  toast.success(t('group-created'))
+  try {
+    await fetchOrgMembers()
+    openAddMembersModal()
+    await dialogStore.onDialogDismiss()
+  }
+  catch (memberError) {
+    console.error('Error opening add-members modal:', memberError)
+  }
+  await router.replace('/settings/organization/groups')
 }
 
 async function saveGroup() {


### PR DESCRIPTION
## Summary

- **Redirection** : après la création d'un groupe, une modale "Add members" s'ouvre avant de rediriger vers la liste des groupes (au lieu de rester sur la page d'édition)
- **Fix UUID** : `fetchGroupMembers` utilisait `groupId` (route param = `'new'`) au lieu de `group.value?.id`, causant une erreur Postgres sur les nouveaux groupes
- **Fix empty state DataTable** : `hasLoadingCycleCompleted` n'était jamais activé quand le DataTable montait après la fin du cycle de chargement — l'empty state restait bloqué en skeleton
- **AccessTable** : ajout d'une colonne "Type" (User / Group) et renommage de la colonne "Email" → "Name"
- **i18n** : correction de la clé `type` en fr/es/it/pt-br/id (forme verbale → nominale)

## Test plan

- [ ] Créer un groupe → modale "Add members" s'ouvre → ajouter des membres ou annuler → redirection vers la liste
- [ ] Onglet Members sur un groupe sans membres → affiche le tableau vide (pas de spinner infini)
- [ ] Page App Access → colonne "Type" affiche "User" ou "Group" selon le principal
- [ ] Vérifier les traductions fr/es/it/pt-br/id pour la colonne "Type"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added principal name column and principal type indicator (group/user) in access tables.

* **Bug Fixes**
  * Improved loading-state handling so pending actions reliably mark as completed when loading finishes.

* **Chores**
  * Updated "type" label translations in Spanish, French, Indonesian, Italian, and Portuguese.
  * Refined group creation flow: fetches members, opens add-members modal, closes dialog, and returns to groups list; improved member search placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->