### PR TITLE
[codex] Fix devices cursor pagination without explicit order

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -625,15 +625,18 @@ function getReadDevicesCFOrder(params: ReadDevicesParams): DevicesOrderCF | null
 }
 
 function buildReadDevicesCFCursorFilter(cursor: string | undefined, devicesOrder: DevicesOrderCF | null) {
-  if (!(cursor && devicesOrder))
+  if (!cursor)
     return ''
 
   const [cursorTime, cursorDeviceId] = cursor.split('|')
   if (!(cursorTime && cursorDeviceId))
     return ''
 
-  const safeCursorTime = escapeSqlString(cursorTime)
   const safeCursorDeviceId = escapeSqlString(cursorDeviceId)
+  if (!devicesOrder)
+    return `WHERE device_id > '${safeCursorDeviceId}'`
+
+  const safeCursorTime = escapeSqlString(cursorTime)
   const comparison = devicesOrder.ascending ? '>' : '<'
 
   return `WHERE (updated_at ${comparison} toDateTime('${safeCursorTime}') OR (updated_at = toDateTime('${safeCursorTime}') AND device_id > '${safeCursorDeviceId}'))`

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1290,14 +1290,15 @@ export async function readDevicesSB(c: Context, params: ReadDevicesParams, custo
 
   const devicesOrder = getDevicesOrder(params.order)
 
-  // Cursor-based pagination only works when an updated_at order is active
-  if (params.cursor && devicesOrder) {
+  if (params.cursor) {
     // Cursor format: "updated_at|device_id"
     const [cursorTime, cursorDeviceId] = params.cursor.split('|')
     if (cursorTime && cursorDeviceId) {
       const quotedCursorTime = quotePostgrestFilterValue(cursorTime)
       const quotedCursorDeviceId = quotePostgrestFilterValue(cursorDeviceId)
-      if (devicesOrder.ascending)
+      if (!devicesOrder)
+        query = query.gt('device_id', cursorDeviceId)
+      else if (devicesOrder.ascending)
         query = query.or(`updated_at.gt.${quotedCursorTime},and(updated_at.eq.${quotedCursorTime},device_id.gt.${quotedCursorDeviceId})`)
       else
         query = query.or(`updated_at.lt.${quotedCursorTime},and(updated_at.eq.${quotedCursorTime},device_id.gt.${quotedCursorDeviceId})`)

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from 'vitest'
 import { buildReadDevicesCFQuery } from '../supabase/functions/_backend/utils/cloudflare.ts'
 
 describe('buildReadDevicesCFQuery', () => {
+  it.concurrent('applies default device_id cursor pagination when no order is provided', () => {
+    const query = buildReadDevicesCFQuery({
+      app_id: 'com.example.app',
+      cursor: '2026-04-04 03:05:59|11111111-1111-4111-8111-111111111111',
+      limit: 1,
+    }, false)
+
+    const groupByIndex = query.indexOf('GROUP BY blob1')
+    const cursorIndex = query.indexOf(`WHERE device_id > '11111111-1111-4111-8111-111111111111'`)
+
+    expect(groupByIndex).toBeGreaterThan(-1)
+    expect(cursorIndex).toBeGreaterThan(groupByIndex)
+    expect(query).toContain('ORDER BY device_id ASC')
+  })
+
   it.concurrent('applies descending cursor pagination after device grouping', () => {
     const query = buildReadDevicesCFQuery({
       app_id: 'com.example.app',

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -1,5 +1,42 @@
-import { describe, expect, it } from 'vitest'
+import type { Context } from 'hono'
+import { createClient } from '@supabase/supabase-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildReadDevicesCFQuery } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { readDevicesSB } from '../supabase/functions/_backend/utils/supabase.ts'
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}))
+
+function createReadDevicesQueryMock() {
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    gt: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    then: vi.fn((resolve, reject) => Promise.resolve({ data: [], error: null }).then(resolve, reject)),
+  }
+  const client = {
+    from: vi.fn(() => query),
+  }
+
+  return { client, query }
+}
+
+function createContextMock() {
+  return {
+    env: {
+      SUPABASE_URL: 'http://localhost:54321',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    },
+    get: vi.fn((key: string) => key === 'requestId' ? 'test-request' : undefined),
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(createClient).mockReset()
+})
 
 describe('buildReadDevicesCFQuery', () => {
   it.concurrent('applies default device_id cursor pagination when no order is provided', () => {
@@ -50,5 +87,24 @@ describe('buildReadDevicesCFQuery', () => {
     expect(query).toContain(`WHERE (updated_at > toDateTime('2026-04-04 03:05:59')`)
     expect(tiebreakerIndex).toBeGreaterThan(cursorIndex)
     expect(query).toContain(`ORDER BY updated_at ASC, device_id ASC`)
+  })
+})
+
+describe('readDevicesSB', () => {
+  it('applies default device_id cursor pagination when no order is provided', async () => {
+    const { client, query } = createReadDevicesQueryMock()
+    vi.mocked(createClient).mockReturnValue(client as unknown as ReturnType<typeof createClient>)
+
+    await readDevicesSB(createContextMock() as unknown as Context, {
+      app_id: 'com.example.app',
+      cursor: '2026-04-04 03:05:59|11111111-1111-4111-8111-111111111111',
+      limit: 1,
+    }, false)
+
+    expect(client.from).toHaveBeenCalledWith('devices')
+    expect(query.gt).toHaveBeenCalledWith('device_id', '11111111-1111-4111-8111-111111111111')
+    expect(query.order).toHaveBeenCalledTimes(1)
+    expect(query.order).toHaveBeenCalledWith('device_id', { ascending: true })
+    expect(query.limit).toHaveBeenCalledWith(2)
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Fixed `/private/devices` cursor pagination when callers omit `order`.
- Made the Cloudflare Analytics Engine path advance by `device_id` for the default `device_id ASC` ordering.
- Matched the Supabase fallback path and added regression coverage for the no-order cursor case.

## Motivation (AI generated)

The security advisory GHSA-8p6w-x7jg-v4xq reported that replaying a returned `nextCursor` on the production Cloudflare worker could return the same device again with the same cursor and `hasMore=true`. The root cause was that cursor filtering only applied when `updated_at` ordering was explicit, while the default query order is `device_id ASC`.

## Business Impact (AI generated)

This prevents duplicate-page loops and inaccessible later rows in device enumeration. It reduces the risk of unbounded client iteration, repeated processing, and broken device-management workflows for customers using paginated device reads.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bunx vitest run tests/cloudflare-device-pagination.unit.test.ts`
- [x] `bun typecheck`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor-based pagination to correctly handle filtering and ordering in various configurations.
  * Fixed pagination behavior when cursor navigation is used without custom ordering.

* **Tests**
  * Added test coverage for default pagination behavior with cursor navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->