### PR TITLE
[codex] add performance benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -42,4 +42,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: npx vitest bench --config vitest.config.bench.ts --run
+          run: bun run bench

--- a/benches/cli-hot-paths.bench.ts
+++ b/benches/cli-hot-paths.bench.ts
@@ -1,0 +1,109 @@
+import type { Compatibility } from '../cli/src/utils.ts'
+import { Buffer } from 'node:buffer'
+import { parse } from '@std/semver'
+import { bench, describe } from 'vitest'
+import { getChecksum } from '../cli/src/checksum.ts'
+import { getCompatibilityDetails, isCompatible, isDeprecatedPluginVersion, regexSemver } from '../cli/src/utils.ts'
+import { autoBumpVersion, getVersionSuggestions } from '../cli/src/versionHelpers.ts'
+
+const bundleVersions = [
+  '1.0.0',
+  '1.2.3-beta.1',
+  '2.0.0+build.7',
+  '8.45.10',
+  '2026.5.7',
+  'invalid-version',
+]
+
+const updaterVersions = [
+  '5.9.9',
+  '5.10.0',
+  '6.24.9',
+  '6.25.0',
+  '7.24.9',
+  '7.25.0',
+  '8.0.0',
+]
+
+const compatibilityMatrix: Compatibility[] = [
+  {
+    name: '@capacitor/app',
+    localVersion: '^8.1.0',
+    remoteVersion: '^8.1.0',
+    localIosChecksum: 'same-ios',
+    remoteIosChecksum: 'same-ios',
+    localAndroidChecksum: 'same-android',
+    remoteAndroidChecksum: 'same-android',
+  },
+  {
+    name: '@capacitor/camera',
+    localVersion: '^8.2.0',
+    remoteVersion: '^7.0.0',
+    localIosChecksum: 'ios-new',
+    remoteIosChecksum: 'ios-old',
+    localAndroidChecksum: 'android-new',
+    remoteAndroidChecksum: 'android-old',
+  },
+  {
+    name: '@capgo/capacitor-updater',
+    localVersion: '^8.45.0',
+    remoteVersion: undefined,
+  },
+  {
+    name: '@capacitor/device',
+    localVersion: undefined,
+    remoteVersion: '^8.0.0',
+  },
+]
+
+const checksumPayload = Buffer.alloc(128 * 1024, 'capgo-benchmark-payload')
+
+describe('cli version helpers', () => {
+  bench('validate bundle semver candidates', () => {
+    for (const version of bundleVersions) {
+      const isExpectedInvalid = version === 'invalid-version'
+      const isValid = regexSemver.test(version)
+      if (!isExpectedInvalid && !isValid)
+        throw new Error(`Expected valid semver fixture: ${version}`)
+      if (isExpectedInvalid && isValid)
+        throw new Error(`Expected invalid semver fixture: ${version}`)
+    }
+  })
+
+  bench('auto bump bundle versions', () => {
+    for (const version of bundleVersions)
+      autoBumpVersion(version)
+  })
+
+  bench('suggest replacement bundle versions', () => {
+    for (const version of bundleVersions)
+      getVersionSuggestions(version)
+  })
+
+  bench('classify updater support windows', () => {
+    for (const version of updaterVersions)
+      isDeprecatedPluginVersion(parse(version))
+  })
+})
+
+describe('cli compatibility helpers', () => {
+  bench('classify native package compatibility - getCompatibilityDetails', () => {
+    for (const entry of compatibilityMatrix)
+      getCompatibilityDetails(entry)
+  })
+
+  bench('classify native package compatibility - isCompatible', () => {
+    for (const entry of compatibilityMatrix)
+      isCompatible(entry)
+  })
+})
+
+describe('cli checksum helpers', () => {
+  bench('sha256 checksum for medium bundle payload', async () => {
+    await getChecksum(checksumPayload, 'sha256')
+  })
+
+  bench('crc32 checksum for medium bundle payload', async () => {
+    await getChecksum(checksumPayload, 'crc32')
+  })
+})

--- a/benches/cloudflare-utils.bench.ts
+++ b/benches/cloudflare-utils.bench.ts
@@ -29,7 +29,7 @@ describe('normalizeAnalyticsLimit', () => {
     normalizeAnalyticsLimit(99.7)
   })
 
