### PR TITLE
fix(sso): trust auth email for account merge

### DIFF
--- a/supabase/functions/_backend/private/sso/provision-user.ts
+++ b/supabase/functions/_backend/private/sso/provision-user.ts
@@ -60,14 +60,10 @@ async function findCanonicalAuthUserIdByEmail(pgClient: ReturnType<typeof getPgC
         ) then 0 else 1 end,
         au.created_at asc,
         au.id asc
-      limit 2
+      limit 1
     `,
     [email, excludedUserId, trustedProviders],
   )
-
-  if (result.rows.length > 1) {
-    throw new Error('ambiguous_existing_auth_users')
-  }
 
   return result.rows[0]?.id ?? null
 }
@@ -303,6 +299,162 @@ async function ensurePublicUserRowExists(
   }
 }
 
+async function ensurePublicUserRowExistsInTransaction(
+  pgClient: ReturnType<typeof getPgClient>,
+  requestId: string,
+  user: PublicUserSeed,
+): Promise<void> {
+  try {
+    await pgClient.query(
+      `
+        insert into public.users (id, email, first_name, last_name, enable_notifications, opt_for_newsletters)
+        values ($1, $2, $3, $4, true, true)
+        on conflict (id) do update
+        set email = excluded.email
+        where public.users.email is distinct from excluded.email
+      `,
+      [user.id, user.email, user.first_name, user.last_name],
+    )
+  }
+  catch (error) {
+    cloudlogErr({ requestId, message: 'Failed to sync public.users row during SSO merge transaction', userId: user.id, email: user.email, error })
+    throw new Error('public_user_sync_failed')
+  }
+}
+
+async function ensureOrgMembershipInTransaction(
+  pgClient: ReturnType<typeof getPgClient>,
+  requestId: string,
+  userId: string,
+  orgId: string,
+  fallbackRole: Exclude<OrgMembershipRight, `invite_${string}`> = 'read',
+): Promise<void> {
+  const promoteExistingInvite = async (membershipId: string, currentRight: OrgMembershipRight | null) => {
+    if (!isInviteRole(currentRight)) {
+      return
+    }
+
+    const promotedRole = promoteInviteRole(currentRight)
+    await pgClient.query(
+      `
+        update public.org_users
+        set user_right = $1
+        where id = $2
+      `,
+      [promotedRole, membershipId],
+    )
+  }
+
+  try {
+    const existingMembership = await pgClient.query<{ id: string, user_right: OrgMembershipRight | null }>(
+      `
+        select id, user_right
+        from public.org_users
+        where user_id = $1
+          and org_id = $2
+        for update
+      `,
+      [userId, orgId],
+    )
+
+    const existing = existingMembership.rows[0]
+    if (existing) {
+      await promoteExistingInvite(existing.id, existing.user_right)
+      return
+    }
+
+    const insertedMembership = await pgClient.query(
+      `
+        insert into public.org_users (user_id, org_id, user_right)
+        values ($1, $2, $3)
+        on conflict do nothing
+      `,
+      [userId, orgId, fallbackRole],
+    )
+
+    if ((insertedMembership.rowCount ?? 0) > 0) {
+      return
+    }
+
+    const racedMembership = await pgClient.query<{ id: string, user_right: OrgMembershipRight | null }>(
+      `
+        select id, user_right
+        from public.org_users
+        where user_id = $1
+          and org_id = $2
+        for update
+      `,
+      [userId, orgId],
+    )
+
+    const raced = racedMembership.rows[0]
+    if (raced) {
+      await promoteExistingInvite(raced.id, raced.user_right)
+      return
+    }
+
+    throw new Error('membership_insert_failed')
+  }
+  catch (error) {
+    cloudlogErr({ requestId, message: 'Failed to ensure org membership during SSO merge transaction', userId, orgId, fallbackRole, error })
+    throw new Error('provision_failed')
+  }
+}
+
+async function mergeSsoIdentityWithExistingAccount(
+  pgClient: ReturnType<typeof getPgClient>,
+  requestId: string,
+  params: {
+    originalUserId: string
+    duplicateUserId: string
+    publicUser: PublicUserSeed
+    orgId: string
+    authorizedSsoProviders: string[]
+    enforceSso: boolean
+  },
+): Promise<void> {
+  await pgClient.query('begin')
+  try {
+    let transferredIdentityCount = 0
+    try {
+      transferredIdentityCount = await transferSsoIdentities(pgClient, params.originalUserId, params.duplicateUserId, params.authorizedSsoProviders)
+    }
+    catch (identityTransferError) {
+      cloudlogErr({ requestId, message: 'Failed to transfer SSO identity during merge', userId: params.duplicateUserId, originalUserId: params.originalUserId, error: identityTransferError })
+      throw new Error('identity_transfer_failed')
+    }
+
+    if (transferredIdentityCount === 0) {
+      cloudlogErr({ requestId, message: 'No SSO identities were transferred during merge', userId: params.duplicateUserId, originalUserId: params.originalUserId })
+      throw new Error('identity_transfer_failed')
+    }
+
+    await ensurePublicUserRowExistsInTransaction(pgClient, requestId, params.publicUser)
+    await ensureOrgMembershipInTransaction(pgClient, requestId, params.originalUserId, params.orgId)
+
+    if (params.enforceSso) {
+      try {
+        await setAuthUserSsoOnly(pgClient, params.originalUserId)
+      }
+      catch (ssoFlagError) {
+        cloudlogErr({ requestId, message: 'Failed to set is_sso_user on original user during merge', originalUserId: params.originalUserId, error: ssoFlagError })
+        throw new Error('sso_flag_update_failed')
+      }
+    }
+
+    await pgClient.query('commit')
+  }
+  catch (error) {
+    try {
+      await pgClient.query('rollback')
+    }
+    catch (rollbackError) {
+      cloudlogErr({ requestId, message: 'Failed to roll back SSO merge transaction', userId: params.duplicateUserId, originalUserId: params.originalUserId, error: rollbackError })
+    }
+    throw error
+  }
+}
+
 app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
   const auth = c.get('auth')
   if (!auth) {
@@ -359,41 +511,23 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       return quickError(400, 'invalid_email', 'User email has no domain')
     }
 
-    // Detect pre-existing user with the same email (different UUID).
+    // Detect pre-existing auth identity with the same trusted email (different UUID).
     // This happens when SSO is enabled for a domain where users already had email/password accounts.
     // Supabase Auth creates a new auth.users record instead of linking — we fix this by merging.
     //
-    // Security note: the email match only selects a merge candidate. The merge must not proceed
-    // until the domain's active SSO provider is resolved and matched against the provider that
-    // authenticated this session; a valid SAML signature alone does not prove email-domain control.
-    const { data: existingUser, error: existingUserError } = await (admin as any)
-      .from('users')
-      .select('id')
-      .eq('email', userEmail)
-      .neq('id', userId)
-      .maybeSingle()
-
-    if (existingUserError) {
-      cloudlogErr({ requestId, message: 'Failed to check for pre-existing user by email', userId, email: userEmail, error: existingUserError })
-      return quickError(500, 'user_lookup_failed', 'Failed to check for existing user')
+    // Security note: never resolve the merge candidate from public.users.email. That profile
+    // column is user-editable; only auth.users.email and the current verified SSO session are
+    // trusted identity sources for account linking.
+    let resolvedExistingUserId: string | null = null
+    try {
+      resolvedExistingUserId = await findCanonicalAuthUserIdByEmail(getSharedPgClient(), userEmail, userId, trustedSsoProviders)
+      if (resolvedExistingUserId) {
+        cloudlog({ requestId, message: 'Canonical pre-existing auth account found — will merge SSO identity after provider authorization', userId, originalUserId: resolvedExistingUserId, email: userEmail })
+      }
     }
-
-    // Fallback: check auth.users directly in case the existing account has no public.users row yet.
-    // This covers cases where the original user authenticated via SSO (with a now-deleted provider)
-    // and their public.users was never created, or was cleaned up.
-    let resolvedExistingUserId: string | null = existingUser?.id ?? null
-    if (!resolvedExistingUserId) {
-      try {
-        const existingAuthUserId = await findCanonicalAuthUserIdByEmail(getSharedPgClient(), userEmail, userId, trustedSsoProviders)
-        if (existingAuthUserId) {
-          cloudlog({ requestId, message: 'Canonical pre-existing auth account found (no public.users row yet) — will merge SSO identity', userId, originalUserId: existingAuthUserId, email: userEmail })
-          resolvedExistingUserId = existingAuthUserId
-        }
-      }
-      catch (existingAuthUserError) {
-        cloudlogErr({ requestId, message: 'Failed to check auth.users for pre-existing account by email', userId, email: userEmail, error: existingAuthUserError })
-        return quickError(500, 'user_lookup_failed', 'Failed to resolve existing account for SSO merge')
-      }
+    catch (existingAuthUserError) {
+      cloudlogErr({ requestId, message: 'Failed to check auth.users for pre-existing account by email', userId, email: userEmail, error: existingAuthUserError })
+      return quickError(500, 'user_lookup_failed', 'Failed to resolve existing account for SSO merge')
     }
 
     if (resolvedExistingUserId) {
@@ -429,47 +563,38 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
         return quickError(403, 'provider_mismatch', 'SSO provider does not match the email domain provider')
       }
 
+      // Step 2: Transfer the SSO identity and provision the merged account atomically.
       try {
-        await ensurePublicUserRowExists(admin, requestId, {
-          ...publicUserSeed,
-          id: originalUserId,
+        await mergeSsoIdentityWithExistingAccount(getSharedPgClient(), requestId, {
+          originalUserId,
+          duplicateUserId: userId,
+          publicUser: {
+            ...publicUserSeed,
+            id: originalUserId,
+          },
+          orgId: mergeProvider.org_id,
+          authorizedSsoProviders,
+          enforceSso: mergeProvider?.enforce_sso === true,
         })
       }
-      catch {
-        return quickError(500, 'public_user_sync_failed', 'Failed to create user profile for merged SSO account')
-      }
-
-      try {
-        await ensureOrgMembership(admin, requestId, originalUserId, mergeProvider.org_id)
-      }
-      catch {
-        return quickError(500, 'provision_failed', 'Failed to provision user to organization')
-      }
-
-      // Step 2: Transfer SSO identity from duplicate user (userId) → original user (originalUserId)
-      try {
-        const transferredIdentityCount = await transferSsoIdentities(getSharedPgClient(), originalUserId, userId, authorizedSsoProviders)
-        if (transferredIdentityCount === 0) {
-          cloudlogErr({ requestId, message: 'No SSO identities were transferred during merge', userId, originalUserId })
-          return quickError(500, 'identity_transfer_failed', 'Failed to merge SSO identity with existing account')
+      catch (mergeError) {
+        if (mergeError instanceof Error) {
+          if (mergeError.message === 'identity_transfer_failed') {
+            return quickError(500, 'identity_transfer_failed', 'Failed to merge SSO identity with existing account')
+          }
+          if (mergeError.message === 'public_user_sync_failed') {
+            return quickError(500, 'public_user_sync_failed', 'Failed to create user profile for merged SSO account')
+          }
+          if (mergeError.message === 'provision_failed') {
+            return quickError(500, 'provision_failed', 'Failed to provision user to organization')
+          }
+          if (mergeError.message === 'sso_flag_update_failed') {
+            return quickError(500, 'sso_flag_update_failed', 'Failed to enforce SSO on merged account')
+          }
         }
-      }
-      catch (identityTransferError) {
-        cloudlogErr({ requestId, message: 'Failed to transfer SSO identity during merge', userId, originalUserId, error: identityTransferError })
-        return quickError(500, 'identity_transfer_failed', 'Failed to merge SSO identity with existing account')
-      }
 
-      // Step 2b: Mark the merged account as SSO-only immediately when enforce_sso is active.
-      // Provider updates sync auth.users.is_sso_user by domain when enforcement changes later,
-      // so this write reflects the current provider state instead of becoming permanently sticky.
-      if (mergeProvider?.enforce_sso === true) {
-        try {
-          await setAuthUserSsoOnly(getSharedPgClient(), originalUserId)
-        }
-        catch (ssoFlagError) {
-          cloudlogErr({ requestId, message: 'Failed to set is_sso_user on original user during merge', originalUserId, error: ssoFlagError })
-          return quickError(500, 'sso_flag_update_failed', 'Failed to enforce SSO on merged account')
-        }
+        cloudlogErr({ requestId, message: 'Failed to complete SSO merge transaction', userId, originalUserId, error: mergeError })
+        return quickError(500, 'merge_failed', 'Failed to merge SSO account')
       }
 
       // Step 3: Delete the duplicate auth user (cascades to public.users, orgs, org_users)

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -1093,7 +1093,6 @@ describe('[POST] /private/sso/provision-user', () => {
     const unrelatedSsoProvider = `sso:${randomUUID()}`
     const unrelatedSsoProviderId = `nameid-${randomUUID()}`
     const unrelatedProviderId = `github-${randomUUID()}`
-    const originalAuthEmail = `stored-original-${randomUUID()}@${domain}`
     const pool = new Pool({ connectionString: POSTGRES_URL })
 
     const { data: originalUser, error: originalUserError } = await getSupabaseClient().auth.admin.createUser({
@@ -1171,25 +1170,22 @@ describe('[POST] /private/sso/provision-user', () => {
 
       const duplicateAuthHeaders = await getAuthHeadersForCredentials(tempSsoEmail, password)
 
-      // Local Supabase Auth enforces unique auth.users emails, unlike the production SSO flow
-      // we're trying to exercise here. Keep public.users on the original email, but free the
-      // auth.users email slot so we can mimic "new SSO auth user arrives with the legacy email".
-      const { error: originalAuthUpdateError } = await getSupabaseClient().auth.admin.updateUserById(originalUser.user.id, {
-        email: originalAuthEmail,
-        email_confirm: true,
-      })
-      if (originalAuthUpdateError)
-        throw originalAuthUpdateError
-
-      const { error: duplicateAuthUpdateError } = await getSupabaseClient().auth.admin.updateUserById(duplicateUser.user.id, {
-        email: targetEmail,
-        email_confirm: true,
-        app_metadata: {
-          provider: identityProvider,
-        },
-      })
-      if (duplicateAuthUpdateError)
-        throw duplicateAuthUpdateError
+      // Local Supabase Auth's admin API enforces unique emails before considering the
+      // SSO-only flag. Update auth.users directly so this test can mimic the production
+      // SSO duplicate-user shape while keeping the canonical merge key in auth.users.email.
+      await pool.query(
+        `
+          update auth.users
+          set email = $1,
+              email_confirmed_at = coalesce(email_confirmed_at, now()),
+              is_sso_user = true,
+              raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb)
+                || jsonb_build_object('provider', $2::text, 'providers', jsonb_build_array($2::text)),
+              updated_at = now()
+          where id = $3
+        `,
+        [targetEmail, identityProvider, duplicateUser.user.id],
+      )
 
       await pool.query(
         'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
@@ -1281,6 +1277,165 @@ describe('[POST] /private/sso/provision-user', () => {
     }
   })
 
+  it('does not merge SSO login into an account that only matches mutable public profile email', async () => {
+    const managedOrgId = randomUUID()
+    const managedCustomerId = `cus_sso_profile_poison_${randomUUID()}`
+    const providerId = randomUUID()
+    const externalProviderId = randomUUID()
+    const domain = `${randomUUID()}.sso.test`
+    const attackerEmail = `profile-poison-attacker-${randomUUID()}@capgo.app`
+    const targetEmail = `profile-poison-victim@${domain}`
+    const password = 'testtest'
+    const identityProvider = `sso:${externalProviderId}`
+    const identityProviderId = `nameid-${randomUUID()}`
+    const pool = new Pool({ connectionString: POSTGRES_URL })
+
+    const { data: attackerUser, error: attackerUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: attackerEmail,
+      password,
+      email_confirm: true,
+      user_metadata: {
+        first_name: 'Profile',
+        last_name: 'Poison',
+      },
+    })
+    if (attackerUserError || !attackerUser.user) {
+      await pool.end()
+      throw attackerUserError ?? new Error('Failed to create profile poisoning user')
+    }
+
+    const { data: ssoUser, error: ssoUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: targetEmail,
+      password,
+      email_confirm: true,
+      app_metadata: {
+        provider: identityProvider,
+      },
+      user_metadata: {
+        first_name: 'SSO',
+        last_name: 'Victim',
+      },
+    })
+    if (ssoUserError || !ssoUser.user) {
+      await pool.end()
+      throw ssoUserError ?? new Error('Failed to create SSO user for profile poisoning regression test')
+    }
+
+    try {
+      const { error: stripeError } = await getSupabaseClient().from('stripe_info').insert({
+        customer_id: managedCustomerId,
+        status: 'succeeded',
+        product_id: 'prod_LQIregjtNduh4q',
+        subscription_id: `sub_sso_profile_poison_${randomUUID()}`,
+        trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+        is_good_plan: true,
+      })
+      if (stripeError)
+        throw stripeError
+
+      const { error: orgError } = await getSupabaseClient().from('orgs').insert({
+        id: managedOrgId,
+        name: `SSO Profile Poison Org ${managedOrgId}`,
+        management_email: `sso-profile-poison-${managedOrgId}@capgo.app`,
+        created_by: USER_ID,
+        customer_id: managedCustomerId,
+      })
+      if (orgError)
+        throw orgError
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: managedOrgId,
+        domain,
+        provider_id: externalProviderId,
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
+
+      const { error: poisonedPublicUserError } = await getSupabaseClient().from('users').upsert({
+        id: attackerUser.user.id,
+        email: targetEmail,
+        first_name: 'Profile',
+        last_name: 'Poison',
+        country: null,
+        enable_notifications: true,
+        opt_for_newsletters: true,
+      }, { onConflict: 'id' })
+      if (poisonedPublicUserError)
+        throw poisonedPublicUserError
+
+      await pool.query(
+        'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
+        [identityProvider, identityProviderId, targetEmail, ssoUser.user.id],
+      )
+
+      const ssoAuthHeaders = await getAuthHeadersForCredentials(targetEmail, password)
+      const response = await fetchWithRetry(getEndpointUrl('/private/sso/provision-user'), {
+        method: 'POST',
+        headers: ssoAuthHeaders,
+        body: JSON.stringify({}),
+      })
+
+      const responseBody = await response.json() as {
+        success: boolean
+        merged?: boolean
+      }
+      expect(response.status).toBe(200)
+      expect(responseBody).toMatchObject({ success: true })
+      expect(responseBody.merged).toBeUndefined()
+
+      const { data: attackerMembership, error: attackerMembershipError } = await getSupabaseClient()
+        .from('org_users')
+        .select('id')
+        .eq('org_id', managedOrgId)
+        .eq('user_id', attackerUser.user.id)
+        .maybeSingle()
+
+      expect(attackerMembershipError).toBeNull()
+      expect(attackerMembership).toBeNull()
+
+      const { data: ssoMembership, error: ssoMembershipError } = await getSupabaseClient()
+        .from('org_users')
+        .select('org_id, user_id, user_right')
+        .eq('org_id', managedOrgId)
+        .eq('user_id', ssoUser.user.id)
+        .maybeSingle()
+
+      expect(ssoMembershipError).toBeNull()
+      expect(ssoMembership).toMatchObject({
+        org_id: managedOrgId,
+        user_id: ssoUser.user.id,
+        user_right: 'read',
+      })
+
+      const identitiesAfterProvision = await pool.query(
+        'select provider, provider_id, user_id from auth.identities where provider = $1 and provider_id = $2',
+        [identityProvider, identityProviderId],
+      )
+
+      expect(identitiesAfterProvision.rows).toEqual([
+        {
+          provider: identityProvider,
+          provider_id: identityProviderId,
+          user_id: ssoUser.user.id,
+        },
+      ])
+    }
+    finally {
+      await Promise.allSettled([
+        getSupabaseClient().auth.admin.deleteUser(ssoUser.user.id),
+        getSupabaseClient().auth.admin.deleteUser(attackerUser.user.id),
+        (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
+        getSupabaseClient().from('orgs').delete().eq('id', managedOrgId),
+        getSupabaseClient().from('stripe_info').delete().eq('customer_id', managedCustomerId),
+      ])
+      await pool.end()
+    }
+  })
+
   it('rejects account merge when the authenticating SSO provider does not match the email domain provider', async () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_merge_mismatch_${randomUUID()}`
