### PR TITLE
fix(ui): correct modal contrast in dark mode

### DIFF
--- a/src/components/DialogV2.vue
+++ b/src/components/DialogV2.vue
@@ -128,7 +128,7 @@ onUnmounted(() => {
         <!-- Close button -->
         <button
           v-if="!dialogStore.dialogOptions?.preventAccidentalClose"
-          class="absolute z-10 text-2xl text-base-content top-4 right-4 hover:text-white hover:bg-gray-500 d-btn d-btn-sm d-btn-circle d-btn-ghost"
+          class="absolute z-10 text-2xl text-base-content top-4 right-4 hover:text-base-content hover:bg-base-200 d-btn d-btn-sm d-btn-circle d-btn-ghost"
           @click="close()"
         >
           ✕

--- a/src/components/DialogV2.vue
+++ b/src/components/DialogV2.vue
@@ -110,7 +110,7 @@ onUnmounted(() => {
 
 <template>
   <Teleport to="body">
-    <div v-if="dialogStore.showDialog" data-theme="capgolight" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div v-if="dialogStore.showDialog" class="fixed inset-0 z-50 flex items-center justify-center">
       <!-- Backdrop -->
       <div
         class="fixed inset-0 bg-black/50"
@@ -120,7 +120,7 @@ onUnmounted(() => {
 
       <!-- Dialog -->
       <div
-        class="overflow-y-auto relative mx-4 w-full bg-white rounded-lg shadow-xl max-h-[90vh]"
+        class="overflow-y-auto relative mx-4 w-full bg-base-100 rounded-lg shadow-xl max-h-[90vh]"
         :class="[
           sizeClasses[dialogStore.dialogOptions?.size || 'md'],
         ]"
@@ -128,7 +128,7 @@ onUnmounted(() => {
         <!-- Close button -->
         <button
           v-if="!dialogStore.dialogOptions?.preventAccidentalClose"
-          class="absolute z-10 text-2xl text-black top-4 right-4 hover:text-white hover:bg-gray-500 d-btn d-btn-sm d-btn-circle d-btn-ghost"
+          class="absolute z-10 text-2xl text-base-content top-4 right-4 hover:text-white hover:bg-gray-500 d-btn d-btn-sm d-btn-circle d-btn-ghost"
           @click="close()"
         >
           ✕
@@ -136,7 +136,7 @@ onUnmounted(() => {
 
         <!-- Header -->
         <div v-if="dialogStore.dialogOptions?.title" class="px-6 pt-6 pb-2">
-          <h3 class="text-lg font-bold text-gray-900">
+          <h3 class="text-lg font-bold text-base-content">
             {{ dialogStore.dialogOptions.title }}
           </h3>
         </div>
@@ -145,13 +145,13 @@ onUnmounted(() => {
         <div class="px-6" :class="{ 'pt-6': !dialogStore.dialogOptions?.title }">
           <!-- Default description -->
           <div v-if="dialogStore.dialogOptions?.description" class="pb-4">
-            <p class="text-base text-gray-500 whitespace-pre-wrap break-all">
+            <p class="text-base text-base-content/70 whitespace-pre-wrap break-all">
               {{ dialogStore.dialogOptions.description }}
             </p>
           </div>
 
           <!-- Teleport target for custom content -->
-          <div id="dialog-v2-content" class="pb-4 text-gray-500" />
+          <div id="dialog-v2-content" class="pb-4 text-base-content/70" />
         </div>
 
         <!-- Buttons -->

--- a/src/components/dashboard/DemoOnboardingModal.vue
+++ b/src/components/dashboard/DemoOnboardingModal.vue
@@ -255,7 +255,7 @@ function currentStepText(entryId: DemoStep) {
     return 'border-violet-300 bg-violet-50 text-violet-700 shadow-sm'
   if (entryId < step.value)
     return 'border-emerald-200 bg-emerald-50 text-emerald-700'
-  return 'border-slate-200 bg-white text-slate-500'
+  return 'border-base-200 bg-base-100 text-base-content/60'
 }
 
 const wireStyle = computed(() => ({
@@ -615,7 +615,7 @@ onUnmounted(() => {
       aria-modal="true"
     >
       <button
-        class="absolute inline-flex items-center justify-center rounded-full top-4 right-4 h-9 w-9 bg-base-100/90 text-base-content/60 hover:bg-base-200"
+        class="absolute top-4 right-4 h-9 w-9 text-base-content/60 d-btn d-btn-sm d-btn-circle d-btn-ghost"
         aria-label="Close modal"
         type="button"
         @click="closeModal"
@@ -630,7 +630,7 @@ onUnmounted(() => {
               <p class="inline-flex rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-[11px] font-semibold tracking-[0.08em] text-violet-700">
                 START WITH CAPGO
               </p>
-              <div class="p-1.5 mt-3 border rounded-2xl border-slate-200 bg-slate-50">
+              <div class="p-1.5 mt-3 border rounded-2xl border-base-200 bg-base-200">
                 <div class="grid grid-cols-3 gap-2">
                   <div
                     v-for="entry in onboardingSteps"
@@ -641,16 +641,16 @@ onUnmounted(() => {
                     <p class="text-[11px] font-semibold tracking-wide">
                       {{ entry.id }}. {{ entry.label }}
                     </p>
-                    <p class="mt-1 text-[11px]" :class="entry.id <= step ? 'opacity-80' : 'text-slate-400'">
+                    <p class="mt-1 text-[11px]" :class="entry.id <= step ? 'opacity-80' : 'text-base-content/40'">
                       {{ entry.caption }}
                     </p>
                   </div>
                 </div>
               </div>
-              <h2 class="mt-3 text-2xl font-semibold text-slate-900">
+              <h2 class="mt-3 text-2xl font-semibold text-base-content">
                 {{ stepTitle }}
               </h2>
-              <p class="max-w-2xl mt-1.5 text-sm leading-relaxed text-slate-600">
+              <p class="max-w-2xl mt-1.5 text-sm leading-relaxed text-base-content/70">
                 {{ stepDescription }}
               </p>
             </div>
@@ -666,7 +666,7 @@ onUnmounted(() => {
                     placeholder="App Name"
                     maxlength="40"
                     :disabled="isCreatingApp"
-                    class="flex-1 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder-slate-400 shadow-sm outline-none focus:border-violet-400 focus:ring-2 focus:ring-violet-100 disabled:opacity-50"
+                    class="flex-1 rounded-xl border border-base-200 bg-base-100 px-4 py-2.5 text-sm text-base-content placeholder-base-content/40 shadow-sm outline-none focus:border-violet-400 focus:ring-2 focus:ring-violet-100 disabled:opacity-50"
                   >
                   <button
                     type="submit"
@@ -676,7 +676,7 @@ onUnmounted(() => {
                     {{ isCreatingApp ? 'Creating…' : 'Continue' }}
                   </button>
                 </form>
-                <p v-if="isCreatingApp" class="text-xs text-slate-500">
+                <p v-if="isCreatingApp" class="text-xs text-base-content/60">
                   Running <span class="font-mono text-emerald-600">{{ CAPGO_CLI_COMMAND }} app add</span> ...
                 </p>
               </div>
@@ -685,27 +685,27 @@ onUnmounted(() => {
                 <button
                   v-for="choice in updateChoices"
                   :key="choice.id"
-                  class="h-full p-3 text-left transition bg-white border rounded-xl border-slate-200 hover:border-violet-300 hover:bg-violet-50 sm:p-4 sm:rounded-2xl"
+                  class="h-full p-3 text-left transition bg-base-100 border rounded-xl border-base-200 hover:border-violet-300 hover:bg-violet-50 sm:p-4 sm:rounded-2xl"
                   type="button"
                   :disabled="isUploading"
                   :class="isUploading ? 'opacity-60 cursor-not-allowed' : ''"
                   @click="triggerUpload(choice)"
                 >
-                  <p class="text-sm font-semibold text-slate-900">
+                  <p class="text-sm font-semibold text-base-content">
                     {{ choice.label }}
                   </p>
-                  <p class="mt-1 text-xs text-slate-500">
+                  <p class="mt-1 text-xs text-base-content/60">
                     Result: {{ choice.result }}
                   </p>
                 </button>
               </div>
 
               <div v-else class="flex flex-col h-full space-y-3">
-                <article class="p-4 bg-white border shadow-sm rounded-2xl border-slate-200">
-                  <p class="text-sm text-slate-600">
+                <article class="p-4 bg-base-100 border shadow-sm rounded-2xl border-base-200">
+                  <p class="text-sm text-base-content/70">
                     {{ phoneStatusMessage }}
                   </p>
-                  <p class="mt-2 text-xl font-semibold text-slate-900">
+                  <p class="mt-2 text-xl font-semibold text-base-content">
                     {{ selectedActionResult }}
                   </p>
                 </article>

--- a/src/components/dashboard/DemoOnboardingModal.vue
+++ b/src/components/dashboard/DemoOnboardingModal.vue
@@ -610,12 +610,12 @@ onUnmounted(() => {
   <div v-if="open" class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-slate-950/70 backdrop-blur-sm" />
     <div
-      class="relative z-10 w-full max-w-6xl max-h-[90vh] overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-2xl"
+      class="relative z-10 w-full max-w-6xl max-h-[90vh] overflow-hidden rounded-[28px] border border-slate-200 bg-base-100 shadow-2xl"
       role="dialog"
       aria-modal="true"
     >
       <button
-        class="absolute inline-flex items-center justify-center rounded-full top-4 right-4 h-9 w-9 bg-white/90 text-slate-500 hover:bg-slate-100"
+        class="absolute inline-flex items-center justify-center rounded-full top-4 right-4 h-9 w-9 bg-base-100/90 text-base-content/60 hover:bg-base-200"
         aria-label="Close modal"
         type="button"
         @click="closeModal"
@@ -625,7 +625,7 @@ onUnmounted(() => {
 
       <div class="overflow-y-auto max-h-[90vh]">
         <div class="grid gap-0 overflow-hidden md:grid-cols-[1.08fr,0.92fr]">
-          <div class="flex flex-col h-full gap-4 p-5 bg-white md:p-6">
+          <div class="flex flex-col h-full gap-4 p-5 bg-base-100 md:p-6">
             <div>
               <p class="inline-flex rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-[11px] font-semibold tracking-[0.08em] text-violet-700">
                 START WITH CAPGO
@@ -713,7 +713,7 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <div class="relative flex items-center justify-center p-4 border-l border-slate-100 bg-gradient-to-b from-white to-slate-100">
+          <div class="relative flex items-center justify-center p-4 border-l border-slate-100 bg-gradient-to-b from-base-100 to-base-200">
             <div class="w-full max-w-[56rem] space-y-3">
               <div class="flex flex-col items-center gap-3 md:flex-row">
                 <div class="flex-1 w-full p-4 border rounded-xl border-slate-800 bg-slate-950 md:flex-[2.2]">


### PR DESCRIPTION
## Summary

- Suppression de `data-theme="capgolight"` dans `DialogV2.vue` qui forçait le thème clair sur toutes les modales, ignorant la préférence dark mode de l'utilisateur
- Remplacement des classes hardcodées (`bg-white`, `text-gray-900`, `text-gray-500`, `text-black`) par des tokens DaisyUI adaptatifs (`bg-base-100`, `text-base-content`, `text-base-content/70`) dans `DialogV2.vue`
- Même correction sur les conteneurs principaux de `DemoOnboardingModal.vue` (conteneur modal, bouton close, panneau gauche, gradient panneau droit)

Les éléments `bg-white` à l'intérieur du simulateur téléphone dans `DemoOnboardingModal` sont volontairement conservés (ils simulent un écran iPhone).

## Test plan

- [ ] Passer en mode sombre → ouvrir n'importe quelle modale : fond sombre (`#1e293b`), texte blanc lisible
- [ ] Passer en mode clair → fond blanc, texte sombre
- [ ] Vérifier `DemoOnboardingModal` en dark mode : conteneur et panneau gauche en fond sombre
- [ ] Vérifier que le simulateur téléphone dans `DemoOnboardingModal` reste blanc (comportement intentionnel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated dialog and onboarding modal to use theme-aware color tokens instead of hardcoded colors for improved light/dark consistency
  * Refined close button, titles, descriptions and step/card visuals for clearer contrast and hover states
  * Adjusted input, upload-choice, post-upload status and gradient strip styling for cohesive appearance and spacing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->