### PR TITLE
[codex] Load organization images asynchronously

### DIFF
--- a/src/components/AdminOnlyModal.vue
+++ b/src/components/AdminOnlyModal.vue
@@ -7,15 +7,24 @@ import { isAdminRole, useOrganizationStore } from '~/stores/organization'
 const { t } = useI18n()
 const organizationStore = useOrganizationStore()
 
-const admins = ref<{ email: string, image_url: string }[]>([])
+const admins = ref<{ key: string, email: string, image_url: string }[]>([])
 const isLoading = ref(true)
+
+function getMemberKey(member: { uid?: string | null, id?: string | number | null, email: string }) {
+  return String(member.uid ?? member.id ?? member.email)
+}
 
 onMounted(async () => {
   try {
-    const members = await organizationStore.getMembers()
+    const members = await organizationStore.getMembers((signedImages) => {
+      admins.value = admins.value.map((admin) => {
+        const signedImage = signedImages.get(admin.key)
+        return signedImage ? { ...admin, image_url: signedImage } : admin
+      })
+    })
     admins.value = members
       .filter(m => isAdminRole(m.role))
-      .map(m => ({ email: m.email, image_url: m.image_url }))
+      .map(m => ({ key: getMemberKey(m), email: m.email, image_url: m.image_url }))
   }
   catch (e) {
     console.error('Failed to fetch admins:', e)

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -10,7 +10,7 @@ import IconCopy from '~icons/ion/copy-outline'
 import IconCheck from '~icons/lucide/check'
 import IconLoader from '~icons/lucide/loader-2'
 import { createDefaultApiKey } from '~/services/apikeys'
-import { createSignedImageUrl } from '~/services/storage'
+import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getLocalConfig, isLocal, useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useMainStore } from '~/stores/main'
@@ -173,6 +173,23 @@ function getStoreUrls(url: string) {
   return { iosStoreUrl: null, androidStoreUrl: null }
 }
 
+let resumeIconLoadRun = 0
+async function loadResumeIconPreview(rawIconUrl: string | null | undefined, appId: string, run: number) {
+  if (!rawIconUrl || getImmediateImageUrl(rawIconUrl))
+    return
+
+  try {
+    const signedIconUrl = await createSignedImageUrl(rawIconUrl)
+    if (!signedIconUrl || run !== resumeIconLoadRun || createdApp.value?.app_id !== appId)
+      return
+
+    localIconPreview.value = signedIconUrl
+  }
+  catch (error) {
+    console.warn('Cannot load signed resume app icon', { appId, error })
+  }
+}
+
 async function ensureApiKey() {
   const userId = main.user?.id
   if (!userId)
@@ -233,8 +250,9 @@ async function loadResumeApp() {
   existingApp.value = data.existing_app ?? null
   storeUrl.value = data.ios_store_url ?? data.android_store_url ?? ''
   importedStoreAppId.value = extractAndroidAppId(data.android_store_url ?? '') || ''
-  if (data.icon_url)
-    localIconPreview.value = await createSignedImageUrl(data.icon_url) ?? ''
+  const iconLoadRun = ++resumeIconLoadRun
+  localIconPreview.value = getImmediateImageUrl(data.icon_url) || ''
+  void loadResumeIconPreview(data.icon_url, data.app_id, iconLoadRun)
   storeScreenshotPreview.value = ''
   flowStep.value = 'install'
   return true

--- a/src/components/dashboard/AppSetting.vue
+++ b/src/components/dashboard/AppSetting.vue
@@ -14,7 +14,7 @@ import gearSix from '~icons/ph/gear-six?raw'
 import iconName from '~icons/ph/user?raw'
 import Toggle from '~/components/Toggle.vue'
 import { checkPermissions } from '~/services/permissions'
-import { createSignedImageUrl } from '~/services/storage'
+import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
 
@@ -95,6 +95,23 @@ function initializeRetentionPreset() {
   }
 }
 
+let appIconLoadRun = 0
+async function loadAppSettingIcon(rawIconUrl: string | null | undefined, run: number) {
+  if (!rawIconUrl || getImmediateImageUrl(rawIconUrl))
+    return
+
+  try {
+    const signedIconUrl = await createSignedImageUrl(rawIconUrl)
+    if (!signedIconUrl || run !== appIconLoadRun || !appRef.value)
+      return
+
+    appRef.value.icon_url = signedIconUrl
+  }
+  catch (error) {
+    console.warn('Cannot load signed app setting icon', { appId: props.appId, error })
+  }
+}
+
 onMounted(async () => {
   isLoading.value = true
 
@@ -112,9 +129,13 @@ onMounted(async () => {
   }
 
   await organizationStore.awaitInitialLoad()
-  appRef.value = data as any
-  if (appRef.value?.icon_url)
-    appRef.value.icon_url = await createSignedImageUrl(appRef.value.icon_url)
+  const rawIconUrl = data.icon_url
+  const iconLoadRun = ++appIconLoadRun
+  appRef.value = {
+    ...(data as any),
+    icon_url: getImmediateImageUrl(rawIconUrl) || null,
+  }
+  void loadAppSettingIcon(rawIconUrl, iconLoadRun)
   initializeRetentionPreset()
   await loadChannels()
   isLoading.value = false

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -4,7 +4,7 @@ import type { UserModule } from '~/types'
 import { hideLoader } from '~/services/loader'
 import { setUser } from '~/services/posthog'
 import { isSsoUser, provisionSsoUser } from '~/services/ssoProvisioning'
-import { createSignedImageUrl } from '~/services/storage'
+import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getLocalConfig, useSupabase } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useMainStore } from '~/stores/main'
@@ -65,18 +65,43 @@ async function updateUser(
       userRecord.email = main.auth?.email
     }
 
-    if (userRecord.image_url)
-      userRecord.image_url = await createSignedImageUrl(userRecord.image_url) || null
+    const rawImageUrl = userRecord.image_url
+    const immediateImageUrl = getImmediateImageUrl(rawImageUrl)
+    if (rawImageUrl)
+      userRecord.image_url = immediateImageUrl || null
+
+    const updatePosthogUser = (avatar?: string | null) => {
+      setUser(
+        main.auth?.id ?? '',
+        {
+          email: userRecord.email,
+          nickname: [userRecord.first_name, userRecord.last_name].filter(Boolean).join(' ') || undefined,
+          avatar: avatar ?? undefined,
+        },
+        config.supaHost,
+      )
+    }
+
     main.user = userRecord
-    setUser(
-      main.auth?.id ?? '',
-      {
-        email: userRecord.email,
-        nickname: [userRecord.first_name, userRecord.last_name].filter(Boolean).join(' ') || undefined,
-        avatar: userRecord.image_url ?? undefined,
-      },
-      config.supaHost,
-    )
+    updatePosthogUser(userRecord.image_url)
+
+    if (rawImageUrl && !immediateImageUrl) {
+      void (async () => {
+        try {
+          const signedImageUrl = await createSignedImageUrl(rawImageUrl)
+          const currentUser = main.user
+          if (!signedImageUrl || !currentUser || currentUser.id !== userRecord.id)
+            return
+
+          currentUser.image_url = signedImageUrl
+          main.user = currentUser
+          updatePosthogUser(signedImageUrl)
+        }
+        catch (error) {
+          console.warn('Cannot load signed user image', { userId: userRecord.id, error })
+        }
+      })()
+    }
   }
   catch (error) {
     console.error('auth', error)

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia'
 import { computed, ref, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { createSignedImageUrl } from '~/services/storage'
+import { createSignedImageUrl, resolveImagePath } from '~/services/storage'
 import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useOrganizationStore } from '~/stores/organization'
@@ -17,12 +17,14 @@ const isTableLoading = ref(false)
 const supabase = useSupabase()
 const { t } = useI18n()
 const displayStore = useDisplayStore()
-const apps = ref<Database['public']['Tables']['apps']['Row'][]>([])
+type AppRow = Database['public']['Tables']['apps']['Row']
+const apps = ref<AppRow[]>([])
 const currentPage = ref(1)
 const pageSize = 10
 const totalApps = ref(0)
 const searchQuery = ref('')
 const { currentOrganization } = storeToRefs(organizationStore)
+let appIconLoadRun = 0
 
 // Check if user lacks security compliance (2FA or password) - don't load data in this case
 const lacksSecurityAccess = computed(() => {
@@ -32,7 +34,48 @@ const lacksSecurityAccess = computed(() => {
   return lacks2FA || lacksPassword
 })
 
+function appWithImmediateIcon(app: AppRow) {
+  const { normalized, shouldSign } = resolveImagePath(app.icon_url)
+  return {
+    ...app,
+    icon_url: shouldSign ? '' : normalized,
+  }
+}
+
+async function loadAppIcons(sourceApps: AppRow[], runId: number) {
+  const signedIcons = (await Promise.all(sourceApps.map(async (app) => {
+    const { shouldSign } = resolveImagePath(app.icon_url)
+    if (!shouldSign)
+      return null
+
+    try {
+      const signedIcon = await createSignedImageUrl(app.icon_url)
+      return signedIcon ? { appId: app.app_id, signedIcon } : null
+    }
+    catch {
+      return null
+    }
+  })))
+    .filter((entry): entry is { appId: string, signedIcon: string } => !!entry)
+
+  if (appIconLoadRun !== runId || signedIcons.length === 0)
+    return
+
+  const iconByAppId = new Map<string, string>(signedIcons.map(({ appId, signedIcon }) => [appId, signedIcon]))
+  let hasIconUpdate = false
+  for (const app of apps.value) {
+    const signedIcon = iconByAppId.get(app.app_id)
+    if (signedIcon) {
+      app.icon_url = signedIcon
+      hasIconUpdate = true
+    }
+  }
+  if (hasIconUpdate)
+    apps.value = Array.from(apps.value)
+}
+
 async function getMyApps() {
+  const currentRun = ++appIconLoadRun
   isTableLoading.value = true
   try {
     await organizationStore.awaitInitialLoad()
@@ -83,20 +126,9 @@ async function getMyApps() {
       .range(offset, offset + pageSize - 1)
       .order('updated_at', { ascending: false })
 
-    if (data && data.length) {
-      const signedApps = await Promise.all(
-        data.map(async (app) => {
-          return {
-            ...app,
-            icon_url: await createSignedImageUrl(app.icon_url),
-          }
-        }),
-      )
-      apps.value = signedApps
-    }
-    else {
-      apps.value = []
-    }
+    apps.value = data?.map(appWithImmediateIcon) ?? []
+    if (data?.length)
+      void loadAppIcons(data, currentRun)
   }
   finally {
     isTableLoading.value = false

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -52,7 +52,8 @@ async function loadAppIcons(sourceApps: AppRow[], runId: number) {
       const signedIcon = await createSignedImageUrl(app.icon_url)
       return signedIcon ? { appId: app.app_id, signedIcon } : null
     }
-    catch {
+    catch (error) {
+      console.warn('Cannot load signed app icon', { appId: app.app_id, error })
       return null
     }
   })))

--- a/src/pages/settings/organization/Members.vue
+++ b/src/pages/settings/organization/Members.vue
@@ -17,7 +17,7 @@ import IconWrench from '~icons/heroicons/wrench'
 import RoleSelect from '~/components/forms/RoleSelect.vue'
 import SearchInput from '~/components/forms/SearchInput.vue'
 import { checkPermissions } from '~/services/permissions'
-import { createSignedImageUrl } from '~/services/storage'
+import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useMainStore } from '~/stores/main'
@@ -111,6 +111,51 @@ const selectedUserToDelegateAdmin = ref()
 const searchUserForAdminDelegation = ref('')
 
 const members = ref([] as OrganizationMemberRows)
+let memberImageLoadRun = 0
+
+interface MemberImageSource {
+  key: string
+  imageUrl?: string | null
+}
+
+function getMemberImageKey(member: { uid?: string | null, id?: string | number | null, email?: string | null }) {
+  return String(member.uid ?? member.id ?? member.email ?? '')
+}
+
+function applySignedMemberImages(signedImages: Map<string, string>) {
+  members.value = members.value.map((member) => {
+    const signedImage = signedImages.get(getMemberImageKey(member))
+    return signedImage ? { ...member, image_url: signedImage } : member
+  })
+}
+
+async function loadMemberImages(sources: MemberImageSource[], run: number) {
+  const signedEntries = await Promise.all(sources.map(async (source) => {
+    if (!source.key || !source.imageUrl || getImmediateImageUrl(source.imageUrl))
+      return null
+
+    try {
+      const signedImage = await createSignedImageUrl(source.imageUrl)
+      return signedImage ? [source.key, signedImage] as const : null
+    }
+    catch (error) {
+      console.warn('Cannot load signed member image', { memberKey: source.key, error })
+      return null
+    }
+  }))
+
+  if (run !== memberImageLoadRun)
+    return
+
+  const signedImages = new Map<string, string>()
+  for (const entry of signedEntries) {
+    if (entry)
+      signedImages.set(entry[0], entry[1])
+  }
+
+  if (signedImages.size > 0)
+    applySignedMemberImages(signedImages)
+}
 
 const isInviteFormValid = computed(() => {
   return inviteUserFirstName.value.trim() !== ''
@@ -417,6 +462,7 @@ columns.value = [
 
 async function reloadData() {
   isLoading.value = true
+  const imageLoadRun = ++memberImageLoadRun
   try {
     await checkRbacEnabled()
 
@@ -433,29 +479,37 @@ async function reloadData() {
         return
       }
 
+      const memberImageSources: MemberImageSource[] = []
       // Mapper les données RBAC vers le format attendu par la table
-      members.value = await Promise.all((rbacMembers || []).map(async (member: any) => {
+      members.value = (rbacMembers || []).map((member: any) => {
         const isInvite = member.is_invite === true
         const isTmp = member.is_tmp === true
         const orgUserId = member.org_user_id
         const hasOrgUserInvite = isInvite && !isTmp && orgUserId != null && orgUserId !== ''
-        const signedImage = member.image_url ? await createSignedImageUrl(member.image_url) : ''
+        const memberKey = String(member.user_id ?? member.email ?? '')
+        memberImageSources.push({ key: memberKey, imageUrl: member.image_url })
 
         return {
           id: member.user_id,
           aid: hasOrgUserInvite ? Number(orgUserId) : -1,
           uid: member.user_id,
           email: member.email,
-          image_url: signedImage || '',
+          image_url: getImmediateImageUrl(member.image_url) || '',
           role: member.role_name,
           is_tmp: isTmp,
           is_invite: isInvite,
         }
-      }))
+      })
+      void loadMemberImages(memberImageSources, imageLoadRun)
     }
     else {
       // Utiliser l'ancienne méthode pour les orgs sans RBAC
-      members.value = await organizationStore.getMembers()
+      members.value = await organizationStore.getMembers((signedImages) => {
+        if (imageLoadRun !== memberImageLoadRun)
+          return
+
+        applySignedMemberImages(signedImages)
+      })
     }
   }
   catch (error) {

--- a/src/pages/settings/organization/Security.vue
+++ b/src/pages/settings/organization/Security.vue
@@ -15,7 +15,7 @@ import IconShield from '~icons/heroicons/shield-check'
 import IconUser from '~icons/heroicons/user'
 import SsoConfiguration from '~/components/organizations/SsoConfiguration.vue'
 import { checkPermissions } from '~/services/permissions'
-import { createSignedImageUrl } from '~/services/storage'
+import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getCurrentPlanNameOrg, useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useDisplayStore } from '~/stores/display'
@@ -121,6 +121,61 @@ const passwordNonCompliantMembersCount = computed(() => {
 const totalPasswordPolicyMembersCount = computed(() => {
   return membersWithPasswordPolicyStatus.value.filter(m => !m.is_tmp).length
 })
+
+interface MemberImageSource {
+  key: string
+  imageUrl?: string | null
+}
+let mfaMemberImageLoadRun = 0
+let passwordMemberImageLoadRun = 0
+
+async function loadSignedMemberImages(
+  sources: MemberImageSource[],
+  isCurrentRun: () => boolean,
+  applySignedImages: (signedImages: Map<string, string>) => void,
+) {
+  const signedEntries = await Promise.all(sources.map(async (source) => {
+    if (!source.key || !source.imageUrl || getImmediateImageUrl(source.imageUrl))
+      return null
+
+    try {
+      const signedImage = await createSignedImageUrl(source.imageUrl)
+      return signedImage ? [source.key, signedImage] as const : null
+    }
+    catch (error) {
+      console.warn('Cannot load signed security member image', { memberKey: source.key, error })
+      return null
+    }
+  }))
+
+  if (!isCurrentRun())
+    return
+
+  const signedImages = new Map<string, string>()
+  for (const entry of signedEntries) {
+    if (entry)
+      signedImages.set(entry[0], entry[1])
+  }
+
+  if (signedImages.size > 0)
+    applySignedImages(signedImages)
+}
+
+function applyMfaMemberImages(signedImages: Map<string, string>) {
+  membersWithMfaStatus.value = membersWithMfaStatus.value.map((member) => {
+    const signedImage = signedImages.get(member.uid)
+    return signedImage ? { ...member, image_url: signedImage } : member
+  })
+  impactedMembers.value = membersWithMfaStatus.value.filter(m => !m.has_2fa && !m.is_tmp)
+}
+
+function applyPasswordMemberImages(signedImages: Map<string, string>) {
+  membersWithPasswordPolicyStatus.value = membersWithPasswordPolicyStatus.value.map((member) => {
+    const signedImage = signedImages.get(member.uid)
+    return signedImage ? { ...member, image_url: signedImage } : member
+  })
+  nonCompliantPasswordMembers.value = membersWithPasswordPolicyStatus.value.filter(m => !m.password_policy_compliant && !m.is_tmp)
+}
 
 function acronym(email: string) {
   let res = 'NA'
@@ -289,21 +344,28 @@ async function loadMembersWithMfaStatus() {
       }
     }
 
+    const imageLoadRun = ++mfaMemberImageLoadRun
+    const imageSources: MemberImageSource[] = []
     // Merge members with MFA status
-    membersWithMfaStatus.value = await Promise.all((members || []).map(async (member) => {
-      const signedImage = member.image_url ? await createSignedImageUrl(member.image_url) : ''
+    membersWithMfaStatus.value = (members || []).map((member) => {
+      imageSources.push({ key: member.uid, imageUrl: member.image_url })
       return {
         uid: member.uid,
         email: member.email,
-        image_url: signedImage || '',
+        image_url: getImmediateImageUrl(member.image_url) || '',
         role: member.role,
         is_tmp: member.is_tmp,
         has_2fa: mfaMap.get(member.uid) ?? false,
       }
-    }))
+    })
 
     // Calculate impacted members (those without 2FA, excluding pending invites)
     impactedMembers.value = membersWithMfaStatus.value.filter(m => !m.has_2fa && !m.is_tmp)
+    void loadSignedMemberImages(
+      imageSources,
+      () => imageLoadRun === mfaMemberImageLoadRun,
+      applyMfaMemberImages,
+    )
   }
   catch (error) {
     console.error('Error loading members with MFA status:', error)
@@ -354,24 +416,31 @@ async function loadMembersWithPasswordPolicyStatus() {
       }
     }
 
+    const imageLoadRun = ++passwordMemberImageLoadRun
+    const imageSources: MemberImageSource[] = []
     // Merge members with password policy compliance status
-    membersWithPasswordPolicyStatus.value = await Promise.all((members || []).map(async (member) => {
+    membersWithPasswordPolicyStatus.value = (members || []).map((member) => {
       const compliance = complianceMap.get(member.uid)
-      const signedImage = member.image_url ? await createSignedImageUrl(member.image_url) : ''
+      imageSources.push({ key: member.uid, imageUrl: member.image_url })
       return {
         uid: member.uid,
         email: member.email,
         first_name: compliance?.first_name || null,
         last_name: compliance?.last_name || null,
-        image_url: signedImage || '',
+        image_url: getImmediateImageUrl(member.image_url) || '',
         role: member.role,
         is_tmp: member.is_tmp,
         password_policy_compliant: compliance?.compliant ?? false,
       }
-    }))
+    })
 
     // Calculate non-compliant members (excluding pending invites)
     nonCompliantPasswordMembers.value = membersWithPasswordPolicyStatus.value.filter(m => !m.password_policy_compliant && !m.is_tmp)
+    void loadSignedMemberImages(
+      imageSources,
+      () => imageLoadRun === passwordMemberImageLoadRun,
+      applyPasswordMemberImages,
+    )
   }
   catch (error) {
     console.error('Error loading members with password policy status:', error)

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -37,6 +37,11 @@ export function resolveImagePath(raw?: string | null) {
   }
 }
 
+export function getImmediateImageUrl(raw?: string | null) {
+  const { normalized, shouldSign } = resolveImagePath(raw)
+  return shouldSign ? '' : normalized
+}
+
 export async function createSignedImageUrl(path?: string | null, options: { forceRefresh?: boolean } = {}) {
   const { normalized, shouldSign } = resolveImagePath(path)
   if (!normalized)

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -3,7 +3,7 @@ import type { ArrayElement, Concrete, Merge } from '~/services/types'
 import type { Database } from '~/types/supabase.types'
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
-import { createSignedImageUrl, resolveImagePath } from '~/services/storage'
+import { createSignedImageUrl, getImmediateImageUrl, resolveImagePath } from '~/services/storage'
 import { stripeEnabled, useSupabase } from '~/services/supabase'
 import { createDeferredPromise } from '../utils/promise'
 import { useDashboardAppsStore } from './dashboardApps'
@@ -37,6 +37,7 @@ export type OrganizationRole
     | 'org_super_admin'
 export type ExtendedOrganizationMember = Concrete<Merge<ArrayElement<Database['public']['Functions']['get_org_members']['Returns']>, { id: number | string }>>
 export type ExtendedOrganizationMembers = ExtendedOrganizationMember[]
+type SignedMemberImageCallback = (signedImages: Map<string, string>) => void
 
 type LegacyMinRight = Database['public']['Enums']['user_min_right'] | 'owner'
 
@@ -197,6 +198,86 @@ export const useOrganizationStore = defineStore('organization', () => {
   const currentRole = ref<OrganizationRole | null>(null)
 
   const STORAGE_KEY = 'capgo_current_org_id'
+  let organizationLogoLoadRun = 0
+
+  const getMemberImageKey = (member: { uid?: string | null, id?: number | string | null, email?: string | null }) => {
+    return String(member.uid ?? member.id ?? member.email ?? '')
+  }
+
+  const loadSignedMemberImages = async (
+    sources: Array<{ key: string, imageUrl?: string | null }>,
+    onSignedImages: SignedMemberImageCallback,
+  ) => {
+    const signedImageEntries = await Promise.all(sources.map(async (source) => {
+      if (!source.key || !source.imageUrl || getImmediateImageUrl(source.imageUrl))
+        return null
+
+      try {
+        const signedImageUrl = await createSignedImageUrl(source.imageUrl)
+        return signedImageUrl ? [source.key, signedImageUrl] as const : null
+      }
+      catch (error) {
+        console.warn('Cannot load signed member image', { memberKey: source.key, error })
+        return null
+      }
+    }))
+
+    const signedImages = new Map<string, string>()
+    for (const entry of signedImageEntries) {
+      if (entry)
+        signedImages.set(entry[0], entry[1])
+    }
+
+    if (signedImages.size > 0)
+      onSignedImages(signedImages)
+  }
+
+  const loadOrganizationLogos = async (sourceOrganizations: Array<Organization & { id: number }>, run: number) => {
+    const signedLogoEntries = await Promise.all(sourceOrganizations.map(async (org) => {
+      const logoSource = org.logo_storage_path ?? org.logo
+      const { normalized, shouldSign } = resolveImagePath(logoSource)
+      if (!normalized || !shouldSign)
+        return null
+
+      try {
+        const signedLogo = await createSignedImageUrl(normalized)
+        return signedLogo ? [org.gid, { logo: signedLogo, logoStoragePath: normalized }] as const : null
+      }
+      catch (error) {
+        console.warn('Cannot load signed organization logo', { orgId: org.gid, error })
+        return null
+      }
+    }))
+
+    if (run !== organizationLogoLoadRun)
+      return
+
+    const nextOrganizations = new Map(_organizations.value)
+    let updated = false
+    for (const entry of signedLogoEntries) {
+      if (!entry)
+        continue
+
+      const [orgId, logoData] = entry
+      const organization = nextOrganizations.get(orgId)
+      if (!organization || organization.logo === logoData.logo)
+        continue
+
+      nextOrganizations.set(orgId, {
+        ...organization,
+        logo: logoData.logo,
+        logo_storage_path: logoData.logoStoragePath,
+      })
+      updated = true
+    }
+
+    if (!updated)
+      return
+
+    _organizations.value = nextOrganizations
+    if (currentOrganization.value)
+      currentOrganization.value = nextOrganizations.get(currentOrganization.value.gid)
+  }
 
   watch([currentOrganization, stripeEnabled], async ([currentOrganizationRaw, stripeEnabledValue], [previousOrganization]) => {
     if (!currentOrganizationRaw) {
@@ -326,7 +407,7 @@ export const useOrganizationStore = defineStore('organization', () => {
     setCurrentOrganization(organization.gid)
   }
 
-  const getMembers = async (): Promise<ExtendedOrganizationMembers> => {
+  const getMembers = async (onSignedImages?: SignedMemberImageCallback): Promise<ExtendedOrganizationMembers> => {
     const currentOrgId = currentOrganization.value?.gid
     if (!currentOrgId)
       return []
@@ -341,16 +422,20 @@ export const useOrganizationStore = defineStore('organization', () => {
       return []
     }
 
-    return Promise.all(data.map(
-      async (item, id) => {
-        const resolvedImage = item.image_url ? await createSignedImageUrl(item.image_url) : ''
-        return {
-          id,
-          ...item,
-          image_url: resolvedImage || '',
-        }
-      },
-    ))
+    const memberImageSources = data.map(item => ({
+      key: getMemberImageKey(item),
+      imageUrl: item.image_url,
+    }))
+    const mappedMembers = data.map((item, id) => ({
+      id,
+      ...item,
+      image_url: getImmediateImageUrl(item.image_url) || '',
+    }))
+
+    if (onSignedImages)
+      void loadSignedMemberImages(memberImageSources, onSignedImages)
+
+    return mappedMembers
   }
 
   const fetchOrganizations = async () => {
@@ -385,19 +470,20 @@ export const useOrganizationStore = defineStore('organization', () => {
       throw error
     }
 
-    const mappedData = await Promise.all(data.map(async (item, id) => {
-      const resolvedLogo = item.logo ? await createSignedImageUrl(item.logo) : ''
+    const logoLoadRun = ++organizationLogoLoadRun
+    const mappedData = data.map((item, id) => {
       const logoStoragePath = resolveImagePath(item.logo).normalized
       return {
         id,
         ...item,
-        logo: resolvedLogo || null,
+        logo: getImmediateImageUrl(item.logo) || null,
         logo_storage_path: logoStoragePath || null,
         password_policy_config: item.password_policy_config as PasswordPolicyConfig | null,
       } as Organization & { id: number }
-    }))
+    })
 
     _organizations.value = new Map(mappedData.map(item => [item.gid, item as Organization]))
+    void loadOrganizationLogos(mappedData, logoLoadRun)
 
     const selectableOrganizations = mappedData
       .filter(org => isSelectableOrganization(org.role))
@@ -448,10 +534,11 @@ export const useOrganizationStore = defineStore('organization', () => {
     let updated = false
 
     for (const [orgId, org] of nextOrganizations.entries()) {
-      if (!org.logo)
+      const logoSource = org.logo_storage_path ?? org.logo
+      if (!logoSource)
         continue
 
-      const logoStoragePath = resolveImagePath(org.logo_storage_path ?? org.logo).normalized
+      const logoStoragePath = resolveImagePath(logoSource).normalized
       const refreshedLogo = await createSignedImageUrl(logoStoragePath || org.logo, { forceRefresh: true })
       if (!refreshedLogo || refreshedLogo === org.logo)
         continue

--- a/tests/auth-sso-provisioning.unit.test.ts
+++ b/tests/auth-sso-provisioning.unit.test.ts
@@ -145,6 +145,7 @@ vi.mock('~/services/posthog', () => ({
 
 vi.mock('~/services/storage', () => ({
   createSignedImageUrl: (value: string) => getContext().mockCreateSignedImageUrl(value),
+  getImmediateImageUrl: (value?: string | null) => value ?? '',
 }))
 
 vi.mock('~/services/tracking', () => ({

--- a/tests/organization-store-delete.unit.test.ts
+++ b/tests/organization-store-delete.unit.test.ts
@@ -49,6 +49,10 @@ vi.mock('~/services/supabase', () => ({
 
 vi.mock('~/services/storage', () => ({
   createSignedImageUrl: mockCreateSignedImageUrl,
+  getImmediateImageUrl: (value?: string | null) => {
+    const { normalized, shouldSign } = mockResolveImagePath(value)
+    return shouldSign ? '' : normalized
+  },
   resolveImagePath: mockResolveImagePath,
 }))
 


### PR DESCRIPTION
## Summary (AI generated)

- Load organization logos, user avatars, member avatars, app setting icons, and resume-onboarding icons without blocking page data rendering.
- Add immediate image URL handling for public/external images while private storage URLs are signed in the background.
- Update member/admin/security views when signed image URLs arrive and log signing failures for debugging.

## Motivation (AI generated)

Image signing can be slower than the primary page data fetch. Blocking on signed URLs makes organization and app pages feel slow even when the core data is already available.

## Business Impact (AI generated)

This improves perceived dashboard performance for customers with private icons and avatars, especially organizations with many apps or members.

## Test Plan (AI generated)

- [x] Run `bun lint`
- [x] Run `bun typecheck`
- [ ] Wait for GitHub CI to pass
- [ ] Wait for CodeRabbit review to finish and address any comments

Generated with AI