### PR TITLE
fix(frontend): correct build time 'Used in period' always showing 0m

### DIFF
--- a/src/pages/settings/organization/Usage.vue
+++ b/src/pages/settings/organization/Usage.vue
@@ -126,7 +126,7 @@ async function getUsage(orgId: string) {
   const totalBandwidth = bytesToGb(totalBandwidthBytes)
   const totalStorageBytes = await getTotalStorage(orgId)
   const totalStorage = bytesToGb(totalStorageBytes)
-  const totalBuildTime = relevantUsage.reduce((acc, entry) => acc + (entry.build_time_unit ?? 0), 0)
+  const totalBuildTime = relevantUsage.reduce((acc, entry) => acc + (entry.build_time_seconds ?? 0), 0)
 
   detailPlanUsage = maybeDeriveMissingUsagePercents({
     detailPlanUsage,

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -191,7 +191,7 @@ export interface AppUsageByApp {
   mau: number
   storage: number
   bandwidth: number
-  build_time_unit: number
+  build_time_seconds: number
   get: number
 }
 
@@ -208,7 +208,7 @@ export interface AppUsageGlobal {
   bandwidth: number
   mau: number
   storage: number
-  build_time_unit: number
+  build_time_seconds: number
   get: number
 }
 
@@ -283,8 +283,8 @@ export async function getAllDashboard(orgId: string, startDate?: string, endDate
     }
 
     const { global, byApp } = response.data as {
-      global: { mau: number, storage: number, bandwidth: number, build_time_unit: number, date: string, get: number }[]
-      byApp: { app_id: string, mau: number, storage: number, bandwidth: number, build_time_unit: number, date: string, get: number }[]
+      global: { mau: number, storage: number, bandwidth: number, build_time_seconds: number, date: string, get: number }[]
+      byApp: { app_id: string, mau: number, storage: number, bandwidth: number, build_time_seconds: number, date: string, get: number }[]
     }
 
     return {

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -20,7 +20,7 @@ interface TotalStats {
   mau: number
   storage: number
   bandwidth: number
-  build_time_unit: number
+  build_time_seconds: number
 }
 
 export const useMainStore = defineStore('main', () => {
@@ -32,7 +32,7 @@ export const useMainStore = defineStore('main', () => {
     mau: 0,
     storage: 0,
     bandwidth: 0,
-    build_time_unit: 0,
+    build_time_seconds: 0,
   })
   const bestPlan = ref<string>('')
   const statsTime = ref<{ next_run: string, last_run: string }>({
@@ -76,13 +76,13 @@ export const useMainStore = defineStore('main', () => {
       acc.mau += cur.mau
       acc.bandwidth += cur.bandwidth
       acc.storage += cur.storage
-      acc.build_time_unit += cur.build_time_unit
+      acc.build_time_seconds += cur.build_time_seconds
       return acc
     }, {
       mau: 0,
       bandwidth: 0,
       storage: 0,
-      build_time_unit: 0,
+      build_time_seconds: 0,
     })
   }
 


### PR DESCRIPTION
## Summary (AI generated)

- Fixed the "Used in period" field for Build Time always displaying "0m" on the Usage page, despite the percentage bar showing the correct value (e.g. 63%).

## Motivation (AI generated)

The statistics backend returns `build_time_seconds` in its response, but the frontend type definitions and data aggregation code were referencing `build_time_unit` — a field that doesn't exist in the API response. This caused the value to always be `undefined`, falling back to `0`. The percentage was unaffected because it comes from a separate RPC (`get_plan_usage_percent_detailed`) that queries the database directly.

## Business Impact (AI generated)

Users see incorrect build time usage (always 0m) on the org Usage page, which prevents them from understanding their actual consumption and making informed decisions about plan upgrades.

## Test Plan (AI generated)

- [ ] Navigate to Settings > Organization > Usage
- [ ] Verify "Used in period" for Build Time shows the actual accumulated build time (not 0m)
- [ ] Verify the percentage and progress bar remain consistent with the displayed value
- [ ] Run `bun typecheck` — passes cleanly

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build time metrics calculation to use seconds instead of units, improving accuracy in usage tracking and credit overage estimation. Build time statistics displayed in the organization dashboard now reflect proper time measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->