### PR TITLE
feat(cli): accept CAPGO_IOS_PROVISIONING_MAP_BASE64 as alternative env var

### DIFF
--- a/cli/src/build/credentials.ts
+++ b/cli/src/build/credentials.ts
@@ -21,6 +21,7 @@
 
 import type { AllCredentials, CredentialFile, SavedCredentials } from '../schemas/build'
 import type { BuildCredentials } from './request'
+import { Buffer } from 'node:buffer'
 import { readFile as readNodeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -185,7 +186,15 @@ export function loadCredentialsFromEnv(): Partial<BuildCredentials> {
   const appStoreConnectTeamId = readRuntimeEnv('APP_STORE_CONNECT_TEAM_ID')
   const capgoIosScheme = readRuntimeEnv('CAPGO_IOS_SCHEME')
   const capgoIosTarget = readRuntimeEnv('CAPGO_IOS_TARGET')
-  const capgoIosProvisioningMap = readRuntimeEnv('CAPGO_IOS_PROVISIONING_MAP')
+  // Provisioning map can be supplied as raw JSON (CAPGO_IOS_PROVISIONING_MAP) or
+  // base64-encoded JSON (CAPGO_IOS_PROVISIONING_MAP_BASE64). The base64 form
+  // avoids quoting/newline pitfalls when storing the stringified JSON in CI secrets.
+  const capgoIosProvisioningMapRaw = readRuntimeEnv('CAPGO_IOS_PROVISIONING_MAP')
+  const capgoIosProvisioningMapBase64 = readRuntimeEnv('CAPGO_IOS_PROVISIONING_MAP_BASE64')
+  const capgoIosProvisioningMap = capgoIosProvisioningMapRaw
+    || (capgoIosProvisioningMapBase64
+      ? Buffer.from(capgoIosProvisioningMapBase64, 'base64').toString('utf-8')
+      : undefined)
   const rawCapgoAndroidFlavor = readRuntimeEnv('CAPGO_ANDROID_FLAVOR')
   const capgoAndroidFlavor = rawCapgoAndroidFlavor?.trim() || undefined
   const androidKeystoreFile = readRuntimeEnv('ANDROID_KEYSTORE_FILE')

--- a/cli/test/test-credentials.mjs
+++ b/cli/test/test-credentials.mjs
@@ -34,6 +34,7 @@ function clearCredentialEnvVars() {
   const credKeys = [
     'BUILD_CERTIFICATE_BASE64',
     'CAPGO_IOS_PROVISIONING_MAP',
+    'CAPGO_IOS_PROVISIONING_MAP_BASE64',
     'P12_PASSWORD',
     'APPLE_KEY_ID',
     'APPLE_ISSUER_ID',
@@ -468,6 +469,42 @@ await test('--no-playstore-upload: deleting PLAY_CONFIG_JSON removes it from cre
   assert(!('PLAY_CONFIG_JSON' in merged), 'PLAY_CONFIG_JSON should not be in credentials after deletion')
   assertEquals(merged.ANDROID_KEYSTORE_FILE, 'keystoredata', 'Other credentials should remain')
   assertEquals(merged.BUILD_OUTPUT_UPLOAD_ENABLED, 'true', 'Output upload should still be enabled')
+
+  clearCredentialEnvVars()
+  await cleanupTestEnv()
+})
+
+// ─── Test: CAPGO_IOS_PROVISIONING_MAP_BASE64 is decoded into the JSON form ───
+
+await test('CAPGO_IOS_PROVISIONING_MAP_BASE64 is base64-decoded to the JSON form', async () => {
+  await setupTestEnv()
+  clearCredentialEnvVars()
+
+  const json = '{"com.test.app":{"profile":"base64data","name":"match AppStore com.test.app"}}'
+  process.env.CAPGO_IOS_PROVISIONING_MAP_BASE64 = Buffer.from(json, 'utf-8').toString('base64')
+
+  const { loadCredentialsFromEnv } = await importCredentials()
+  const creds = loadCredentialsFromEnv()
+
+  assertEquals(creds.CAPGO_IOS_PROVISIONING_MAP, json, 'BASE64 form must be decoded to raw JSON')
+
+  clearCredentialEnvVars()
+  await cleanupTestEnv()
+})
+
+await test('CAPGO_IOS_PROVISIONING_MAP takes precedence over the BASE64 form', async () => {
+  await setupTestEnv()
+  clearCredentialEnvVars()
+
+  const rawJson = '{"com.test.app":{"profile":"raw","name":"raw"}}'
+  const otherJson = '{"com.test.app":{"profile":"b64","name":"b64"}}'
+  process.env.CAPGO_IOS_PROVISIONING_MAP = rawJson
+  process.env.CAPGO_IOS_PROVISIONING_MAP_BASE64 = Buffer.from(otherJson, 'utf-8').toString('base64')
+
+  const { loadCredentialsFromEnv } = await importCredentials()
+  const creds = loadCredentialsFromEnv()
+
+  assertEquals(creds.CAPGO_IOS_PROVISIONING_MAP, rawJson, 'Raw JSON form must win over BASE64')
 
   clearCredentialEnvVars()
   await cleanupTestEnv()


### PR DESCRIPTION
## Summary

- Accept `CAPGO_IOS_PROVISIONING_MAP_BASE64` (base64-encoded JSON) anywhere `CAPGO_IOS_PROVISIONING_MAP` (raw JSON) is read in the CLI.
- Decoding happens at the env-loading boundary, so downstream code paths and the credentials blob sent to the builder remain unchanged.
- Raw `CAPGO_IOS_PROVISIONING_MAP` takes precedence if both are set — fully backwards compatible.

## Why

The provisioning map is a stringified JSON value (`'{"com.example":{"profile":"...","name":"..."}}'`). Storing that verbatim in CI secret stores is fragile — quotes, newlines, and shell escaping all conspire to corrupt it on the way through the runner. A base64 wrapper turns the secret into a single opaque blob that round-trips cleanly through GitHub Actions, GitLab CI, and similar.

Companion PR in `capgo_builder` mirrors the same fallback in the Fastlane template so users hitting the worker API directly (without the CLI) get the same convenience: https://github.com/Cap-go/capgo_builder/pull/new/feat/provisioning-map-base64

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test:credentials` — all 17 tests pass, including 2 new ones:
  - `CAPGO_IOS_PROVISIONING_MAP_BASE64 is base64-decoded to the JSON form`
  - `CAPGO_IOS_PROVISIONING_MAP takes precedence over the BASE64 form`

## Follow-up

- [ ] Update `cli/cloud-build/credentials.mdx` and `cli/cloud-build/configuration.mdx` on the website to document the new var. Happy to do this in a separate PR once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for base64-encoded iOS provisioning map input as an alternative configuration method, with fallback to raw JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->