### PR TITLE
fix(auth): simplify auth page framing

### DIFF
--- a/src/components/auth/pageStyles.ts
+++ b/src/components/auth/pageStyles.ts
@@ -1,5 +1,5 @@
 export const authPrimaryButtonClass = [
-  'inline-flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-4 text-base font-semibold text-white',
+  'inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-4 text-base font-semibold text-white',
   'bg-[linear-gradient(135deg,rgba(36,67,102,1)_0%,rgba(12,110,184,1)_100%)] shadow-[0_20px_38px_-26px_rgba(17,158,255,0.85)]',
   'transition duration-200 hover:-translate-y-0.5 hover:brightness-105',
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
@@ -7,7 +7,7 @@ export const authPrimaryButtonClass = [
 ].join(' ')
 
 export const authSecondaryButtonClass = [
-  'inline-flex w-full items-center justify-center rounded-2xl border border-slate-400/55 bg-white/92 px-4 py-4 text-base font-semibold text-slate-700',
+  'inline-flex w-full items-center justify-center rounded-xl border border-slate-400/55 bg-white/92 px-4 py-4 text-base font-semibold text-slate-700',
   'transition duration-200 hover:border-[rgba(17,158,255,0.45)] hover:bg-slate-100/95',
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
   'dark:border-slate-600/90 dark:bg-slate-950/85 dark:text-slate-200 dark:hover:bg-slate-800/95',
@@ -15,7 +15,7 @@ export const authSecondaryButtonClass = [
 ].join(' ')
 
 export const authInlineLinkClass = [
-  'inline-flex items-center justify-center gap-1 border-none bg-transparent p-0 text-[0.95rem] font-semibold text-[rgb(255,114,17)]',
+  'inline-flex min-h-6 items-center justify-center gap-1 border-none bg-transparent p-0 text-[0.95rem] font-semibold text-[rgb(255,114,17)]',
   'transition-colors duration-200 hover:text-[rgb(235,94,0)]',
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
 ].join(' ')
@@ -26,6 +26,6 @@ export const authGhostButtonClass = [
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
 ].join(' ')
 
-export const authPanelClass = 'border-t border-slate-200/80 pt-4 text-center dark:border-slate-700 sm:rounded-2xl sm:border sm:bg-slate-50/80 sm:px-4 sm:py-4 sm:dark:bg-slate-900/70'
+export const authPanelClass = 'flex flex-wrap items-center justify-center gap-x-2 gap-y-1 border-t border-slate-200/70 pt-4 text-center text-sm dark:border-slate-700/80'
 
-export const authInsetCardClass = 'overflow-hidden rounded-xl sm:rounded-2xl sm:border sm:border-slate-200/80 sm:bg-white/70 sm:p-4 sm:shadow-[0_18px_40px_-34px_rgba(15,23,42,0.45)] sm:dark:border-slate-700/80 sm:dark:bg-slate-950/55'
+export const authInsetCardClass = 'overflow-hidden rounded-xl border border-slate-200/75 bg-slate-50/80 p-3 dark:border-slate-700/80 dark:bg-slate-900/65'

--- a/src/pages/delete_account.vue
+++ b/src/pages/delete_account.vue
@@ -8,7 +8,7 @@ import { toast } from 'vue-sonner'
 import VueTurnstile from 'vue-turnstile'
 import iconEmail from '~icons/oui/email?raw'
 import iconPassword from '~icons/ph/key?raw'
-import { authGhostButtonClass, authInsetCardClass, authPanelClass, authPrimaryButtonClass, authSecondaryButtonClass } from '~/components/auth/pageStyles'
+import { authGhostButtonClass, authPanelClass, authPrimaryButtonClass, authSecondaryButtonClass } from '~/components/auth/pageStyles'
 import { getRecentEmailOtpVerification } from '~/services/emailOtp'
 import { hideLoader } from '~/services/loader'
 import { useSupabase } from '~/services/supabase'
@@ -251,8 +251,7 @@ onMounted (() => {
 
     <div
       v-else-if="isDeleteBlocked"
-      class="border-amber-200/80 bg-amber-50/90 text-amber-900 dark:border-amber-700/70 dark:bg-amber-900/25 dark:text-amber-100"
-      :class="authInsetCardClass"
+      class="overflow-hidden rounded-xl border border-amber-200/80 bg-amber-50/90 p-3 text-amber-900 dark:border-amber-700/70 dark:bg-amber-900/25 dark:text-amber-100"
     >
       <p class="font-semibold">
         {{ t('email-not-verified') }}
@@ -306,7 +305,7 @@ onMounted (() => {
           />
         </div>
 
-        <div v-if="captchaKey" :class="authInsetCardClass">
+        <div v-if="captchaKey" class="space-y-2 overflow-hidden">
           <label class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200">
             {{ t('captcha') }}
           </label>

--- a/src/pages/forgot_password.vue
+++ b/src/pages/forgot_password.vue
@@ -8,7 +8,7 @@ import { toast } from 'vue-sonner'
 import VueTurnstile from 'vue-turnstile'
 import iconEmail from '~icons/oui/email?raw'
 import iconPassword from '~icons/ph/key?raw'
-import { authGhostButtonClass, authInsetCardClass, authPanelClass, authPrimaryButtonClass } from '~/components/auth/pageStyles'
+import { authGhostButtonClass, authPanelClass, authPrimaryButtonClass } from '~/components/auth/pageStyles'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -230,7 +230,7 @@ watchEffect(() => {
           />
         </div>
 
-        <div v-if="step === 1 && captchaKey" :class="authInsetCardClass">
+        <div v-if="step === 1 && captchaKey" class="overflow-hidden">
           <VueTurnstile v-model="turnstileToken" size="flexible" :site-key="captchaKey" />
         </div>
 

--- a/src/pages/invitation.vue
+++ b/src/pages/invitation.vue
@@ -262,7 +262,7 @@ function openPrivacy() {
         </div>
       </div>
 
-      <div v-if="captchaKey" :class="authInsetCardClass">
+      <div v-if="captchaKey" class="overflow-hidden">
         <VueTurnstile ref="captchaComponent" v-model="turnstileToken" size="flexible" :site-key="captchaKey" />
       </div>
 

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -71,29 +71,25 @@ const authCardShellClass = [
   'sm:dark:border-slate-600/70 sm:dark:bg-[linear-gradient(180deg,rgba(15,23,42,0.88)_0%,rgba(15,23,42,0.7)_100%)]',
 ].join(' ')
 const authCardHeaderClass = 'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between'
-const authStepCardClass = [
-  'min-w-0',
-  'sm:overflow-hidden sm:rounded-3xl sm:border sm:border-slate-200/75 sm:bg-white/88 sm:shadow-[0_26px_60px_-40px_rgba(15,23,42,0.42)]',
-  'sm:dark:border-slate-600/70 sm:dark:bg-slate-950/80',
-].join(' ')
-const authCardBodyClass = 'py-1 sm:p-7'
-const authPanelClass = 'border-t border-slate-200/80 pt-4 text-center dark:border-slate-700 sm:rounded-2xl sm:border sm:bg-slate-50/80 sm:px-4 sm:py-4 sm:dark:bg-slate-900/70'
+const authStepCardClass = 'min-w-0'
+const authCardBodyClass = 'py-1'
+const authPanelClass = 'flex flex-wrap items-center justify-center gap-x-2 gap-y-1 border-t border-slate-200/70 pt-4 text-center text-sm dark:border-slate-700/80'
 const authPrimaryButtonClass = [
-  'inline-flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-4 text-base font-semibold text-white',
+  'inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-4 text-base font-semibold text-white',
   'bg-[linear-gradient(135deg,rgba(36,67,102,1)_0%,rgba(12,110,184,1)_100%)] shadow-[0_20px_38px_-26px_rgba(17,158,255,0.85)]',
   'transition duration-200 hover:-translate-y-0.5 hover:brightness-105',
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
   'disabled:pointer-events-none disabled:opacity-60',
 ].join(' ')
 const authSecondaryButtonClass = [
-  'inline-flex w-full items-center justify-center rounded-2xl border border-slate-400/55 bg-white/92 px-4 py-4 text-base font-semibold text-slate-700',
+  'inline-flex w-full items-center justify-center rounded-xl border border-slate-400/55 bg-white/92 px-4 py-4 text-base font-semibold text-slate-700',
   'transition duration-200 hover:border-[rgba(17,158,255,0.45)] hover:bg-slate-100/95',
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
   'dark:border-slate-600/90 dark:bg-slate-950/85 dark:text-slate-200 dark:hover:bg-slate-800/95',
   'disabled:pointer-events-none disabled:opacity-60',
 ].join(' ')
 const authInlineLinkClass = [
-  'inline-flex items-center justify-center gap-1 border-none bg-transparent p-0 text-[0.95rem] font-semibold text-[rgb(255,114,17)]',
+  'inline-flex min-h-6 items-center justify-center gap-1 border-none bg-transparent p-0 text-[0.95rem] font-semibold text-[rgb(255,114,17)]',
   'transition-colors duration-200 hover:text-[rgb(235,94,0)]',
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
 ].join(' ')
@@ -778,18 +774,16 @@ onMounted(checkLogin)
                       </div>
 
                       <div :class="authPanelClass">
-                        <p class="text-xs font-semibold tracking-[0.2em] text-slate-400 uppercase dark:text-slate-500">
-                          {{ t('login-auth-kicker') }}
-                        </p>
-                        <div class="mt-3">
-                          <a
-                            :href="registerUrl"
-                            data-test="register"
-                            :class="authInlineLinkClass"
-                          >
-                            {{ t('create-a-free-account') }}
-                          </a>
-                        </div>
+                        <span class="text-slate-500 dark:text-slate-400">
+                          {{ t('dont-have-an-account') }}
+                        </span>
+                        <a
+                          :href="registerUrl"
+                          data-test="register"
+                          :class="authInlineLinkClass"
+                        >
+                          {{ t('create-a-free-account') }}
+                        </a>
                       </div>
                     </div>
                   </FormKit>
@@ -841,7 +835,7 @@ onMounted(checkLogin)
                     </div>
                     <div class="text-center">
                       <button type="button" data-test="back-to-email" class="appearance-none" :class="authInlineLinkClass" @click="goBackToEmail">
-                        ← {{ t('go-back') }}
+                        {{ t('go-back') }}
                       </button>
                     </div>
                   </div>
@@ -928,29 +922,23 @@ onMounted(checkLogin)
                         </div>
 
                         <div :class="authPanelClass">
-                          <div>
-                            <button type="button" data-test="back-to-email" class="appearance-none" :class="authInlineLinkClass" @click="goBackToEmail">
-                              ← {{ t('go-back') }}
-                            </button>
-                          </div>
-                          <div class="mt-3">
-                            <a
-                              :href="registerUrl"
-                              data-test="register"
-                              :class="authInlineLinkClass"
-                            >
-                              {{ t('create-a-free-account') }}
-                            </a>
-                          </div>
-                          <div class="mt-3">
-                            <router-link
-                              to="/forgot_password"
-                              data-test="forgot-password"
-                              :class="authInlineLinkClass"
-                            >
-                              {{ t('forgot') }} {{ t('password') }} ?
-                            </router-link>
-                          </div>
+                          <button type="button" data-test="back-to-email" class="appearance-none" :class="authInlineLinkClass" @click="goBackToEmail">
+                            {{ t('go-back') }}
+                          </button>
+                          <a
+                            :href="registerUrl"
+                            data-test="register"
+                            :class="authInlineLinkClass"
+                          >
+                            {{ t('create-a-free-account') }}
+                          </a>
+                          <router-link
+                            to="/forgot_password"
+                            data-test="forgot-password"
+                            :class="authInlineLinkClass"
+                          >
+                            {{ t('forgot') }} {{ t('password') }} ?
+                          </router-link>
                         </div>
                       </div>
                     </FormKit>
@@ -999,7 +987,6 @@ onMounted(checkLogin)
                       </div>
 
                       <div :class="authPanelClass">
-                        <p class="text-base text-slate-600 dark:text-slate-300" />
                         <button type="button" class="appearance-none" :class="authInlineLinkClass" @click="goback">
                           {{ t('go-back') }}
                         </button>

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -8,7 +8,7 @@ import VueTurnstile from 'vue-turnstile'
 import iconEmail from '~icons/oui/email?raw'
 import iconPassword from '~icons/ph/key?raw'
 import iconName from '~icons/ph/user?raw'
-import { authGhostButtonClass, authInlineLinkClass, authInsetCardClass, authPanelClass, authPrimaryButtonClass } from '~/components/auth/pageStyles'
+import { authGhostButtonClass, authInlineLinkClass, authPanelClass, authPrimaryButtonClass } from '~/components/auth/pageStyles'
 import { hashEmail, useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 
@@ -152,10 +152,8 @@ async function submit(form: { first_name: string, last_name: string, password: s
           :validation-label="t('password-confirmatio')"
         />
 
-        <div v-if="captchaKey" class="md:col-span-2">
-          <div :class="authInsetCardClass">
-            <VueTurnstile v-model="turnstileToken" size="flexible" :site-key="captchaKey" />
-          </div>
+        <div v-if="captchaKey" class="md:col-span-2 overflow-hidden">
+          <VueTurnstile v-model="turnstileToken" size="flexible" :site-key="captchaKey" />
         </div>
 
         <div class="md:col-span-2">

--- a/src/pages/resend_email.vue
+++ b/src/pages/resend_email.vue
@@ -123,8 +123,7 @@ onMounted(async () => {
     <template v-else>
       <div
         v-if="emailVerificationBlockingReason"
-        class="mb-5 border-amber-200/80 bg-amber-50/90 text-amber-900 dark:border-amber-700/70 dark:bg-amber-900/25 dark:text-amber-100"
-        :class="authInsetCardClass"
+        class="mb-5 overflow-hidden rounded-xl border border-amber-200/80 bg-amber-50/90 p-3 text-amber-900 dark:border-amber-700/70 dark:bg-amber-900/25 dark:text-amber-100"
       >
         <p class="font-semibold">
           {{ t('email-not-verified-banner-title') }}


### PR DESCRIPTION
## Summary (AI generated)

- Removed nested card framing from the login step content.
- Changed auth footer panels into lightweight link rows across auth pages.
- Removed extra captcha wrapper surfaces on register, forgot password, invitation, and account deletion auth flows.

## Motivation (AI generated)

The auth screens were visually over-framed, especially login where the form sat inside multiple card-like containers. Simplifying the hierarchy makes the primary action clearer and keeps the auth family consistent.

## Business Impact (AI generated)

Cleaner authentication screens reduce friction at sign-in, registration, password recovery, and invitation acceptance entry points.

## Test Plan (AI generated)

- [x] Run `bun lint`
- [x] Run `bun typecheck`
- [x] Capture headless screenshots for `/login`, `/register`, and `/forgot_password`
- [x] Verify `/login` in dark mode with a headless screenshot

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored authentication page styling for buttons, panels, and cards across all authentication flows.
  * Updated login page navigation text and added a "don't have an account?" register link.
  * Simplified styling approach by replacing dynamic class bindings with explicit static styles.
  * Adjusted button appearance and link styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->