### PR TITLE
[codex] add churn revenue plan breakdown

### DIFF
--- a/scripts/backfill_retention_metrics.ts
+++ b/scripts/backfill_retention_metrics.ts
@@ -57,7 +57,9 @@ type StripeInfoRevenueState = {
   product_id?: string | null
   status?: StripeStatus | null
 } | null | undefined
-type RevenuePlanRow = Pick<PlanRow, 'price_m' | 'price_m_id' | 'price_y' | 'price_y_id' | 'stripe_id'>
+type RevenuePlanRow = Pick<PlanRow, 'name' | 'price_m' | 'price_m_id' | 'price_y' | 'price_y_id' | 'stripe_id'>
+type RevenuePlanKey = 'solo' | 'maker' | 'team' | 'enterprise'
+type RevenuePlanBreakdown = Record<RevenuePlanKey, number>
 
 interface CustomerRevenueBaselineRow {
   customer_id: string
@@ -86,6 +88,7 @@ export interface BackfillRevenueMovementEvent {
   expansion_mrr: number
   contraction_mrr: number
   churn_mrr: number
+  lost_plan: RevenuePlanKey | null
 }
 
 export interface BackfillSummary {
@@ -150,6 +153,10 @@ interface RetentionMetricSummaryRow {
   has_global_stats: boolean
   lost_churn_mrr: number | string | null
   lost_contraction_mrr: number | string | null
+  lost_revenue_enterprise_mrr: number | string | null
+  lost_revenue_maker_mrr: number | string | null
+  lost_revenue_solo_mrr: number | string | null
+  lost_revenue_team_mrr: number | string | null
   previous_mrr: number | string | null
   retained_churn_mrr: number | string | null
   retained_contraction_mrr: number | string | null
@@ -163,6 +170,7 @@ interface RevenueMovement {
   expansionMrr: number
   contractionMrr: number
   churnMrr: number
+  lostPlan: RevenuePlanKey | null
 }
 
 interface DailyRevenueChangeSummary {
@@ -178,6 +186,7 @@ const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
   expansionMrr: 0,
   contractionMrr: 0,
   churnMrr: 0,
+  lostPlan: null,
 }
 
 function getArgValue(args: string[], prefix: string): string | null {
@@ -226,7 +235,9 @@ export function getRequiredDatabaseUrl(env: Record<string, string | undefined>) 
     throw new Error(`--apply requires ${DATABASE_URL_ENV_KEYS.join(', ')} so metric writes and processed-event markers are committed atomically`)
 
   try {
-    new URL(value)
+    const parsed = new URL(value)
+    if (!parsed.protocol)
+      throw new Error('Missing URL protocol')
   }
   catch {
     throw new Error(`--apply requires a valid Postgres URL from ${DATABASE_URL_ENV_KEYS.join(', ')}`)
@@ -521,6 +532,29 @@ function getPreviousDateId(dateId: string) {
   return getRevenueMetricDateId(target)
 }
 
+function getPlanKey(name: string | null | undefined): RevenuePlanKey | null {
+  const normalized = name?.toLowerCase()
+  if (normalized === 'solo' || normalized === 'maker' || normalized === 'team' || normalized === 'enterprise')
+    return normalized
+  return null
+}
+
+function createZeroPlanBreakdown(): RevenuePlanBreakdown {
+  return {
+    solo: 0,
+    maker: 0,
+    team: 0,
+    enterprise: 0,
+  }
+}
+
+function getMovementPlanBreakdown(lostPlan: RevenuePlanKey | null, amount: number): RevenuePlanBreakdown {
+  const breakdown = createZeroPlanBreakdown()
+  if (lostPlan && amount > 0)
+    breakdown[lostPlan] = amount
+  return breakdown
+}
+
 function getPlanMrr(plan: RevenuePlanRow | null | undefined, priceId: string | null | undefined) {
   if (!plan || !priceId)
     return 0
@@ -541,11 +575,15 @@ function getPlanByProductId(plans: RevenuePlanRow[], productId: string | null | 
   return plans.find(plan => plan.stripe_id === productId) ?? null
 }
 
-function getSubscriptionMrr(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
+function getSubscriptionPlan(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
   if (stripeInfo?.status !== 'succeeded' || stripeInfo?.is_good_plan === false)
-    return 0
+    return null
 
-  return getPlanMrr(getPlanByProductId(plans, stripeInfo.product_id), stripeInfo.price_id)
+  return getPlanByProductId(plans, stripeInfo.product_id)
+}
+
+function getSubscriptionMrr(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
+  return getPlanMrr(getSubscriptionPlan(plans, stripeInfo), stripeInfo?.price_id)
 }
 
 function classifyRevenueMovement(
@@ -553,8 +591,11 @@ function classifyRevenueMovement(
   nextStripeInfo: StripeInfoRevenueState,
   plans: RevenuePlanRow[],
 ): RevenueMovement {
-  const currentMrr = getSubscriptionMrr(plans, currentStripeInfo)
-  const nextMrr = getSubscriptionMrr(plans, nextStripeInfo)
+  const currentPlan = getSubscriptionPlan(plans, currentStripeInfo)
+  const nextPlan = getSubscriptionPlan(plans, nextStripeInfo)
+  const currentMrr = getPlanMrr(currentPlan, currentStripeInfo?.price_id)
+  const nextMrr = getPlanMrr(nextPlan, nextStripeInfo?.price_id)
+  const lostPlan = getPlanKey(currentPlan?.name)
 
   if (currentMrr === 0 && nextMrr === 0)
     return { ...ZERO_REVENUE_MOVEMENT }
@@ -583,6 +624,7 @@ function classifyRevenueMovement(
       currentMrr,
       nextMrr,
       churnMrr: currentMrr,
+      lostPlan,
     }
   }
 
@@ -601,6 +643,7 @@ function classifyRevenueMovement(
       currentMrr,
       nextMrr,
       contractionMrr: currentMrr - nextMrr,
+      lostPlan,
     }
   }
 
@@ -697,6 +740,7 @@ function toMovementEvent(
     expansion_mrr: movement.expansionMrr,
     contraction_mrr: movement.contractionMrr,
     churn_mrr: movement.churnMrr,
+    lost_plan: movement.lostPlan,
   }
 }
 
@@ -824,6 +868,8 @@ export function aggregateRevenueMovementEvents(movements: BackfillRevenueMovemen
     const key = `${movement.date_id}:${movement.customer_id}`
     const existing = metricsByKey.get(key)
     if (!existing) {
+      const churnBreakdown = getMovementPlanBreakdown(movement.lost_plan, movement.churn_mrr)
+      const contractionBreakdown = getMovementPlanBreakdown(movement.lost_plan, movement.contraction_mrr)
       metricsByKey.set(key, {
         date_id: movement.date_id,
         customer_id: movement.customer_id,
@@ -832,14 +878,32 @@ export function aggregateRevenueMovementEvents(movements: BackfillRevenueMovemen
         expansion_mrr: movement.expansion_mrr,
         contraction_mrr: movement.contraction_mrr,
         churn_mrr: movement.churn_mrr,
+        churn_mrr_solo: churnBreakdown.solo,
+        churn_mrr_maker: churnBreakdown.maker,
+        churn_mrr_team: churnBreakdown.team,
+        churn_mrr_enterprise: churnBreakdown.enterprise,
+        contraction_mrr_solo: contractionBreakdown.solo,
+        contraction_mrr_maker: contractionBreakdown.maker,
+        contraction_mrr_team: contractionBreakdown.team,
+        contraction_mrr_enterprise: contractionBreakdown.enterprise,
       })
       continue
     }
 
+    const churnBreakdown = getMovementPlanBreakdown(movement.lost_plan, movement.churn_mrr)
+    const contractionBreakdown = getMovementPlanBreakdown(movement.lost_plan, movement.contraction_mrr)
     existing.new_business_mrr = Number(existing.new_business_mrr) + movement.new_business_mrr
     existing.expansion_mrr = Number(existing.expansion_mrr) + movement.expansion_mrr
     existing.contraction_mrr = Number(existing.contraction_mrr) + movement.contraction_mrr
     existing.churn_mrr = Number(existing.churn_mrr) + movement.churn_mrr
+    existing.churn_mrr_solo = Number(existing.churn_mrr_solo) + churnBreakdown.solo
+    existing.churn_mrr_maker = Number(existing.churn_mrr_maker) + churnBreakdown.maker
+    existing.churn_mrr_team = Number(existing.churn_mrr_team) + churnBreakdown.team
+    existing.churn_mrr_enterprise = Number(existing.churn_mrr_enterprise) + churnBreakdown.enterprise
+    existing.contraction_mrr_solo = Number(existing.contraction_mrr_solo) + contractionBreakdown.solo
+    existing.contraction_mrr_maker = Number(existing.contraction_mrr_maker) + contractionBreakdown.maker
+    existing.contraction_mrr_team = Number(existing.contraction_mrr_team) + contractionBreakdown.team
+    existing.contraction_mrr_enterprise = Number(existing.contraction_mrr_enterprise) + contractionBreakdown.enterprise
   }
 
   return [...metricsByKey.values()].sort((left, right) => {
@@ -961,7 +1025,7 @@ function getCustomerIdsFromEvents(events: Stripe.Event[], customerId?: string | 
 async function fetchRevenuePlans(supabase: SupabaseClient): Promise<RevenuePlanRow[]> {
   const { data, error } = await supabase
     .from('plans')
-    .select('stripe_id, price_m, price_y, price_m_id, price_y_id')
+    .select('name, stripe_id, price_m, price_y, price_m_id, price_y_id')
     .in('name', ['Solo', 'Maker', 'Team', 'Enterprise'])
 
   if (error)
@@ -1021,6 +1085,14 @@ export function mergeMetricRows(existingRows: DailyRevenueMetricRow[], rowsToAdd
       expansion_mrr: (Number(existing.expansion_mrr) || 0) + (Number(row.expansion_mrr) || 0),
       contraction_mrr: (Number(existing.contraction_mrr) || 0) + (Number(row.contraction_mrr) || 0),
       churn_mrr: (Number(existing.churn_mrr) || 0) + (Number(row.churn_mrr) || 0),
+      churn_mrr_solo: (Number(existing.churn_mrr_solo) || 0) + (Number(row.churn_mrr_solo) || 0),
+      churn_mrr_maker: (Number(existing.churn_mrr_maker) || 0) + (Number(row.churn_mrr_maker) || 0),
+      churn_mrr_team: (Number(existing.churn_mrr_team) || 0) + (Number(row.churn_mrr_team) || 0),
+      churn_mrr_enterprise: (Number(existing.churn_mrr_enterprise) || 0) + (Number(row.churn_mrr_enterprise) || 0),
+      contraction_mrr_solo: (Number(existing.contraction_mrr_solo) || 0) + (Number(row.contraction_mrr_solo) || 0),
+      contraction_mrr_maker: (Number(existing.contraction_mrr_maker) || 0) + (Number(row.contraction_mrr_maker) || 0),
+      contraction_mrr_team: (Number(existing.contraction_mrr_team) || 0) + (Number(row.contraction_mrr_team) || 0),
+      contraction_mrr_enterprise: (Number(existing.contraction_mrr_enterprise) || 0) + (Number(row.contraction_mrr_enterprise) || 0),
     }
   })
 }
@@ -1063,7 +1135,7 @@ async function upsertDailyRevenueMetricsPg(client: PgClient, rows: DailyRevenueM
 
     const values: Array<number | string> = []
     const placeholders = chunk.map((row, index) => {
-      const offset = index * 7
+      const offset = index * 15
       values.push(
         row.date_id,
         row.customer_id,
@@ -1072,8 +1144,16 @@ async function upsertDailyRevenueMetricsPg(client: PgClient, rows: DailyRevenueM
         Number(row.expansion_mrr) || 0,
         Number(row.contraction_mrr) || 0,
         Number(row.churn_mrr) || 0,
+        Number(row.churn_mrr_solo) || 0,
+        Number(row.churn_mrr_maker) || 0,
+        Number(row.churn_mrr_team) || 0,
+        Number(row.churn_mrr_enterprise) || 0,
+        Number(row.contraction_mrr_solo) || 0,
+        Number(row.contraction_mrr_maker) || 0,
+        Number(row.contraction_mrr_team) || 0,
+        Number(row.contraction_mrr_enterprise) || 0,
       )
-      return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7})`
+      return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12}, $${offset + 13}, $${offset + 14}, $${offset + 15})`
     })
 
     const updateClause = mode === 'exact'
@@ -1082,13 +1162,29 @@ async function upsertDailyRevenueMetricsPg(client: PgClient, rows: DailyRevenueM
         new_business_mrr = EXCLUDED.new_business_mrr,
         expansion_mrr = EXCLUDED.expansion_mrr,
         contraction_mrr = EXCLUDED.contraction_mrr,
-        churn_mrr = EXCLUDED.churn_mrr
+        churn_mrr = EXCLUDED.churn_mrr,
+        churn_mrr_solo = EXCLUDED.churn_mrr_solo,
+        churn_mrr_maker = EXCLUDED.churn_mrr_maker,
+        churn_mrr_team = EXCLUDED.churn_mrr_team,
+        churn_mrr_enterprise = EXCLUDED.churn_mrr_enterprise,
+        contraction_mrr_solo = EXCLUDED.contraction_mrr_solo,
+        contraction_mrr_maker = EXCLUDED.contraction_mrr_maker,
+        contraction_mrr_team = EXCLUDED.contraction_mrr_team,
+        contraction_mrr_enterprise = EXCLUDED.contraction_mrr_enterprise
       `
       : `
         new_business_mrr = public.daily_revenue_metrics.new_business_mrr + EXCLUDED.new_business_mrr,
         expansion_mrr = public.daily_revenue_metrics.expansion_mrr + EXCLUDED.expansion_mrr,
         contraction_mrr = public.daily_revenue_metrics.contraction_mrr + EXCLUDED.contraction_mrr,
-        churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr
+        churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr,
+        churn_mrr_solo = public.daily_revenue_metrics.churn_mrr_solo + EXCLUDED.churn_mrr_solo,
+        churn_mrr_maker = public.daily_revenue_metrics.churn_mrr_maker + EXCLUDED.churn_mrr_maker,
+        churn_mrr_team = public.daily_revenue_metrics.churn_mrr_team + EXCLUDED.churn_mrr_team,
+        churn_mrr_enterprise = public.daily_revenue_metrics.churn_mrr_enterprise + EXCLUDED.churn_mrr_enterprise,
+        contraction_mrr_solo = public.daily_revenue_metrics.contraction_mrr_solo + EXCLUDED.contraction_mrr_solo,
+        contraction_mrr_maker = public.daily_revenue_metrics.contraction_mrr_maker + EXCLUDED.contraction_mrr_maker,
+        contraction_mrr_team = public.daily_revenue_metrics.contraction_mrr_team + EXCLUDED.contraction_mrr_team,
+        contraction_mrr_enterprise = public.daily_revenue_metrics.contraction_mrr_enterprise + EXCLUDED.contraction_mrr_enterprise
       `
 
     await client.query(`
@@ -1099,7 +1195,15 @@ async function upsertDailyRevenueMetricsPg(client: PgClient, rows: DailyRevenueM
         new_business_mrr,
         expansion_mrr,
         contraction_mrr,
-        churn_mrr
+        churn_mrr,
+        churn_mrr_solo,
+        churn_mrr_maker,
+        churn_mrr_team,
+        churn_mrr_enterprise,
+        contraction_mrr_solo,
+        contraction_mrr_maker,
+        contraction_mrr_team,
+        contraction_mrr_enterprise
       )
       VALUES ${placeholders.join(', ')}
       ON CONFLICT (date_id, customer_id) DO UPDATE
@@ -1204,7 +1308,11 @@ async function refreshGlobalRetentionMetricsPg(client: PgClient, dateIds: string
         COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN contraction_mrr ELSE 0 END), 0) AS retained_contraction_mrr,
         COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN expansion_mrr ELSE 0 END), 0) AS retained_expansion_mrr,
         COALESCE(SUM(churn_mrr), 0) AS lost_churn_mrr,
-        COALESCE(SUM(contraction_mrr), 0) AS lost_contraction_mrr
+        COALESCE(SUM(contraction_mrr), 0) AS lost_contraction_mrr,
+        COALESCE(SUM(churn_mrr_solo + contraction_mrr_solo), 0) AS lost_revenue_solo_mrr,
+        COALESCE(SUM(churn_mrr_maker + contraction_mrr_maker), 0) AS lost_revenue_maker_mrr,
+        COALESCE(SUM(churn_mrr_team + contraction_mrr_team), 0) AS lost_revenue_team_mrr,
+        COALESCE(SUM(churn_mrr_enterprise + contraction_mrr_enterprise), 0) AS lost_revenue_enterprise_mrr
       FROM public.daily_revenue_metrics
       WHERE date_id = $1
     `, [dateId, getPreviousDateId(dateId)])
@@ -1219,7 +1327,11 @@ async function refreshGlobalRetentionMetricsPg(client: PgClient, dateIds: string
       UPDATE public.global_stats
       SET
         churn_revenue = $2,
-        nrr = $3
+        nrr = $3,
+        churn_revenue_solo = $4,
+        churn_revenue_maker = $5,
+        churn_revenue_team = $6,
+        churn_revenue_enterprise = $7
       WHERE date_id = $1
     `, [
       dateId,
@@ -1233,6 +1345,10 @@ async function refreshGlobalRetentionMetricsPg(client: PgClient, dateIds: string
         contractionMrr: Number(row.retained_contraction_mrr) || 0,
         expansionMrr: Number(row.retained_expansion_mrr) || 0,
       }),
+      Number(row.lost_revenue_solo_mrr) || 0,
+      Number(row.lost_revenue_maker_mrr) || 0,
+      Number(row.lost_revenue_team_mrr) || 0,
+      Number(row.lost_revenue_enterprise_mrr) || 0,
     ])
     updated++
   }

--- a/scripts/backfill_revenue_trend_metrics.ts
+++ b/scripts/backfill_revenue_trend_metrics.ts
@@ -43,6 +43,10 @@ type GlobalStatsRow = Pick<
   Database['public']['Tables']['global_stats']['Row'],
   | 'canceled_orgs'
   | 'churn_revenue'
+  | 'churn_revenue_enterprise'
+  | 'churn_revenue_maker'
+  | 'churn_revenue_solo'
+  | 'churn_revenue_team'
   | 'date_id'
   | 'mrr'
   | 'new_paying_orgs'
@@ -92,12 +96,17 @@ interface RevenueSubscriptionState {
 interface DailyCounters {
   canceledCustomerIds: Set<string>
   churnRevenue: number
+  churnRevenueByPlan: Record<PlanKey, number>
   newCustomerIds: Set<string>
 }
 
 export interface RevenueTrendMetricValues {
   canceled_orgs: number
   churn_revenue: number
+  churn_revenue_enterprise: number
+  churn_revenue_maker: number
+  churn_revenue_solo: number
+  churn_revenue_team: number
   mrr: number
   new_paying_orgs: number
   paying_monthly: number
@@ -195,6 +204,10 @@ function createEmptyMetrics(): RevenueTrendMetricValues {
   return {
     canceled_orgs: 0,
     churn_revenue: 0,
+    churn_revenue_enterprise: 0,
+    churn_revenue_maker: 0,
+    churn_revenue_solo: 0,
+    churn_revenue_team: 0,
     mrr: 0,
     new_paying_orgs: 0,
     paying_monthly: 0,
@@ -468,10 +481,16 @@ function getStateKey(state: Pick<RevenueSubscriptionState, 'subscriptionId'>) {
   return state.subscriptionId
 }
 
-function createDailyCounters() {
+function createDailyCounters(): DailyCounters {
   return {
     canceledCustomerIds: new Set<string>(),
     churnRevenue: 0,
+    churnRevenueByPlan: {
+      solo: 0,
+      maker: 0,
+      team: 0,
+      enterprise: 0,
+    },
     newCustomerIds: new Set<string>(),
   }
 }
@@ -502,11 +521,17 @@ function recordTransition(
   if (currentMrr > 0 && nextMrr <= 0) {
     daily.canceledCustomerIds.add(customerId)
     daily.churnRevenue += currentMrr
+    if (currentState)
+      daily.churnRevenueByPlan[currentState.plan] += currentMrr
     return
   }
 
-  if (currentMrr > nextMrr)
-    daily.churnRevenue += currentMrr - nextMrr
+  if (currentMrr > nextMrr) {
+    const lostMrr = currentMrr - nextMrr
+    daily.churnRevenue += lostMrr
+    if (currentState)
+      daily.churnRevenueByPlan[currentState.plan] += lostMrr
+  }
 }
 
 function applySubscriptionEventToStates(
@@ -632,6 +657,7 @@ function expireStatesForDate(states: Map<string, RevenueSubscriptionState>, date
 
     daily.canceledCustomerIds.add(state.customerId)
     daily.churnRevenue += state.mrr
+    daily.churnRevenueByPlan[state.plan] += state.mrr
     states.delete(getStateKey(state))
   }
 }
@@ -684,6 +710,10 @@ export function summarizeRevenueSnapshot(states: Iterable<RevenueSubscriptionSta
   metrics.new_paying_orgs = daily.newCustomerIds.size
   metrics.canceled_orgs = daily.canceledCustomerIds.size
   metrics.churn_revenue = daily.churnRevenue
+  metrics.churn_revenue_solo = daily.churnRevenueByPlan.solo
+  metrics.churn_revenue_maker = daily.churnRevenueByPlan.maker
+  metrics.churn_revenue_team = daily.churnRevenueByPlan.team
+  metrics.churn_revenue_enterprise = daily.churnRevenueByPlan.enterprise
   metrics.mrr = roundMoney(metrics.mrr)
   metrics.total_revenue = roundMoney(metrics.mrr * 12)
   metrics.revenue_solo = roundMoney(metrics.revenue_solo)
@@ -691,6 +721,10 @@ export function summarizeRevenueSnapshot(states: Iterable<RevenueSubscriptionSta
   metrics.revenue_team = roundMoney(metrics.revenue_team)
   metrics.revenue_enterprise = roundMoney(metrics.revenue_enterprise)
   metrics.churn_revenue = roundMoney(metrics.churn_revenue)
+  metrics.churn_revenue_solo = roundMoney(metrics.churn_revenue_solo)
+  metrics.churn_revenue_maker = roundMoney(metrics.churn_revenue_maker)
+  metrics.churn_revenue_team = roundMoney(metrics.churn_revenue_team)
+  metrics.churn_revenue_enterprise = roundMoney(metrics.churn_revenue_enterprise)
 
   return metrics
 }
@@ -892,7 +926,11 @@ async function fetchGlobalStatsRows(supabase: SupabaseClient, fromDateId: string
         plan_team_yearly,
         plan_enterprise_monthly,
         plan_enterprise_yearly,
-        churn_revenue
+        churn_revenue,
+        churn_revenue_solo,
+        churn_revenue_maker,
+        churn_revenue_team,
+        churn_revenue_enterprise
       `)
       .gte('date_id', fromDateId)
       .lte('date_id', toDateId)
@@ -917,6 +955,10 @@ function toGlobalStatsUpdate(row: RevenueTrendBackfillRow): GlobalStatsUpdate {
   return {
     canceled_orgs: row.canceled_orgs,
     churn_revenue: row.churn_revenue,
+    churn_revenue_enterprise: row.churn_revenue_enterprise,
+    churn_revenue_maker: row.churn_revenue_maker,
+    churn_revenue_solo: row.churn_revenue_solo,
+    churn_revenue_team: row.churn_revenue_team,
     mrr: row.mrr,
     new_paying_orgs: row.new_paying_orgs,
     paying_monthly: row.paying_monthly,
@@ -953,7 +995,7 @@ async function updateGlobalStatsRow(supabase: SupabaseClient, row: RevenueTrendB
 
 function printSampleRows(rows: RevenueTrendBackfillRow[]) {
   for (const row of rows.slice(0, 10)) {
-    console.log(`${row.date_id}: monthly=${row.paying_monthly}, yearly=${row.paying_yearly}, mrr=$${row.mrr.toFixed(2)}, arr=$${row.total_revenue.toFixed(2)}, new=${row.new_paying_orgs}, canceled=${row.canceled_orgs}, churn=$${row.churn_revenue.toFixed(2)}, plans=${row.plan_solo}/${row.plan_maker}/${row.plan_team}/${row.plan_enterprise}`)
+    console.log(`${row.date_id}: monthly=${row.paying_monthly}, yearly=${row.paying_yearly}, mrr=$${row.mrr.toFixed(2)}, arr=$${row.total_revenue.toFixed(2)}, new=${row.new_paying_orgs}, canceled=${row.canceled_orgs}, churn=$${row.churn_revenue.toFixed(2)}, churn_plans=$${row.churn_revenue_solo.toFixed(2)}/$${row.churn_revenue_maker.toFixed(2)}/$${row.churn_revenue_team.toFixed(2)}/$${row.churn_revenue_enterprise.toFixed(2)}, plans=${row.plan_solo}/${row.plan_maker}/${row.plan_team}/${row.plan_enterprise}`)
   }
 }
 

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -52,6 +52,10 @@ const globalStatsTrendData = ref<Array<{
   mrr: number
   nrr: number
   churn_revenue: number
+  churn_revenue_solo: number
+  churn_revenue_maker: number
+  churn_revenue_team: number
+  churn_revenue_enterprise: number
   total_revenue: number
   revenue_solo: number
   revenue_maker: number
@@ -186,16 +190,53 @@ const churnRevenueSeries = computed(() => {
   if (globalStatsTrendData.value.length === 0)
     return []
 
-  return [
+  const totalSeries = {
+    label: 'Total Lost MRR ($)',
+    data: globalStatsTrendData.value.map(item => ({
+      date: item.date,
+      value: item.churn_revenue || 0,
+    })),
+    color: '#ef4444', // red
+  }
+  const planSeries = [
     {
-      label: 'Churn Revenue - Lost MRR ($)',
+      label: 'Solo Lost MRR ($)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
-        value: item.churn_revenue || 0,
+        value: item.churn_revenue_solo || 0,
       })),
-      color: '#ef4444', // red
+      color: '#8b5cf6', // purple
+    },
+    {
+      label: 'Maker Lost MRR ($)',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.churn_revenue_maker || 0,
+      })),
+      color: '#ec4899', // pink
+    },
+    {
+      label: 'Team Lost MRR ($)',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.churn_revenue_team || 0,
+      })),
+      color: '#10b981', // green
+    },
+    {
+      label: 'Enterprise Lost MRR ($)',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.churn_revenue_enterprise || 0,
+      })),
+      color: '#f59e0b', // amber
     },
   ]
+
+  if (planSeries.some(series => series.data.some(point => point.value > 0)))
+    return [totalSeries, ...planSeries]
+
+  return [totalSeries]
 })
 
 const arrSeries = computed(() => {
@@ -590,7 +631,7 @@ displayStore.defaultBack = '/dashboard'
             </ChartCard>
 
             <ChartCard
-              title="Churn Revenue - Lost MRR"
+              title="Churn Revenue - Lost MRR by Plan"
               :is-loading="isLoadingGlobalStatsTrend"
               :has-data="churnRevenueSeries.length > 0"
             >

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -913,7 +913,15 @@ export type Database = {
       daily_revenue_metrics: {
         Row: {
           churn_mrr: number
+          churn_mrr_enterprise: number
+          churn_mrr_maker: number
+          churn_mrr_solo: number
+          churn_mrr_team: number
           contraction_mrr: number
+          contraction_mrr_enterprise: number
+          contraction_mrr_maker: number
+          contraction_mrr_solo: number
+          contraction_mrr_team: number
           created_at: string
           customer_id: string
           date_id: string
@@ -924,7 +932,15 @@ export type Database = {
         }
         Insert: {
           churn_mrr?: number
+          churn_mrr_enterprise?: number
+          churn_mrr_maker?: number
+          churn_mrr_solo?: number
+          churn_mrr_team?: number
           contraction_mrr?: number
+          contraction_mrr_enterprise?: number
+          contraction_mrr_maker?: number
+          contraction_mrr_solo?: number
+          contraction_mrr_team?: number
           created_at?: string
           customer_id: string
           date_id: string
@@ -935,7 +951,15 @@ export type Database = {
         }
         Update: {
           churn_mrr?: number
+          churn_mrr_enterprise?: number
+          churn_mrr_maker?: number
+          churn_mrr_solo?: number
+          churn_mrr_team?: number
           contraction_mrr?: number
+          contraction_mrr_enterprise?: number
+          contraction_mrr_maker?: number
+          contraction_mrr_solo?: number
+          contraction_mrr_team?: number
           created_at?: string
           customer_id?: string
           date_id?: string
@@ -1210,6 +1234,10 @@ export type Database = {
           bundle_storage_gb: number
           canceled_orgs: number
           churn_revenue: number
+          churn_revenue_enterprise: number
+          churn_revenue_maker: number
+          churn_revenue_solo: number
+          churn_revenue_team: number
           created_at: string | null
           credits_bought: number
           credits_consumed: number
@@ -1279,6 +1307,10 @@ export type Database = {
           bundle_storage_gb?: number
           canceled_orgs?: number
           churn_revenue?: number
+          churn_revenue_enterprise?: number
+          churn_revenue_maker?: number
+          churn_revenue_solo?: number
+          churn_revenue_team?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number
@@ -1348,6 +1380,10 @@ export type Database = {
           bundle_storage_gb?: number
           canceled_orgs?: number
           churn_revenue?: number
+          churn_revenue_enterprise?: number
+          churn_revenue_maker?: number
+          churn_revenue_solo?: number
+          churn_revenue_team?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -69,6 +69,10 @@ interface DailyRevenueChangeSummary {
 }
 interface RevenueRetentionMetrics {
   churnRevenue: number
+  churnRevenueSolo: number
+  churnRevenueMaker: number
+  churnRevenueTeam: number
+  churnRevenueEnterprise: number
   nrr: number
 }
 interface GlobalStats {
@@ -485,6 +489,10 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
       retained_expansion_mrr: number
       total_churn_mrr: number
       total_contraction_mrr: number
+      churn_revenue_solo: number
+      churn_revenue_maker: number
+      churn_revenue_team: number
+      churn_revenue_enterprise: number
       previous_mrr: number
     }>(sql`
       WITH daily AS (
@@ -493,8 +501,24 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
           COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN contraction_mrr ELSE 0 END), 0)::float AS retained_contraction_mrr,
           COALESCE(SUM(CASE WHEN opening_mrr > 0 THEN expansion_mrr ELSE 0 END), 0)::float AS retained_expansion_mrr,
           COALESCE(SUM(churn_mrr), 0)::float AS total_churn_mrr,
-          COALESCE(SUM(contraction_mrr), 0)::float AS total_contraction_mrr
-        FROM public.daily_revenue_metrics
+          COALESCE(SUM(contraction_mrr), 0)::float AS total_contraction_mrr,
+          COALESCE(SUM(
+            COALESCE(NULLIF(to_jsonb(drm) ->> 'churn_mrr_solo', '')::float, 0)
+            + COALESCE(NULLIF(to_jsonb(drm) ->> 'contraction_mrr_solo', '')::float, 0)
+          ), 0)::float AS churn_revenue_solo,
+          COALESCE(SUM(
+            COALESCE(NULLIF(to_jsonb(drm) ->> 'churn_mrr_maker', '')::float, 0)
+            + COALESCE(NULLIF(to_jsonb(drm) ->> 'contraction_mrr_maker', '')::float, 0)
+          ), 0)::float AS churn_revenue_maker,
+          COALESCE(SUM(
+            COALESCE(NULLIF(to_jsonb(drm) ->> 'churn_mrr_team', '')::float, 0)
+            + COALESCE(NULLIF(to_jsonb(drm) ->> 'contraction_mrr_team', '')::float, 0)
+          ), 0)::float AS churn_revenue_team,
+          COALESCE(SUM(
+            COALESCE(NULLIF(to_jsonb(drm) ->> 'churn_mrr_enterprise', '')::float, 0)
+            + COALESCE(NULLIF(to_jsonb(drm) ->> 'contraction_mrr_enterprise', '')::float, 0)
+          ), 0)::float AS churn_revenue_enterprise
+        FROM public.daily_revenue_metrics drm
         WHERE date_id = ${dateId}
       ),
       previous_snapshot AS (
@@ -509,6 +533,10 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
         daily.retained_expansion_mrr,
         daily.total_churn_mrr,
         daily.total_contraction_mrr,
+        daily.churn_revenue_solo,
+        daily.churn_revenue_maker,
+        daily.churn_revenue_team,
+        daily.churn_revenue_enterprise,
         COALESCE(previous_snapshot.previous_mrr, 0)::float AS previous_mrr
       FROM daily
       LEFT JOIN previous_snapshot ON true
@@ -529,6 +557,10 @@ async function getRevenueRetentionMetrics(c: Context, dateId: string): Promise<R
 
     return {
       churnRevenue: calculateChurnRevenue(totalLostRevenue),
+      churnRevenueSolo: Number((Number(row?.churn_revenue_solo) || 0).toFixed(2)),
+      churnRevenueMaker: Number((Number(row?.churn_revenue_maker) || 0).toFixed(2)),
+      churnRevenueTeam: Number((Number(row?.churn_revenue_team) || 0).toFixed(2)),
+      churnRevenueEnterprise: Number((Number(row?.churn_revenue_enterprise) || 0).toFixed(2)),
       nrr: calculateNrr(previousMrr, retainedChanges),
     }
   }
@@ -994,6 +1026,10 @@ app.post('/', middlewareAPISecret, async (c) => {
     ...(retention_metrics
       ? {
           churn_revenue: retention_metrics.churnRevenue,
+          churn_revenue_solo: retention_metrics.churnRevenueSolo,
+          churn_revenue_maker: retention_metrics.churnRevenueMaker,
+          churn_revenue_team: retention_metrics.churnRevenueTeam,
+          churn_revenue_enterprise: retention_metrics.churnRevenueEnterprise,
           nrr: retention_metrics.nrr,
         }
       : {}),

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -37,7 +37,9 @@ type StripeInfoRevenueState = {
   product_id?: string | null
   status?: Database['public']['Enums']['stripe_status'] | null
 } | null | undefined
-type RevenuePlanRow = Pick<PlanRow, 'price_m' | 'price_m_id' | 'price_y' | 'price_y_id' | 'stripe_id'>
+type RevenuePlanRow = Pick<PlanRow, 'name' | 'price_m' | 'price_m_id' | 'price_y' | 'price_y_id' | 'stripe_id'>
+type RevenuePlanKey = 'solo' | 'maker' | 'team' | 'enterprise'
+type RevenuePlanBreakdown = Record<RevenuePlanKey, number>
 
 interface RevenueMovement {
   currentMrr: number
@@ -46,6 +48,7 @@ interface RevenueMovement {
   expansionMrr: number
   contractionMrr: number
   churnMrr: number
+  lostPlan: RevenuePlanKey | null
 }
 
 type PersistRevenueMovementResult = 'applied' | 'duplicate' | 'missing' | 'stale'
@@ -57,6 +60,7 @@ const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
   expansionMrr: 0,
   contractionMrr: 0,
   churnMrr: 0,
+  lostPlan: null,
 }
 const STRIPE_INFO_TRANSACTION_COLUMNS = [
   'bandwidth_exceeded',
@@ -182,6 +186,29 @@ function getEventDateId(eventOccurredAtIso: string) {
   return new Date(eventOccurredAtIso).toISOString().slice(0, 10)
 }
 
+function getPlanKey(name: string | null | undefined): RevenuePlanKey | null {
+  const normalized = name?.toLowerCase()
+  if (normalized === 'solo' || normalized === 'maker' || normalized === 'team' || normalized === 'enterprise')
+    return normalized
+  return null
+}
+
+function createZeroPlanBreakdown(): RevenuePlanBreakdown {
+  return {
+    solo: 0,
+    maker: 0,
+    team: 0,
+    enterprise: 0,
+  }
+}
+
+function getMovementPlanBreakdown(movement: RevenueMovement, amount: number): RevenuePlanBreakdown {
+  const breakdown = createZeroPlanBreakdown()
+  if (movement.lostPlan && amount > 0)
+    breakdown[movement.lostPlan] = amount
+  return breakdown
+}
+
 function getPlanMrr(plan: RevenuePlanRow | null | undefined, priceId: string | null | undefined) {
   if (!plan || !priceId)
     return 0
@@ -202,11 +229,15 @@ function getPlanByProductId(plans: RevenuePlanRow[], productId: string | null | 
   return plans.find(plan => plan.stripe_id === productId) ?? null
 }
 
-function getSubscriptionMrr(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
+function getSubscriptionPlan(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
   if (!stripeInfo || stripeInfo.status !== 'succeeded' || stripeInfo.is_good_plan === false)
-    return 0
+    return null
 
-  return getPlanMrr(getPlanByProductId(plans, stripeInfo.product_id), stripeInfo.price_id)
+  return getPlanByProductId(plans, stripeInfo.product_id)
+}
+
+function getSubscriptionMrr(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
+  return getPlanMrr(getSubscriptionPlan(plans, stripeInfo), stripeInfo?.price_id)
 }
 
 function classifyRevenueMovement(
@@ -214,8 +245,11 @@ function classifyRevenueMovement(
   nextStripeInfo: StripeInfoRevenueState,
   plans: RevenuePlanRow[],
 ): RevenueMovement {
-  const currentMrr = getSubscriptionMrr(plans, currentStripeInfo)
-  const nextMrr = getSubscriptionMrr(plans, nextStripeInfo)
+  const currentPlan = getSubscriptionPlan(plans, currentStripeInfo)
+  const nextPlan = getSubscriptionPlan(plans, nextStripeInfo)
+  const currentMrr = getPlanMrr(currentPlan, currentStripeInfo?.price_id)
+  const nextMrr = getPlanMrr(nextPlan, nextStripeInfo?.price_id)
+  const lostPlan = getPlanKey(currentPlan?.name)
 
   if (currentMrr === 0 && nextMrr === 0)
     return { ...ZERO_REVENUE_MOVEMENT }
@@ -244,6 +278,7 @@ function classifyRevenueMovement(
       currentMrr,
       nextMrr,
       churnMrr: currentMrr,
+      lostPlan,
     }
   }
 
@@ -262,6 +297,7 @@ function classifyRevenueMovement(
       currentMrr,
       nextMrr,
       contractionMrr: currentMrr - nextMrr,
+      lostPlan,
     }
   }
 
@@ -299,7 +335,7 @@ function isStaleStripeEvent(
 async function getRevenuePlans(c: Context): Promise<RevenuePlanRow[]> {
   const { data: plans, error } = await supabaseAdmin(c)
     .from('plans')
-    .select('stripe_id, price_m, price_y, price_m_id, price_y_id')
+    .select('name, stripe_id, price_m, price_y, price_m_id, price_y_id')
     .in('name', ['Solo', 'Maker', 'Team', 'Enterprise'])
 
   if (error) {
@@ -404,6 +440,8 @@ async function persistStripeInfoAndRevenueMovement(
     }
 
     if (shouldRecordMovement) {
+      const churnBreakdown = getMovementPlanBreakdown(movement, movement.churnMrr)
+      const contractionBreakdown = getMovementPlanBreakdown(movement, movement.contractionMrr)
       await pgClient.query(`
         INSERT INTO public.daily_revenue_metrics (
           date_id,
@@ -412,16 +450,32 @@ async function persistStripeInfoAndRevenueMovement(
           new_business_mrr,
           expansion_mrr,
           contraction_mrr,
-          churn_mrr
+          churn_mrr,
+          churn_mrr_solo,
+          churn_mrr_maker,
+          churn_mrr_team,
+          churn_mrr_enterprise,
+          contraction_mrr_solo,
+          contraction_mrr_maker,
+          contraction_mrr_team,
+          contraction_mrr_enterprise
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         ON CONFLICT (date_id, customer_id)
         DO UPDATE SET
           updated_at = now(),
           new_business_mrr = public.daily_revenue_metrics.new_business_mrr + EXCLUDED.new_business_mrr,
           expansion_mrr = public.daily_revenue_metrics.expansion_mrr + EXCLUDED.expansion_mrr,
           contraction_mrr = public.daily_revenue_metrics.contraction_mrr + EXCLUDED.contraction_mrr,
-          churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr
+          churn_mrr = public.daily_revenue_metrics.churn_mrr + EXCLUDED.churn_mrr,
+          churn_mrr_solo = public.daily_revenue_metrics.churn_mrr_solo + EXCLUDED.churn_mrr_solo,
+          churn_mrr_maker = public.daily_revenue_metrics.churn_mrr_maker + EXCLUDED.churn_mrr_maker,
+          churn_mrr_team = public.daily_revenue_metrics.churn_mrr_team + EXCLUDED.churn_mrr_team,
+          churn_mrr_enterprise = public.daily_revenue_metrics.churn_mrr_enterprise + EXCLUDED.churn_mrr_enterprise,
+          contraction_mrr_solo = public.daily_revenue_metrics.contraction_mrr_solo + EXCLUDED.contraction_mrr_solo,
+          contraction_mrr_maker = public.daily_revenue_metrics.contraction_mrr_maker + EXCLUDED.contraction_mrr_maker,
+          contraction_mrr_team = public.daily_revenue_metrics.contraction_mrr_team + EXCLUDED.contraction_mrr_team,
+          contraction_mrr_enterprise = public.daily_revenue_metrics.contraction_mrr_enterprise + EXCLUDED.contraction_mrr_enterprise
       `, [
         getEventDateId(eventOccurredAtIso),
         customerId,
@@ -430,6 +484,14 @@ async function persistStripeInfoAndRevenueMovement(
         movement.expansionMrr,
         movement.contractionMrr,
         movement.churnMrr,
+        churnBreakdown.solo,
+        churnBreakdown.maker,
+        churnBreakdown.team,
+        churnBreakdown.enterprise,
+        contractionBreakdown.solo,
+        contractionBreakdown.maker,
+        contractionBreakdown.team,
+        contractionBreakdown.enterprise,
       ])
     }
 
@@ -1074,6 +1136,7 @@ export const stripeEventTestUtils = {
   buildSubscriptionEventMetadata,
   classifyRevenueMovement,
   getEventDateId,
+  getMovementPlanBreakdown,
   getPaidAtUpdate,
   getPlanChangeTrackingEventName,
   getSubscriptionMrr,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1114,6 +1114,10 @@ export interface AdminGlobalStatsTrend {
   mrr: number
   nrr: number
   churn_revenue: number
+  churn_revenue_solo: number
+  churn_revenue_maker: number
+  churn_revenue_team: number
+  churn_revenue_enterprise: number
   total_revenue: number
   revenue_solo: number
   revenue_maker: number
@@ -1192,6 +1196,10 @@ export async function getAdminGlobalStatsTrend(
         mrr::float,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'nrr', '')::float, 100)::float AS nrr,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'churn_revenue', '')::float, 0)::float AS churn_revenue,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'churn_revenue_solo', '')::float, 0)::float AS churn_revenue_solo,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'churn_revenue_maker', '')::float, 0)::float AS churn_revenue_maker,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'churn_revenue_team', '')::float, 0)::float AS churn_revenue_team,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'churn_revenue_enterprise', '')::float, 0)::float AS churn_revenue_enterprise,
         total_revenue::float,
         revenue_solo::float,
         revenue_maker::float,
@@ -1286,6 +1294,10 @@ export async function getAdminGlobalStatsTrend(
       mrr: Number(row.mrr) || 0,
       nrr: Number(row.nrr) || 0,
       churn_revenue: Number(row.churn_revenue) || 0,
+      churn_revenue_solo: Number(row.churn_revenue_solo) || 0,
+      churn_revenue_maker: Number(row.churn_revenue_maker) || 0,
+      churn_revenue_team: Number(row.churn_revenue_team) || 0,
+      churn_revenue_enterprise: Number(row.churn_revenue_enterprise) || 0,
       total_revenue: Number(row.total_revenue) || 0,
       revenue_solo: Number(row.revenue_solo) || 0,
       revenue_maker: Number(row.revenue_maker) || 0,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -913,7 +913,15 @@ export type Database = {
       daily_revenue_metrics: {
         Row: {
           churn_mrr: number
+          churn_mrr_enterprise: number
+          churn_mrr_maker: number
+          churn_mrr_solo: number
+          churn_mrr_team: number
           contraction_mrr: number
+          contraction_mrr_enterprise: number
+          contraction_mrr_maker: number
+          contraction_mrr_solo: number
+          contraction_mrr_team: number
           created_at: string
           customer_id: string
           date_id: string
@@ -924,7 +932,15 @@ export type Database = {
         }
         Insert: {
           churn_mrr?: number
+          churn_mrr_enterprise?: number
+          churn_mrr_maker?: number
+          churn_mrr_solo?: number
+          churn_mrr_team?: number
           contraction_mrr?: number
+          contraction_mrr_enterprise?: number
+          contraction_mrr_maker?: number
+          contraction_mrr_solo?: number
+          contraction_mrr_team?: number
           created_at?: string
           customer_id: string
           date_id: string
@@ -935,7 +951,15 @@ export type Database = {
         }
         Update: {
           churn_mrr?: number
+          churn_mrr_enterprise?: number
+          churn_mrr_maker?: number
+          churn_mrr_solo?: number
+          churn_mrr_team?: number
           contraction_mrr?: number
+          contraction_mrr_enterprise?: number
+          contraction_mrr_maker?: number
+          contraction_mrr_solo?: number
+          contraction_mrr_team?: number
           created_at?: string
           customer_id?: string
           date_id?: string
@@ -1210,6 +1234,10 @@ export type Database = {
           bundle_storage_gb: number
           canceled_orgs: number
           churn_revenue: number
+          churn_revenue_enterprise: number
+          churn_revenue_maker: number
+          churn_revenue_solo: number
+          churn_revenue_team: number
           created_at: string | null
           credits_bought: number
           credits_consumed: number
@@ -1279,6 +1307,10 @@ export type Database = {
           bundle_storage_gb?: number
           canceled_orgs?: number
           churn_revenue?: number
+          churn_revenue_enterprise?: number
+          churn_revenue_maker?: number
+          churn_revenue_solo?: number
+          churn_revenue_team?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number
@@ -1348,6 +1380,10 @@ export type Database = {
           bundle_storage_gb?: number
           canceled_orgs?: number
           churn_revenue?: number
+          churn_revenue_enterprise?: number
+          churn_revenue_maker?: number
+          churn_revenue_solo?: number
+          churn_revenue_team?: number
           created_at?: string | null
           credits_bought?: number
           credits_consumed?: number

--- a/supabase/migrations/20260506101503_add_churn_revenue_plan_breakdown.sql
+++ b/supabase/migrations/20260506101503_add_churn_revenue_plan_breakdown.sql
@@ -1,0 +1,53 @@
+ALTER TABLE public.daily_revenue_metrics
+ADD COLUMN IF NOT EXISTS churn_mrr_solo
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_mrr_maker
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_mrr_team
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_mrr_enterprise
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS contraction_mrr_solo
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS contraction_mrr_maker
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS contraction_mrr_team
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS contraction_mrr_enterprise
+double precision DEFAULT 0 NOT NULL;
+
+COMMENT ON COLUMN public.daily_revenue_metrics.churn_mrr_solo IS
+'Solo plan MRR fully lost to churn on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.churn_mrr_maker IS
+'Maker plan MRR fully lost to churn on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.churn_mrr_team IS
+'Team plan MRR fully lost to churn on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.churn_mrr_enterprise IS
+'Enterprise plan MRR fully lost to churn on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.contraction_mrr_solo IS
+'Solo plan MRR lost to downgrades on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.contraction_mrr_maker IS
+'Maker plan MRR lost to downgrades on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.contraction_mrr_team IS
+'Team plan MRR lost to downgrades on the day.';
+COMMENT ON COLUMN public.daily_revenue_metrics.contraction_mrr_enterprise IS
+'Enterprise plan MRR lost to downgrades on the day.';
+
+ALTER TABLE public.global_stats
+ADD COLUMN IF NOT EXISTS churn_revenue_solo
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_revenue_maker
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_revenue_team
+double precision DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS churn_revenue_enterprise
+double precision DEFAULT 0 NOT NULL;
+
+COMMENT ON COLUMN public.global_stats.churn_revenue_solo IS
+'Solo plan MRR lost to churn and downgrades on the day.';
+COMMENT ON COLUMN public.global_stats.churn_revenue_maker IS
+'Maker plan MRR lost to churn and downgrades on the day.';
+COMMENT ON COLUMN public.global_stats.churn_revenue_team IS
+'Team plan MRR lost to churn and downgrades on the day.';
+COMMENT ON COLUMN public.global_stats.churn_revenue_enterprise IS
+'Enterprise plan MRR lost to churn and downgrades on the day.';

--- a/tests/backfill-retention-metrics.unit.test.ts
+++ b/tests/backfill-retention-metrics.unit.test.ts
@@ -4,6 +4,7 @@ import { aggregateRevenueMovementEvents, buildRevenueMovementEvents, fetchStripe
 
 const plans = [
   {
+    name: 'Solo',
     stripe_id: 'prod_solo',
     price_m: 12,
     price_m_id: 'price_solo_monthly',
@@ -11,6 +12,7 @@ const plans = [
     price_y_id: 'price_solo_yearly',
   },
   {
+    name: 'Team',
     stripe_id: 'prod_team',
     price_m: 49,
     price_m_id: 'price_team_monthly',
@@ -200,6 +202,7 @@ describe('retention metric backfill helpers', () => {
       current_mrr: 39,
       next_mrr: 0,
       churn_mrr: 39,
+      lost_plan: 'team',
     })
   })
 
@@ -235,6 +238,14 @@ describe('retention metric backfill helpers', () => {
         expansion_mrr: 37,
         contraction_mrr: 0,
         churn_mrr: 49,
+        churn_mrr_solo: 0,
+        churn_mrr_maker: 0,
+        churn_mrr_team: 49,
+        churn_mrr_enterprise: 0,
+        contraction_mrr_solo: 0,
+        contraction_mrr_maker: 0,
+        contraction_mrr_team: 0,
+        contraction_mrr_enterprise: 0,
       },
     ])
     expect(summarizeDailyRevenueMetrics(rows)).toMatchObject({
@@ -268,6 +279,7 @@ describe('retention metric backfill helpers', () => {
       new_business_mrr: 0,
       expansion_mrr: 0,
       churn_mrr: 12,
+      lost_plan: 'solo',
     })
   })
 
@@ -315,6 +327,7 @@ describe('retention metric backfill helpers', () => {
         expansion_mrr: 0,
         contraction_mrr: 0,
         churn_mrr: 0,
+        lost_plan: null,
       },
     ], ['evt_known', 'evt_missing'])
 
@@ -458,6 +471,7 @@ describe('retention metric backfill helpers', () => {
     expect(result.movements[0]).toMatchObject({
       event_id: 'evt_deleted',
       churn_mrr: 49,
+      lost_plan: 'team',
     })
   })
 })

--- a/tests/backfill-revenue-trend-metrics.unit.test.ts
+++ b/tests/backfill-revenue-trend-metrics.unit.test.ts
@@ -17,6 +17,10 @@ function globalStatsRow(dateId: string) {
   return {
     canceled_orgs: 0,
     churn_revenue: 0,
+    churn_revenue_enterprise: 0,
+    churn_revenue_maker: 0,
+    churn_revenue_solo: 0,
+    churn_revenue_team: 0,
     date_id: dateId,
     mrr: 0,
     new_paying_orgs: 0,
@@ -155,6 +159,7 @@ describe('revenue trend backfill metrics', () => {
     expect(rows[1]).toMatchObject({
       canceled_orgs: 1,
       churn_revenue: 12,
+      churn_revenue_solo: 12,
       mrr: 0,
       new_paying_orgs: 0,
       paying_monthly: 0,
@@ -281,6 +286,7 @@ describe('revenue trend backfill metrics', () => {
     expect(rows[0]).toMatchObject({
       canceled_orgs: 0,
       churn_revenue: 37,
+      churn_revenue_team: 37,
       mrr: 12,
       plan_solo: 1,
       plan_team: 0,
@@ -337,6 +343,7 @@ describe('revenue trend backfill metrics', () => {
     expect(rows[2]).toMatchObject({
       canceled_orgs: 1,
       churn_revenue: 49,
+      churn_revenue_team: 49,
       mrr: 0,
       plan_team: 0,
     })

--- a/tests/stripe-revenue-movement.unit.test.ts
+++ b/tests/stripe-revenue-movement.unit.test.ts
@@ -3,6 +3,7 @@ import { stripeEventTestUtils } from '../supabase/functions/_backend/triggers/st
 
 const plans = [
   {
+    name: 'Solo',
     stripe_id: 'prod_solo',
     price_m: 12,
     price_m_id: 'price_solo_monthly',
@@ -10,6 +11,7 @@ const plans = [
     price_y_id: 'price_solo_yearly',
   },
   {
+    name: 'Team',
     stripe_id: 'prod_team',
     price_m: 49,
     price_m_id: 'price_team_monthly',
@@ -147,6 +149,7 @@ describe('stripe revenue movement classification', () => {
       newBusinessMrr: 0,
       expansionMrr: 0,
       churnMrr: 0,
+      lostPlan: 'team',
     })
   })
 
@@ -174,6 +177,7 @@ describe('stripe revenue movement classification', () => {
       newBusinessMrr: 0,
       expansionMrr: 0,
       contractionMrr: 0,
+      lostPlan: 'team',
     })
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- Added plan-level churn revenue storage for daily retention metrics and global admin snapshots.
- Updated Stripe webhook tracking, Logsnag admin snapshots, admin stats API, and backfill scripts to preserve Solo/Maker/Team/Enterprise lost MRR.
- Updated the admin revenue chart to show total lost MRR plus per-plan lines when plan breakdown data exists.

## Motivation (AI generated)

The admin Churn Revenue chart showed total lost MRR but did not explain which plans contributed to churn or downgrade losses. Plan-level breakdown makes revenue retention review more actionable.

## Business Impact (AI generated)

This improves admin revenue diagnostics by showing whether churn is concentrated in low-touch plans or higher-value plans, helping prioritize retention and pricing work.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `sqlfluff lint --dialect postgres supabase/migrations/20260506101503_add_churn_revenue_plan_breakdown.sql`
- [x] `bunx eslint --no-ignore scripts/backfill_retention_metrics.ts scripts/backfill_revenue_trend_metrics.ts tests/backfill-retention-metrics.unit.test.ts tests/backfill-revenue-trend-metrics.unit.test.ts tests/stripe-revenue-movement.unit.test.ts`
- [x] `bunx vitest run tests/stripe-revenue-movement.unit.test.ts tests/logsnag-insights-revenue.unit.test.ts tests/backfill-retention-metrics.unit.test.ts tests/backfill-revenue-trend-metrics.unit.test.ts`
- [x] `bun typecheck`
- [x] `bun run build`

Generated with AI