### PR TITLE
[codex] Hide active bundle chart legend

### DIFF
--- a/src/components/dashboard/DevicesStats.vue
+++ b/src/components/dashboard/DevicesStats.vue
@@ -301,20 +301,6 @@ function generateDayLabels(_totalLength: number) {
   return generateChartDayLabels(props.useBillingPeriod, startDate, endDate)
 }
 
-function roundPercentageInString(text: string) {
-  if (!text)
-    return text
-
-  return text.replace(/(\d+(?:\.\d+)?)(?=%)/g, (match) => {
-    const numeric = Number(match)
-    if (Number.isNaN(numeric))
-      return match
-
-    const rounded = Number(numeric.toFixed(1))
-    return Number.isInteger(rounded) ? Math.trunc(rounded).toString() : rounded.toFixed(1)
-  })
-}
-
 const processedChartData = computed<ChartData<'line'> | null>(() => {
   if (!rawChartData.value)
     return null
@@ -537,22 +523,7 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
 
   const pluginOptions = {
     legend: {
-      display: hasMultipleDatasets,
-      position: 'bottom',
-      labels: {
-        color: isDark.value ? 'white' : 'black',
-        padding: 10,
-        font: {
-          size: 11,
-        },
-        generateLabels(chart: Chart) {
-          const original = Chart.defaults.plugins.legend.labels.generateLabels(chart)
-          return original.map(item => ({
-            ...item,
-            text: roundPercentageInString(item.text),
-          }))
-        },
-      },
+      display: false,
     },
     title: { display: false },
     tooltip: tooltipOptions,
@@ -746,6 +717,6 @@ watch(
       </div>
     </template>
 
-    <Line :data="processedChartData!" :options="chartOptions" :plugins="chartPlugins" />
+    <Line class="h-full w-full" :data="processedChartData!" :options="chartOptions" :plugins="chartPlugins" />
   </ChartCard>
 </template>


### PR DESCRIPTION
## Summary (AI generated)

- Hide the Chart.js legend on the Active bundle device-version chart.
- Keep the chart canvas sized to fill the existing dashboard card.

## Motivation (AI generated)

The version legend could overflow the fixed-height card when many bundle versions were present, and this chart should visually match the other dashboard charts that do not show a default legend.

## Business Impact (AI generated)

This improves dashboard polish and prevents a broken-looking chart card for apps with many active bundle versions, reducing confusion for customers reviewing rollout adoption.

## Test Plan (AI generated)

- [x] Run `bun lint`
- [x] Run `bun typecheck`
- [x] Run `bun run build`

Generated with AI