### PR TITLE
[codex] fix API key RBAC oracle

### DIFF
--- a/supabase/migrations/20260507090436_fix_apikey_rbac_rpc_oracle_and_expiration_scope.sql
+++ b/supabase/migrations/20260507090436_fix_apikey_rbac_rpc_oracle_and_expiration_scope.sql
@@ -1,0 +1,235 @@
+CREATE OR REPLACE FUNCTION "public"."cli_check_permission"(
+  "apikey" "text" DEFAULT NULL,
+  "permission_key" "text" DEFAULT NULL,
+  "org_id" "uuid" DEFAULT NULL,
+  "app_id" "text" DEFAULT NULL,
+  "channel_id" bigint DEFAULT NULL
+) RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_request_apikey text;
+  v_api_key public.apikeys%ROWTYPE;
+BEGIN
+  IF permission_key IS NULL OR permission_key = '' THEN
+    RETURN false;
+  END IF;
+
+  SELECT public.get_apikey_header() INTO v_request_apikey;
+
+  IF v_request_apikey IS NULL OR v_request_apikey = '' THEN
+    RETURN false;
+  END IF;
+
+  IF apikey IS NOT NULL AND apikey <> '' AND apikey IS DISTINCT FROM v_request_apikey THEN
+    RETURN false;
+  END IF;
+
+  SELECT * INTO v_api_key
+  FROM public.find_apikey_by_value(v_request_apikey)
+  LIMIT 1;
+
+  IF v_api_key.id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  RETURN public.rbac_check_permission_direct(
+    permission_key,
+    v_api_key.user_id,
+    org_id,
+    app_id,
+    channel_id,
+    v_request_apikey
+  );
+END;
+$$;
+
+ALTER FUNCTION "public"."cli_check_permission"(
+  "apikey" "text",
+  "permission_key" "text",
+  "org_id" "uuid",
+  "app_id" "text",
+  "channel_id" bigint
+) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."cli_check_permission"(
+  "apikey" "text",
+  "permission_key" "text",
+  "org_id" "uuid",
+  "app_id" "text",
+  "channel_id" bigint
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION "public"."cli_check_permission"(
+  "apikey" "text",
+  "permission_key" "text",
+  "org_id" "uuid",
+  "app_id" "text",
+  "channel_id" bigint
+) TO "anon";
+GRANT EXECUTE ON FUNCTION "public"."cli_check_permission"(
+  "apikey" "text",
+  "permission_key" "text",
+  "org_id" "uuid",
+  "app_id" "text",
+  "channel_id" bigint
+) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."cli_check_permission"(
+  "apikey" "text",
+  "permission_key" "text",
+  "org_id" "uuid",
+  "app_id" "text",
+  "channel_id" bigint
+) TO "service_role";
+
+COMMENT ON FUNCTION "public"."cli_check_permission"(
+  "apikey" "text",
+  "permission_key" "text",
+  "org_id" "uuid",
+  "app_id" "text",
+  "channel_id" bigint
+) IS 'CLI permission wrapper bound to the request capgkey header. The apikey argument is retained for CLI compatibility and must match the header when provided.';
+
+CREATE OR REPLACE FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text" DEFAULT NULL
+) RETURNS SETOF "public"."apps"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_request_apikey text;
+  v_api_key public.apikeys%ROWTYPE;
+BEGIN
+  SELECT public.get_apikey_header() INTO v_request_apikey;
+
+  IF v_request_apikey IS NULL OR v_request_apikey = '' THEN
+    RETURN;
+  END IF;
+
+  IF apikey IS NOT NULL AND apikey <> '' AND apikey IS DISTINCT FROM v_request_apikey THEN
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_api_key
+  FROM public.find_apikey_by_value(v_request_apikey)
+  LIMIT 1;
+
+  IF v_api_key.id IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT a.*
+  FROM public.apps a
+  WHERE public.rbac_check_permission_direct(
+    public.rbac_perm_app_read(),
+    v_api_key.user_id,
+    a.owner_org,
+    a.app_id,
+    NULL,
+    v_request_apikey
+  )
+  ORDER BY a.created_at DESC;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text"
+) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text"
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text"
+) TO "anon";
+GRANT EXECUTE ON FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text"
+) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text"
+) TO "service_role";
+
+COMMENT ON FUNCTION "public"."get_accessible_apps_for_apikey_v2"(
+  "apikey" "text"
+) IS 'Returns apps visible to the request capgkey using RBAC-aware permission checks with legacy fallback. The apikey argument is retained for CLI compatibility and must match the header when provided.';
+
+CREATE OR REPLACE FUNCTION public.enforce_apikey_expiration_policy()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  scoped_org RECORD;
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND NEW.expires_at IS NOT DISTINCT FROM OLD.expires_at
+    AND NEW.limited_to_orgs IS NOT DISTINCT FROM OLD.limited_to_orgs
+    AND NEW.limited_to_apps IS NOT DISTINCT FROM OLD.limited_to_apps THEN
+    RETURN NEW;
+  END IF;
+
+  FOR scoped_org IN
+    WITH explicit_scope_orgs AS (
+      SELECT unnest(COALESCE(NEW.limited_to_orgs, '{}'::uuid[])) AS org_id
+      UNION
+      SELECT public.apps.owner_org
+      FROM public.apps
+      WHERE public.apps.app_id = ANY(COALESCE(NEW.limited_to_apps, '{}'::text[]))
+    ),
+    scope_orgs AS (
+      SELECT explicit_scope_orgs.org_id
+      FROM explicit_scope_orgs
+      UNION
+      SELECT public.org_users.org_id
+      FROM public.org_users
+      WHERE public.org_users.user_id = NEW.user_id
+        AND COALESCE(array_length(NEW.limited_to_orgs, 1), 0) = 0
+        AND COALESCE(array_length(NEW.limited_to_apps, 1), 0) = 0
+    )
+    SELECT
+      public.orgs.id,
+      public.orgs.require_apikey_expiration,
+      public.orgs.max_apikey_expiration_days
+    FROM public.orgs
+    JOIN scope_orgs ON scope_orgs.org_id = public.orgs.id
+  LOOP
+    IF scoped_org.require_apikey_expiration AND NEW.expires_at IS NULL THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = 'expiration_required',
+        DETAIL = 'This organization requires API keys to have an expiration date';
+    END IF;
+
+    IF scoped_org.max_apikey_expiration_days IS NOT NULL
+      AND NEW.expires_at IS NOT NULL
+      AND NEW.expires_at > clock_timestamp()
+        + make_interval(days => scoped_org.max_apikey_expiration_days) THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = 'expiration_exceeds_max',
+        DETAIL = format(
+          'API key expiration cannot exceed %s days for this organization',
+          scoped_org.max_apikey_expiration_days
+        );
+    END IF;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.enforce_apikey_expiration_policy() OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.enforce_apikey_expiration_policy() FROM public;
+GRANT EXECUTE ON FUNCTION public.enforce_apikey_expiration_policy() TO service_role;
+
+DROP TRIGGER IF EXISTS apikeys_enforce_expiration_policy ON public.apikeys;
+
+CREATE TRIGGER apikeys_enforce_expiration_policy
+BEFORE INSERT OR UPDATE ON public.apikeys
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_apikey_expiration_policy();

