### PR TITLE
[codex] add plugin region version check

### DIFF
--- a/cloudflare_workers/api/index.ts
+++ b/cloudflare_workers/api/index.ts
@@ -39,6 +39,7 @@ import { app as channel } from '../../supabase/functions/_backend/public/channel
 import { app as check_cpu_usage } from '../../supabase/functions/_backend/public/check_cpu_usage.ts'
 import { app as device } from '../../supabase/functions/_backend/public/device/index.ts'
 import { app as ok } from '../../supabase/functions/_backend/public/ok.ts'
+import { app as pluginRegions } from '../../supabase/functions/_backend/public/plugin_regions.ts'
 import { app as organization } from '../../supabase/functions/_backend/public/organization/index.ts'
 import { app as replication } from '../../supabase/functions/_backend/public/replication.ts'
 import { app as statistics } from '../../supabase/functions/_backend/public/statistics/index.ts'
@@ -91,6 +92,7 @@ app.route('/build', build)
 app.route('/replication', replication)
 app.route('/check_cpu_usage', check_cpu_usage)
 app.route('/translation', translation)
+app.route('/plugin_regions', pluginRegions)
 
 // Private API
 const functionNamePrivate = 'private'

--- a/configs.json
+++ b/configs.json
@@ -28,5 +28,11 @@
     "preprod": "0x4AAAAAAAxItBa5rCQ3Vvhl",
     "development": "0x4AAAAAAAxDbvW2bw7mcEZs",
     "local": ""
+  },
+  "plugin_region_targets": {
+    "prod": "[{\"name\":\"eu\",\"envName\":\"capgo_plugin-eu-prod\",\"url\":\"https://plugin.eu.capgo.app/ok\"},{\"name\":\"me\",\"envName\":\"capgo_plugin-me-prod\",\"url\":\"https://plugin.me.capgo.app/ok\"},{\"name\":\"hk\",\"envName\":\"capgo_plugin-hk-prod\",\"url\":\"https://plugin.hk.capgo.app/ok\"},{\"name\":\"jp\",\"envName\":\"capgo_plugin-jp-prod\",\"url\":\"https://plugin.jp.capgo.app/ok\"},{\"name\":\"as\",\"envName\":\"capgo_plugin-as-prod\",\"url\":\"https://plugin.as.capgo.app/ok\"},{\"name\":\"na\",\"envName\":\"capgo_plugin-na-prod\",\"url\":\"https://plugin.na.capgo.app/ok\"},{\"name\":\"af\",\"envName\":\"capgo_plugin-af-prod\",\"url\":\"https://plugin.af.capgo.app/ok\"},{\"name\":\"oc\",\"envName\":\"capgo_plugin-oc-prod\",\"url\":\"https://plugin.oc.capgo.app/ok\"},{\"name\":\"sa\",\"envName\":\"capgo_plugin-sa-prod\",\"url\":\"https://plugin.sa.capgo.app/ok\"}]",
+    "preprod": "[{\"name\":\"eu\",\"envName\":\"capgo_plugin-eu-preprod\",\"url\":\"https://plugin.preprod.capgo.app/ok\"}]",
+    "development": "[{\"name\":\"alpha\",\"envName\":\"capgo_plugin-alpha\",\"url\":\"https://plugin.dev.capgo.app/ok\"}]",
+    "local": "[{\"name\":\"local\",\"envName\":\"capgo_plugin-local\",\"url\":\"http://localhost:8788/ok\"}]"
   }
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -366,6 +366,10 @@ import_map = "./functions/deno.json"
 verify_jwt = false
 import_map = "./functions/deno.json"
 
+[functions.plugin_regions]
+verify_jwt = false
+import_map = "./functions/deno.json"
+
 [functions.build]
 verify_jwt = false
 import_map = "./functions/deno.json"

