### PR TITLE
fix: restore bundle upload for API keys with app-only RBAC bindings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "capgo-app",

--- a/supabase/functions/_backend/public/apikey/post.ts
+++ b/supabase/functions/_backend/public/apikey/post.ts
@@ -222,7 +222,22 @@ app.post('/', middlewareV2(['all']), async (c) => {
           throw new Error('Created API key is missing rbac_id')
         }
 
-        for (const binding of bindings) {
+        // Mirror the user-binding invariant: every org that has app-level bindings
+        // must also have an org-level binding (at minimum org_member) so that the
+        // API key carries org.read — required by get_organization_cli_warnings and
+        // other org-scoped checks.
+        const enrichedBindings: BindingInput[] = [...bindings]
+        const orgsWithOrgBinding = new Set(
+          bindings.filter(b => b.scope_type === 'org').map(b => b.org_id),
+        )
+        for (const b of bindings) {
+          if (b.scope_type === 'app' && !orgsWithOrgBinding.has(b.org_id)) {
+            enrichedBindings.push({ role_name: 'org_member', scope_type: 'org', org_id: b.org_id })
+            orgsWithOrgBinding.add(b.org_id)
+          }
+        }
+
+        for (const binding of enrichedBindings) {
           const bindingParams: CreateBindingParams = {
             principal_type: 'apikey',
             principal_id: apikeyData.rbac_id,

--- a/supabase/migrations/20260508122137_fix_app_versions_trigger_owner_org.sql
+++ b/supabase/migrations/20260508122137_fix_app_versions_trigger_owner_org.sql
@@ -26,8 +26,10 @@ REVOKE ALL ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "t
 COMMENT ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") IS
 'Internal helper for the auto_owner_org_by_app_id trigger only. Resolves the owning org for an app without performing auth checks — the trigger fires after RLS has already validated the caller.';
 
+-- The trigger runs as SECURITY DEFINER (owner = postgres) so it can call
+-- get_owner_org_by_app_id_internal without granting EXECUTE to anon/authenticated.
 CREATE OR REPLACE FUNCTION "public"."auto_owner_org_by_app_id"() RETURNS "trigger"
-    LANGUAGE "plpgsql"
+    LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
 AS $$
 BEGIN

--- a/supabase/migrations/20260508122137_fix_app_versions_trigger_owner_org.sql
+++ b/supabase/migrations/20260508122137_fix_app_versions_trigger_owner_org.sql
@@ -1,0 +1,45 @@
+-- Fix app_versions BEFORE INSERT trigger returning NULL for owner_org.
+--
+-- The trigger auto_owner_org_by_app_id calls get_user_main_org_id_by_app_id,
+-- which since migration 20260203150000 includes auth checks intended to prevent
+-- anonymous lookups. In a PostgREST trigger context (session_user = 'authenticator',
+-- auth.uid() = NULL, auth.role() = 'anon'), those checks can fail even for
+-- legitimately authorized inserts, causing owner_org to be set to NULL and
+-- violating the NOT NULL constraint (error code 23502).
+--
+-- The RLS INSERT policy already verified the caller's rights before the trigger
+-- fires, so re-checking auth inside the trigger is redundant and harmful.
+-- Replace the call with a minimal SECURITY DEFINER helper that simply resolves
+-- owner_org from the apps table without any auth logic.
+
+CREATE OR REPLACE FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text")
+RETURNS "uuid"
+LANGUAGE "sql" SECURITY DEFINER STABLE
+SET "search_path" TO ''
+AS $$
+  SELECT owner_org FROM public.apps WHERE apps.app_id = p_app_id LIMIT 1;
+$$;
+
+ALTER FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") FROM PUBLIC;
+
+COMMENT ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") IS
+'Internal helper for the auto_owner_org_by_app_id trigger only. Resolves the owning org for an app without performing auth checks — the trigger fires after RLS has already validated the caller.';
+
+CREATE OR REPLACE FUNCTION "public"."auto_owner_org_by_app_id"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO ''
+AS $$
+BEGIN
+  IF NEW."app_id" IS DISTINCT FROM OLD."app_id" AND OLD."app_id" IS DISTINCT FROM NULL THEN
+    RAISE EXCEPTION 'changing the app_id is not allowed';
+  END IF;
+
+  NEW.owner_org = public.get_owner_org_by_app_id_internal(NEW."app_id");
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."auto_owner_org_by_app_id"() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."auto_owner_org_by_app_id"() FROM PUBLIC;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -1338,6 +1338,23 @@ $$;
 ALTER FUNCTION "public"."auto_apikey_name_by_id"() OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text")
+RETURNS "uuid"
+LANGUAGE "sql" SECURITY DEFINER STABLE
+SET "search_path" TO ''
+AS $$
+  SELECT owner_org FROM public.apps WHERE apps.app_id = p_app_id LIMIT 1;
+$$;
+
+
+ALTER FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") FROM PUBLIC;
+
+
+COMMENT ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text") IS
+'Internal helper for the auto_owner_org_by_app_id trigger only. Resolves the owning org for an app without performing auth checks — the trigger fires after RLS has already validated the caller.';
+
+
 CREATE OR REPLACE FUNCTION "public"."auto_owner_org_by_app_id"() RETURNS "trigger"
     LANGUAGE "plpgsql"
     SET "search_path" TO ''
@@ -1347,9 +1364,9 @@ BEGIN
     RAISE EXCEPTION 'changing the app_id is not allowed';
   END IF;
 
-  NEW.owner_org = public.get_user_main_org_id_by_app_id(NEW."app_id");
+  NEW.owner_org = public.get_owner_org_by_app_id_internal(NEW."app_id");
 
-   RETURN NEW;
+  RETURN NEW;
 END;
 $$;
 

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -1356,7 +1356,7 @@ COMMENT ON FUNCTION "public"."get_owner_org_by_app_id_internal"("p_app_id" "text
 
 
 CREATE OR REPLACE FUNCTION "public"."auto_owner_org_by_app_id"() RETURNS "trigger"
-    LANGUAGE "plpgsql"
+    LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
     AS $$
 BEGIN


### PR DESCRIPTION
## Summary

- **Bug 1 — null owner_org (23502)**: The `BEFORE INSERT` trigger on `app_versions` called `get_user_main_org_id_by_app_id` which, since migration `20260203150000`, runs auth checks that fail under PostgREST's `authenticator` role (`auth.uid() = NULL`, `auth.role() = 'anon'`). The trigger fires *after* RLS has already validated the insert, so re-checking auth is redundant and causes `owner_org` to be set to `NULL`. Fix: new minimal SECURITY DEFINER helper `get_owner_org_by_app_id_internal` that resolves `owner_org` from `apps` without auth logic.

- **Bug 2 — no read access**: `get_organization_cli_warnings` requires `org.read`. API keys created with only app-level bindings (e.g. `app_uploader`) don't have `org_member` and therefore lack `org.read`. For users, `org_member + app_uploader` are always created together — API keys must respect the same invariant. Fix: `post.ts` now auto-inserts an `org_member` binding for each org that has app-level bindings but no explicit org-level binding.

Both `bundle list` (unaffected) and `bundle upload` (broken) used the same API keys, confirming auth was valid but upload-specific paths were broken.

## Test plan

- [ ] Create an API key with only `app_uploader` binding (no org role selected in the UI)
- [ ] Verify the key's `role_bindings` now includes an `org_member` entry for the org
- [ ] Run `capgo bundle upload` with that key → no "no read access" error
- [ ] Run `capgo bundle upload` with any valid key → `app_versions.owner_org` is never NULL
- [ ] Run `capgo bundle list` → still works
- [ ] Existing keys without `org_member` need to be recreated by affected users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API key creation now auto-adds a corresponding organization-scoped permission when app-scoped permissions are included, avoiding missing org permissions.
  * App records now reliably set owner organization during create/update and guard against unexpected app ID changes.

* **Security**
  * Hardened database trigger/helper logic by tightening ownership and revoking public privileges for sensitive functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->