### PR TITLE
fix(api): block uploads to ready bundle paths

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -997,6 +997,39 @@ async function checkWriteAppAccess(c: Context, next: Next) {
       }, 429)
     }
 
+    // Ready bundle objects are immutable. Refuse resumable uploads that target a
+    // finalized bundle path even if the caller has upload permission on the app.
+    const readyBundlePath = await pgClient.query<{ id: number }>(
+      `
+        SELECT id
+        FROM public.app_versions
+        WHERE owner_org = $1
+          AND app_id = $2
+          AND r2_path = $3
+          AND COALESCE(deleted, false) = false
+          AND storage_provider IS DISTINCT FROM 'r2-direct'
+        LIMIT 1
+      `,
+      [owner_org, app_id, requestId],
+    )
+
+    if (readyBundlePath.rows.length > 0) {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'checkWriteAppAccess - ready bundle path mutation blocked',
+        app_id,
+        owner_org,
+        fileId: requestId,
+      })
+      throw new HTTPException(409, {
+        res: c.json({
+          error: 'bundle_already_ready',
+          message: 'Bundle content cannot be changed after upload is complete. Upload a new bundle instead.',
+          moreInfo: { app_id, requestId: c.get('requestId') },
+        }),
+      })
+    }
+
     cloudlog({
       requestId: c.get('requestId'),
       message: 'checkWriteAppAccess - access granted',

--- a/tests/files-security.test.ts
+++ b/tests/files-security.test.ts
@@ -83,6 +83,29 @@ async function seedApp(appId: string, orgId: string, stripeCustomerId: string) {
   )
 }
 
+async function seedReadyBundle(appId: string, orgId: string, filename: string) {
+  const filePath = `orgs/${orgId}/apps/${appId}/${filename}`
+  const { uploadMetadata } = buildAttachmentPath(orgId, appId, filename)
+  const { error } = await getSupabaseClient()
+    .from('app_versions')
+    .insert({
+      app_id: appId,
+      name: `ready-${randomUUID()}`,
+      checksum: randomUUID().replaceAll('-', ''),
+      owner_org: orgId,
+      user_id: USER_ID,
+      storage_provider: 'r2',
+      r2_path: filePath,
+      deleted: false,
+      session_key: `ready-session-${randomUUID()}`,
+    })
+
+  if (error)
+    throw new Error(`Failed to seed ready bundle: ${error.message}`)
+
+  return { filePath, uploadMetadata }
+}
+
 describe('attachment upload plan gating regression', () => {
   const scopeId = randomUUID().replaceAll('-', '')
   const orgId = randomUUID()
@@ -126,6 +149,46 @@ describe('attachment upload plan gating regression', () => {
     expect(response.status).toBe(429)
     const data = await response.json() as { error?: string }
     expect(data.error).toBe('on_premise_app')
+  })
+})
+
+describe('ready bundle upload immutability regression', () => {
+  const scopeId = randomUUID().replaceAll('-', '')
+  const orgId = randomUUID()
+  const stripeCustomerId = `cus_files_ready_${scopeId}`
+  const appId = `com.files.ready.${scopeId}`
+  let uploadKeyId: number | undefined
+  let uploadKey: string | undefined
+  let readyBundle: { filePath: string, uploadMetadata: string } | undefined
+
+  beforeAll(async () => {
+    await seedApp(appId, orgId, stripeCustomerId)
+
+    const createdKey = await createSeededApiKey({ appId, limitedToApp: true, mode: 'upload', name: `upload-ready-${appId}` })
+    uploadKeyId = createdKey.id
+    uploadKey = createdKey.key
+    readyBundle = await seedReadyBundle(appId, orgId, `ready-${scopeId}.zip`)
+  }, 60_000)
+
+  afterAll(async () => {
+    await cleanupSeededOrg(appId, orgId, stripeCustomerId, [uploadKeyId])
+  }, 60_000)
+
+  it.concurrent('blocks resumable upload creation for an already ready bundle path', async () => {
+    const response = await fetch(getEndpointUrl('/files/upload/attachments'), {
+      method: 'POST',
+      headers: {
+        'Authorization': uploadKey!,
+        'Content-Type': 'application/offset+octet-stream',
+        'Tus-Resumable': TUS_VERSION,
+        'Upload-Length': '4',
+        'Upload-Metadata': readyBundle!.uploadMetadata,
+      },
+    })
+
+    expect(response.status).toBe(409)
+    const data = await response.json() as { error?: string }
+    expect(data.error).toBe('bundle_already_ready')
   })
 })
 


### PR DESCRIPTION
## Summary (AI generated)

- Block resumable attachment uploads when the requested file path already belongs to a ready bundle.
- Return `bundle_already_ready` for ready bundle path upload attempts.
- Add a regression test covering the ready bundle upload path guard.

## Motivation (AI generated)

Ready bundles should be immutable after upload completes. The database trigger protects bundle row fields, but the file upload API also needs to reject attempts to overwrite the stored bundle object path.

## Business Impact (AI generated)

This prevents users or API keys from replacing finalized bundle contents without creating a new bundle version, protecting update integrity and auditability.

## Test Plan (AI generated)

- [x] `bunx eslint supabase/functions/_backend/files/files.ts tests/files-security.test.ts`
- [x] `bun run lint:backend`
- [x] `bun run supabase:with-env -- bunx vitest run tests/files-security.test.ts`
- [x] `bun run cli:check`
- [x] Pre-commit: `bun run cli:build && vue-tsc --noEmit`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent uploading or modifying finalized application bundles. The system now returns an error when attempting to overwrite a bundle that is already marked as ready.

* **Tests**
  * Added test coverage for finalized bundle protection, verifying that finalized bundles cannot be overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->