--- a/supabase/functions/_backend/public/plugin_regions.ts
+++ b/supabase/functions/_backend/public/plugin_regions.ts
@@ -1,0 +1,182 @@
+import type { Context } from 'hono'
+import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { PluginRegion } from '../utils/pluginRegionTargets.ts'
+import { BRES, honoFactory, middlewareAPISecret, quickError } from '../utils/hono.ts'
+import { cloudlog } from '../utils/logging.ts'
+import { getConfiguredPluginRegions, PLUGIN_REGIONS } from '../utils/pluginRegionTargets.ts'
+
+export { PLUGIN_REGIONS }
+
+const PLUGIN_REGION_TIMEOUT_MS = 5_000
+
+interface PluginRegionResult {
+  name: PluginRegion['name']
+  url: PluginRegion['url']
+  status: number | null
+  workerSource: string | null
+  version: string | null
+  error: string | null
+}
+
+interface PluginRegionDifference extends PluginRegionResult {
+  expectedVersion: string | null
+}
+
+function toErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Unknown fetch error'
+}
+
+function parseWorkerVersion(workerSource: string | null, envName: string) {
+  if (!workerSource)
+    return null
+
+  const prefix = `${envName}-`
+  if (!workerSource.startsWith(prefix))
+    return null
+
+  return workerSource.slice(prefix.length)
+}
+
+async function fetchRegionVersion(region: PluginRegion): Promise<PluginRegionResult> {
+  const timeout = AbortSignal.timeout(PLUGIN_REGION_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(region.url, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+      signal: timeout,
+    })
+    const workerSource = response.headers.get('x-worker-source')
+    const version = parseWorkerVersion(workerSource, region.envName)
+    let error: string | null = null
+
+    if (!response.ok)
+      error = 'http_error'
+    else if (!workerSource)
+      error = 'missing_worker_source'
+    else if (!version)
+      error = 'unexpected_worker_source'
+
+    return {
+      name: region.name,
+      url: region.url,
+      status: response.status,
+      workerSource,
+      version,
+      error,
+    }
+  }
+  catch (error) {
+    return {
+      name: region.name,
+      url: region.url,
+      status: null,
+      workerSource: null,
+      version: null,
+      error: toErrorMessage(error),
+    }
+  }
+}
+
+function getExpectedVersion(results: PluginRegionResult[]) {
+  const counts = new Map<string, number>()
+
+  for (const result of results) {
+    if (!result.version || result.error)
+      continue
+
+    counts.set(result.version, (counts.get(result.version) ?? 0) + 1)
+  }
+
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1])
+
+  if (!sorted.length)
+    return null
+
+  if (sorted[1] && sorted[0][1] === sorted[1][1])
+    return null
+
+  return sorted[0][0]
+}
+
+function getDifferences(results: PluginRegionResult[], expectedVersion: string | null): PluginRegionDifference[] {
+  if (!expectedVersion)
+    return []
+
+  return results
+    .filter(result => !result.error && result.version !== expectedVersion)
+    .map(result => ({
+      ...result,
+      expectedVersion,
+    }))
+}
+
+async function getPluginRegionVersions(c: Context<MiddlewareKeyVariables>) {
+  let configuredRegions: PluginRegion[]
+
+  try {
+    configuredRegions = getConfiguredPluginRegions(c)
+  }
+  catch (error) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Invalid plugin region version check configuration',
+      error: toErrorMessage(error),
+    })
+    return quickError(500, 'invalid_plugin_region_targets', 'Cannot parse plugin region targets')
+  }
+
+  const regions = await Promise.all(configuredRegions.map(fetchRegionVersion))
+  const expectedVersion = getExpectedVersion(regions)
+  const differences = getDifferences(regions, expectedVersion)
+  const unavailableRegions = regions.filter(result => !!result.error)
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Plugin region version check',
+    expectedVersion,
+    differences: differences.length,
+    unavailableRegions: unavailableRegions.length,
+    regions: regions.length,
+  })
+
+  if (!expectedVersion) {
+    return c.json({
+      status: 'indeterminate',
+      version: null,
+      regions,
+    })
+  }
+
+  if (differences.length) {
+    return c.json({
+      status: 'mismatch',
+      expectedVersion,
+      differences,
+      regions,
+    }, 409)
+  }
+
+  if (unavailableRegions.length) {
+    return c.json({
+      status: 'indeterminate',
+      version: expectedVersion,
+      unavailableRegions,
+      regions,
+    })
+  }
+
+  return c.json({
+    ...BRES,
+    version: expectedVersion,
+    regions,
+  })
+}
+
+export const app = honoFactory.createApp()
+
+app.use('*', middlewareAPISecret)
+app.get('/', getPluginRegionVersions)
+app.get('/versions', getPluginRegionVersions)

