### PR TITLE
[codex] Strip password auth after SSO merge

### DIFF
--- a/supabase/functions/_backend/private/sso/provision-user.ts
+++ b/supabase/functions/_backend/private/sso/provision-user.ts
@@ -146,12 +146,41 @@ async function transferSsoIdentities(pgClient: ReturnType<typeof getPgClient>, o
   return result.rowCount ?? 0
 }
 
-async function setAuthUserSsoOnly(pgClient: ReturnType<typeof getPgClient>, userId: string): Promise<void> {
+async function setAuthUserSsoOnly(pgClient: ReturnType<typeof getPgClient>, userId: string, authorizedSsoProviders: string[]): Promise<void> {
+  const primarySsoProvider = authorizedSsoProviders[0]
+  if (!primarySsoProvider) {
+    throw new Error('missing_sso_provider')
+  }
+
   await pgClient.query(
     `
       update auth.users
-      set is_sso_user = true
+      set is_sso_user = true,
+          encrypted_password = null,
+          raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb)
+            || jsonb_build_object(
+              'provider', $2::text,
+              'providers', to_jsonb($3::text[])
+            ),
+          updated_at = now()
       where id = $1
+    `,
+    [userId, primarySsoProvider, authorizedSsoProviders],
+  )
+
+  await pgClient.query(
+    `
+      delete from auth.identities
+      where user_id = $1
+        and provider <> all($2::text[])
+    `,
+    [userId, authorizedSsoProviders],
+  )
+
+  await pgClient.query(
+    `
+      delete from auth.sessions
+      where user_id = $1
     `,
     [userId],
   )
@@ -410,7 +439,6 @@ async function mergeSsoIdentityWithExistingAccount(
     publicUser: PublicUserSeed
     orgId: string
     authorizedSsoProviders: string[]
-    enforceSso: boolean
   },
 ): Promise<void> {
   await pgClient.query('begin')
@@ -432,14 +460,12 @@ async function mergeSsoIdentityWithExistingAccount(
     await ensurePublicUserRowExistsInTransaction(pgClient, requestId, params.publicUser)
     await ensureOrgMembershipInTransaction(pgClient, requestId, params.originalUserId, params.orgId)
 
-    if (params.enforceSso) {
-      try {
-        await setAuthUserSsoOnly(pgClient, params.originalUserId)
-      }
-      catch (ssoFlagError) {
-        cloudlogErr({ requestId, message: 'Failed to set is_sso_user on original user during merge', originalUserId: params.originalUserId, error: ssoFlagError })
-        throw new Error('sso_flag_update_failed')
-      }
+    try {
+      await setAuthUserSsoOnly(pgClient, params.originalUserId, params.authorizedSsoProviders)
+    }
+    catch (ssoFlagError) {
+      cloudlogErr({ requestId, message: 'Failed to enforce SSO-only auth state on original user during merge', originalUserId: params.originalUserId, error: ssoFlagError })
+      throw new Error('sso_flag_update_failed')
     }
 
     await pgClient.query('commit')
@@ -542,7 +568,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       // Step 1: Resolve the SSO provider org so we can ensure the original user is a member
       const { data: mergeProvider, error: mergeProviderError } = await (admin as any)
         .from('sso_providers')
-        .select('id, org_id, provider_id, enforce_sso')
+        .select('id, org_id, provider_id')
         .eq('domain', userDomain)
         .eq('status', 'active')
         .maybeSingle()
@@ -574,7 +600,6 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
           },
           orgId: mergeProvider.org_id,
           authorizedSsoProviders,
-          enforceSso: mergeProvider?.enforce_sso === true,
         })
       }
       catch (mergeError) {
@@ -602,18 +627,6 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
       if (deleteError) {
         cloudlogErr({ requestId, message: 'Failed to delete duplicate SSO user after identity transfer', userId, originalUserId, error: deleteError })
         // Identity already transferred — log but still return merged so frontend redirects to login
-      }
-
-      // Update app_metadata.provider on the original user to reflect the SSO provider.
-      // Our raw identity transfer bypasses Supabase Auth's normal flow, which would otherwise
-      // update this field. Without this, the next SSO login returns provider='email' and
-      // the provider check above rejects the user with sso_auth_required.
-      const { error: updateProviderError } = await admin.auth.admin.updateUserById(originalUserId, {
-        app_metadata: { provider: authorizedSsoProviders[0] },
-      })
-      if (updateProviderError) {
-        cloudlogErr({ requestId, message: 'Failed to update app_metadata.provider on original user after merge', originalUserId, error: updateProviderError })
-        // Non-fatal: identity transfer succeeded; log but continue
       }
 
       cloudlog({ requestId, message: 'SSO account merged successfully — user must re-login', userId, originalUserId })

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -167,7 +167,7 @@ describe('[POST] /private/sso/check-enforcement', () => {
         management_email: `sso-enforcement-${enforcementOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: enforcementCustomerId,
-          })
+      })
       if (enforcementOrgError)
         throw enforcementOrgError
 
@@ -322,7 +322,7 @@ describe('[POST] /private/sso/prelink-users', () => {
         management_email: `sso-prelink-${prelinkOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: prelinkCustomerId,
-          })
+      })
       if (prelinkOrgError)
         throw prelinkOrgError
 