--- a/supabase/tests/42_test_apikey_expiration.sql
+++ b/supabase/tests/42_test_apikey_expiration.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(24);
+SELECT plan(26);
 
 SELECT tests.authenticate_as_service_role();
 
@@ -441,6 +441,72 @@ SELECT
     ok(
         (SELECT count(*) > 0 FROM get_user_org_ids()),
         'get_user_org_ids: Returns results for valid (not expired) API key'
+    );
+
+-- Test 25: Unscoped keys must honor expiration-required org memberships
+UPDATE orgs
+SET
+    require_apikey_expiration = TRUE,
+    max_apikey_expiration_days = 30
+WHERE id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8';
+
+SELECT
+    throws_ok(
+        $$
+        INSERT INTO apikeys (
+            id,
+            user_id,
+            key,
+            mode,
+            name,
+            expires_at,
+            limited_to_orgs,
+            limited_to_apps
+        )
+        VALUES (
+            99913,
+            '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid,
+            'test-unscoped-key-missing-expiration',
+            'all',
+            'Test unscoped missing expiration',
+            NULL,
+            '{}'::uuid[],
+            '{}'::text[]
+        )
+        $$,
+        'P0001',
+        'expiration_required',
+        'enforce_apikey_expiration_policy: unscoped keys inherit membership expiration requirement'
+    );
+
+-- Test 26: Unscoped keys must honor max expiration days from org memberships
+SELECT
+    throws_ok(
+        $$
+        INSERT INTO apikeys (
+            id,
+            user_id,
+            key,
+            mode,
+            name,
+            expires_at,
+            limited_to_orgs,
+            limited_to_apps
+        )
+        VALUES (
+            99914,
+            '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid,
+            'test-unscoped-key-too-long-expiration',
+            'all',
+            'Test unscoped too long expiration',
+            now() + interval '31 days',
+            '{}'::uuid[],
+            '{}'::text[]
+        )
+        $$,
+        'P0001',
+        'expiration_exceeds_max',
+        'enforce_apikey_expiration_policy: unscoped keys inherit membership max expiration days'
     );
 
 SELECT *

