### PR TITLE
[codex] Cover plugin version ladder backfill

### DIFF
--- a/scripts/backfill_plugin_version_ladder.ts
+++ b/scripts/backfill_plugin_version_ladder.ts
@@ -146,6 +146,9 @@ function parseJsonString(value: string) {
   }
 }
 
+/**
+ * Normalizes the stored plugin version percentage object from global_stats.
+ */
 export function parseBreakdown(value: Json | null): Record<string, number> {
   if (!value)
     return {}
@@ -162,6 +165,9 @@ export function parseBreakdown(value: Json | null): Record<string, number> {
   }, {})
 }
 
+/**
+ * Normalizes stored ladder JSON so existing rows can be compared safely.
+ */
 export function parseLadder(value: Json | null): PluginVersionLadderEntry[] {
   if (!value)
     return []
@@ -222,6 +228,9 @@ function normalizeLadderForCompare(ladder: PluginVersionLadderEntry[]) {
   })))
 }
 
+/**
+ * Reuses stored chart percentages so ladder and chart snapshots stay aligned.
+ */
 export function applyStoredPercents(ladder: PluginVersionLadderEntry[], storedBreakdown: Record<string, number>) {
   return ladder.map(entry => ({
     ...entry,
@@ -229,6 +238,9 @@ export function applyStoredPercents(ladder: PluginVersionLadderEntry[], storedBr
   }))
 }
 
+/**
+ * Aggregates Analytics Engine rows into chart breakdowns and top-app ladder entries.
+ */
 export function buildPluginBreakdownResult(result: PluginBreakdownRow[]): PluginBreakdownResult {
   const emptyResult: PluginBreakdownResult = { version_breakdown: {}, major_breakdown: {}, version_ladder: [] }
   if (result.length === 0)

--- a/scripts/backfill_plugin_version_ladder.ts
+++ b/scripts/backfill_plugin_version_ladder.ts
@@ -146,7 +146,7 @@ function parseJsonString(value: string) {
   }
 }
 
-function parseBreakdown(value: Json | null): Record<string, number> {
+export function parseBreakdown(value: Json | null): Record<string, number> {
   if (!value)
     return {}
 
@@ -162,7 +162,7 @@ function parseBreakdown(value: Json | null): Record<string, number> {
   }, {})
 }
 
-function parseLadder(value: Json | null): PluginVersionLadderEntry[] {
+export function parseLadder(value: Json | null): PluginVersionLadderEntry[] {
   if (!value)
     return []
 
@@ -222,14 +222,14 @@ function normalizeLadderForCompare(ladder: PluginVersionLadderEntry[]) {
   })))
 }
 
