### PR TITLE
[codex] add channel preview tab

### DIFF
--- a/src/constants/channelTabs.ts
+++ b/src/constants/channelTabs.ts
@@ -2,6 +2,7 @@ import type { Tab } from '~/components/comp_def'
 import IconChartBar from '~icons/heroicons/chart-bar'
 import IconHistory from '~icons/heroicons/clock'
 import IconDevice from '~icons/heroicons/device-phone-mobile'
+import IconEye from '~icons/heroicons/eye'
 import IconInfo from '~icons/heroicons/information-circle'
 
 export const channelTabs: Tab[] = [
@@ -9,4 +10,5 @@ export const channelTabs: Tab[] = [
   { label: 'info', icon: IconInfo, key: '' },
   { label: 'devices', icon: IconDevice, key: '/devices' },
   { label: 'history', icon: IconHistory, key: '/history' },
+  { label: 'preview-tab', icon: IconEye, key: '/preview' },
 ]


### PR DESCRIPTION
## Summary (AI generated)

- Added the missing Preview tab to channel detail pages.
- Reused the existing preview translation key and eye icon used by bundle tabs.

## Motivation (AI generated)

Channel preview routing and page implementation already existed, but users could not reach it from the channel tab navigation.

## Business Impact (AI generated)

This makes the channel preview feature discoverable in the console so teams can validate channel previews without manually editing URLs.

## Test Plan (AI generated)

- [x] Ran `bun lint`
- [x] Ran `bun typecheck`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new preview tab to the channel navigation interface, providing users with an additional viewing option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->