### PR TITLE
fix(cli): support v2 RBAC API keys for setVersionInChannel

### DIFF
--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -20,7 +20,7 @@ import { getChecksum } from '../checksum'
 import { getRepoStarStatus, isRepoStarredInSession, starRepository } from '../github'
 import { confirmWithRememberedChoice } from '../promptPreferences'
 import { showReplicationProgress } from '../replicationProgress'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasCliPermission, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { checkIndexPosition, searchInDirectory } from './check'
 import { prepareBundlePartialFiles, uploadPartial } from './partial'
@@ -680,9 +680,7 @@ async function setVersionInChannel(
   if (!versionId)
     uploadFail('Cannot get version id, cannot set channel')
 
-  const { data: apiAccess } = await supabase
-    .rpc('is_allowed_capgkey', { apikey, keymode: ['write', 'all'] })
-    .single()
+  const apiAccess = await hasCliPermission(supabase, apikey, 'app.create_channel', { appId: appid })
 
   if (apiAccess) {
     const { error: dbError3, data } = await updateOrCreateChannel(supabase, {


### PR DESCRIPTION
## Summary

- Replace the `is_allowed_capgkey({ apikey, keymode: ['write','all'] })` gate in `setVersionInChannel` with `hasCliPermission(supabase, apikey, 'app.create_channel', { appId: appid })`.
- v2 RBAC keys (`mode IS NULL` since migration `20260505163356_apikey_nullable_mode_with_bindings`) were silently denied here because `mode = ANY(keymode)` evaluates to `NULL` for v2 keys.
- `cli_check_permission` (called via `hasCliPermission`) goes through `rbac_check_permission_direct`, which natively handles **both** v1 (legacy mode fallback) and v2 (RBAC bindings). `app.create_channel` is the canonical "write tier" probe — `get_org_perm_for_apikey_v2` already uses it to detect `perm_write`.

## Behavior matrix

| Key | Before | After |
|---|---|---|
| v2 `app_developer` (or higher) | warning shown :x: | channel set :white_check_mark: |
| v2 `app_uploader` / `app_reader` | warning shown | warning shown (correct — uploader tier intentionally cannot promote) |
| v1 `all` mode | channel set | channel set |
| v1 `write` mode | channel set | channel set |
| v1 `upload` mode | warning shown | warning shown |
| v1 `read` mode | warning shown | warning shown |
| v1 with `limited_to_apps` excluding target | passed gate, then RLS error | warning shown (improvement) |

## Why this approach

The CLI already has `hasCliPermission` (see `cli/src/utils.ts:1630`) and uses `cli_check_permission` for every other RBAC-aware gate (`org.create_app`, `app.build_native`, …). This brings `setVersionInChannel` in line with that pattern instead of being the only call site still using legacy `is_allowed_capgkey`.

No SQL migration. Single CLI file changed (2 insertions, 4 deletions).

## Test plan

- [ ] v2 key with `app_developer` role on Updater Example → `npx @capgo/cli@next bundle upload` sets the channel
- [ ] v2 key with `app_uploader` role → bundle uploads, warning shown (no regression)
- [ ] v1 `all` mode key → channel still set (no regression)
- [ ] v1 `write` mode key → channel still set (no regression)
- [ ] v1 `upload` mode key → warning still shown (no regression)
- [ ] v1 key with `limited_to_apps` excluding the target app → warning shown at gate instead of RLS failure on channel upsert

## Related

- Builds on #2012 (atomic API key creation with RBAC role bindings) and #2079 (trigger fix for app-only bindings).
- Reported symptom: `is_allowed_capgkey` returning `false` for v2 keys with `org_member` + `app_developer` bindings even though they should be allowed to set channel versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the permission validation mechanism for CLI uploads to use an improved utility for API key permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->