### PR TITLE
fix(db): secure exist_app_versions RPC

### DIFF
--- a/cli/src/app/list.ts
+++ b/cli/src/app/list.ts
@@ -1,10 +1,9 @@
-import type { SupabaseClient } from '@supabase/supabase-js'
 import type { OptionsBase } from '../schemas/base'
 import type { Database } from '../types/supabase.types'
 import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
 import { checkAlerts } from '../api/update'
-import { createSupabaseClient, findSavedKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
+import { createSupabaseClient, findSavedKey, getAccessibleAppsForApiKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
 
 function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   const table = new Table()
@@ -16,21 +15,6 @@ function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
 
   log.success('Apps')
   log.success(table.toString())
-}
-
-async function getActiveApps(supabase: SupabaseClient<Database>, silent: boolean) {
-  const { data, error } = await supabase
-    .from('apps')
-    .select()
-    .order('created_at', { ascending: false })
-
-  if (error) {
-    if (!silent)
-      log.error('Apps not found')
-    throw new Error('Apps not found')
-  }
-
-  return data ?? []
 }
 
 export async function listAppInternal(options: OptionsBase, silent = false) {
@@ -48,7 +32,7 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
   if (!silent)
     log.info('Getting active bundle in Capgo')
 
-  const allApps = await getActiveApps(supabase, silent)
+  const allApps = await getAccessibleAppsForApiKey(supabase, options.apikey)
 
   if (!allApps.length) {
     if (!silent)

--- a/cli/src/app/list.ts
+++ b/cli/src/app/list.ts
@@ -1,9 +1,10 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
 import type { OptionsBase } from '../schemas/base'
 import type { Database } from '../types/supabase.types'
 import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
 import { checkAlerts } from '../api/update'
-import { createSupabaseClient, findSavedKey, getAccessibleAppsForApiKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
+import { createSupabaseClient, findSavedKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
 
 function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   const table = new Table()
@@ -15,6 +16,21 @@ function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
 
   log.success('Apps')
   log.success(table.toString())
+}
+
+async function getActiveApps(supabase: SupabaseClient<Database>, silent: boolean) {
+  const { data, error } = await supabase
+    .from('apps')
+    .select()
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    if (!silent)
+      log.error('Apps not found')
+    throw new Error('Apps not found')
+  }
+
+  return data ?? []
 }
 
 export async function listAppInternal(options: OptionsBase, silent = false) {
@@ -32,7 +48,7 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
   if (!silent)
     log.info('Getting active bundle in Capgo')
 
-  const allApps = await getAccessibleAppsForApiKey(supabase, options.apikey)
+  const allApps = await getActiveApps(supabase, silent)
 
   if (!allApps.length) {
     if (!silent)

--- a/cli/src/types/supabase.types.ts
+++ b/cli/src/types/supabase.types.ts
@@ -3169,40 +3169,6 @@ export type Database = {
           name: string
         }[]
       }
-      get_accessible_apps_for_apikey_v2: {
-        Args: { apikey: string }
-        Returns: {
-          allow_device_custom_id: boolean
-          allow_preview: boolean
-          android_store_url: string | null
-          app_id: string
-          channel_device_count: number
-          created_at: string | null
-          default_upload_channel: string
-          existing_app: boolean
-          expose_metadata: boolean
-          icon_url: string
-          id: string | null
-          ios_store_url: string | null
-          last_version: string | null
-          manifest_bundle_count: number
-          name: string | null
-          need_onboarding: boolean
-          owner_org: string
-          retention: number
-          stats_refresh_requested_at: string | null
-          stats_updated_at: string | null
-          transfer_history: Json[] | null
-          updated_at: string | null
-          user_id: string | null
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "apps"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
       get_account_removal_date: { Args: never; Returns: string }
       get_apikey: { Args: never; Returns: string }
       get_apikey_header: { Args: never; Returns: string }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1682,21 +1682,6 @@ export async function assertOrgPermission(
   await assertCliPermission(supabase, apikey, permissionKey, { orgId }, { message, silent })
 }
 
-export async function getAccessibleAppsForApiKey(
-  supabase: SupabaseClient<Database>,
-  apikey: string,
-): Promise<Database['public']['Tables']['apps']['Row'][]> {
-  const { data, error } = await supabase.rpc('get_accessible_apps_for_apikey_v2' as any, { apikey })
-
-  if (error) {
-    log.error('Cannot get accessible apps for API key')
-    log.error(formatError(error))
-    throw new Error('Cannot get accessible apps for API key')
-  }
-
-  return (data || []) as Database['public']['Tables']['apps']['Row'][]
-}
-
 export async function getOrganizationId(supabase: SupabaseClient<Database>, appId: string) {
   const { data, error } = await supabase.from('apps')
     .select('owner_org')

--- a/cli/test/fixtures/setup-test-projects.sh
+++ b/cli/test/fixtures/setup-test-projects.sh
@@ -7,7 +7,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES_DIR="$SCRIPT_DIR"
 PACKAGE_NAME="@capgo/capacitor-updater"
-PACKAGE_VERSION="6.25.5"
+PACKAGE_VERSION="6.45.10"
 
 echo "🧹 Cleaning up old fixtures..."
 rm -rf "$FIXTURES_DIR/npm-project"
@@ -334,8 +334,8 @@ echo "   ✓ lerna monorepo created"
 # ============================================================================
 
 # ============================================================================
-# 11. Version Mismatch: package.json says old, node_modules has new
-# This simulates: user has ^6.14.10 in package.json but 6.30.0 installed
+# 11. Version Mismatch: package.json says old, node_modules has the installed fixture version
+# This simulates: user has ^6.14.10 in package.json but a newer fixture version installed
 # ============================================================================
 echo ""
 echo "🎭 Creating version mismatch trap (package.json lies)..."

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -3209,40 +3209,6 @@ export type Database = {
           name: string
         }[]
       }
-      get_accessible_apps_for_apikey_v2: {
-        Args: { apikey: string }
-        Returns: {
-          allow_device_custom_id: boolean
-          allow_preview: boolean
-          android_store_url: string | null
-          app_id: string
-          channel_device_count: number
-          created_at: string | null
-          default_upload_channel: string
-          existing_app: boolean
-          expose_metadata: boolean
-          icon_url: string
-          id: string | null
-          ios_store_url: string | null
-          last_version: string | null
-          manifest_bundle_count: number
-          name: string | null
-          need_onboarding: boolean
-          owner_org: string
-          retention: number
-          stats_refresh_requested_at: string | null
-          stats_updated_at: string | null
-          transfer_history: Json[] | null
-          updated_at: string | null
-          user_id: string | null
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "apps"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
       get_account_removal_date: { Args: never; Returns: string }
       get_apikey: { Args: never; Returns: string }
       get_apikey_header: { Args: never; Returns: string }

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -3209,40 +3209,6 @@ export type Database = {
           name: string
         }[]
       }
-      get_accessible_apps_for_apikey_v2: {
-        Args: { apikey: string }
-        Returns: {
-          allow_device_custom_id: boolean
-          allow_preview: boolean
-          android_store_url: string | null
-          app_id: string
-          channel_device_count: number
-          created_at: string | null
-          default_upload_channel: string
-          existing_app: boolean
-          expose_metadata: boolean
-          icon_url: string
-          id: string | null
-          ios_store_url: string | null
-          last_version: string | null
-          manifest_bundle_count: number
-          name: string | null
-          need_onboarding: boolean
-          owner_org: string
-          retention: number
-          stats_refresh_requested_at: string | null
-          stats_updated_at: string | null
-          transfer_history: Json[] | null
-          updated_at: string | null
-          user_id: string | null
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "apps"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
       get_account_removal_date: { Args: never; Returns: string }
       get_apikey: { Args: never; Returns: string }
       get_apikey_header: { Args: never; Returns: string }

--- a/supabase/migrations/20260507091347_secure_exist_app_versions_rpc.sql
+++ b/supabase/migrations/20260507091347_secure_exist_app_versions_rpc.sql
@@ -1,3 +1,163 @@
+CREATE OR REPLACE FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) RETURNS boolean
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+DECLARE
+  v_perm text;
+  v_scope text;
+  v_apikey text;
+  v_use_rbac boolean;
+  v_effective_org_id uuid := org_id;
+  v_app_owner_org uuid;
+  v_org_enforcing_2fa boolean;
+  v_password_policy_ok boolean;
+BEGIN
+  -- Existing apps are always authorized in the app owner's org scope.
+  -- Keep nonexistent apps on the caller org so API handlers can still return their
+  -- own not-found errors after a valid org-level check.
+  IF app_id IS NOT NULL THEN
+    SELECT owner_org INTO v_app_owner_org
+    FROM public.apps
+    WHERE public.apps.app_id = check_min_rights.app_id
+    LIMIT 1;
+
+    IF v_app_owner_org IS NOT NULL THEN
+      IF v_effective_org_id IS NOT NULL AND v_effective_org_id IS DISTINCT FROM v_app_owner_org THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_APP_ORG_MISMATCH', jsonb_build_object(
+          'org_id', v_effective_org_id,
+          'app_owner_org', v_app_owner_org,
+          'app_id', app_id,
+          'channel_id', channel_id,
+          'min_right', min_right::text,
+          'user_id', user_id
+        ));
+        RETURN false;
+      END IF;
+
+      v_effective_org_id := v_app_owner_org;
+    END IF;
+  END IF;
+
+  -- Derive org from channel when not provided to honor org-level flag and scoping.
+  IF v_effective_org_id IS NULL AND channel_id IS NOT NULL THEN
+    SELECT owner_org INTO v_effective_org_id
+    FROM public.channels
+    WHERE public.channels.id = channel_id
+    LIMIT 1;
+  END IF;
+
+  -- Enforce 2FA if the org requires it.
+  IF v_effective_org_id IS NOT NULL THEN
+    SELECT enforcing_2fa INTO v_org_enforcing_2fa
+    FROM public.orgs
+    WHERE id = v_effective_org_id;
+
+    IF v_org_enforcing_2fa = true AND (user_id IS NULL OR NOT public.has_2fa_enabled(user_id)) THEN
+      PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_2FA_ENFORCEMENT', jsonb_build_object(
+        'org_id', COALESCE(org_id, v_effective_org_id),
+        'app_id', app_id,
+        'channel_id', channel_id,
+        'min_right', min_right::text,
+        'user_id', user_id
+      ));
+      RETURN false;
+    END IF;
+  END IF;
+
+  -- Enforce password policy if enabled for the org.
+  IF v_effective_org_id IS NOT NULL THEN
+    v_password_policy_ok := public.user_meets_password_policy(user_id, v_effective_org_id);
+    IF v_password_policy_ok = false THEN
+      PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_PASSWORD_POLICY_ENFORCEMENT', jsonb_build_object(
+        'org_id', COALESCE(org_id, v_effective_org_id),
+        'app_id', app_id,
+        'channel_id', channel_id,
+        'min_right', min_right::text,
+        'user_id', user_id
+      ));
+      RETURN false;
+    END IF;
+  END IF;
+
+  v_use_rbac := public.rbac_is_enabled_for_org(v_effective_org_id);
+  IF NOT v_use_rbac THEN
+    RETURN public.check_min_rights_legacy(min_right, user_id, COALESCE(org_id, v_effective_org_id), app_id, channel_id);
+  END IF;
+
+  IF channel_id IS NOT NULL THEN
+    v_scope := public.rbac_scope_channel();
+  ELSIF app_id IS NOT NULL THEN
+    v_scope := public.rbac_scope_app();
+  ELSE
+    v_scope := public.rbac_scope_org();
+  END IF;
+
+  v_perm := public.rbac_permission_for_legacy(min_right, v_scope);
+  SELECT public.get_apikey_header() INTO v_apikey;
+
+  -- Keep RLS authorization semantics aligned with explicit RBAC checks. In
+  -- particular, an API key with direct role bindings must be evaluated as the
+  -- API-key principal and must not inherit broader owner-user permissions.
+  RETURN public.rbac_check_permission_direct(
+    v_perm,
+    user_id,
+    v_effective_org_id,
+    app_id,
+    channel_id,
+    v_apikey
+  );
+END;
+$$;
+
+ALTER FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) TO "anon";
+
+GRANT EXECUTE ON FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) TO "authenticated";
+
+GRANT EXECUTE ON FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_accessible_apps_for_apikey_v2"("apikey" "text");
+
 CREATE OR REPLACE FUNCTION "public"."exist_app_versions"(
   "appid" character varying,
   "name_version" character varying

--- a/supabase/migrations/20260507091347_secure_exist_app_versions_rpc.sql
+++ b/supabase/migrations/20260507091347_secure_exist_app_versions_rpc.sql
@@ -1,0 +1,153 @@
+CREATE OR REPLACE FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying
+) RETURNS boolean
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+BEGIN
+  RETURN public.exist_app_versions(
+    exist_app_versions.appid,
+    exist_app_versions.name_version,
+    public.get_apikey_header()
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying,
+  "apikey" "text"
+) RETURNS boolean
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+DECLARE
+  v_org_id uuid;
+  v_request_role text;
+  v_user_id uuid;
+  v_api_key text;
+BEGIN
+  SELECT owner_org
+  INTO v_org_id
+  FROM public.apps
+  WHERE app_id = exist_app_versions.appid
+  LIMIT 1;
+
+  IF v_org_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  SELECT public.current_request_role()
+  INTO v_request_role;
+
+  IF public.is_internal_request_role(v_request_role) THEN
+    RETURN (
+      SELECT EXISTS (
+        SELECT 1
+        FROM public.app_versions
+        WHERE app_id = exist_app_versions.appid
+          AND name = exist_app_versions.name_version
+          AND owner_org = v_org_id
+      )
+    );
+  END IF;
+
+  SELECT auth.uid()
+  INTO v_user_id;
+
+  v_api_key := exist_app_versions.apikey;
+
+  IF v_api_key = '' THEN
+    v_api_key := NULL;
+  END IF;
+
+  IF v_api_key IS NULL THEN
+    SELECT public.get_apikey_header()
+    INTO v_api_key;
+  END IF;
+
+  IF v_user_id IS NULL AND v_api_key IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF public.rbac_check_permission_direct(
+    public.rbac_perm_app_read_bundles(),
+    v_user_id,
+    v_org_id,
+    exist_app_versions.appid,
+    NULL::bigint,
+    v_api_key
+  ) IS NOT TRUE THEN
+    RETURN false;
+  END IF;
+
+  RETURN (
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.app_versions
+      WHERE app_id = exist_app_versions.appid
+        AND name = exist_app_versions.name_version
+        AND owner_org = v_org_id
+    )
+  );
+END;
+$$;
+
+ALTER FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying
+) OWNER TO "postgres";
+
+ALTER FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying,
+  "apikey" "text"
+) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying
+) FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying,
+  "apikey" "text"
+) FROM PUBLIC;
+
+-- API key requests reach PostgREST as anon, so keep EXECUTE while the function gates data with RBAC.
+GRANT EXECUTE ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying
+) TO "anon";
+
+GRANT EXECUTE ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying
+) TO "authenticated";
+
+GRANT EXECUTE ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying
+) TO "service_role";
+
+GRANT EXECUTE ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying,
+  "apikey" "text"
+) TO "anon";
+
+GRANT EXECUTE ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying,
+  "apikey" "text"
+) TO "authenticated";
+
+GRANT EXECUTE ON FUNCTION "public"."exist_app_versions"(
+  "appid" character varying,
+  "name_version" character varying,
+  "apikey" "text"
+) TO "service_role";

