### PR TITLE
[codex] fix preview frame corners

### DIFF
--- a/src/components/BundlePreviewFrame.vue
+++ b/src/components/BundlePreviewFrame.vue
@@ -21,12 +21,14 @@ const devices = {
     width: 375,
     height: 812,
     frameClass: 'rounded-[40px]',
+    screenRadius: 28,
   },
   pixel: {
     name: 'Google Pixel',
     width: 412,
     height: 915,
     frameClass: 'rounded-[30px]',
+    screenRadius: 18,
   },
 }
 
@@ -176,7 +178,10 @@ function openExternal() {
           <!-- Screen -->
           <div
             class="w-full h-full overflow-hidden bg-white"
-            :class="currentDevice.frameClass.replace('40', '35').replace('30', '25')"
+            :style="{
+              borderRadius: `${currentDevice.screenRadius}px`,
+              clipPath: `inset(0 round ${currentDevice.screenRadius}px)`,
+            }"
           >
             <iframe
               title="Preview App"

--- a/src/components/BundlePreviewFrame.vue
+++ b/src/components/BundlePreviewFrame.vue
@@ -21,14 +21,14 @@ const devices = {
     width: 375,
     height: 812,
     frameClass: 'rounded-[40px]',
-    screenRadius: 28,
+    screenClass: 'rounded-[28px] [clip-path:inset(0_round_28px)]',
   },
   pixel: {
     name: 'Google Pixel',
     width: 412,
     height: 915,
     frameClass: 'rounded-[30px]',
-    screenRadius: 18,
+    screenClass: 'rounded-[18px] [clip-path:inset(0_round_18px)]',
   },
 }
 
@@ -178,10 +178,7 @@ function openExternal() {
           <!-- Screen -->
           <div
             class="w-full h-full overflow-hidden bg-white"
-            :style="{
-              borderRadius: `${currentDevice.screenRadius}px`,
-              clipPath: `inset(0 round ${currentDevice.screenRadius}px)`,
-            }"
+            :class="currentDevice.screenClass"
           >
             <iframe
               title="Preview App"


### PR DESCRIPTION
## Summary (AI generated)

- Added explicit screen clipping radii for the iPhone and Pixel preview frames.
- Replaced the generated Tailwind radius class with inline radius and clip-path values so iframe content follows the phone corners.

## Motivation (AI generated)

The preview page rendered the embedded app as a square surface inside a rounded phone frame, making the top and bottom corners look broken.

## Business Impact (AI generated)

This improves the polish of bundle and channel previews so users see a more accurate mobile-device representation.

## Test Plan (AI generated)

- [x] bun lint
- [x] bun typecheck
- [x] bun run build
- [x] git diff --check

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved device preview rendering: updated screen radius styling for iPhone and Google Pixel presets for more accurate rounded corners and clipping.
  * Preview container now applies the device-specific screen styling directly for consistent visuals.
  * Public API and props remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->