### PR TITLE
fix(cli): sync bun.lock with CLI workspace version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "7.95.2",
+      "version": "7.95.3",
       "bin": {
         "capgo": "dist/index.js",
       },


### PR DESCRIPTION
## Summary (AI generated)

- Syncs `bun.lock` to match the current CLI workspace version (7.95.2 → 7.95.3)

## Motivation (AI generated)

The lockfile referenced CLI `v7.95.2` while `cli/package.json` had `v7.95.3` after the latest release. This version mismatch caused `bun install` to not properly resolve the CLI workspace's dependencies (ink, @sauber/table, @modelcontextprotocol/sdk, etc.), resulting in ~100 false TypeScript errors when running `bun typecheck`. The pre-commit hook (`bun typecheck`) was effectively broken on `main`.

## Business Impact (AI generated)

- Unblocks the pre-commit hook for all developers — commits were failing typecheck on main
- Prevents false CI failures from stale lockfile state

## Test Plan (AI generated)

- [x] `bun typecheck` passes cleanly (0 errors)
- [x] `bun run cli:build` succeeds
- [x] `vue-tsc --noEmit` succeeds

Generated with AI