### PR TITLE
[codex] Add admin plugin version ladder

### DIFF
--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -25,6 +25,19 @@ interface PluginBreakdownTrendPoint {
   major_breakdown: Record<string, number>
 }
 
+interface PluginVersionTopApp {
+  app_id: string
+  device_count: number
+  share: number
+}
+
+interface PluginVersionLadderEntry {
+  version: string
+  device_count: number
+  percent: number
+  top_apps: PluginVersionTopApp[]
+}
+
 interface PluginBreakdownData {
   date: string | null
   devices_last_month: number
@@ -32,6 +45,7 @@ interface PluginBreakdownData {
   devices_last_month_android: number
   version_breakdown: Record<string, number>
   major_breakdown: Record<string, number>
+  version_ladder?: PluginVersionLadderEntry[]
   trend?: PluginBreakdownTrendPoint[]
 }
 
@@ -112,10 +126,16 @@ const majorValues = computed(() => majorEntries.value.map(entry => entry.percent
 
 const hasVersionData = computed(() => versionEntries.value.length > 0)
 const hasMajorData = computed(() => majorEntries.value.length > 0)
+const versionLadderEntries = computed(() => (pluginBreakdown.value?.version_ladder ?? []).slice(0, maxVersionRows))
+const hasVersionLadderData = computed(() => versionLadderEntries.value.length > 0)
 
 const versionCountTotal = computed(() => Object.keys(pluginBreakdown.value?.version_breakdown ?? {}).length)
 const versionCountShown = computed(() => versionEntries.value.length)
 const versionTrendPoints = computed(() => pluginBreakdown.value?.trend ?? [])
+
+function formatPercent(value: number) {
+  return `${Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`
+}
 
 function getTopBreakdownEntries(
   latestPoint: PluginBreakdownTrendPoint | undefined,
@@ -286,6 +306,77 @@ displayStore.defaultBack = '/dashboard'
               value-suffix="%"
               :suggested-max="100"
             />
+          </ChartCard>
+
+          <ChartCard
+            title="Version Ladder"
+            :is-loading="isLoadingBreakdown"
+            :has-data="hasVersionLadderData"
+            no-data-message="No plugin version ladder data available"
+          >
+            <template #header>
+              <div class="flex flex-col gap-1">
+                <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                  Version Ladder
+                </h2>
+                <p class="text-xs text-slate-500 dark:text-slate-400">
+                  Top {{ maxVersionRows }} plugin versions with their top 3 app IDs
+                </p>
+              </div>
+            </template>
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+                  <tr>
+                    <th class="px-4 py-3">
+                      Rank
+                    </th>
+                    <th class="px-4 py-3">
+                      Version
+                    </th>
+                    <th class="px-4 py-3 text-right">
+                      Devices
+                    </th>
+                    <th class="px-4 py-3">
+                      Top app IDs
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+                  <tr v-for="(entry, index) in versionLadderEntries" :key="entry.version" class="align-top">
+                    <td class="px-4 py-4 font-semibold text-slate-500 dark:text-slate-400">
+                      #{{ index + 1 }}
+                    </td>
+                    <td class="px-4 py-4">
+                      <div class="font-semibold text-slate-900 dark:text-white">
+                        {{ entry.version }}
+                      </div>
+                      <div class="text-xs text-slate-500 dark:text-slate-400">
+                        {{ formatPercent(entry.percent) }} share
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-right font-semibold text-slate-700 dark:text-slate-200">
+                      {{ entry.device_count.toLocaleString() }}
+                    </td>
+                    <td class="px-4 py-4">
+                      <div v-if="entry.top_apps.length > 0" class="min-w-[16rem] space-y-2">
+                        <div
+                          v-for="app in entry.top_apps"
+                          :key="`${entry.version}-${app.app_id}`"
+                          class="flex flex-col gap-1 rounded-md bg-slate-50 px-3 py-2 dark:bg-slate-800/80 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <span class="min-w-0 break-all font-medium text-slate-700 dark:text-slate-200">{{ app.app_id }}</span>
+                          <span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">
+                            {{ app.device_count.toLocaleString() }} ({{ formatPercent(app.share) }})
+                          </span>
+                        </div>
+                      </div>
+                      <span v-else class="text-slate-400">-</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </ChartCard>
 
           <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1242,6 +1242,7 @@ export type Database = {
           plan_team_yearly: number
           plugin_major_breakdown: Json
           plugin_version_breakdown: Json
+          plugin_version_ladder: Json
           registers_today: number
           revenue_enterprise: number
           revenue_maker: number
@@ -1311,6 +1312,7 @@ export type Database = {
           plan_team_yearly?: number
           plugin_major_breakdown?: Json
           plugin_version_breakdown?: Json
+          plugin_version_ladder?: Json
           registers_today?: number
           revenue_enterprise?: number
           revenue_maker?: number
@@ -1380,6 +1382,7 @@ export type Database = {
           plan_team_yearly?: number
           plugin_major_breakdown?: Json
           plugin_version_breakdown?: Json
+          plugin_version_ladder?: Json
           registers_today?: number
           revenue_enterprise?: number
           revenue_maker?: number

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import type { DevicesByPlatform, PluginBreakdownResult } from '../utils/cloudflare.ts'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
-import type { Database } from '../utils/supabase.types.ts'
+import type { Database, Json } from '../utils/supabase.types.ts'
 
 import { sql } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
@@ -980,6 +980,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     // Plugin version breakdown (percentage per version)
     plugin_version_breakdown: plugin_breakdown.version_breakdown,
     plugin_major_breakdown: plugin_breakdown.major_breakdown,
+    plugin_version_ladder: plugin_breakdown.version_ladder as unknown as Json,
     // Build statistics (all time)
     builds_total: build_stats.total,
     builds_ios: build_stats.ios,

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1945,9 +1945,99 @@ export interface PluginVersionBreakdown {
   [version: string]: number // percentage (0-100)
 }
 
+export interface PluginVersionTopApp {
+  app_id: string
+  device_count: number
+  share: number
+}
+
+export interface PluginVersionLadderEntry {
+  version: string
+  device_count: number
+  percent: number
+  top_apps: PluginVersionTopApp[]
+}
+
+export interface PluginBreakdownRow {
+  plugin_version: string
+  app_id: string
+  device_count: number | string
+}
+
 export interface PluginBreakdownResult {
   version_breakdown: PluginVersionBreakdown // Full version breakdown (e.g., {"6.2.5": 45.2})
   major_breakdown: PluginVersionBreakdown // Major version breakdown (e.g., {"6": 75.3})
+  version_ladder: PluginVersionLadderEntry[]
+}
+
+export function buildPluginBreakdownResult(result: PluginBreakdownRow[]): PluginBreakdownResult {
+  const emptyResult: PluginBreakdownResult = { version_breakdown: {}, major_breakdown: {}, version_ladder: [] }
+  if (result.length === 0)
+    return emptyResult
+
+  const versionCounts = new Map<string, number>()
+  const versionAppCounts = new Map<string, Map<string, number>>()
+  for (const row of result) {
+    const version = row.plugin_version
+    const appId = row.app_id
+    const deviceCount = Number(row.device_count) || 0
+    if (!(version && appId && deviceCount > 0))
+      continue
+
+    versionCounts.set(version, (versionCounts.get(version) || 0) + deviceCount)
+    const appCounts = versionAppCounts.get(version) ?? new Map<string, number>()
+    appCounts.set(appId, (appCounts.get(appId) || 0) + deviceCount)
+    versionAppCounts.set(version, appCounts)
+  }
+
+  const total = Array.from(versionCounts.values()).reduce((sum, count) => sum + count, 0)
+
+  if (total === 0)
+    return emptyResult
+
+  const version_breakdown: PluginVersionBreakdown = {}
+  const majorCounts = new Map<string, number>()
+
+  for (const [version, count] of versionCounts) {
+    const percentage = Number(((count / total) * 100).toFixed(2))
+    if (percentage > 0)
+      version_breakdown[version] = percentage
+
+    const major = version.split('.')[0]
+    if (major)
+      majorCounts.set(major, (majorCounts.get(major) || 0) + count)
+  }
+
+  const major_breakdown: PluginVersionBreakdown = {}
+  for (const [major, count] of majorCounts) {
+    const percentage = Number(((count / total) * 100).toFixed(2))
+    if (percentage > 0)
+      major_breakdown[major] = percentage
+  }
+
+  const version_ladder = Array.from(versionCounts.entries())
+    .sort(([versionA, countA], [versionB, countB]) => countB - countA || versionA.localeCompare(versionB))
+    .slice(0, 20)
+    .map(([version, count]) => {
+      const appCounts = versionAppCounts.get(version) ?? new Map<string, number>()
+      const top_apps = Array.from(appCounts.entries())
+        .sort(([appA, countA], [appB, countB]) => countB - countA || appA.localeCompare(appB))
+        .slice(0, 3)
+        .map(([app_id, device_count]) => ({
+          app_id,
+          device_count,
+          share: Number(((device_count / count) * 100).toFixed(2)),
+        }))
+
+      return {
+        version,
+        device_count: count,
+        percent: Number(version_breakdown[version]) || 0,
+        top_apps,
+      }
+    })
+
+  return { version_breakdown, major_breakdown, version_ladder }
 }
 
 /**
@@ -1955,79 +2045,40 @@ export interface PluginBreakdownResult {
  * Returns percentage breakdown of plugin versions installed on devices (last 30 days)
  */
 export async function getPluginBreakdownCF(c: Context): Promise<PluginBreakdownResult> {
+  const emptyResult: PluginBreakdownResult = { version_breakdown: {}, major_breakdown: {}, version_ladder: [] }
   if (!c.env.DEVICE_INFO)
-    return { version_breakdown: {}, major_breakdown: {} }
+    return emptyResult
 
   const last30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
 
-  // Query latest plugin_version per device, then aggregate counts by version
-  // Using a subquery keeps the result set small (one row per version).
+  // Query latest plugin_version per app/device pair, then aggregate by version and app.
   const query = `SELECT
     plugin_version,
+    app_id,
     count() AS device_count
   FROM (
     SELECT
+      argMax(index1, timestamp) AS app_id,
       argMax(blob3, timestamp) AS plugin_version,
       blob1 AS device_id
     FROM device_info
     WHERE timestamp >= toDateTime('${formatDateCF(last30d)}')
       AND timestamp < now()
       AND blob3 != ''
-    GROUP BY blob1
+    GROUP BY index1, blob1
   )
   WHERE plugin_version != ''
-  GROUP BY plugin_version`
+    AND app_id != ''
+  GROUP BY plugin_version, app_id`
 
   cloudlog({ requestId: c.get('requestId'), message: 'getPluginBreakdownCF query', query })
 
   try {
-    const result = await runQueryToCFA<{ plugin_version: string, device_count: number }>(c, query)
-
-    if (result.length === 0)
-      return { version_breakdown: {}, major_breakdown: {} }
-
-    // Aggregate by full version
-    const versionCounts = new Map<string, number>()
-    for (const row of result) {
-      const version = row.plugin_version
-      versionCounts.set(version, (versionCounts.get(version) || 0) + row.device_count)
-    }
-
-    // Calculate total devices
-    const total = Array.from(versionCounts.values()).reduce((sum, count) => sum + count, 0)
-
-    if (total === 0)
-      return { version_breakdown: {}, major_breakdown: {} }
-
-    // Calculate full version breakdown
-    const version_breakdown: PluginVersionBreakdown = {}
-    const majorCounts = new Map<string, number>()
-
-    for (const [version, count] of versionCounts) {
-      const percentage = Number(((count / total) * 100).toFixed(2))
-      if (percentage > 0) {
-        version_breakdown[version] = percentage
-      }
-
-      // Extract major version (first number before first dot)
-      const major = version.split('.')[0]
-      if (major) {
-        majorCounts.set(major, (majorCounts.get(major) || 0) + count)
-      }
-    }
-
-    // Calculate major version breakdown
-    const major_breakdown: PluginVersionBreakdown = {}
-    for (const [major, count] of majorCounts) {
-      const percentage = Number(((count / total) * 100).toFixed(2))
-      if (percentage > 0)
-        major_breakdown[major] = percentage
-    }
-
-    return { version_breakdown, major_breakdown }
+    const result = await runQueryToCFA<PluginBreakdownRow>(c, query)
+    return buildPluginBreakdownResult(result)
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error in getPluginBreakdownCF', error: serializeError(e) })
-    return { version_breakdown: {}, major_breakdown: {} }
+    return emptyResult
   }
 }

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1571,12 +1571,6 @@ export interface AdminPluginVersionLadderEntry {
   top_apps: AdminPluginVersionTopApp[]
 }
 
-export interface AdminPluginVersionLadderRow {
-  plugin_version: unknown
-  device_count: unknown
-  top_apps: unknown
-}
-
 function parseBreakdownJson(value: unknown): Record<string, number> {
   if (!value)
     return {}
@@ -1612,6 +1606,9 @@ function parsePluginTopApps(value: unknown): AdminPluginVersionTopApp[] {
 
   return rawValue
     .map((item) => {
+      if (!(item && typeof item === 'object'))
+        return null
+
       const app = item as Record<string, unknown>
       const appId = typeof app.app_id === 'string' ? app.app_id : ''
       const deviceCount = Number(app.device_count) || 0
@@ -1623,26 +1620,44 @@ function parsePluginTopApps(value: unknown): AdminPluginVersionTopApp[] {
         share,
       }
     })
-    .filter(app => app.app_id.length > 0 && app.device_count > 0)
+    .filter((app): app is AdminPluginVersionTopApp => !!app && app.app_id.length > 0 && app.device_count > 0)
 }
 
-export function buildAdminPluginVersionLadder(
-  rows: AdminPluginVersionLadderRow[],
-  versionBreakdown: Record<string, number>,
-): AdminPluginVersionLadderEntry[] {
-  return rows
-    .map((row) => {
-      const version = typeof row.plugin_version === 'string' ? row.plugin_version : ''
-      const deviceCount = Number(row.device_count) || 0
+function parsePluginVersionLadderJson(value: unknown): AdminPluginVersionLadderEntry[] {
+  if (!value)
+    return []
+
+  let rawValue: unknown = value
+  if (typeof value === 'string') {
+    try {
+      rawValue = JSON.parse(value) as unknown
+    }
+    catch {
+      return []
+    }
+  }
+
+  if (!Array.isArray(rawValue))
+    return []
+
+  return rawValue
+    .map((item) => {
+      if (!(item && typeof item === 'object'))
+        return null
+
+      const entry = item as Record<string, unknown>
+      const version = typeof entry.version === 'string' ? entry.version : ''
+      const deviceCount = Number(entry.device_count) || 0
+      const percent = Number(entry.percent) || 0
 
       return {
         version,
         device_count: deviceCount,
-        percent: Number(versionBreakdown[version]) || 0,
-        top_apps: parsePluginTopApps(row.top_apps),
+        percent,
+        top_apps: parsePluginTopApps(entry.top_apps),
       }
     })
-    .filter(entry => entry.version.length > 0 && entry.device_count > 0)
+    .filter((entry): entry is AdminPluginVersionLadderEntry => !!entry && entry.version.length > 0 && entry.device_count > 0)
 }
 
 function normalizeTimestamp(value: unknown): string | null {
@@ -2094,85 +2109,6 @@ export async function getAdminOnboardingFunnel(
   }
 }
 
-async function fetchAdminPluginVersionLadder(
-  c: Context,
-  drizzleClient: ReturnType<typeof getDrizzleClient>,
-  snapshotDate: string,
-  versionBreakdown: Record<string, number>,
-): Promise<AdminPluginVersionLadderEntry[]> {
-  try {
-    const query = sql`
-      WITH per_app AS (
-        SELECT
-          d.plugin_version,
-          d.app_id,
-          COUNT(*)::int AS device_count
-        FROM devices d
-        WHERE d.plugin_version != ''
-          AND d.updated_at >= (${snapshotDate}::date - INTERVAL '30 days')
-          AND d.updated_at < (${snapshotDate}::date + INTERVAL '1 day')
-        GROUP BY d.plugin_version, d.app_id
-      ),
-      version_totals AS (
-        SELECT
-          plugin_version,
-          SUM(device_count)::int AS device_count
-        FROM per_app
-        GROUP BY plugin_version
-      ),
-      top_versions AS (
-        SELECT
-          plugin_version,
-          device_count,
-          ROW_NUMBER() OVER (ORDER BY device_count DESC, plugin_version ASC) AS version_rank
-        FROM version_totals
-      ),
-      ranked_apps AS (
-        SELECT
-          per_app.plugin_version,
-          per_app.app_id,
-          per_app.device_count,
-          ROUND((per_app.device_count::numeric / NULLIF(top_versions.device_count, 0)) * 100, 2)::float AS share,
-          ROW_NUMBER() OVER (
-            PARTITION BY per_app.plugin_version
-            ORDER BY per_app.device_count DESC, per_app.app_id ASC
-          ) AS app_rank
-        FROM per_app
-        INNER JOIN top_versions
-          ON top_versions.plugin_version = per_app.plugin_version
-        WHERE top_versions.version_rank <= 20
-      )
-      SELECT
-        top_versions.plugin_version,
-        top_versions.device_count,
-        COALESCE(
-          jsonb_agg(
-            jsonb_build_object(
-              'app_id', ranked_apps.app_id,
-              'device_count', ranked_apps.device_count,
-              'share', ranked_apps.share
-            )
-            ORDER BY ranked_apps.app_rank
-          ) FILTER (WHERE ranked_apps.app_rank <= 3),
-          '[]'::jsonb
-        ) AS top_apps
-      FROM top_versions
-      LEFT JOIN ranked_apps
-        ON ranked_apps.plugin_version = top_versions.plugin_version
-      WHERE top_versions.version_rank <= 20
-      GROUP BY top_versions.plugin_version, top_versions.device_count, top_versions.version_rank
-      ORDER BY top_versions.version_rank ASC
-    `
-
-    const result = await drizzleClient.execute(query)
-    return buildAdminPluginVersionLadder(result.rows as unknown as AdminPluginVersionLadderRow[], versionBreakdown)
-  }
-  catch (e: unknown) {
-    logPgError(c, 'fetchAdminPluginVersionLadder', e)
-    return []
-  }
-}
-
 export async function getAdminPluginBreakdown(
   c: Context,
   start_date: string,
@@ -2192,7 +2128,8 @@ export async function getAdminPluginBreakdown(
         COALESCE(devices_last_month_ios, 0)::int AS devices_last_month_ios,
         COALESCE(devices_last_month_android, 0)::int AS devices_last_month_android,
         plugin_version_breakdown,
-        plugin_major_breakdown
+        plugin_major_breakdown,
+        plugin_version_ladder
       FROM global_stats
       WHERE date_id >= ${startDateOnly}
         AND date_id <= ${endDateOnly}
@@ -2227,7 +2164,7 @@ export async function getAdminPluginBreakdown(
     const latestDate = latestRow.date instanceof Date ? latestRow.date.toISOString().split('T')[0] : String(latestRow.date)
     const versionBreakdown = parseBreakdownJson(latestRow.plugin_version_breakdown)
     const majorBreakdown = parseBreakdownJson(latestRow.plugin_major_breakdown)
-    const versionLadder = await fetchAdminPluginVersionLadder(c, drizzleClient, latestDate, versionBreakdown)
+    const versionLadder = parsePluginVersionLadderJson(latestRow.plugin_version_ladder)
 
     return {
       date: latestDate,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1550,11 +1550,31 @@ export interface AdminPluginBreakdown {
   devices_last_month_android: number
   version_breakdown: Record<string, number>
   major_breakdown: Record<string, number>
+  version_ladder: AdminPluginVersionLadderEntry[]
   trend: Array<{
     date: string
     version_breakdown: Record<string, number>
     major_breakdown: Record<string, number>
   }>
+}
+
+export interface AdminPluginVersionTopApp {
+  app_id: string
+  device_count: number
+  share: number
+}
+
+export interface AdminPluginVersionLadderEntry {
+  version: string
+  device_count: number
+  percent: number
+  top_apps: AdminPluginVersionTopApp[]
+}
+
+export interface AdminPluginVersionLadderRow {
+  plugin_version: unknown
+  device_count: unknown
+  top_apps: unknown
 }
 
 function parseBreakdownJson(value: unknown): Record<string, number> {
@@ -1571,6 +1591,58 @@ function parseBreakdownJson(value: unknown): Record<string, number> {
   if (typeof value === 'object')
     return value as Record<string, number>
   return {}
+}
+
+function parsePluginTopApps(value: unknown): AdminPluginVersionTopApp[] {
+  if (!value)
+    return []
+
+  let rawValue: unknown = value
+  if (typeof value === 'string') {
+    try {
+      rawValue = JSON.parse(value) as unknown
+    }
+    catch {
+      return []
+    }
+  }
+
+  if (!Array.isArray(rawValue))
+    return []
+
+  return rawValue
+    .map((item) => {
+      const app = item as Record<string, unknown>
+      const appId = typeof app.app_id === 'string' ? app.app_id : ''
+      const deviceCount = Number(app.device_count) || 0
+      const share = Number(app.share) || 0
+
+      return {
+        app_id: appId,
+        device_count: deviceCount,
+        share,
+      }
+    })
+    .filter(app => app.app_id.length > 0 && app.device_count > 0)
+}
+
+export function buildAdminPluginVersionLadder(
+  rows: AdminPluginVersionLadderRow[],
+  versionBreakdown: Record<string, number>,
+): AdminPluginVersionLadderEntry[] {
+  return rows
+    .map((row) => {
+      const version = typeof row.plugin_version === 'string' ? row.plugin_version : ''
+      const deviceCount = Number(row.device_count) || 0
+
+      return {
+        version,
+        device_count: deviceCount,
+        percent: Number(versionBreakdown[version]) || 0,
+        top_apps: parsePluginTopApps(row.top_apps),
+      }
+    })
+    .filter(entry => entry.version.length > 0 && entry.device_count > 0)
 }
 
 function normalizeTimestamp(value: unknown): string | null {
@@ -2022,6 +2094,85 @@ export async function getAdminOnboardingFunnel(
   }
 }
 
+async function fetchAdminPluginVersionLadder(
+  c: Context,
+  drizzleClient: ReturnType<typeof getDrizzleClient>,
+  snapshotDate: string,
+  versionBreakdown: Record<string, number>,
+): Promise<AdminPluginVersionLadderEntry[]> {
+  try {
+    const query = sql`
+      WITH per_app AS (
+        SELECT
+          d.plugin_version,
+          d.app_id,
+          COUNT(*)::int AS device_count
+        FROM devices d
+        WHERE d.plugin_version != ''
+          AND d.updated_at >= (${snapshotDate}::date - INTERVAL '30 days')
+          AND d.updated_at < (${snapshotDate}::date + INTERVAL '1 day')
+        GROUP BY d.plugin_version, d.app_id
+      ),
+      version_totals AS (
+        SELECT
+          plugin_version,
+          SUM(device_count)::int AS device_count
+        FROM per_app
+        GROUP BY plugin_version
+      ),
+      top_versions AS (
+        SELECT
+          plugin_version,
+          device_count,
+          ROW_NUMBER() OVER (ORDER BY device_count DESC, plugin_version ASC) AS version_rank
+        FROM version_totals
+      ),
+      ranked_apps AS (
+        SELECT
+          per_app.plugin_version,
+          per_app.app_id,
+          per_app.device_count,
+          ROUND((per_app.device_count::numeric / NULLIF(top_versions.device_count, 0)) * 100, 2)::float AS share,
+          ROW_NUMBER() OVER (
+            PARTITION BY per_app.plugin_version
+            ORDER BY per_app.device_count DESC, per_app.app_id ASC
+          ) AS app_rank
+        FROM per_app
+        INNER JOIN top_versions
+          ON top_versions.plugin_version = per_app.plugin_version
+        WHERE top_versions.version_rank <= 20
+      )
+      SELECT
+        top_versions.plugin_version,
+        top_versions.device_count,
+        COALESCE(
+          jsonb_agg(
+            jsonb_build_object(
+              'app_id', ranked_apps.app_id,
+              'device_count', ranked_apps.device_count,
+              'share', ranked_apps.share
+            )
+            ORDER BY ranked_apps.app_rank
+          ) FILTER (WHERE ranked_apps.app_rank <= 3),
+          '[]'::jsonb
+        ) AS top_apps
+      FROM top_versions
+      LEFT JOIN ranked_apps
+        ON ranked_apps.plugin_version = top_versions.plugin_version
+      WHERE top_versions.version_rank <= 20
+      GROUP BY top_versions.plugin_version, top_versions.device_count, top_versions.version_rank
+      ORDER BY top_versions.version_rank ASC
+    `
+
+    const result = await drizzleClient.execute(query)
+    return buildAdminPluginVersionLadder(result.rows as unknown as AdminPluginVersionLadderRow[], versionBreakdown)
+  }
+  catch (e: unknown) {
+    logPgError(c, 'fetchAdminPluginVersionLadder', e)
+    return []
+  }
+}
+
 export async function getAdminPluginBreakdown(
   c: Context,
   start_date: string,
@@ -2059,6 +2210,7 @@ export async function getAdminPluginBreakdown(
         devices_last_month_android: 0,
         version_breakdown: {},
         major_breakdown: {},
+        version_ladder: [],
         trend: [],
       }
     }
@@ -2073,14 +2225,18 @@ export async function getAdminPluginBreakdown(
     })
     const latestRow = rows[rows.length - 1]
     const latestDate = latestRow.date instanceof Date ? latestRow.date.toISOString().split('T')[0] : String(latestRow.date)
+    const versionBreakdown = parseBreakdownJson(latestRow.plugin_version_breakdown)
+    const majorBreakdown = parseBreakdownJson(latestRow.plugin_major_breakdown)
+    const versionLadder = await fetchAdminPluginVersionLadder(c, drizzleClient, latestDate, versionBreakdown)
 
     return {
       date: latestDate,
       devices_last_month: Number(latestRow.devices_last_month) || 0,
       devices_last_month_ios: Number(latestRow.devices_last_month_ios) || 0,
       devices_last_month_android: Number(latestRow.devices_last_month_android) || 0,
-      version_breakdown: parseBreakdownJson(latestRow.plugin_version_breakdown),
-      major_breakdown: parseBreakdownJson(latestRow.plugin_major_breakdown),
+      version_breakdown: versionBreakdown,
+      major_breakdown: majorBreakdown,
+      version_ladder: versionLadder,
       trend,
     }
   }
@@ -2093,6 +2249,7 @@ export async function getAdminPluginBreakdown(
       devices_last_month_android: 0,
       version_breakdown: {},
       major_breakdown: {},
+      version_ladder: [],
       trend: [],
     }
   }

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1242,6 +1242,7 @@ export type Database = {
           plan_team_yearly: number
           plugin_major_breakdown: Json
           plugin_version_breakdown: Json
+          plugin_version_ladder: Json
           registers_today: number
           revenue_enterprise: number
           revenue_maker: number
@@ -1311,6 +1312,7 @@ export type Database = {
           plan_team_yearly?: number
           plugin_major_breakdown?: Json
           plugin_version_breakdown?: Json
+          plugin_version_ladder?: Json
           registers_today?: number
           revenue_enterprise?: number
           revenue_maker?: number
@@ -1380,6 +1382,7 @@ export type Database = {
           plan_team_yearly?: number
           plugin_major_breakdown?: Json
           plugin_version_breakdown?: Json
+          plugin_version_ladder?: Json
           registers_today?: number
           revenue_enterprise?: number
           revenue_maker?: number

--- a/supabase/migrations/20260506103727_add_plugin_version_ladder_to_global_stats.sql
+++ b/supabase/migrations/20260506103727_add_plugin_version_ladder_to_global_stats.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."global_stats"
+ADD COLUMN IF NOT EXISTS "plugin_version_ladder" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/tests/admin-stats.unit.test.ts
+++ b/tests/admin-stats.unit.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { adminStatsBodySchema, MAX_ADMIN_STATS_LIMIT, MAX_ADMIN_STATS_OFFSET } from '../supabase/functions/_backend/private/admin_stats.ts'
 import { safeParseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
-import { normalizeAnalyticsLimit } from '../supabase/functions/_backend/utils/cloudflare.ts'
-import { buildAdminPluginVersionLadder } from '../supabase/functions/_backend/utils/pg.ts'
+import { buildPluginBreakdownResult, normalizeAnalyticsLimit } from '../supabase/functions/_backend/utils/cloudflare.ts'
 
 describe('admin stats validation', () => {
   const baseBody = {
@@ -77,35 +76,40 @@ describe('normalizeAnalyticsLimit', () => {
   })
 })
 
-describe('buildAdminPluginVersionLadder', () => {
-  it.concurrent('normalizes top plugin versions with top app IDs', () => {
-    const result = buildAdminPluginVersionLadder([
-      {
-        plugin_version: '8.1.0',
-        device_count: '12',
-        top_apps: JSON.stringify([
-          { app_id: 'com.capgo.first', device_count: '8', share: '66.67' },
-          { app_id: 'com.capgo.second', device_count: 4, share: 33.33 },
-          { app_id: '', device_count: 1, share: 8.33 },
-        ]),
-      },
-      {
-        plugin_version: '',
-        device_count: 10,
-        top_apps: [],
-      },
-    ], {
-      '8.1.0': 42.5,
-    })
+describe('buildPluginBreakdownResult', () => {
+  it.concurrent('aggregates plugin versions with major breakdown and top app IDs', () => {
+    const result = buildPluginBreakdownResult([
+      { plugin_version: '8.1.0', app_id: 'com.capgo.first', device_count: '8' },
+      { plugin_version: '8.1.0', app_id: 'com.capgo.second', device_count: 4 },
+      { plugin_version: '7.5.1', app_id: 'com.capgo.third', device_count: 4 },
+      { plugin_version: '', app_id: 'com.capgo.empty', device_count: 10 },
+      { plugin_version: '8.1.0', app_id: '', device_count: 10 },
+    ])
 
-    expect(result).toEqual([
+    expect(result.version_breakdown).toEqual({
+      '8.1.0': 75,
+      '7.5.1': 25,
+    })
+    expect(result.major_breakdown).toEqual({
+      8: 75,
+      7: 25,
+    })
+    expect(result.version_ladder).toEqual([
       {
         version: '8.1.0',
         device_count: 12,
-        percent: 42.5,
+        percent: 75,
         top_apps: [
           { app_id: 'com.capgo.first', device_count: 8, share: 66.67 },
           { app_id: 'com.capgo.second', device_count: 4, share: 33.33 },
+        ],
+      },
+      {
+        version: '7.5.1',
+        device_count: 4,
+        percent: 25,
+        top_apps: [
+          { app_id: 'com.capgo.third', device_count: 4, share: 100 },
         ],
       },
     ])

--- a/tests/admin-stats.unit.test.ts
+++ b/tests/admin-stats.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { adminStatsBodySchema, MAX_ADMIN_STATS_LIMIT, MAX_ADMIN_STATS_OFFSET } from '../supabase/functions/_backend/private/admin_stats.ts'
 import { safeParseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
 import { normalizeAnalyticsLimit } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { buildAdminPluginVersionLadder } from '../supabase/functions/_backend/utils/pg.ts'
 
 describe('admin stats validation', () => {
   const baseBody = {
@@ -73,5 +74,40 @@ describe('normalizeAnalyticsLimit', () => {
     ['oversized', 99_999_999, 50_000],
   ])('normalizes %s', (_label, input, expected) => {
     expect(normalizeAnalyticsLimit(input, 100)).toBe(expected)
+  })
+})
+
+describe('buildAdminPluginVersionLadder', () => {
+  it.concurrent('normalizes top plugin versions with top app IDs', () => {
+    const result = buildAdminPluginVersionLadder([
+      {
+        plugin_version: '8.1.0',
+        device_count: '12',
+        top_apps: JSON.stringify([
+          { app_id: 'com.capgo.first', device_count: '8', share: '66.67' },
+          { app_id: 'com.capgo.second', device_count: 4, share: 33.33 },
+          { app_id: '', device_count: 1, share: 8.33 },
+        ]),
+      },
+      {
+        plugin_version: '',
+        device_count: 10,
+        top_apps: [],
+      },
+    ], {
+      '8.1.0': 42.5,
+    })
+
+    expect(result).toEqual([
+      {
+        version: '8.1.0',
+        device_count: 12,
+        percent: 42.5,
+        top_apps: [
+          { app_id: 'com.capgo.first', device_count: 8, share: 66.67 },
+          { app_id: 'com.capgo.second', device_count: 4, share: 33.33 },
+        ],
+      },
+    ])
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Added a top-20 plugin version ladder to the admin plugins dashboard.
- Included the top 3 app IDs for each plugin version, with device counts and share.
- Kept the existing full-version and major-version charts intact, including the major-version trend.

## Motivation (AI generated)

Admins need to see both major-version adoption over time and which apps are driving each top plugin version.

## Business Impact (AI generated)

This improves platform observability and helps prioritize support, upgrade nudges, and compatibility work based on real app usage.

## Test Plan (AI generated)

- [x] bunx vitest run tests/admin-stats.unit.test.ts
- [x] bun lint
- [x] bun lint:backend
- [x] bun typecheck
- [x] bun run build

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Version Ladder feature to the admin plugins dashboard, displaying top plugin versions with associated device counts and top-performing applications per version in a dedicated table view.

* **Tests**
  * Added test coverage for version ladder data normalization and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->