### PR TITLE
[codex] Fix TUS upload HEAD resume probes

### DIFF
--- a/supabase/functions/_backend/public/build/index.ts
+++ b/supabase/functions/_backend/public/build/index.ts
@@ -99,11 +99,11 @@ async function proxyTusHead(c: Parameters<typeof tusProxy>[0]) {
 }
 
 function isTusHeadProbe(c: Parameters<typeof tusProxy>[0]) {
-  return !!c.req.header('Tus-Resumable')
+  return c.req.method === 'HEAD' || !!c.req.header('Tus-Resumable')
 }
 
-// Some runtimes normalize HEAD to GET on mounted routes.
-// Accept only TUS-shaped GET probes here and forward them upstream as HEAD.
+// Hono serves HEAD through GET handlers on mounted routes.
+// Accept real HEAD requests plus TUS-shaped GET probes and forward them upstream as HEAD.
 app.get(
   '/upload/:jobId',
   async (c, next) => {

--- a/tests/build-upload-head-routing.test.ts
+++ b/tests/build-upload-head-routing.test.ts
@@ -21,6 +21,15 @@ describe('build upload HEAD routing', () => {
     expect([400, 401]).toContain(response.status)
   })
 
+  it.concurrent('routes HEAD /build/upload/:jobId/* without Tus-Resumable through auth middleware', async () => {
+    const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job/file.zip', {
+      method: 'HEAD',
+    }))
+
+    expect(response.status).not.toBe(404)
+    expect([400, 401]).toContain(response.status)
+  })
+
   it.concurrent('routes HEAD /build/upload/:jobId through auth middleware', async () => {
     const response = await createMountedBuildApp().request(new Request('http://localhost/build/upload/test-job', {
       method: 'HEAD',

--- a/tests/build-upload-security.test.ts
+++ b/tests/build-upload-security.test.ts
@@ -152,6 +152,54 @@ describe('build upload proxy security', () => {
     }
   })
 
+  it('keeps TUS resume state discoverable between PATCH chunks', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, {
+        status: 204,
+        headers: {
+          'Upload-Offset': '4',
+          'Tus-Resumable': '1.0.0',
+        },
+      }))
+      .mockResolvedValueOnce(new Response(null, {
+        status: 200,
+        headers: {
+          'Upload-Offset': '4',
+          'Tus-Resumable': '1.0.0',
+        },
+      }))
+      .mockResolvedValueOnce(new Response(null, {
+        status: 204,
+        headers: {
+          'Upload-Offset': '5',
+          'Tus-Resumable': '1.0.0',
+        },
+      }))
+
+    try {
+      const uploadUrl = `http://localhost/build/upload/${jobId}/artifact.zip`
+      const apikey = { user_id: 'user-test', key: 'api-test' } as any
+      const firstPatchResponse = await tusProxy(fakeContext(uploadUrl, 'PATCH') as any, jobId, apikey)
+      const headResponse = await tusProxy(fakeContext(uploadUrl, 'HEAD') as any, jobId, apikey, 'HEAD')
+      const secondPatchResponse = await tusProxy(fakeContext(uploadUrl, 'PATCH') as any, jobId, apikey)
+      const forwardedMethods = fetchMock.mock.calls.map(([, init]) => (init as RequestInit).method)
+      const [, headInit] = fetchMock.mock.calls[1] as [string, RequestInit]
+
+      expect(firstPatchResponse.status).toBe(204)
+      expect(firstPatchResponse.headers.get('Upload-Offset')).toBe('4')
+      expect(headResponse.status).toBe(200)
+      expect(headResponse.headers.get('Upload-Offset')).toBe('4')
+      expect(secondPatchResponse.status).toBe(204)
+      expect(secondPatchResponse.headers.get('Upload-Offset')).toBe('5')
+      expect(forwardedMethods).toEqual(['PATCH', 'HEAD', 'PATCH'])
+      expect(headInit).not.toHaveProperty('body')
+      expect(headInit).not.toHaveProperty('duplex')
+    }
+    finally {
+      fetchMock.mockRestore()
+    }
+  })
+
   it('forwards HEAD probes to builder without a request body', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, {
       status: 204,


### PR DESCRIPTION
## Summary (AI generated)

- Route real build-upload `HEAD` requests through the TUS proxy even when `Tus-Resumable` is absent.
- Keep plain `GET` upload URLs hidden unless they are TUS-shaped HEAD fallbacks.
- Add regression tests for route-level HEAD handling and `PATCH -> HEAD -> PATCH` resume behavior.

## Motivation (AI generated)

The build TUS proxy could return route-level `404` for active upload URLs on `HEAD`, while `PATCH` continued to work. Standard TUS clients rely on `HEAD` to discover the current upload offset before resuming.

## Business Impact (AI generated)

This restores resumable native build uploads, reducing failed uploads, wasted bandwidth, repeated build attempts, and support risk for customers using standard TUS clients.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/build-upload-head-routing.test.ts tests/build-upload-security.test.ts`
- [x] `bun lint:backend`
- [x] `bun run supabase:db:reset`
- [x] `bunx supabase test db supabase/tests/49_test_apikey_oracle_rpc_permissions.sql --workdir .context/supabase-worktrees/7d95798b`
- [x] pre-commit hook: `bun run cli:build && vue-tsc --noEmit`
- [x] `git diff --check`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced HEAD request recognition in upload routing to properly handle both standard HTTP and TUS protocol requests.
  * Improved upload state continuity tracking across multiple requests.

* **Tests**
  * Added tests for upload HEAD request routing behavior.
  * Added tests for upload resume state preservation across request sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->