### PR TITLE
[codex] Deploy Japan plugin worker on release

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -192,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region: [eu, as, us, sa, oc, af, me, hk]
+        region: [eu, as, us, sa, oc, af, me, hk, jp]
         include:
           - region: eu
             region_label: Europe (EU)
@@ -218,6 +218,9 @@ jobs:
           - region: hk
             region_label: Hong Kong (HK)
             cf_target: plugin_hk
+          - region: jp
+            region_label: Japan (JP)
+            cf_target: plugin_jp
     name: Deploy CF Worker Plugin (${{ matrix.region_label }})
     steps:
       - name: Checkout

--- a/cli/test/fixtures/setup-test-projects.sh
+++ b/cli/test/fixtures/setup-test-projects.sh
@@ -35,7 +35,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -55,7 +55,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -75,7 +75,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -95,7 +95,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -123,7 +123,7 @@ cat > apps/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -154,7 +154,7 @@ cat > apps/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -180,7 +180,7 @@ packages:
   - 'apps/*'
 
 catalog:
-  '@capgo/capacitor-updater': ^$PACKAGE_VERSION
+  '@capgo/capacitor-updater': $PACKAGE_VERSION
 EOF
 cat > apps/mobile/package.json << EOF
 {
@@ -216,7 +216,7 @@ cat > apps/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -252,7 +252,7 @@ cat > apps/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -286,7 +286,7 @@ cat > apps/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -321,7 +321,7 @@ cat > packages/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -348,7 +348,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -364,7 +364,7 @@ cat > package.json << EOF
   }
 }
 EOF
-echo "   ✓ version mismatch trap created (package.json says 6.14.10, node_modules has latest)"
+echo "   ✓ version mismatch trap created (package.json says 6.14.10, node_modules has the fixture version)"
 
 # ============================================================================
 # 12. Fake nested package.json: Wrong version in a nested fake location
@@ -380,7 +380,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -393,7 +393,7 @@ cat > "src/@capgo/capacitor-updater/package.json" << EOF
   "version": "1.0.0-FAKE"
 }
 EOF
-echo "   ✓ wrong nested version trap created (fake 1.0.0-FAKE in src/, real in node_modules)"
+echo "   ✓ wrong nested version trap created (fake 1.0.0-FAKE in src/, fixture version in node_modules)"
 
 # ============================================================================
 # 13. Monorepo with different versions: root and app have different versions
@@ -418,7 +418,7 @@ cat > apps/mobile/package.json << EOF
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "$PACKAGE_NAME": "^$PACKAGE_VERSION"
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
   }
 }
 EOF
@@ -435,7 +435,7 @@ cat > apps/mobile/package.json << EOF
   }
 }
 EOF
-echo "   ✓ monorepo fake version trap created (app package.json lies, node_modules has real)"
+echo "   ✓ monorepo fake version trap created (app package.json lies, node_modules has the fixture version)"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "deploy:cloudflare:plugin_me:prod": "bunx wrangler deploy --config cloudflare_workers/plugin/wrangler.jsonc --env=prod_me --minify",
     "deploy:cloudflare:plugin_hk:prod": "bunx wrangler deploy --config cloudflare_workers/plugin/wrangler.jsonc --env=prod_hk --minify",
     "deploy:cloudflare:plugin_jp:prod": "bunx wrangler deploy --config cloudflare_workers/plugin/wrangler.jsonc --env=prod_jp --minify",
+    "deploy:cloudflare:plugin_jp:dev": "bun run deploy:cloudflare:plugin:dev",
     "deploy:cloudflare_env:api:prod": "bunx wrangler secret bulk internal/cloudflare/.env.prod --config cloudflare_workers/api/wrangler.jsonc --env=prod",
     "deploy:cloudflare_env:api:preprod": "bunx wrangler secret bulk internal/cloudflare/.env.preprod --config cloudflare_workers/api/wrangler.jsonc --env=preprod",
     "deploy:cloudflare_env:api:dev": "bunx wrangler secret bulk internal/cloudflare/.env.alpha --config cloudflare_workers/api/wrangler.jsonc --env=alpha",


### PR DESCRIPTION
## Summary (AI generated)

- Added Japan (`jp`) to the plugin worker deployment matrix so release tags deploy `plugin_jp` with the other regional workers.
- Added the matching `deploy:cloudflare:plugin_jp:dev` script alias for alpha deploy paths.
- Pinned CLI version-detection fixtures to exact package versions so pnpm-based fixture installs stay deterministic in CI.

## Motivation (AI generated)

Japan already had a Cloudflare worker environment and package deploy script, but the release workflow matrix did not include `jp`, so it was not auto-redeployed with the other plugin regions.

## Business Impact (AI generated)

Keeping the Japan plugin worker on the same release cadence prevents the JP endpoint from serving stale `/updates` behavior after production fixes ship, including the deleted-bundle advisory path.

## Test Plan (AI generated)

- [x] Parsed `.github/workflows/build_and_deploy.yml` as YAML.
- [x] Ran `git diff --check`.
- [x] Ran `bun lint:backend`.
- [x] Ran CLI version-detection fixture setup and tests.
- [x] Waited for GitHub CI to pass after pushing the PR.

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Japan region deployment support for the Cloudflare plugin.

* **Chores**
  * Updated fixture projects with explicit version pinning for dependencies.
  * Added development deployment script for Japan region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->