### PR TITLE
[codex] Suppress expected files Durable Object timeout alerts

### DIFF
--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -8,6 +8,19 @@ import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
 
+function isFilesDurableObjectStorageTimeout(functionName: string, error: unknown): boolean {
+  if (functionName !== 'files' || !error || typeof error !== 'object' || !('message' in error))
+    return false
+
+  const { message } = error as { message?: unknown }
+  if (typeof message !== 'string')
+    return false
+
+  const normalizedMessage = message.toLowerCase()
+  return normalizedMessage.includes('storage operation exceeded timeout')
+    && normalizedMessage.includes('object to be reset')
+}
+
 export function onError(functionName: string) {
   return async (e: any, c: Context) => {
     let body = 'N/A'
@@ -153,6 +166,7 @@ export function onError(functionName: string) {
       return c.json(defaultResponse, 500)
     }
     // Non-HTTP errors: log with stack and return 500
+    const suppressDiscordAlert = isFilesDurableObjectStorageTimeout(functionName, e)
     cloudlogErr({
       requestId: c.get('requestId'),
       functionName,
@@ -162,7 +176,9 @@ export function onError(functionName: string) {
       errorMessage: e?.message ?? 'Unknown error',
       stack: serializeError(e)?.stack ?? 'N/A',
     })
-    await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
+    if (!suppressDiscordAlert)
+      await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
+
     void backgroundTask(c, capturePosthogException(c, {
       error: e,
       functionName,

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -7,9 +7,10 @@ import { capturePosthogException } from './posthog.ts'
 import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
+const filesUploadFunctionNames = new Set(['files', 'TUS handler'])
 
 function isFilesDurableObjectStorageTimeout(functionName: string, error: unknown): boolean {
-  if (functionName !== 'files' || !error || typeof error !== 'object' || !('message' in error))
+  if (!filesUploadFunctionNames.has(functionName) || !error || typeof error !== 'object' || !('message' in error))
     return false
 
   const { message } = error as { message?: unknown }

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -174,6 +174,37 @@ describe('onError PostHog capture', () => {
     })
   })
 
+  it('skips Discord for expected files Durable Object storage timeouts', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const error = Object.assign(
+      new Error('Durable Object storage operation exceeded timeout which caused object to be reset.'),
+      {
+        durableObjectReset: true,
+        overloaded: true,
+      },
+    )
+
+    const response = await onError('files')(error, createContext())
+
+    expect(backgroundTaskMock).toHaveBeenCalledTimes(1)
+    expect(backgroundTaskMock.mock.calls[0]?.[1]).toBeInstanceOf(Promise)
+    expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
+    expect(capturePosthogExceptionMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      functionName: 'files',
+      kind: 'unhandled_error',
+      status: 500,
+    }))
+    expect(response).toEqual({
+      body: {
+        error: 'unknown_error',
+        message: 'Unknown error',
+        moreInfo: {},
+      },
+      status: 500,
+    })
+  })
+
   it('captures generic unhandled errors in PostHog', async () => {
     const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
 

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -205,6 +205,21 @@ describe('onError PostHog capture', () => {
     })
   })
 
+  it('skips Discord for expected TUS handler Durable Object storage timeouts', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const response = await onError('TUS handler')(new Error('Durable Object storage operation exceeded timeout which caused object to be reset.'), createContext())
+
+    expect(backgroundTaskMock).toHaveBeenCalledTimes(1)
+    expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
+    expect(capturePosthogExceptionMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      functionName: 'TUS handler',
+      kind: 'unhandled_error',
+      status: 500,
+    }))
+    expect(response.status).toBe(500)
+  })
+
   it('captures generic unhandled errors in PostHog', async () => {
     const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
 


### PR DESCRIPTION
## Summary (AI generated)

- Suppress Discord 500 alerts for expected files Durable Object storage timeout/reset errors.
- Keep logging and PostHog capture active for the same files error path.
- Add unit coverage for the files-specific Discord suppression.

## Motivation (AI generated)

Cloudflare Durable Object storage timeout resets are expected for files uploads in some cases, but they currently create noisy Discord failure reports.

## Business Impact (AI generated)

Reduces alert fatigue for normal files upload timeout behavior while preserving operational visibility in logs and PostHog.

## Test Plan (AI generated)

- [x] bun lint
- [x] bun lint:backend
- [x] bunx vitest run tests/on-error-posthog.unit.test.ts
- [x] git diff --check
- [x] pre-commit: bun run cli:build && vue-tsc --noEmit

Generated with AI