--- a/supabase/functions/_backend/utils/pluginRegionTargets.ts
+++ b/supabase/functions/_backend/utils/pluginRegionTargets.ts
@@ -1,0 +1,49 @@
+import type { Context } from 'hono'
+import { existInEnv, getEnv } from './utils.ts'
+
+const PLUGIN_REGION_TARGETS_ENV = 'PLUGIN_REGION_TARGETS'
+
+export interface PluginRegion {
+  name: string
+  envName: string
+  url: string
+}
+
+export const PLUGIN_REGIONS: PluginRegion[] = [
+  { name: 'eu', envName: 'capgo_plugin-eu-prod', url: 'https://plugin.eu.capgo.app/ok' },
+  { name: 'me', envName: 'capgo_plugin-me-prod', url: 'https://plugin.me.capgo.app/ok' },
+  { name: 'hk', envName: 'capgo_plugin-hk-prod', url: 'https://plugin.hk.capgo.app/ok' },
+  { name: 'jp', envName: 'capgo_plugin-jp-prod', url: 'https://plugin.jp.capgo.app/ok' },
+  { name: 'as', envName: 'capgo_plugin-as-prod', url: 'https://plugin.as.capgo.app/ok' },
+  { name: 'na', envName: 'capgo_plugin-na-prod', url: 'https://plugin.na.capgo.app/ok' },
+  { name: 'af', envName: 'capgo_plugin-af-prod', url: 'https://plugin.af.capgo.app/ok' },
+  { name: 'oc', envName: 'capgo_plugin-oc-prod', url: 'https://plugin.oc.capgo.app/ok' },
+  { name: 'sa', envName: 'capgo_plugin-sa-prod', url: 'https://plugin.sa.capgo.app/ok' },
+]
+
+function isPluginRegion(value: unknown): value is PluginRegion {
+  if (!value || typeof value !== 'object')
+    return false
+
+  const region = value as Record<string, unknown>
+  return typeof region.name === 'string'
+    && typeof region.envName === 'string'
+    && typeof region.url === 'string'
+    && region.url.length > 0
+}
+
+function parsePluginRegions(rawRegions: string) {
+  const parsed = JSON.parse(rawRegions) as unknown
+
+  if (!Array.isArray(parsed) || !parsed.every(isPluginRegion) || !parsed.length)
+    throw new Error('Invalid plugin region targets')
+
+  return parsed
+}
+
+export function getConfiguredPluginRegions(c: Context) {
+  if (!existInEnv(c, PLUGIN_REGION_TARGETS_ENV))
+    return PLUGIN_REGIONS
+
+  return parsePluginRegions(getEnv(c, PLUGIN_REGION_TARGETS_ENV))
+}

--- a/supabase/functions/plugin_regions/index.ts
+++ b/supabase/functions/plugin_regions/index.ts
@@ -1,0 +1,11 @@
+import { app } from '../_backend/public/plugin_regions.ts'
+import { createAllCatch, createHono } from '../_backend/utils/hono.ts'
+import { version } from '../_backend/utils/version.ts'
+
+const functionName = 'plugin_regions'
+const appGlobal = createHono(functionName, version)
+appGlobal.route('/', app)
+
+createAllCatch(appGlobal, functionName)
+
+Deno.serve(appGlobal.fetch)

