### PR TITLE
fix(plugin): gate usage credits on active balance

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -49,14 +49,11 @@ function buildPlanValidationExpression(
   )`
   // IMPORTANT: read replicas replicate table data but not views/functions.
   // Keep this expression replica-safe by relying on a replicated org flag.
-  //
-  // Semantics note: this flag means "org uses credits/top-up billing", not
-  // "org currently has a positive balance". This avoids plugin read-path
-  // depending on credit ledger tables/views which are not present on replicas.
+  // has_usage_credits means the org currently has positive, unexpired credits.
   //
   // Backward compatibility for replicas that haven't replicated the column yet:
   // read via `to_jsonb(row)->>'has_usage_credits'` so the query still parses
-  // even if the column doesn't exist.
+  // even if the column doesn't exist. Missing column fails closed.
   const hasCreditsExpression = sql`EXISTS (
     SELECT 1
     FROM ${schema.orgs}

--- a/supabase/migrations/20260507082135_active_usage_credits_flag.sql
+++ b/supabase/migrations/20260507082135_active_usage_credits_flag.sql
@@ -84,6 +84,15 @@ GRANT EXECUTE
 ON FUNCTION public.sync_org_has_usage_credits_from_grants()
 TO service_role;
 
+DROP TRIGGER IF EXISTS trg_sync_org_has_usage_credits
+ON public.usage_credit_grants;
+
+CREATE TRIGGER trg_sync_org_has_usage_credits
+AFTER INSERT OR UPDATE OR DELETE
+ON public.usage_credit_grants
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_org_has_usage_credits_from_grants();
+
 SELECT public.refresh_orgs_has_usage_credits();
 
 UPDATE public.cron_tasks

--- a/supabase/migrations/20260507082135_active_usage_credits_flag.sql
+++ b/supabase/migrations/20260507082135_active_usage_credits_flag.sql
@@ -1,0 +1,94 @@
+BEGIN;
+
+COMMENT ON COLUMN public.orgs.has_usage_credits
+IS 'True only with positive, unexpired usage credits.';
+
+CREATE OR REPLACE FUNCTION public.refresh_orgs_has_usage_credits()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  WITH credit_state AS (
+    SELECT
+      o."id",
+      COALESCE(g."has_usage_credits", false) AS "has_usage_credits"
+    FROM "public"."orgs" AS o
+    LEFT JOIN (
+      SELECT
+        grant_rows."org_id",
+        bool_or(
+          grant_rows."expires_at" >= now()
+          AND grant_rows."credits_consumed" < grant_rows."credits_total"
+        ) AS "has_usage_credits"
+      FROM "public"."usage_credit_grants" AS grant_rows
+      GROUP BY grant_rows."org_id"
+    ) AS g ON g."org_id" = o."id"
+  )
+  UPDATE "public"."orgs" AS o
+  SET "has_usage_credits" = credit_state."has_usage_credits"
+  FROM credit_state
+  WHERE o."id" = credit_state."id"
+    AND o."has_usage_credits" IS DISTINCT FROM credit_state."has_usage_credits";
+END;
+$$;
+
+ALTER FUNCTION public.refresh_orgs_has_usage_credits() OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION public.refresh_orgs_has_usage_credits() FROM public;
+GRANT EXECUTE
+ON FUNCTION public.refresh_orgs_has_usage_credits()
+TO service_role;
+
+CREATE OR REPLACE FUNCTION public.sync_org_has_usage_credits_from_grants()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org_id uuid;
+BEGIN
+  FOR v_org_id IN
+    SELECT DISTINCT affected."org_id"
+    FROM (VALUES (NEW."org_id"), (OLD."org_id")) AS affected("org_id")
+    WHERE affected."org_id" IS NOT NULL
+  LOOP
+    UPDATE "public"."orgs" AS o
+    SET "has_usage_credits" = credit_state."has_usage_credits"
+    FROM (
+      SELECT EXISTS (
+        SELECT 1
+        FROM "public"."usage_credit_grants" AS g
+        WHERE g."org_id" = v_org_id
+          AND g."expires_at" >= now()
+          AND g."credits_consumed" < g."credits_total"
+      ) AS "has_usage_credits"
+    ) AS credit_state
+    WHERE o."id" = v_org_id
+      AND o."has_usage_credits" IS DISTINCT FROM credit_state."has_usage_credits";
+  END LOOP;
+
+  RETURN NULL;
+END;
+$$;
+
+ALTER FUNCTION public.sync_org_has_usage_credits_from_grants()
+OWNER TO "postgres";
+
+REVOKE ALL
+ON FUNCTION public.sync_org_has_usage_credits_from_grants()
+FROM public;
+GRANT EXECUTE
+ON FUNCTION public.sync_org_has_usage_credits_from_grants()
+TO service_role;
+
+SELECT public.refresh_orgs_has_usage_credits();
+
+UPDATE public.cron_tasks
+SET
+    description = 'Refresh active credit flag for replica plugin gates'
+WHERE name = 'refresh_org_usage_credits_flag';
+
+COMMIT;

--- a/tests/plugin-credits-flag.test.ts
+++ b/tests/plugin-credits-flag.test.ts
@@ -31,13 +31,14 @@ describe('plugin plan gating: credits flag', () => {
   })
 
   afterAll(async () => {
+    await supabase.from('usage_credit_grants').delete().eq('org_id', orgId)
     await resetAppData(appId)
     await supabase.from('org_users').delete().eq('org_id', orgId)
     await supabase.from('orgs').delete().eq('id', orgId)
     await supabase.from('stripe_info').delete().eq('customer_id', stripeCustomerId)
   })
 
-  it('allows /updates when has_usage_credits is true (replica-safe)', async () => {
+  it('blocks /updates for expired or exhausted credits', async () => {
     const baseData = getBaseData(appId)
 
     const responseBlocked = await postUpdate(baseData)
@@ -45,7 +46,58 @@ describe('plugin plan gating: credits flag', () => {
     const jsonBlocked = await responseBlocked.json<{ error?: string }>()
     expect(jsonBlocked.error).toBe('on_premise_app')
 
-    await executeSQL('UPDATE public.orgs SET has_usage_credits = true WHERE id = $1', [orgId])
+    await executeSQL(`
+      INSERT INTO public.usage_credit_grants (
+        org_id,
+        credits_total,
+        credits_consumed,
+        expires_at,
+        source,
+        notes
+      )
+      VALUES ($1, 1, 0, now() - interval '1 day', 'manual', 'expired grant regression')
+    `, [orgId])
+
+    const expiredGrantRows = await executeSQL('SELECT has_usage_credits FROM public.orgs WHERE id = $1', [orgId])
+    expect(expiredGrantRows[0]?.has_usage_credits).toBe(false)
+
+    const responseExpiredGrant = await postUpdate({
+      ...baseData,
+      device_id: randomUUID().toLowerCase(),
+    })
+    expect(responseExpiredGrant.status).toBe(429)
+    const jsonExpiredGrant = await responseExpiredGrant.json<{ error?: string }>()
+    expect(jsonExpiredGrant.error).toBe('on_premise_app')
+
+    await executeSQL(`
+      UPDATE public.usage_credit_grants
+      SET
+        credits_consumed = credits_total,
+        expires_at = now() + interval '1 day'
+      WHERE org_id = $1
+    `, [orgId])
+
+    const exhaustedGrantRows = await executeSQL('SELECT has_usage_credits FROM public.orgs WHERE id = $1', [orgId])
+    expect(exhaustedGrantRows[0]?.has_usage_credits).toBe(false)
+
+    const responseExhaustedGrant = await postUpdate({
+      ...baseData,
+      device_id: randomUUID().toLowerCase(),
+    })
+    expect(responseExhaustedGrant.status).toBe(429)
+    const jsonExhaustedGrant = await responseExhaustedGrant.json<{ error?: string }>()
+    expect(jsonExhaustedGrant.error).toBe('on_premise_app')
+
+    await executeSQL(`
+      UPDATE public.usage_credit_grants
+      SET
+        credits_consumed = 0,
+        expires_at = now() + interval '1 day'
+      WHERE org_id = $1
+    `, [orgId])
+
+    const activeGrantRows = await executeSQL('SELECT has_usage_credits FROM public.orgs WHERE id = $1', [orgId])
+    expect(activeGrantRows[0]?.has_usage_credits).toBe(true)
 
     const responseAllowed = await postUpdate({
       ...baseData,


### PR DESCRIPTION
## Summary (AI generated)

- Recomputes `orgs.has_usage_credits` from positive, unexpired usage credit grants.
- Keeps plugin plan validation replica-safe while failing closed for expired or exhausted credits.
- Adds regression coverage for `/updates` with expired, exhausted, and active credits.

## Motivation (AI generated)

`has_usage_credits` previously stayed true when any credit grant row existed, including consumed or expired grants. Plugin endpoints used that flag as a plan gate, allowing exhausted credit-backed orgs to keep passing billing checks.

## Business Impact (AI generated)

This prevents continued plugin service access after prepaid credits are depleted or expired, protecting usage-based revenue while preserving the read-replica hot path.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bunx eslint tests/plugin-credits-flag.test.ts`
- [x] `sqlfluff lint --dialect postgres supabase/migrations/20260507082135_active_usage_credits_flag.sql`
- [x] `bun run supabase:db:reset`
- [x] `bun run supabase:with-env -- bunx vitest run tests/plugin-credits-flag.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/files-security.test.ts tests/security-definer-execute-hardening.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/organization-put-stripe-sync.unit.test.ts`
- [x] `bun run typecheck`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization credit status tracking so active, unexpired credits are detected and plan gating correctly blocks requests when credits are absent.

* **Chores**
  * Added a database migration to maintain and refresh the organization credits flag reliably.

* **Tests**
  * Added regression tests covering expired, exhausted, and restored credit scenarios to ensure blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->