--- a/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
+++ b/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(20);
+SELECT plan(26);
 
 SELECT
     is(
@@ -166,6 +166,11 @@ ON CONFLICT (bucket_id, name) DO NOTHING;
 
 SET LOCAL ROLE anon;
 
+DO $$
+BEGIN
+    PERFORM set_config('request.headers', '{}', true);
+END $$;
+
 SELECT
     is(
         (
@@ -179,6 +184,31 @@ SELECT
         ),
         0::bigint,
         'anon without capgkey cannot read app-scoped storage objects'
+    );
+
+SELECT
+    is(
+        public.cli_check_permission(
+            'ae6e7458-c46d-4c00-aa3b-153b0b8520ea',
+            public.rbac_perm_app_read(),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        false,
+        'anon cannot use cli_check_permission with only an apikey argument'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM public.get_accessible_apps_for_apikey_v2(
+                'ae6e7458-c46d-4c00-aa3b-153b0b8520ea'
+            )
+        ),
+        0::bigint,
+        'anon cannot enumerate apps with only an apikey argument'
     );
 
 DO $$
@@ -210,6 +240,53 @@ SELECT
         ),
         1::bigint,
         'anon API-key apps query still works through RLS helper identity'
+    );
+
+SELECT
+    is(
+        public.cli_check_permission(
+            'ae6e7458-c46d-4c00-aa3b-153b0b8520ea',
+            public.rbac_perm_app_read(),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        true,
+        'anon can use cli_check_permission when apikey matches capgkey header'
+    );
+
+SELECT
+    ok(
+        (
+            SELECT count(*) > 0
+            FROM public.get_accessible_apps_for_apikey_v2(
+                'ae6e7458-c46d-4c00-aa3b-153b0b8520ea'
+            )
+        ),
+        'anon can list accessible apps when apikey matches capgkey header'
+    );
+
+SELECT
+    is(
+        public.cli_check_permission(
+            'different-key',
+            public.rbac_perm_app_read(),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        false,
+        'anon cannot use cli_check_permission when apikey argument differs from capgkey header'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM public.get_accessible_apps_for_apikey_v2('different-key')
+        ),
+        0::bigint,
+        'anon cannot list accessible apps when apikey argument differs from capgkey header'
     );
 
 DO $$

--- a/tests/apikeys-expiration.test.ts
+++ b/tests/apikeys-expiration.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { env } from 'node:process'
 import { createClient } from '@supabase/supabase-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, fetchWithRetry, getAuthHeadersForCredentials, getSupabaseClient, normalizeLocalhostUrl, resetAndSeedAppData, resetAppData, TEST_EMAIL, USER_EMAIL_APIKEY_EXPIRATION, USER_ID_APIKEY_EXPIRATION, USER_PASSWORD } from './test-utils.ts'
+import { BASE_URL, executeSQL, fetchWithRetry, getAuthHeadersForCredentials, getSupabaseClient, normalizeLocalhostUrl, resetAndSeedAppData, resetAppData, TEST_EMAIL, USER_EMAIL_APIKEY_EXPIRATION, USER_ID_APIKEY_EXPIRATION, USER_PASSWORD } from './test-utils.ts'
 
 const id = randomUUID()
 const BASE_ORG_ID = randomUUID()
@@ -22,7 +22,7 @@ function keyName(name: string): string {
   return `${name}-${id}`
 }
 
-async function seedPlainApiKey(name: string, expiresAt: string | null) {
+async function seedPlainApiKey(name: string, expiresAt: string | null, limitedToOrgs: string[] = []) {
   const key = randomUUID()
   const { data, error } = await getSupabaseClient()
     .from('apikeys')
@@ -33,7 +33,7 @@ async function seedPlainApiKey(name: string, expiresAt: string | null) {
       mode: 'all',
       name: keyName(name),
       limited_to_apps: [],
-      limited_to_orgs: [],
+      limited_to_orgs: limitedToOrgs,
       expires_at: expiresAt,
     })
     .select('id, key, expires_at')
@@ -199,6 +199,7 @@ describe('[POST] /apikey with expiration', () => {
       body: JSON.stringify({
         name: keyName('key-no-expiration'),
         mode: 'all',
+        limited_to_orgs: [BASE_ORG_ID],
       }),
     })
     const data = await response.json<{ key: string, id: number, expires_at: string | null }>()
@@ -250,6 +251,7 @@ describe('[PUT] /apikey/:id with expiration', () => {
       body: JSON.stringify({
         name: keyName('key-for-update-expiration'),
         mode: 'all',
+        limited_to_orgs: [BASE_ORG_ID],
       }),
     })
     expect(response.status).toBe(200)
@@ -339,6 +341,7 @@ describe('[GET] /apikey with expiration info', () => {
       body: JSON.stringify({
         name: keyName('key-without-exp-get-test'),
         mode: 'all',
+        limited_to_orgs: [BASE_ORG_ID],
       }),
     })
     expect(response2.status).toBe(200)
@@ -513,6 +516,7 @@ describe('organization API key expiration policy', () => {
       body: JSON.stringify({
         name: keyName('key-policy-app-scope-update'),
         mode: 'all',
+        limited_to_orgs: [BASE_ORG_ID],
       }),
     })
     expect(createResponse.status).toBe(200)
@@ -552,6 +556,7 @@ describe('organization API key expiration policy', () => {
       body: JSON.stringify({
         name: keyName('key-policy-sibling-target'),
         mode: 'all',
+        limited_to_orgs: [BASE_ORG_ID],
       }),
     })
     expect(siblingKeyResponse.status).toBe(200)
@@ -822,20 +827,17 @@ describe('api key expiration boundary conditions', () => {
     }
   })
 
-  it.concurrent('api key with null expiration should never expire', async () => {
-    const data = await seedPlainApiKey('key-no-expiration-test', null)
+  it.concurrent('api key with null expiration should not be expired', async () => {
+    const data = await seedPlainApiKey('key-no-expiration-test', null, [BASE_ORG_ID])
 
     try {
       expect(data.expires_at).toBeNull()
 
-      const authResponse = await apiFetch('/apikey', {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': data.key,
-        },
-      })
-      expect(authResponse.status).toBe(200)
+      const [{ expired }] = await executeSQL(
+        'SELECT public.is_apikey_expired($1::timestamptz) AS expired',
+        [data.expires_at],
+      )
+      expect(expired).toBe(false)
     }
     finally {
       await deleteSeededApiKeys([data.id])


### PR DESCRIPTION
## Summary (AI generated)

- Bound CLI RBAC API-key RPC wrappers to the request capgkey header.
- Preserved existing CLI RPC signatures while rejecting headerless or mismatched API-key probes.
- Extended API-key expiration trigger enforcement to unscoped keys through user org memberships.
- Added pgTAP regression coverage for the oracle and unscoped expiration cases.

## Motivation (AI generated)

The existing wrapper RPCs accepted arbitrary apikey arguments from anon callers, bypassing the earlier public EXECUTE revocation on get_user_id(text). The expiration trigger also skipped policy checks for unscoped API keys.

## Business Impact (AI generated)

This reduces API-key oracle and metadata exposure risk while preserving CLI compatibility for clients that already send capgkey headers. It also enforces organization API-key expiration settings consistently for unscoped user keys.

## Test Plan (AI generated)

- [x] bun run lint:backend
- [x] git diff --check
- [x] Local Supabase startup applied the new migration cleanly
- [x] docker exec -i supabase_db_capgo-app-fac9e6f5 psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
- [x] docker exec -i supabase_db_capgo-app-fac9e6f5 psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/42_test_apikey_expiration.sql
- [x] Commit hook: bun run cli:build && vue-tsc --noEmit

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced API key expiration policy enforcement with organization-level constraints.
  * Improved API key authorization and permission validation through updated access control mechanisms.
  * Added support for scoped API key validation to ensure compliance with organizational restrictions.

* **Tests**
  * Expanded test coverage for API key expiration policies and permission-based access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->