@@ -1293,7 +1448,6 @@ describe('[POST] /private/sso/provision-user', () => {
     const password = 'testtest'
     const attackerIdentityProvider = `sso:${attackerExternalProviderId}`
     const attackerIdentityProviderId = `nameid-${randomUUID()}`
-    const originalAuthEmail = `stored-original-mismatch-${randomUUID()}@${domain}`
     const pool = new Pool({ connectionString: POSTGRES_URL })
 
     const { data: originalUser, error: originalUserError } = await getSupabaseClient().auth.admin.createUser({
@@ -1376,22 +1530,19 @@ describe('[POST] /private/sso/provision-user', () => {
 
       const duplicateAuthHeaders = await getAuthHeadersForCredentials(tempSsoEmail, password)
 
-      const { error: originalAuthUpdateError } = await getSupabaseClient().auth.admin.updateUserById(originalUser.user.id, {
-        email: originalAuthEmail,
-        email_confirm: true,
-      })
-      if (originalAuthUpdateError)
-        throw originalAuthUpdateError
-
-      const { error: duplicateAuthUpdateError } = await getSupabaseClient().auth.admin.updateUserById(duplicateUser.user.id, {
-        email: targetEmail,
-        email_confirm: true,
-        app_metadata: {
-          provider: attackerIdentityProvider,
-        },
-      })
-      if (duplicateAuthUpdateError)
-        throw duplicateAuthUpdateError
+      await pool.query(
+        `
+          update auth.users
+          set email = $1,
+              email_confirmed_at = coalesce(email_confirmed_at, now()),
+              is_sso_user = true,
+              raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb)
+                || jsonb_build_object('provider', $2::text, 'providers', jsonb_build_array($2::text)),
+              updated_at = now()
+          where id = $3
+        `,
+        [targetEmail, attackerIdentityProvider, duplicateUser.user.id],
+      )
 
       await pool.query(
         'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',


### PR DESCRIPTION
## Summary (AI generated)

- Changed SSO account merge candidate lookup to trust `auth.users.email` instead of mutable `public.users.email`.
- Kept SSO provider-domain authorization before membership provisioning or identity transfer.
- Added regression coverage for profile-email poisoning during SSO provisioning.

## Motivation (AI generated)

GHSA-wqc6-fhwf-qpww showed that user-controlled profile email could poison the SSO merge path and attach a victim SSO identity to the wrong account. The merge key must come from trusted auth identity data.

## Business Impact (AI generated)

This protects enterprise SSO tenants from unauthorized org membership, identity transfer, and account merge corruption while preserving legitimate SSO account linking for existing password accounts.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun run supabase:with-env -- bunx vitest run tests/sso.test.ts`
- [x] `bun test:backend`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO provisioning validation to prevent unauthorized merges and ensure provider-domain mismatches are rejected.
  * Made SSO account merges more reliable and atomic, reducing partial/failed merge states and clearer failure responses.

* **Tests**
  * Added regression tests covering SSO provisioning, safe merge scenarios, and protections against attacker-crafted public-profile email matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->