@@ -351,7 +351,7 @@ describe('[POST] /private/sso/prelink-users', () => {
         management_email: `sso-foreign-${foreignOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: foreignCustomerId,
-          })
+      })
       if (foreignOrgError)
         throw foreignOrgError
 
@@ -531,7 +531,7 @@ describe('generate_org_on_user_create', () => {
         management_email: `managed-sso-${managedOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: managedCustomerId,
-          })
+      })
       if (orgError)
         throw orgError
 
@@ -617,7 +617,7 @@ describe('generate_org_on_user_create', () => {
         management_email: `email-managed-${managedOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: managedCustomerId,
-          })
+      })
       if (orgError)
         throw orgError
 
@@ -771,7 +771,7 @@ describe('[POST] /private/sso/provision-user', () => {
         management_email: `sso-missing-profile-${managedOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: managedCustomerId,
-          })
+      })
       if (orgError)
         throw orgError
 
@@ -1002,7 +1002,7 @@ describe('[POST] /private/sso/provision-user', () => {
         management_email: `sso-invite-promotion-${managedOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: managedCustomerId,
-          })
+      })
       if (orgError)
         throw orgError
 
@@ -1140,7 +1140,7 @@ describe('[POST] /private/sso/provision-user', () => {
         management_email: `sso-merge-${managedOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: managedCustomerId,
-          })
+      })
       if (orgError)
         throw orgError
 
@@ -1167,6 +1167,13 @@ describe('[POST] /private/sso/provision-user', () => {
       })
       if (originalPublicUserError)
         throw originalPublicUserError
+
+      await getAuthHeadersForCredentials(targetEmail, password)
+      const originalSessionsBeforeMerge = await pool.query<{ count: string }>(
+        'select count(*) from auth.sessions where user_id = $1',
+        [originalUser.user.id],
+      )
+      expect(Number(originalSessionsBeforeMerge.rows[0]?.count ?? 0)).toBeGreaterThan(0)
 
       const duplicateAuthHeaders = await getAuthHeadersForCredentials(tempSsoEmail, password)
 
@@ -1256,6 +1263,8 @@ describe('[POST] /private/sso/provision-user', () => {
         && row.user_id === originalUser.user.id
         && row.email === targetEmail,
       )).toBe(true)
+      expect(identitiesAfterMerge.rows.every(row => row.provider === identityProvider)).toBe(true)
+      expect(identitiesAfterMerge.rows.some(row => row.provider === 'email')).toBe(false)
       expect(identitiesAfterMerge.rows.some(row =>
         row.provider === 'github'
         && row.provider_id === unrelatedProviderId,
@@ -1264,6 +1273,22 @@ describe('[POST] /private/sso/provision-user', () => {
         row.provider === unrelatedSsoProvider
         && row.provider_id === unrelatedSsoProviderId,
       )).toBe(false)
+
+      const mergedAuthUser = await pool.query<{ encrypted_password: string | null, is_sso_user: boolean }>(
+        'select encrypted_password, is_sso_user from auth.users where id = $1',
+        [originalUser.user.id],
+      )
+
+      expect(mergedAuthUser.rows[0]).toMatchObject({
+        encrypted_password: null,
+        is_sso_user: true,
+      })
+
+      const originalSessionsAfterMerge = await pool.query<{ count: string }>(
+        'select count(*) from auth.sessions where user_id = $1',
+        [originalUser.user.id],
+      )
+      expect(Number(originalSessionsAfterMerge.rows[0]?.count ?? 0)).toBe(0)
     }
     finally {
       await Promise.allSettled([
@@ -1643,7 +1668,7 @@ describe('[POST] /private/sso/provision-user', () => {
         management_email: `sso-first-login-${managedOrgId}@capgo.app`,
         created_by: USER_ID,
         customer_id: managedCustomerId,
-          })
+      })
       if (orgError)
         throw orgError
 


### PR DESCRIPTION
## Summary (AI generated)

- Converts merged SSO accounts to SSO-only during account merge.
- Clears password auth, removes non-authorized identities, and revokes old sessions atomically.
- Adds regression coverage for the merged account auth state.

## Motivation (AI generated)

Existing password accounts should still be merged when the same user first logs in through SSO, but the merged account should not keep password access once SSO proves the identity.

## Business Impact (AI generated)

This preserves the SSO migration path while reducing account takeover risk for organizations that use SSO domains with email confirmations disabled.

## Test Plan (AI generated)

- [x] bun run lint:backend
- [x] bunx eslint tests/sso.test.ts
- [x] bun run supabase:with-env -- bunx vitest run tests/sso.test.ts
- [x] bunx supabase test db supabase/tests/49_test_apikey_oracle_rpc_permissions.sql --local --workdir .context/supabase-worktrees/c34a21a4
- [x] GitHub CI

Generated with AI