-function applyStoredPercents(ladder: PluginVersionLadderEntry[], storedBreakdown: Record<string, number>) {
+export function applyStoredPercents(ladder: PluginVersionLadderEntry[], storedBreakdown: Record<string, number>) {
   return ladder.map(entry => ({
     ...entry,
     percent: Number(storedBreakdown[entry.version]) || entry.percent,
   }))
 }
 
-function buildPluginBreakdownResult(result: PluginBreakdownRow[]): PluginBreakdownResult {
+export function buildPluginBreakdownResult(result: PluginBreakdownRow[]): PluginBreakdownResult {
   const emptyResult: PluginBreakdownResult = { version_breakdown: {}, major_breakdown: {}, version_ladder: [] }
   if (result.length === 0)
     return emptyResult

--- a/tests/backfill-plugin-version-ladder.unit.test.ts
+++ b/tests/backfill-plugin-version-ladder.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { applyStoredPercents, buildPluginBreakdownResult, parseBreakdown, parseLadder } from '../scripts/backfill_plugin_version_ladder.ts'
+
+describe('plugin version ladder backfill helpers', () => {
+  it.concurrent('aggregates top plugin versions with the top three apps per version', () => {
+    const result = buildPluginBreakdownResult([
+      { plugin_version: '7.1.0', app_id: 'app.a', device_count: 5 },
+      { plugin_version: '7.1.0', app_id: 'app.b', device_count: 4 },
+      { plugin_version: '7.1.0', app_id: 'app.c', device_count: 3 },
+      { plugin_version: '7.1.0', app_id: 'app.d', device_count: 2 },
+      { plugin_version: '6.0.0', app_id: 'app.a', device_count: 4 },
+      { plugin_version: '6.0.0', app_id: 'app.b', device_count: 1 },
+      { plugin_version: '5.2.0', app_id: 'app.z', device_count: '5' },
+      { plugin_version: '', app_id: 'app.skip', device_count: 10 },
+      { plugin_version: '4.0.0', app_id: '', device_count: 10 },
+      { plugin_version: '3.0.0', app_id: 'app.zero', device_count: 0 },
+    ])
+
+    expect(result.version_breakdown).toEqual({
+      '7.1.0': 58.33,
+      '6.0.0': 20.83,
+      '5.2.0': 20.83,
+    })
+    expect(result.major_breakdown).toEqual({
+      7: 58.33,
+      6: 20.83,
+      5: 20.83,
+    })
+    expect(result.version_ladder).toEqual([
+      {
+        version: '7.1.0',
+        device_count: 14,
+        percent: 58.33,
+        top_apps: [
+          { app_id: 'app.a', device_count: 5, share: 35.71 },
+          { app_id: 'app.b', device_count: 4, share: 28.57 },
+          { app_id: 'app.c', device_count: 3, share: 21.43 },
+        ],
+      },
+      {
+        version: '5.2.0',
+        device_count: 5,
+        percent: 20.83,
+        top_apps: [
+          { app_id: 'app.z', device_count: 5, share: 100 },
+        ],
+      },
+      {
+        version: '6.0.0',
+        device_count: 5,
+        percent: 20.83,
+        top_apps: [
+          { app_id: 'app.a', device_count: 4, share: 80 },
+          { app_id: 'app.b', device_count: 1, share: 20 },
+        ],
+      },
+    ])
+  })
+
+  it.concurrent('uses stored chart percentages when rebuilding ladder rows', () => {
+    const result = applyStoredPercents([
+      {
+        version: '7.1.0',
+        device_count: 14,
+        percent: 58.33,
+        top_apps: [],
+      },
+    ], { '7.1.0': 60 })
+
+    expect(result[0].percent).toBe(60)
+  })
+
+  it.concurrent('normalizes stored breakdown and ladder json', () => {
+    expect(parseBreakdown('{"7.1.0":58.33,"bad":0,"skip":"0"}')).toEqual({ '7.1.0': 58.33 })
+    expect(parseBreakdown('not-json')).toEqual({})
+
+    expect(parseLadder(JSON.stringify([
+      {
+        version: '7.1.0',
+        device_count: '14',
+        percent: '58.33',
+        top_apps: [
+          { app_id: 'app.a', device_count: '5', share: '35.71' },
+          { app_id: '', device_count: 4, share: 28.57 },
+        ],
+      },
+      { version: '', device_count: 10 },
+    ]))).toEqual([
+      {
+        version: '7.1.0',
+        device_count: 14,
+        percent: 58.33,
+        top_apps: [
+          { app_id: 'app.a', device_count: 5, share: 35.71 },
+        ],
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Added focused unit coverage for the plugin version ladder backfill aggregation helpers.
- Exported pure helper functions from the backfill script so the aggregation and JSON normalization paths are directly testable.

## Motivation (AI generated)

The merged plugin version ladder backfill script should have coverage for the top-version and top-app aggregation logic that populates admin ladder data.

## Business Impact (AI generated)

This reduces regression risk for admin production analytics backfills, which helps keep plugin adoption reporting trustworthy for operational decisions.

## Test Plan (AI generated)

- [x] bunx eslint scripts/backfill_plugin_version_ladder.ts tests/backfill-plugin-version-ladder.unit.test.ts --no-ignore
- [x] bunx vitest run tests/backfill-plugin-version-ladder.unit.test.ts
- [x] bunx tsc --noEmit --allowImportingTsExtensions --moduleResolution bundler --module esnext --target es2022 --skipLibCheck --types vitest --ignoreConfig scripts/backfill_plugin_version_ladder.ts tests/backfill-plugin-version-ladder.unit.test.ts
- [x] bun lint
- [x] bun lint:backend
- [x] bun typecheck

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for plugin version ladder utilities, validating breakdown aggregation, percentage application, and input format handling.

* **Refactor**
  * Improved internal module API structure to enhance code organization and reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->