--- a/supabase/tests/05_app_functions.sql
+++ b/supabase/tests/05_app_functions.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 
-SELECT plan(12);
+SELECT plan(16);
 
 SELECT tests.authenticate_as('test_user');
 
@@ -40,6 +40,57 @@ SELECT
     );
 
 SELECT tests.clear_authentication();
+
+-- Test exist_app_versions authorization
+SELECT
+    set_config('request.headers', '{}', true);
+
+SELECT
+    is(
+        exist_app_versions('com.demo.app', '1.0.0'),
+        false,
+        'exist_app_versions test - anonymous caller without capgkey cannot enumerate version'
+    );
+
+SELECT
+    set_config(
+        'request.headers',
+        '{"capgkey":"ae6e7458-c46d-4c00-aa3b-153b0b8520ea"}',
+        true
+    );
+
+SELECT
+    is(
+        exist_app_versions('com.demo.app', '1.0.0'),
+        true,
+        'exist_app_versions test - valid capgkey header can read existing version'
+    );
+
+SELECT
+    set_config('request.headers', '{}', true);
+
+SELECT
+    is(
+        exist_app_versions(
+            'com.demo.app',
+            '1.0.0',
+            'ae6e7458-c46d-4c00-aa3b-153b0b8520ea'
+        ),
+        true,
+        'exist_app_versions test - valid apikey argument can read existing version'
+    );
+
+SELECT
+    is(
+        exist_app_versions('com.demo.app', '1.0.0', 'not-a-real-key'),
+        false,
+        'exist_app_versions test - invalid apikey argument cannot enumerate version'
+    );
+
+SELECT tests.clear_authentication();
+
+SELECT
+    set_config('request.headers', '{}', true);
 
 -- Test get_app_versions
 SELECT tests.authenticate_as('test_user');