--- a/tests/plugin-region-versions.unit.test.ts
+++ b/tests/plugin-region-versions.unit.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { app, PLUGIN_REGIONS } from '../supabase/functions/_backend/public/plugin_regions.ts'
+
+const originalFetch = globalThis.fetch
+const originalApiSecret = process.env.API_SECRET
+const API_SECRET = 'test-secret'
+
+interface PluginRegionVersionsResponse {
+  status: string
+  version?: string | null
+  expectedVersion?: string
+  regions: Array<{ version: string | null }>
+  differences?: Array<{
+    name: string
+    version: string | null
+    expectedVersion: string | null
+    error: string | null
+  }>
+  unavailableRegions?: Array<{
+    name: string
+    error: string | null
+  }>
+}
+
+function requestPluginRegions(path = '/') {
+  return app.request(`http://local${path}`, {
+    headers: {
+      apisecret: API_SECRET,
+    },
+  })
+}
+
+function mockRegionFetch(versionByRegion: Partial<Record<typeof PLUGIN_REGIONS[number]['name'], string | null>>, failedRegions: Array<typeof PLUGIN_REGIONS[number]['name']> = []) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input)
+    const region = PLUGIN_REGIONS.find(item => item.url === url)
+
+    if (!region)
+      return new Response(null, { status: 404 })
+
+    if (failedRegions.includes(region.name))
+      throw new Error('network unavailable')
+
+    const version = Object.hasOwn(versionByRegion, region.name) ? versionByRegion[region.name] : '1.0.0'
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    }
+
+    if (version)
+      headers['x-worker-source'] = `${region.envName}-${version}`
+
+    return new Response(JSON.stringify({ status: 'ok' }), {
+      status: 200,
+      headers,
+    })
+  })
+}
+
+describe('plugin region versions', () => {
+  beforeEach(() => {
+    process.env.API_SECRET = API_SECRET
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    globalThis.fetch = originalFetch
+
+    if (originalApiSecret === undefined)
+      delete process.env.API_SECRET
+    else
+      process.env.API_SECRET = originalApiSecret
+  })
+
+  it('requires the API secret header', async () => {
+    const response = await app.request('http://local/')
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(body).toContain('Cannot find authorization')
+  })
+
+  it('returns ok when every plugin region runs the same version', async () => {
+    mockRegionFetch({})
+
+    const response = await requestPluginRegions()
+    const body = await response.json() as PluginRegionVersionsResponse
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      status: 'ok',
+      version: '1.0.0',
+    })
+    expect(body.regions).toHaveLength(PLUGIN_REGIONS.length)
+    expect(body.regions.every(region => region.version === '1.0.0')).toBe(true)
+  })
+
+  it('serves the same ok payload from the versions alias', async () => {
+    mockRegionFetch({})
+
+    const response = await requestPluginRegions('/versions')
+    const body = await response.json() as PluginRegionVersionsResponse
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      status: 'ok',
+      version: '1.0.0',
+    })
+    expect(body.regions).toHaveLength(PLUGIN_REGIONS.length)
+  })
+
+  it('lists the differing regions when one plugin region is behind', async () => {
+    mockRegionFetch({ jp: '0.9.9' })
+
+    const response = await requestPluginRegions()
+    const body = await response.json() as PluginRegionVersionsResponse
+
+    expect(response.status).toBe(409)
+    expect(body).toMatchObject({
+      status: 'mismatch',
+      expectedVersion: '1.0.0',
+    })
+    expect(body.differences).toEqual([
+      expect.objectContaining({
+        name: 'jp',
+        version: '0.9.9',
+        expectedVersion: '1.0.0',
+        error: null,
+      }),
+    ])
+  })
+
+  it('returns indeterminate when no unique baseline version exists', async () => {
+    mockRegionFetch({
+      eu: '2.0.0',
+      me: '2.0.0',
+      hk: '2.0.0',
+      jp: '2.0.0',
+      as: '1.0.0',
+      na: '1.0.0',
+      af: '1.0.0',
+      oc: '1.0.0',
+      sa: null,
+    })
+
+    const response = await requestPluginRegions()
+    const body = await response.json() as PluginRegionVersionsResponse
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      status: 'indeterminate',
+      version: null,
+    })
+    expect(body.regions).toHaveLength(PLUGIN_REGIONS.length)
+    expect(body.differences).toBeUndefined()
+  })
+
+  it('returns indeterminate when a region is unreachable but successful regions match', async () => {
+    mockRegionFetch({}, ['jp'])
+
+    const response = await requestPluginRegions()
+    const body = await response.json() as PluginRegionVersionsResponse
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      status: 'indeterminate',
+      version: '1.0.0',
+    })
+    expect(body.differences).toBeUndefined()
+    expect(body.unavailableRegions).toEqual([
+      expect.objectContaining({
+        name: 'jp',
+        error: 'network unavailable',
+      }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Added an API-secret-protected `/plugin_regions` API endpoint, with `/plugin_regions/versions` as an alias, to query every configured plugin region `/ok` endpoint.
- Reports `status: ok` when all regions expose the same worker version, `status: mismatch` with the differing regions when drift is detected, and `status: indeterminate` when there is no unique baseline.
- Moved plugin region targets into shared config defaults with runtime env override support for non-prod/self-hosted deployments.
- Added focused unit coverage for auth, success, alias, mismatch, and indeterminate responses.

## Motivation (AI generated)

The Japan plugin worker lagged behind other regions, and there was no API-level way to verify regional deployment consistency without manually probing each region.

## Business Impact (AI generated)

This gives Capgo a low-friction operational check for plugin rollout drift, reducing time to detect regional deployment issues before customers are affected.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx eslint tests/plugin-region-versions.unit.test.ts`
- [x] `bunx vitest run tests/plugin-region-versions.unit.test.ts`
- [x] `bun typecheck`
- [x] Live smoke through the handler: all 9 plugin regions returned `12.128.6` with `status: ok`
- [x] GitHub CI passed after the previous push; waiting again after the latest CodeRabbit follow-up fix

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New public API endpoint to report plugin-region versions, detect mismatches, and indicate indeterminate states.
  * Returns per-region status, expected baseline version, and highlights differing or unavailable regions.
* **Tests**
  * Unit tests covering success, mismatch, indeterminate, and unreachable-region scenarios.
* **Chores**
  * Added local/dev configuration for plugin region targets and a local function endpoint for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->