### PR TITLE
[codex] Fix dashboard chart height

### DIFF
--- a/src/components/dashboard/ChartCard.vue
+++ b/src/components/dashboard/ChartCard.vue
@@ -49,7 +49,7 @@ const displayNoDataMessage = computed(() => props.noDataMessage ?? t('no-data'))
 </script>
 
 <template>
-  <div class="relative col-span-full flex min-h-[24rem] flex-col overflow-hidden rounded-[1.75rem] border border-slate-200/80 bg-white/95 shadow-[0_20px_60px_-38px_rgba(15,23,42,0.3)] backdrop-blur dark:border-slate-700/70 dark:bg-slate-900/85 dark:shadow-[0_24px_70px_-42px_rgba(2,6,23,0.72)]">
+  <div class="relative col-span-full flex h-[460px] flex-col overflow-hidden rounded-[1.75rem] border border-slate-200/80 bg-white/95 shadow-[0_20px_60px_-38px_rgba(15,23,42,0.3)] backdrop-blur dark:border-slate-700/70 dark:bg-slate-900/85 dark:shadow-[0_24px_70px_-42px_rgba(2,6,23,0.72)]">
     <div class="pointer-events-none absolute inset-x-0 top-0 h-28 bg-gradient-to-br from-slate-50 via-white to-transparent dark:from-slate-800/70 dark:via-slate-900/40 dark:to-transparent" />
 
     <!-- Header with title and stats -->
@@ -91,7 +91,7 @@ const displayNoDataMessage = computed(() => props.noDataMessage ?? t('no-data'))
     </div>
 
     <!-- Chart content area -->
-    <div class="relative flex-1 px-5 pb-5 pt-4">
+    <div class="relative min-h-0 flex-1 px-5 pb-5 pt-4">
       <!-- Loading state -->
       <div v-if="isLoading" class="flex justify-center items-center h-full">
         <Spinner size="w-24 h-24" />


### PR DESCRIPTION
## Summary (AI generated)

- Restored the shared dashboard chart card to a fixed 460px height.
- Added `min-h-0` to the chart content area so Chart.js canvases can use the available card space.

## Motivation (AI generated)

The refreshed dashboard design changed chart cards to a minimum height, which let the onboarding trend canvas render short while the card kept large empty space.

## Business Impact (AI generated)

This keeps admin analytics charts readable and preserves the refreshed dashboard layout without wasting visual space.

## Test Plan (AI generated)

- [x] Run `bun lint`
- [x] Run `bun typecheck`
- [x] Verify the local Vite app loads headlessly at `/admin/dashboard/users?page=1`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chart card layout with fixed height container and improved inner content spacing for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->