--- a/supabase/tests/33_test_rbac_phase1.sql
+++ b/supabase/tests/33_test_rbac_phase1.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(7);
+SELECT plan(9);
 
 -- Test fixtures - DEDICATED DATA FOR TEST ISOLATION (parallel test execution)
 -- Create dedicated test users to avoid conflicts with other parallel tests
@@ -191,6 +191,23 @@ SELECT
     'rbac-test-apikey'
 FROM seed_data;
 
+-- Restricted API key principal owned by an org admin. The explicit key binding
+-- must limit the key even though the owner user has broader app permissions.
+WITH seed_data AS (
+    SELECT
+        '44444444-4444-4444-8444-444444444444'::uuid AS member_user,
+        'rbac-test-restricted-key-phase1'::text AS api_key_value
+)
+
+INSERT INTO public.apikeys (id, user_id, key, mode, name)
+SELECT
+    33002,
+    member_user,
+    api_key_value,
+    'all'::public.key_mode,
+    'rbac-test-restricted-apikey'
+FROM seed_data;
+
 -- RBAC bindings (org_admin to user, app_admin to apikey)
 WITH seed_data AS (
     SELECT
@@ -276,6 +293,35 @@ WHERE
     AND r.name = 'app_admin'
     AND a.app_id = 'com.rbac.new';
 
+-- Explicit org_member binding for restricted API key. org_member has no app.read
+-- permission, so apps RLS must not fall back to the owner user's org_admin role.
+WITH seed_data AS (
+    SELECT
+        'rbac-test-restricted-key-phase1'::text AS api_key_value,
+        '33333333-3333-4333-8333-333333333333'::uuid AS admin_user,
+        '22222222-2222-4222-8222-222222222222'::uuid AS org_rbac
+)
+
+INSERT INTO public.role_bindings (
+    principal_type,
+    principal_id,
+    role_id,
+    scope_type,
+    org_id,
+    granted_by
+)
+SELECT
+    'apikey',
+    api.rbac_id,
+    r.id,
+    'org',
+    org_rbac,
+    admin_user
+FROM public.apikeys AS api, public.roles AS r, seed_data
+WHERE
+    api.key = api_key_value
+    AND r.name = public.rbac_role_org_member();
+
 -- 1) Legacy path still works when RBAC flag is off
 SELECT
     ok(
@@ -344,6 +390,37 @@ SELECT
         ),
         'App admin binding on apikey grants app.update_settings permission'
     );