-  bench('NaN and Infinity', () => {
+  bench('nan and infinity', () => {
     normalizeAnalyticsLimit(Number.NaN)
     normalizeAnalyticsLimit(Number.POSITIVE_INFINITY)
   })

--- a/benches/device-comparison.bench.ts
+++ b/benches/device-comparison.bench.ts
@@ -1,5 +1,5 @@
-import { bench, describe } from 'vitest'
 import type { DeviceWithoutCreatedAt } from '../supabase/functions/_backend/utils/types.ts'
+import { bench, describe } from 'vitest'
 import {
   buildNormalizedDeviceForWrite,
   hasComparableDeviceChanged,

--- a/benches/password-policy.bench.ts
+++ b/benches/password-policy.bench.ts
@@ -6,7 +6,7 @@ import {
 } from '../supabase/functions/_backend/utils/password_policy.ts'
 
 describe('getPasswordUtf8ByteLength', () => {
-  bench('ASCII password', () => {
+  bench('ascii password', () => {
     getPasswordUtf8ByteLength('MyP@ssw0rd!2024')
   })
 

--- a/benches/plugin-hot-paths.bench.ts
+++ b/benches/plugin-hot-paths.bench.ts
@@ -1,0 +1,118 @@
+import type { Context } from 'hono'
+import type { StandardSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
+import type { DeviceLink } from '../supabase/functions/_backend/utils/plugin_parser.ts'
+import type { Database } from '../supabase/functions/_backend/utils/supabase.types.ts'
+import type { AppInfos, AppStats } from '../supabase/functions/_backend/utils/types.ts'
+import { bench, describe } from 'vitest'
+import { convertQueryToBody, makeDevice, parsePluginBody } from '../supabase/functions/_backend/utils/plugin_parser.ts'
+import { channelSelfGetRequestSchema, channelSelfRequestSchema, statsRequestSchema, updateRequestSchema } from '../supabase/functions/_backend/utils/plugin_validation.ts'
+import { getUpdateResponseKind, resToVersion } from '../supabase/functions/_backend/utils/update.ts'
+
+interface ChannelSelfPayload extends AppInfos {
+  channel: string
+}
+
+const postContext = { req: { method: 'POST' } } as Context
+const getContext = { req: { method: 'GET' } } as Context
+const channelSelfGetSchema = channelSelfGetRequestSchema as StandardSchema<DeviceLink>
+
+const updatePayload: AppInfos = {
+  app_id: 'com.capgo.bench',
+  device_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  platform: 'ios',
+  plugin_version: '8.45.0',
+  version_name: '1.0.0',
+  version_build: '1.0.0',
+  version_os: '18.2',
+  defaultChannel: 'production',
+  is_prod: true,
+  is_emulator: false,
+  key_id: 'abcdefghijklmnopqrst',
+}
+
+const statsPayload: AppStats = {
+  ...updatePayload,
+  device_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  platform: 'android',
+  action: 'set',
+}
+
+const channelSelfPayload: ChannelSelfPayload = {
+  ...updatePayload,
+  device_id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  channel: 'production',
+}
+
+const channelSelfQuery = {
+  app_id: updatePayload.app_id,
+  device_id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  platform: 'ios',
+  plugin_version: '8.45.0',
+  version_name: '1.0.0',
+  version_build: '1.0.0',
+  version_os: '18.2',
+  defaultChannel: 'production',
+  channel: 'production',
+  custom_id: 'customer-42',
+  is_emulator: 'false',
+  is_prod: 'true',
+  key_id: 'abcdefghijklmnopqrst',
+}
+
+const manifestEntries = Array.from({ length: 25 }, (_, index) => ({
+  file_name: `assets/chunk-${index}.js`,
+  file_hash: `hash-${index}`,
+  s3_path: `apps/com.capgo.bench/1.2.3/chunk-${index}.js`,
+  download_url: `https://files.capgo.app/chunk-${index}.js`,
+}))
+
+const appVersion = {
+  name: '1.2.3',
+  session_key: 'session-key',
+  checksum: 'sha256-checksum',
+  link: 'https://capgo.app/changelog/1.2.3',
+  comment: 'Benchmark release',
+} as Database['public']['Tables']['app_versions']['Row']
+
+const updateErrorCodes = [
+  'no_new_version_available',
+  'already_on_builtin',
+  'disable_auto_update_to_major',
+  'disable_device',
+  'key_id_mismatch',
+  'semver_error',
+  'no_channel',
+]
+
+describe('plugin endpoint request parsing', () => {
+  bench('/updates payload validation', () => {
+    parsePluginBody(postContext, { ...updatePayload }, updateRequestSchema)
+  })
+
+  bench('/stats payload validation', () => {
+    parsePluginBody(postContext, { ...statsPayload }, statsRequestSchema)
+  })
+
+  bench('/channel_self set payload validation', () => {
+    parsePluginBody(postContext, { ...channelSelfPayload }, channelSelfRequestSchema)
+  })
+
+  bench('/channel_self GET query normalization', () => {
+    parsePluginBody(getContext, convertQueryToBody(channelSelfQuery), channelSelfGetSchema, false)
+  })
+
+  bench('device row normalization', () => {
+    makeDevice(statsPayload)
+  })
+})
+
+describe('plugin endpoint response shaping', () => {
+  bench('/updates manifest response with metadata', () => {
+    resToVersion('8.45.0', 'https://files.capgo.app/bundle.zip', appVersion, manifestEntries, true)
+  })
+
+  bench('/updates error kind classification', () => {
+    for (const code of updateErrorCodes)
+      getUpdateResponseKind(code)
+  })
+})

--- a/cli/src/types/capacitor__cli.d.ts
+++ b/cli/src/types/capacitor__cli.d.ts
@@ -1,16 +1,18 @@
-// CapacitorConfig
+interface CapacitorCliConfig {
+  app: {
+    extConfig: import('../schemas/config').CapacitorConfig
+    extConfigFilePath: string
+  }
+}
 
 declare module '@capacitor/cli/dist/config' {
-  export function loadConfig(): CapacitorConfig
-  export function writeConfig(extConfig: CapacitorConfig, extConfigFilePath: string): void
-};
+  export function loadConfig(): Promise<CapacitorCliConfig>
+  export function writeConfig(extConfig: import('../schemas/config').CapacitorConfig, extConfigFilePath: string): Promise<void>
+}
 
 declare module '@capacitor/cli/dist/util/monorepotools' {
   export function findMonorepoRoot(currentPath: string): string
-  // isMonorepo
   export function isMonorepo(currentPath: string): boolean
-  // isNXMonorepo
   export function isNXMonorepo(currentPath: string): boolean
-  // findNXMonorepoRoot
   export function findNXMonorepoRoot(currentPath: string): string
 }

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -9,14 +9,11 @@
     "moduleResolution": "Bundler",
     "paths": {
       "*": [
-        "src/types/*"
-      ],
-      "@capacitor/cli/dist/config": [
-        "src/types/capacitor-cli.d.ts"
+        "types/*"
       ]
     },
     "resolveJsonModule": true,
-    "typeRoots": ["src/types/*", "node_modules/@types"],
+    "typeRoots": ["src/types", "node_modules/@types"],
     "strict": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test:cloudflare:plugin": "USE_CLOUDFLARE_WORKERS=true vitest run tests/updates*.test.ts tests/stats*.test.ts tests/channel_self*.test.ts --config vitest.config.cloudflare-plugin.ts",
     "test:cloudflare:api": "vitest run --exclude=tests/cli* --exclude=tests/updates* --exclude=tests/stats* --exclude=tests/channel_self* --config vitest.config.cloudflare.ts",
     "test:cloudflare:updates": "vitest run tests/updates* --config vitest.config.cloudflare.ts",
+    "bench": "vitest bench --config vitest.config.bench.ts --run",
     "admin:backfill-plugin-version-ladder": "bun scripts/backfill_plugin_version_ladder.ts",
     "stripe:backfill-retention-metrics": "bun scripts/backfill_retention_metrics.ts",
     "stripe:backfill-org-conversion-rate": "bun scripts/backfill_org_conversion_rate_trend.ts",

--- a/supabase/functions/_backend/utils/deviceComparison.ts
+++ b/supabase/functions/_backend/utils/deviceComparison.ts
@@ -1,5 +1,4 @@
 import type { DeviceWithoutCreatedAt } from './types.ts'
-import { cloudlog } from './logging.ts'
 
 const normalizeOptionalString = (value: string | null | undefined) => (value === undefined || value === null || value === '' ? null : value)
 
@@ -98,44 +97,11 @@ export function hasComparableDeviceChanged(existing: DeviceExistingRowLike, devi
   const comparableExisting = toComparableExisting(existing)
   const comparableDevice = toComparableDevice(device)
 
-  // DEBUG: Log the comparison details
-  const changed = Object.entries(comparableDevice).some(([key, value]) => {
+  return Object.entries(comparableDevice).some(([key, value]) => {
     const existingValue = comparableExisting[key as keyof DeviceComparable]
-    const hasChanged = existingValue !== value
-
-    if (hasChanged) {
-      cloudlog({
-        message: `[DEVICE_COMPARISON] Field "${key}" changed:`,
-        context: {
-          existing: existingValue,
-          new: value,
-          existingType: typeof existingValue,
-          newType: typeof value,
-          device_id: device.device_id,
-          app_id: device.app_id,
-        },
-      })
-    }
-
-    return hasChanged
+    return existingValue !== value
   })
-
-  if (!changed) {
-    cloudlog(`[DEVICE_COMPARISON] No changes detected for device ${device.device_id}`)
-  }
-  else {
-    cloudlog({
-      message: `[DEVICE_COMPARISON] Changes detected for device ${device.device_id}`,
-      context: {
-        comparableExisting,
-        comparableDevice,
-      },
-    })
-  }
-
-  return changed
 }
-
 export function buildNormalizedDeviceForWrite(device: DeviceWithoutCreatedAt) {
   const comparableDevice = toComparableDevice(device)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,7 @@
     "supabase/functions/_script",
     "cypress",
     "cli",
+    "benches",
     "vite.config.mts",
     "temp_cli_test",
     "tests/device_comparison.test.ts"

--- a/vitest.config.bench.ts
+++ b/vitest.config.bench.ts
@@ -1,9 +1,18 @@
+import path from 'node:path'
+import { cwd } from 'node:process'
 import codspeedPlugin from '@codspeed/vitest-plugin'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [codspeedPlugin()],
+  resolve: {
+    alias: {
+      '@capgo/cli/sdk': path.resolve(cwd(), 'cli/src/sdk.ts'),
+      '~/': `${path.resolve(cwd(), 'src')}/`,
+    },
+  },
   test: {
+    environment: 'node',
     benchmark: {
       include: ['benches/**/*.bench.ts'],
     },


### PR DESCRIPTION
## Summary (AI generated)

- Adds a Bun-backed benchmark command and makes the CodSpeed PR workflow use it.
- Adds hot-path benchmarks for Capgo CLI helpers, plugin endpoint request parsing, update response shaping, checksums, and compatibility checks.
- Removes per-device debug logging from the device comparison hot path so production and benchmarks do not spend time writing comparison logs.
- Keeps benchmark files out of the app typecheck while preserving dedicated benchmark lint and execution.

## Motivation (AI generated)

Recent production performance regressions need to be caught before merge. CodSpeed was installed but only covered a few utility helpers and the workflow still invoked the benchmark runner through npm-style tooling. This expands PR performance coverage around the paths most likely to affect CLI uploads and plugin traffic.

## Business Impact (AI generated)

This reduces the chance of shipping changes that slow down update checks, stats ingestion, channel self-selection, and CLI upload preparation. Better PR performance signal protects production reliability for high-volume plugin traffic and lowers incident risk from accidental hot-path regressions.

## Test Plan (AI generated)

- [x] bun run lint:backend
- [x] bunx eslint "benches/**/*.ts" vitest.config.bench.ts
- [x] bun run cli:lint
- [x] bun run cli:typecheck
- [x] bun run cli:build
- [x] bunx vitest run tests/device_comparison.test.ts
- [x] bun typecheck
- [x] bun run bench

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple benchmark suites for CLI and plugin hot paths and a new bench script for easy execution.

* **Chores**
  * CI benchmark workflow now runs benchmarks via Bun.
  * Benchmark runner configured with path aliases; TypeScript config updated to exclude benchmarks.
  * Capacitor CLI type declarations updated.

* **Bug Fixes**
  * Removed debug logging from device-comparison logic.

* **Tests**
  * Minor benchmark label tweaks and broader edge-case coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->