### PR TITLE
[codex] Show async image loading states

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -34,6 +34,7 @@ type AppRow = Database['public']['Tables']['apps']['Row']
 const isLoading = ref(true)
 const isSubmitting = ref(false)
 const isImportingStore = ref(false)
+const isResumeIconLoading = ref(false)
 const isSeedingDemo = ref(false)
 const isCliCommandVisible = ref(false)
 const apiKey = ref<string | null>(null)
@@ -175,9 +176,13 @@ function getStoreUrls(url: string) {
 
 let resumeIconLoadRun = 0
 async function loadResumeIconPreview(rawIconUrl: string | null | undefined, appId: string, run: number) {
-  if (!rawIconUrl || getImmediateImageUrl(rawIconUrl))
+  if (!rawIconUrl || getImmediateImageUrl(rawIconUrl)) {
+    if (run === resumeIconLoadRun)
+      isResumeIconLoading.value = false
     return
+  }
 
+  isResumeIconLoading.value = true
   try {
     const signedIconUrl = await createSignedImageUrl(rawIconUrl)
     if (!signedIconUrl || run !== resumeIconLoadRun || createdApp.value?.app_id !== appId)
@@ -187,6 +192,10 @@ async function loadResumeIconPreview(rawIconUrl: string | null | undefined, appI
   }
   catch (error) {
     console.warn('Cannot load signed resume app icon', { appId, error })
+  }
+  finally {
+    if (run === resumeIconLoadRun)
+      isResumeIconLoading.value = false
   }
 }
 
@@ -310,6 +319,7 @@ function onSelectIconFormKit(value: unknown) {
   if (localIconPreview.value.startsWith('blob:'))
     URL.revokeObjectURL(localIconPreview.value)
   localIconPreview.value = file ? URL.createObjectURL(file) : ''
+  isResumeIconLoading.value = false
 }
 
 function onAppIdInput(event: Event) {
@@ -809,6 +819,7 @@ watch(suggestedAppId, (value) => {
                 <div class="flex items-center gap-4">
                   <div class="flex h-18 w-18 items-center justify-center overflow-hidden rounded-[22px] bg-slate-800 text-3xl">
                     <img v-if="iconPreview" :src="iconPreview" :alt="t('app-onboarding-icon-preview-alt')" class="h-full w-full object-cover">
+                    <span v-else-if="isResumeIconLoading" class="h-7 w-7 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" :aria-label="t('loading')" />
                     <span v-else>📱</span>
                   </div>
                   <div class="min-w-0">

--- a/src/components/dashboard/AppSetting.vue
+++ b/src/components/dashboard/AppSetting.vue
@@ -67,6 +67,7 @@ const RETENTION_PRESETS = [
 const selectedRetentionPreset = ref<number>(2592000)
 const customRetentionValue = ref<number>(0)
 const isImportingStoreIcon = ref(false)
+const isAppIconLoading = ref(false)
 
 const isCustomRetention = computed(() => selectedRetentionPreset.value === -1)
 
@@ -97,9 +98,13 @@ function initializeRetentionPreset() {
 
 let appIconLoadRun = 0
 async function loadAppSettingIcon(rawIconUrl: string | null | undefined, run: number) {
-  if (!rawIconUrl || getImmediateImageUrl(rawIconUrl))
+  if (!rawIconUrl || getImmediateImageUrl(rawIconUrl)) {
+    if (run === appIconLoadRun)
+      isAppIconLoading.value = false
     return
+  }
 
+  isAppIconLoading.value = true
   try {
     const signedIconUrl = await createSignedImageUrl(rawIconUrl)
     if (!signedIconUrl || run !== appIconLoadRun || !appRef.value)
@@ -109,6 +114,10 @@ async function loadAppSettingIcon(rawIconUrl: string | null | undefined, run: nu
   }
   catch (error) {
     console.warn('Cannot load signed app setting icon', { appId: props.appId, error })
+  }
+  finally {
+    if (run === appIconLoadRun)
+      isAppIconLoading.value = false
   }
 }
 
@@ -268,7 +277,7 @@ async function submit(form: {
 }
 
 const storeImportUrl = computed(() => appRef.value?.ios_store_url || appRef.value?.android_store_url || '')
-const shouldShowStoreIconImport = computed(() => !appRef.value?.icon_url && !!storeImportUrl.value)
+const shouldShowStoreIconImport = computed(() => !appRef.value?.icon_url && !isAppIconLoading.value && !!storeImportUrl.value)
 
 function normalizeStoreUrl(rawUrl: string, expectedHost: 'apps.apple.com' | 'play.google.com') {
   const trimmedUrl = rawUrl.trim()
@@ -352,6 +361,7 @@ async function uploadIconFromSource(iconSourceUrl: string) {
   }
 
   appRef.value.icon_url = await createSignedImageUrl(iconPath)
+  isAppIconLoading.value = false
 }
 
 async function importIconFromStore() {
@@ -931,8 +941,10 @@ async function editPhoto() {
             return false
           }
 
-          if (appRef.value)
+          if (appRef.value) {
             appRef.value.icon_url = await createSignedImageUrl(iconPath)
+            isAppIconLoading.value = false
+          }
 
           toast.success(t('picture-uploaded'))
         },
@@ -1113,6 +1125,14 @@ async function transferAppOwnership() {
                 v-if="appRef?.icon_url" class="object-cover w-20 h-20 d-mask d-mask-squircle" :src="appRef?.icon_url"
                 width="80" height="80" alt="User upload"
               >
+              <div
+                v-else-if="isAppIconLoading"
+                class="flex items-center justify-center w-20 h-20 bg-gray-700 d-mask d-mask-squircle"
+                :aria-label="t('loading')"
+              >
+                <span class="w-8 h-8 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
+                <span class="sr-only">{{ t('loading') }}</span>
+              </div>
               <div v-else class="p-6 text-xl bg-gray-700 d-mask d-mask-squircle">
                 <span class="font-medium text-gray-300">
                   {{ acronym }}

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -338,6 +338,14 @@ watch(
             @error="refreshBrokenOrganizationLogo(currentOrganization)"
           >
           <div
+            v-else-if="currentOrganization?.logo_is_loading"
+            class="flex items-center justify-center w-6 h-6 mr-2 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
+            :aria-label="t('loading')"
+          >
+            <span class="w-3.5 h-3.5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
+            <span class="sr-only">{{ t('loading') }}</span>
+          </div>
+          <div
             v-else
             class="flex items-center justify-center w-6 h-6 mr-2 text-xs font-semibold text-gray-300 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
           >
@@ -381,6 +389,14 @@ watch(
                   class="object-cover w-6 h-6 mr-2 rounded-sm d-mask d-mask-squircle shrink-0"
                   @error="refreshBrokenOrganizationLogo(org)"
                 >
+                <div
+                  v-else-if="org.logo_is_loading"
+                  class="flex items-center justify-center w-6 h-6 mr-2 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
+                  :aria-label="t('loading')"
+                >
+                  <span class="w-3.5 h-3.5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
+                  <span class="sr-only">{{ t('loading') }}</span>
+                </div>
                 <div
                   v-else
                   class="flex items-center justify-center w-6 h-6 mr-2 text-xs font-semibold text-gray-300 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"

--- a/src/components/tables/AppTable.vue
+++ b/src/components/tables/AppTable.vue
@@ -127,9 +127,18 @@ const columns = ref<TableColumn[]>([
             width: 42,
             height: 42,
           })
-        : h('div', { class: 'p-2 mr-2 text-xl bg-gray-700 d-mask d-mask-squircle' }, [
-            h('span', { class: 'font-medium text-gray-300' }, (item.name?.slice(0, 2).toUpperCase() || 'AP')),
-          ])
+        : item.icon_url_loading
+          ? h('div', {
+              'class': 'flex items-center justify-center mr-2 bg-gray-700 rounded-sm shrink-0 sm:mr-3 d-mask d-mask-squircle',
+              'style': 'width: 42px; height: 42px;',
+              'aria-label': t('loading'),
+            }, [
+              h('span', { class: 'w-5 h-5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin' }),
+              h('span', { class: 'sr-only' }, t('loading')),
+            ])
+          : h('div', { class: 'p-2 mr-2 text-xl bg-gray-700 d-mask d-mask-squircle' }, [
+              h('span', { class: 'font-medium text-gray-300' }, (item.name?.slice(0, 2).toUpperCase() || 'AP')),
+            ])
 
       return h('div', { class: 'flex flex-wrap items-center text-slate-800 dark:text-white' }, [
         avatar,

--- a/src/components/tables/AppTable.vue
+++ b/src/components/tables/AppTable.vue
@@ -110,6 +110,36 @@ watchEffect(async () => {
     await loadAppRoles()
 })
 
+function renderAvatar(item: any) {
+  const sourceItem = props.apps.find((app: any) => app.app_id === item.app_id) as any || item
+  const appName = sourceItem.name || item.name
+
+  if (sourceItem.icon_url) {
+    return h('img', {
+      src: sourceItem.icon_url,
+      alt: `App icon ${appName}`,
+      class: 'mr-2 rounded-sm shrink-0 sm:mr-3 d-mask d-mask-squircle',
+      width: 42,
+      height: 42,
+    })
+  }
+
+  if (sourceItem.icon_url_loading) {
+    return h('div', {
+      'class': 'flex items-center justify-center mr-2 bg-gray-700 rounded-sm shrink-0 sm:mr-3 d-mask d-mask-squircle',
+      'style': 'width: 42px; height: 42px;',
+      'aria-label': t('loading'),
+    }, [
+      h('span', { class: 'w-5 h-5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin' }),
+      h('span', { class: 'sr-only' }, t('loading')),
+    ])
+  }
+
+  return h('div', { class: 'p-2 mr-2 text-xl bg-gray-700 d-mask d-mask-squircle' }, [
+    h('span', { class: 'font-medium text-gray-300' }, (appName?.slice(0, 2).toUpperCase() || 'AP')),
+  ])
+}
+
 const columns = ref<TableColumn[]>([
   {
     label: t('name'),
@@ -119,26 +149,7 @@ const columns = ref<TableColumn[]>([
     head: true,
     onClick: item => openPackage(item),
     renderFunction: (item) => {
-      const avatar = item.icon_url
-        ? h('img', {
-            src: item.icon_url,
-            alt: `App icon ${item.name}`,
-            class: 'mr-2 rounded-sm shrink-0 sm:mr-3 d-mask d-mask-squircle',
-            width: 42,
-            height: 42,
-          })
-        : item.icon_url_loading
-          ? h('div', {
-              'class': 'flex items-center justify-center mr-2 bg-gray-700 rounded-sm shrink-0 sm:mr-3 d-mask d-mask-squircle',
-              'style': 'width: 42px; height: 42px;',
-              'aria-label': t('loading'),
-            }, [
-              h('span', { class: 'w-5 h-5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin' }),
-              h('span', { class: 'sr-only' }, t('loading')),
-            ])
-          : h('div', { class: 'p-2 mr-2 text-xl bg-gray-700 d-mask d-mask-squircle' }, [
-              h('span', { class: 'font-medium text-gray-300' }, (item.name?.slice(0, 2).toUpperCase() || 'AP')),
-            ])
+      const avatar = renderAvatar(item)
 
       return h('div', { class: 'flex flex-wrap items-center text-slate-800 dark:text-white' }, [
         avatar,

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -75,8 +75,12 @@ async function loadAppIcon(app: AppRow, runId: number) {
 }
 
 function loadAppIcons(sourceApps: AppRow[], runId: number) {
-  for (const app of sourceApps)
-    void loadAppIcon(app, runId)
+  for (const app of sourceApps) {
+    loadAppIcon(app, runId).catch((error) => {
+      console.warn('Cannot load signed app icon', { appId: app.app_id, error })
+      updateAppIconState(app.app_id, { icon_url_loading: false }, runId)
+    })
+  }
 }
 
 async function getMyApps() {
@@ -133,7 +137,7 @@ async function getMyApps() {
 
     apps.value = data?.map(appWithImmediateIcon) ?? []
     if (data?.length)
-      void loadAppIcons(data, currentRun)
+      loadAppIcons(data, currentRun)
   }
   finally {
     isTableLoading.value = false

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -48,16 +48,12 @@ function updateAppIconState(appId: string, patch: Partial<AppRowWithIconState>, 
   if (appIconLoadRun !== runId)
     return
 
-  let hasIconUpdate = false
   for (const app of apps.value) {
     if (app.app_id === appId) {
       Object.assign(app, patch)
-      hasIconUpdate = true
-      break
+      return
     }
   }
-  if (hasIconUpdate)
-    apps.value = Array.from(apps.value)
 }
 
 async function loadAppIcon(app: AppRow, runId: number) {

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -18,7 +18,8 @@ const supabase = useSupabase()
 const { t } = useI18n()
 const displayStore = useDisplayStore()
 type AppRow = Database['public']['Tables']['apps']['Row']
-const apps = ref<AppRow[]>([])
+type AppRowWithIconState = AppRow & { icon_url_loading?: boolean }
+const apps = ref<AppRowWithIconState[]>([])
 const currentPage = ref(1)
 const pageSize = 10
 const totalApps = ref(0)
@@ -39,40 +40,47 @@ function appWithImmediateIcon(app: AppRow) {
   return {
     ...app,
     icon_url: shouldSign ? '' : normalized,
+    icon_url_loading: shouldSign,
   }
 }
 
-async function loadAppIcons(sourceApps: AppRow[], runId: number) {
-  const signedIcons = (await Promise.all(sourceApps.map(async (app) => {
-    const { shouldSign } = resolveImagePath(app.icon_url)
-    if (!shouldSign)
-      return null
-
-    try {
-      const signedIcon = await createSignedImageUrl(app.icon_url)
-      return signedIcon ? { appId: app.app_id, signedIcon } : null
-    }
-    catch (error) {
-      console.warn('Cannot load signed app icon', { appId: app.app_id, error })
-      return null
-    }
-  })))
-    .filter((entry): entry is { appId: string, signedIcon: string } => !!entry)
-
-  if (appIconLoadRun !== runId || signedIcons.length === 0)
+function updateAppIconState(appId: string, patch: Partial<AppRowWithIconState>, runId: number) {
+  if (appIconLoadRun !== runId)
     return
 
-  const iconByAppId = new Map<string, string>(signedIcons.map(({ appId, signedIcon }) => [appId, signedIcon]))
   let hasIconUpdate = false
   for (const app of apps.value) {
-    const signedIcon = iconByAppId.get(app.app_id)
-    if (signedIcon) {
-      app.icon_url = signedIcon
+    if (app.app_id === appId) {
+      Object.assign(app, patch)
       hasIconUpdate = true
+      break
     }
   }
   if (hasIconUpdate)
     apps.value = Array.from(apps.value)
+}
+
+async function loadAppIcon(app: AppRow, runId: number) {
+  const { shouldSign } = resolveImagePath(app.icon_url)
+  if (!shouldSign)
+    return
+
+  try {
+    const signedIcon = await createSignedImageUrl(app.icon_url)
+    updateAppIconState(app.app_id, {
+      icon_url: signedIcon || '',
+      icon_url_loading: false,
+    }, runId)
+  }
+  catch (error) {
+    console.warn('Cannot load signed app icon', { appId: app.app_id, error })
+    updateAppIconState(app.app_id, { icon_url_loading: false }, runId)
+  }
+}
+
+function loadAppIcons(sourceApps: AppRow[], runId: number) {
+  for (const app of sourceApps)
+    void loadAppIcon(app, runId)
 }
 
 async function getMyApps() {

--- a/src/pages/settings/organization/index.vue
+++ b/src/pages/settings/organization/index.vue
@@ -235,6 +235,14 @@ async function copyOrganizationId() {
                   id="org-avatar" class="object-cover w-20 h-20 d-mask d-mask-squircle" :src="currentOrganization.logo"
                   width="80" height="80" alt="User upload"
                 >
+                <div
+                  v-else-if="currentOrganization?.logo_is_loading"
+                  class="flex items-center justify-center w-20 h-20 bg-gray-700 d-mask d-mask-squircle"
+                  :aria-label="t('loading')"
+                >
+                  <span class="w-8 h-8 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
+                  <span class="sr-only">{{ t('loading') }}</span>
+                </div>
                 <div v-else class="p-6 text-xl bg-gray-700 d-mask d-mask-squircle">
                   <span class="font-medium text-gray-300">
                     {{ acronym }}

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -24,6 +24,7 @@ export interface PasswordPolicyConfig {
 type RawOrganization = ArrayElement<Database['public']['Functions']['get_orgs_v7']['Returns']>
 export type Organization = Omit<RawOrganization, 'password_policy_config' | 'stats_refresh_requested_at' | 'stats_updated_at'> & {
   logo_storage_path?: string | null
+  logo_is_loading?: boolean
   password_policy_config: PasswordPolicyConfig | null
   stats_refresh_requested_at: string | null
   stats_updated_at: string | null
@@ -232,51 +233,51 @@ export const useOrganizationStore = defineStore('organization', () => {
       onSignedImages(signedImages)
   }
 
-  const loadOrganizationLogos = async (sourceOrganizations: Array<Organization & { id: number }>, run: number) => {
-    const signedLogoEntries = await Promise.all(sourceOrganizations.map(async (org) => {
-      const logoSource = org.logo_storage_path ?? org.logo
-      const { normalized, shouldSign } = resolveImagePath(logoSource)
-      if (!normalized || !shouldSign)
-        return null
-
-      try {
-        const signedLogo = await createSignedImageUrl(normalized)
-        return signedLogo ? [org.gid, { logo: signedLogo, logoStoragePath: normalized }] as const : null
-      }
-      catch (error) {
-        console.warn('Cannot load signed organization logo', { orgId: org.gid, error })
-        return null
-      }
-    }))
-
+  const updateOrganizationLogoState = (orgId: string, patch: Partial<Organization>, run: number) => {
     if (run !== organizationLogoLoadRun)
       return
 
-    const nextOrganizations = new Map(_organizations.value)
-    let updated = false
-    for (const entry of signedLogoEntries) {
-      if (!entry)
-        continue
-
-      const [orgId, logoData] = entry
-      const organization = nextOrganizations.get(orgId)
-      if (!organization || organization.logo === logoData.logo)
-        continue
-
-      nextOrganizations.set(orgId, {
-        ...organization,
-        logo: logoData.logo,
-        logo_storage_path: logoData.logoStoragePath,
-      })
-      updated = true
-    }
-
-    if (!updated)
+    const organization = _organizations.value.get(orgId)
+    if (!organization)
       return
 
+    const nextOrganization = {
+      ...organization,
+      ...patch,
+    }
+    const nextOrganizations = new Map(_organizations.value)
+    nextOrganizations.set(orgId, nextOrganization)
     _organizations.value = nextOrganizations
-    if (currentOrganization.value)
-      currentOrganization.value = nextOrganizations.get(currentOrganization.value.gid)
+
+    if (currentOrganization.value?.gid === orgId)
+      currentOrganization.value = nextOrganization
+  }
+
+  const loadOrganizationLogo = async (org: Organization & { id: number }, run: number) => {
+    const logoSource = org.logo_storage_path ?? org.logo
+    const { normalized, shouldSign } = resolveImagePath(logoSource)
+    if (!normalized || !shouldSign) {
+      updateOrganizationLogoState(org.gid, { logo_is_loading: false }, run)
+      return
+    }
+
+    try {
+      const signedLogo = await createSignedImageUrl(normalized)
+      updateOrganizationLogoState(org.gid, {
+        logo: signedLogo || org.logo,
+        logo_storage_path: normalized,
+        logo_is_loading: false,
+      }, run)
+    }
+    catch (error) {
+      console.warn('Cannot load signed organization logo', { orgId: org.gid, error })
+      updateOrganizationLogoState(org.gid, { logo_is_loading: false }, run)
+    }
+  }
+
+  const loadOrganizationLogos = (sourceOrganizations: Array<Organization & { id: number }>, run: number) => {
+    for (const org of sourceOrganizations)
+      void loadOrganizationLogo(org, run)
   }
 
   watch([currentOrganization, stripeEnabled], async ([currentOrganizationRaw, stripeEnabledValue], [previousOrganization]) => {
@@ -472,12 +473,13 @@ export const useOrganizationStore = defineStore('organization', () => {
 
     const logoLoadRun = ++organizationLogoLoadRun
     const mappedData = data.map((item, id) => {
-      const logoStoragePath = resolveImagePath(item.logo).normalized
+      const { normalized: logoStoragePath, shouldSign: shouldSignLogo } = resolveImagePath(item.logo)
       return {
         id,
         ...item,
         logo: getImmediateImageUrl(item.logo) || null,
         logo_storage_path: logoStoragePath || null,
+        logo_is_loading: shouldSignLogo,
         password_policy_config: item.password_policy_config as PasswordPolicyConfig | null,
       } as Organization & { id: number }
     })
@@ -547,6 +549,7 @@ export const useOrganizationStore = defineStore('organization', () => {
         ...org,
         logo: refreshedLogo,
         logo_storage_path: logoStoragePath || null,
+        logo_is_loading: false,
       })
       updated = true
     }

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -280,8 +280,12 @@ export const useOrganizationStore = defineStore('organization', () => {
   }
 
   const loadOrganizationLogos = (sourceOrganizations: Array<Organization & { id: number }>, run: number) => {
-    for (const org of sourceOrganizations)
-      void loadOrganizationLogo(org, run)
+    for (const org of sourceOrganizations) {
+      loadOrganizationLogo(org, run).catch((error) => {
+        console.warn('Cannot load signed organization logo', { orgId: org.gid, error })
+        updateOrganizationLogoState(org.gid, { logo_is_loading: false }, run)
+      })
+    }
   }
 
   watch([currentOrganization, stripeEnabled], async ([currentOrganizationRaw, stripeEnabledValue], [previousOrganization]) => {
@@ -437,8 +441,11 @@ export const useOrganizationStore = defineStore('organization', () => {
       image_url: getImmediateImageUrl(item.image_url) || '',
     }))
 
-    if (onSignedImages)
-      void loadSignedMemberImages(memberImageSources, onSignedImages)
+    if (onSignedImages) {
+      loadSignedMemberImages(memberImageSources, onSignedImages).catch((error) => {
+        console.warn('Cannot load signed member images', error)
+      })
+    }
 
     return mappedMembers
   }
@@ -489,7 +496,7 @@ export const useOrganizationStore = defineStore('organization', () => {
     })
 
     _organizations.value = new Map(mappedData.map(item => [item.gid, item as Organization]))
-    void loadOrganizationLogos(mappedData, logoLoadRun)
+    loadOrganizationLogos(mappedData, logoLoadRun)
 
     const selectableOrganizations = mappedData
       .filter(org => isSelectableOrganization(org.role))

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -241,6 +241,10 @@ export const useOrganizationStore = defineStore('organization', () => {
     if (!organization)
       return
 
+    const hasChanges = Object.entries(patch).some(([key, value]) => organization[key as keyof Organization] !== value)
+    if (!hasChanges)
+      return
+
     const nextOrganization = {
       ...organization,
       ...patch,


### PR DESCRIPTION
## Summary (AI generated)

- Added visible loading indicators while signed app and organization images resolve asynchronously.
- Updated the apps list so each app icon signs and renders independently instead of waiting for all icons.
- Added loading states for app settings, app onboarding resume previews, organization dropdown logos, and organization settings logos.

## Motivation (AI generated)

Async image signing should not block page load, but users should still see that private images are actively loading instead of seeing fallback initials immediately.

## Business Impact (AI generated)

This improves perceived performance and reduces confusion in app and organization lists with private image assets, while preserving fast non-blocking page load.

## Test Plan (AI generated)

- [x] Run `bun lint`
- [x] Run `bun typecheck`
- [x] Run targeted Vitest image/store tests
- [x] Wait for GitHub CI, including backend, Cloudflare backend, Playwright, CodeQL, SonarCloud, CodSpeed, and Socket checks
- [x] Wait for CodeRabbit review to complete with no review-in-progress state

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Loading spinners now appear when app icons and organization logos are being loaded, providing clear visual feedback instead of blank spaces.

* **Improvements**
  * Enhanced loading state tracking for individual apps and organizations for better reliability.
  * Strengthened organization deletion with additional validation and permission checks.
  * Improved member image loading with enhanced error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->