+
+
+SELECT tests.clear_authentication();
+SELECT set_config('request.headers', '{"capgkey":"rbac-test-restricted-key-phase1"}', true);
+
+SELECT
+    is(
+        (
+            SELECT count(*)::integer
+            FROM public.apps
+            WHERE app_id = 'com.rbac.new'
+        ),
+        0,
+        'Apps RLS denies explicitly restricted API key even when owner has org_admin'
+    );
+
+SELECT set_config('request.headers', '{"capgkey":"rbac-test-key-phase1"}', true);
+
+SELECT
+    is(
+        (
+            SELECT count(*)::integer
+            FROM public.apps
+            WHERE app_id = 'com.rbac.new'
+        ),
+        1,
+        'Apps RLS allows API key with explicit app read permission'
+    );
+
+SELECT tests.authenticate_as_service_role();
+SELECT set_config('request.headers', '{}', true);
 
 -- 6) Disabling RBAC removes RBAC-granted access when no legacy rights exist
 UPDATE public.orgs SET use_new_rbac = false


### PR DESCRIPTION
## Summary (AI generated)

- Secures both `exist_app_versions` RPC overloads with service-role bypass plus RBAC/API-key authorization before returning bundle existence.
- Fixes `check_min_rights` so direct `apps` RLS respects explicit API-key RBAC bindings instead of falling back to broader owner-user permissions.
- Removes the unused CLI `getAccessibleAppsForApiKey` helper and drops `get_accessible_apps_for_apikey_v2`; the CLI now relies on the corrected `apps` RLS path.
- Adds pgTAP regression coverage for anonymous/version checks and restricted API-key app-list RLS.

## Motivation (AI generated)

`exist_app_versions` was an unauthenticated oracle for release-history enumeration. While reviewing the CLI app-list path, the API-key RBAC restriction belonged in `check_min_rights` itself so direct table RLS stays correct and no app-list wrapper RPC is needed.

## Business Impact (AI generated)

This protects customer release timelines and security-fix history from public enumeration, and keeps restricted API keys restricted consistently across CLI and direct table access.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run cli:check`
- [x] `bun scripts/supabase-worktree.ts test db supabase/tests/00-supabase_test_helpers.sql supabase/tests/05_app_functions.sql supabase/tests/33_test_rbac_phase1.sql`
- [x] Local REST check: anon request without `capgkey` returns `false`
- [x] Local REST check: request with valid `capgkey` returns `true`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test fixture version bumped to 6.45.10.
  * Removed a legacy RPC and corresponding client helpers/types.

* **Bug Fixes**
  * Tightened DB-side authorization and RBAC checks for app version access.
  * Normalized API‑key handling and strengthened permission enforcement.

* **Tests**
  * Expanded authorization and RBAC test coverage, including API‑key and anonymous scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->