### PR TITLE
[codex] Capture CLI exceptions in PostHog

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -74,6 +74,7 @@
     "test:build-zip-filter": "bun test/test-build-zip-filter.mjs",
     "test:checksum": "bun test/test-checksum-algorithm.mjs",
     "test:ci-prompts": "bun test/test-ci-prompts.mjs",
+    "test:posthog-exception": "bun test/test-posthog-exception.mjs",
     "test:onboarding-recovery": "bun test/test-onboarding-recovery.mjs",
     "test:onboarding-run-targets": "bun test/test-onboarding-run-targets.mjs",
     "test:run-device-command": "bun test/test-run-device-command.mjs",
@@ -86,7 +87,7 @@
     "test:version-detection:setup": "./test/fixtures/setup-test-projects.sh",
     "test:platform-paths": "bun test/test-platform-paths.mjs",
     "test:payload-split": "bun test/test-payload-split.mjs",
-    "test": "bun run build && bun run test:version-detection:setup && bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:build-zip-filter && bun run test:checksum && bun run test:ci-prompts && bun run test:build-platform-selection && bun run test:onboarding-recovery && bun run test:onboarding-run-targets && bun run test:run-device-command && bun run test:init-app-conflict && bun run test:init-guardrails && bun run test:prompt-preferences && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths && bun run test:payload-split",
+    "test": "bun run build && bun run test:version-detection:setup && bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:build-zip-filter && bun run test:checksum && bun run test:ci-prompts && bun run test:posthog-exception && bun run test:build-platform-selection && bun run test:onboarding-recovery && bun run test:onboarding-run-targets && bun run test:run-device-command && bun run test:init-app-conflict && bun run test:init-guardrails && bun run test:prompt-preferences && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths && bun run test:payload-split",
     "test:build-platform-selection": "bun test/test-build-platform-selection.mjs"
   },
   "dependencies": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,6 +34,7 @@ import { createKey, deleteOldKey, saveKeyCommand } from './key'
 import { login } from './login'
 import { startMcpServer } from './mcp/server'
 import { addOrganization, deleteOrganization, listMembers, listOrganizations, setOrganization } from './organization'
+import { capturePosthogException, getCommandPath, shouldCapturePosthogException } from './posthog'
 import { probe } from './probe'
 import { testRunDeviceCommand } from './run/device'
 import { getUserId } from './user/account'
@@ -58,6 +59,12 @@ program
   .name(pack.name)
   .description(`📦 Manage packages and bundle versions in Capgo Cloud`)
   .version(pack.version, '-v, --version', `output the current version`)
+
+let currentCommandPath = 'unknown'
+
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  currentCommandPath = getCommandPath(actionCommand)
+})
 
 program
   .command('init [apikey] [appId]')
@@ -1027,12 +1034,20 @@ program.configureOutput({
   },
 })
 
-program.parseAsync().catch((error: unknown) => {
+program.parseAsync().catch(async (error: unknown) => {
   if (typeof error === 'object' && error !== null && 'code' in error) {
     const commanderError = error as { code: string, exitCode?: number, message?: string }
     // These are normal Commander.js exits (help, version, etc.) - exit silently
     if (commanderError.code === 'commander.version' || commanderError.code === 'commander.helpDisplayed') {
       exit(0)
+    }
+    if (shouldCapturePosthogException(error)) {
+      await capturePosthogException({
+        error,
+        functionName: currentCommandPath,
+        kind: 'unhandled_error',
+        status: commanderError.exitCode ?? 1,
+      })
     }
     // For actual errors, show just the message without the full stack trace
     if (commanderError.message) {
@@ -1041,6 +1056,12 @@ program.parseAsync().catch((error: unknown) => {
     const exitCode = commanderError.exitCode ?? 1
     exit(exitCode)
   }
+  await capturePosthogException({
+    error,
+    functionName: currentCommandPath,
+    kind: 'unhandled_error',
+    status: 1,
+  })
   // For non-Commander errors, show full error details
   log.error(`Error: ${formatError(error)}`)
   exit(1)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1041,22 +1041,23 @@ program.parseAsync().catch(async (error: unknown) => {
     if (commanderError.code === 'commander.version' || commanderError.code === 'commander.helpDisplayed') {
       exit(0)
     }
-    if (shouldCapturePosthogException(error)) {
-      await capturePosthogException({
-        error,
-        functionName: currentCommandPath,
-        kind: 'unhandled_error',
-        status: commanderError.exitCode ?? 1,
-      })
-    }
+    const capturePromise = shouldCapturePosthogException(error)
+      ? capturePosthogException({
+          error,
+          functionName: currentCommandPath,
+          kind: 'unhandled_error',
+          status: commanderError.exitCode ?? 1,
+        })
+      : Promise.resolve(false)
     // For actual errors, show just the message without the full stack trace
     if (commanderError.message) {
       log.error(commanderError.message)
     }
+    await capturePromise
     const exitCode = commanderError.exitCode ?? 1
     exit(exitCode)
   }
-  await capturePosthogException({
+  const capturePromise = capturePosthogException({
     error,
     functionName: currentCommandPath,
     kind: 'unhandled_error',
@@ -1064,5 +1065,6 @@ program.parseAsync().catch(async (error: unknown) => {
   })
   // For non-Commander errors, show full error details
   log.error(`Error: ${formatError(error)}`)
+  await capturePromise
   exit(1)
 })

--- a/cli/src/posthog.ts
+++ b/cli/src/posthog.ts
@@ -64,8 +64,9 @@ function serializeError(error: unknown): SerializedError {
   }
 
   try {
+    const message = JSON.stringify(error)
     return {
-      message: JSON.stringify(error),
+      message: message ?? String(error),
       name: 'Error',
       stack: undefined,
     }
@@ -90,6 +91,28 @@ function sanitizeFilename(filename: string) {
     sanitized = sanitized.replaceAll(homeDirectory, '~')
 
   return sanitized
+}
+
+function sanitizeTelemetryText(value: string) {
+  let sanitized = value
+  const workingDirectory = cwd()
+  const homeDirectory = homedir()
+
+  if (workingDirectory)
+    sanitized = sanitized.replaceAll(workingDirectory, '<cwd>')
+  if (homeDirectory)
+    sanitized = sanitized.replaceAll(homeDirectory, '~')
+
+  return sanitized
+    .replace(/<cwd>\/[^\s"',)]+/g, '<cwd>/<path>')
+    .replace(/~\/[^\s"',)]+/g, '~/<path>')
+    .replace(/[\w.%+-]+@[\w.-]+\.[A-Z]{2,}/gi, '<email>')
+    .replace(/(https?:\/\/)([^/\s:@]+):([^/\s@]+)@/gi, '$1<redacted>@')
+    .replace(/\b[a-z][\w-]*(?:\.[\w-]+){2,}\b/gi, '<app_id>')
+    .replace(/\b[a-z]:\\[^\s"',)]+/gi, '<path>')
+    .replace(/(^|[\s"'(])\/[^\s"',)]+/g, '$1<path>')
+    .replace(/(--(?:token|api[-_]?key|key|password|secret|private[-_]?key|jwt|session|auth)(?:=|\s+))("[^"]+"|'[^']+'|\S+)/gi, '$1<redacted>')
+    .replace(/\b((?:token|api[-_]?key|password|secret|authorization)\s*[:=]\s*)[^\s,;]+/gi, '$1<redacted>')
 }
 
 function parseExceptionFrames(stack: string | undefined, fallbackFunctionName: string) {
@@ -186,6 +209,7 @@ export async function capturePosthogException(payload: CapturePosthogExceptionPa
   }
 
   const serializedError = serializeError(payload.error)
+  const sanitizedMessage = sanitizeTelemetryText(serializedError.message)
   const distinctId = `cli:${pack.version}:${payload.functionName}`
   const frames = parseExceptionFrames(serializedError.stack, payload.functionName)
   const topFrame = frames[0]
@@ -205,7 +229,7 @@ export async function capturePosthogException(payload: CapturePosthogExceptionPa
       distinct_id: distinctId,
       $exception_list: [{
         type: serializedError.name || 'Error',
-        value: serializedError.message,
+        value: sanitizedMessage,
         mechanism: {
           handled: true,
           synthetic: false,

--- a/cli/src/posthog.ts
+++ b/cli/src/posthog.ts
@@ -1,0 +1,254 @@
+import type { Command } from 'commander'
+import { homedir, platform, release } from 'node:os'
+import { arch, cwd, env, version as nodeVersion } from 'node:process'
+import pack from '../package.json'
+
+const POSTHOG_EXCEPTION_URL = 'https://eu.i.posthog.com/i/v0/e/'
+const CAPGO_POSTHOG_PROJECT_TOKEN = 'phc_NXDyDajQaTQVwb25DEhIVZfxVUn4R0Y348Z7vWYHZUi'
+const POSTHOG_TIMEOUT_MS = 1500
+
+type CliPosthogExceptionKind = 'unhandled_error'
+
+interface SerializedError {
+  cause?: unknown
+  message: string
+  name: string
+  stack?: string
+}
+
+interface CapturePosthogExceptionPayload {
+  error: unknown
+  functionName: string
+  kind: CliPosthogExceptionKind
+  status?: number
+}
+
+function isTruthyEnvValue(value: string | undefined) {
+  return value === '1' || value?.toLowerCase() === 'true' || value?.toLowerCase() === 'yes'
+}
+
+function getPosthogToken() {
+  if (isTruthyEnvValue(env.CAPGO_DISABLE_TELEMETRY) || isTruthyEnvValue(env.CAPGO_DISABLE_POSTHOG))
+    return undefined
+
+  return env.CAPGO_CLI_POSTHOG_API_KEY?.trim()
+    || env.POSTHOG_API_KEY?.trim()
+    || CAPGO_POSTHOG_PROJECT_TOKEN
+}
+
+function getPosthogExceptionUrl(host: string) {
+  const trimmedHost = host.replace(/\/+$/, '')
+  if (trimmedHost.endsWith('/i/v0/e'))
+    return `${trimmedHost}/`
+
+  const normalizedHost = trimmedHost.replace(/\/capture$/, '/')
+  return new URL('i/v0/e/', normalizedHost.endsWith('/') ? normalizedHost : `${normalizedHost}/`).toString()
+}
+
+function serializeError(error: unknown): SerializedError {
+  if (error instanceof Error) {
+    return {
+      cause: error.cause,
+      message: error.message,
+      name: error.name || 'Error',
+      stack: error.stack,
+    }
+  }
+
+  if (typeof error === 'string') {
+    return {
+      message: error,
+      name: 'Error',
+      stack: undefined,
+    }
+  }
+
+  try {
+    return {
+      message: JSON.stringify(error),
+      name: 'Error',
+      stack: undefined,
+    }
+  }
+  catch {
+    return {
+      message: String(error),
+      name: 'Error',
+      stack: undefined,
+    }
+  }
+}
+
+function sanitizeFilename(filename: string) {
+  let sanitized = filename
+  const workingDirectory = cwd()
+  const homeDirectory = homedir()
+
+  if (workingDirectory)
+    sanitized = sanitized.replaceAll(workingDirectory, '<cwd>')
+  if (homeDirectory)
+    sanitized = sanitized.replaceAll(homeDirectory, '~')
+
+  return sanitized
+}
+
+function parseExceptionFrames(stack: string | undefined, fallbackFunctionName: string) {
+  const frames = stack?.split('\n')
+    .slice(1)
+    .map((line) => {
+      const trimmed = line.trim()
+      const withoutAt = trimmed.startsWith('at ') ? trimmed.slice(3) : trimmed
+      let functionName = fallbackFunctionName
+      let location = withoutAt
+
+      const groupedLocationIndex = withoutAt.lastIndexOf(' (')
+      if (groupedLocationIndex !== -1 && withoutAt.endsWith(')')) {
+        functionName = withoutAt.slice(0, groupedLocationIndex).trim() || fallbackFunctionName
+        location = withoutAt.slice(groupedLocationIndex + 2, -1)
+      }
+      else {
+        const lastSpaceIndex = withoutAt.lastIndexOf(' ')
+        const possibleLocation = lastSpaceIndex === -1 ? '' : withoutAt.slice(lastSpaceIndex + 1)
+        if (/:\d+:\d+$/.test(possibleLocation)) {
+          functionName = withoutAt.slice(0, lastSpaceIndex).trim() || fallbackFunctionName
+          location = possibleLocation
+        }
+      }
+
+      const lastColonIndex = location.lastIndexOf(':')
+      const secondLastColonIndex = lastColonIndex === -1 ? -1 : location.lastIndexOf(':', lastColonIndex - 1)
+      if (lastColonIndex === -1 || secondLastColonIndex === -1) {
+        return {
+          function: fallbackFunctionName,
+          platform: 'custom',
+          lang: 'javascript',
+        }
+      }
+
+      return {
+        function: functionName,
+        filename: sanitizeFilename(location.slice(0, secondLastColonIndex)),
+        lineno: Number.parseInt(location.slice(secondLastColonIndex + 1, lastColonIndex), 10),
+        colno: Number.parseInt(location.slice(lastColonIndex + 1), 10),
+        platform: 'custom',
+        lang: 'javascript',
+      }
+    })
+    .filter(Boolean)
+
+  return frames && frames.length > 0
+    ? frames
+    : [{
+        function: fallbackFunctionName,
+        platform: 'custom',
+        lang: 'javascript',
+      }]
+}
+
+function getCommanderCode(error: unknown) {
+  if (!error || typeof error !== 'object' || !('code' in error))
+    return undefined
+
+  const { code } = error as { code?: unknown }
+  return typeof code === 'string' ? code : undefined
+}
+
+export function shouldCapturePosthogException(error: unknown) {
+  return !getCommanderCode(error)?.startsWith('commander.')
+}
+
+export function getCommandPath(command: Command) {
+  const names: string[] = []
+  let current: Command | null | undefined = command
+
+  while (current?.parent) {
+    const name = current.name()
+    if (name)
+      names.push(name)
+    current = current.parent
+  }
+
+  return names.reverse().join(' ') || 'unknown'
+}
+
+export async function capturePosthogException(payload: CapturePosthogExceptionPayload) {
+  const token = getPosthogToken()
+  if (!token)
+    return false
+
+  const host = env.CAPGO_CLI_POSTHOG_API_HOST?.trim() || env.POSTHOG_API_HOST?.trim() || POSTHOG_EXCEPTION_URL
+  let posthogUrl: string
+  try {
+    posthogUrl = getPosthogExceptionUrl(host)
+  }
+  catch {
+    return false
+  }
+
+  const serializedError = serializeError(payload.error)
+  const distinctId = `cli:${pack.version}:${payload.functionName}`
+  const frames = parseExceptionFrames(serializedError.stack, payload.functionName)
+  const topFrame = frames[0]
+  const fingerprint = [
+    distinctId,
+    payload.kind,
+    serializedError.name || 'Error',
+    topFrame?.function || payload.functionName,
+    topFrame && 'filename' in topFrame ? topFrame.filename : 'unknown',
+    String(payload.status ?? 1),
+  ].join(':')
+
+  const body = {
+    token,
+    event: '$exception',
+    properties: {
+      distinct_id: distinctId,
+      $exception_list: [{
+        type: serializedError.name || 'Error',
+        value: serializedError.message,
+        mechanism: {
+          handled: true,
+          synthetic: false,
+        },
+        stacktrace: {
+          type: 'raw',
+          frames,
+        },
+      }],
+      $exception_fingerprint: fingerprint,
+      architecture: arch,
+      cli_version: pack.version,
+      error_kind: payload.kind,
+      function_name: payload.functionName,
+      is_ci: Boolean(env.CI),
+      node_version: nodeVersion,
+      os_platform: platform(),
+      os_release: release(),
+      runtime: 'cli',
+      status: payload.status,
+    },
+    timestamp: new Date().toISOString(),
+  }
+
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), POSTHOG_TIMEOUT_MS)
+    try {
+      const res = await fetch(posthogUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+      return res.ok
+    }
+    finally {
+      clearTimeout(timeoutId)
+    }
+  }
+  catch {
+    return false
+  }
+}

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -73,6 +73,32 @@ try {
   assert.equal(requests[0].init.signal instanceof AbortSignal, true)
 
   requests.length = 0
+  const sensitiveError = new Error(`Cannot upload ${cwd()}/bundle.zip for test@example.com app com.example.secret --token abc123`)
+  await capturePosthogException({
+    error: sensitiveError,
+    functionName: 'bundle upload',
+    kind: 'unhandled_error',
+    status: 1,
+  })
+
+  const sensitiveBody = JSON.parse(requests[0].init.body)
+  assert.equal(
+    sensitiveBody.properties.$exception_list[0].value,
+    'Cannot upload <cwd>/<path> for <email> app <app_id> --token <redacted>',
+  )
+
+  requests.length = 0
+  await capturePosthogException({
+    error: undefined,
+    functionName: 'bundle upload',
+    kind: 'unhandled_error',
+    status: 1,
+  })
+
+  const undefinedBody = JSON.parse(requests[0].init.body)
+  assert.equal(undefinedBody.properties.$exception_list[0].value, 'undefined')
+
+  requests.length = 0
   process.env.CAPGO_DISABLE_TELEMETRY = 'true'
   const disabledSent = await capturePosthogException({
     error,

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { cwd } from 'node:process'
+import { Command } from 'commander'
+import {
+  capturePosthogException,
+  getCommandPath,
+  shouldCapturePosthogException,
+} from '../src/posthog.ts'
+
+const originalFetch = globalThis.fetch
+const originalEnv = {
+  CAPGO_CLI_POSTHOG_API_HOST: process.env.CAPGO_CLI_POSTHOG_API_HOST,
+  CAPGO_CLI_POSTHOG_API_KEY: process.env.CAPGO_CLI_POSTHOG_API_KEY,
+  CAPGO_DISABLE_POSTHOG: process.env.CAPGO_DISABLE_POSTHOG,
+  CAPGO_DISABLE_TELEMETRY: process.env.CAPGO_DISABLE_TELEMETRY,
+  POSTHOG_API_HOST: process.env.POSTHOG_API_HOST,
+  POSTHOG_API_KEY: process.env.POSTHOG_API_KEY,
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined)
+      delete process.env[key]
+    else
+      process.env[key] = value
+  }
+}
+
+try {
+  console.log('Testing CLI PostHog exception capture...')
+
+  const requests = []
+  globalThis.fetch = async (url, init) => {
+    requests.push({ init, url })
+    return new Response('', { status: 200 })
+  }
+
+  process.env.CAPGO_CLI_POSTHOG_API_KEY = 'posthog-key'
+  process.env.CAPGO_CLI_POSTHOG_API_HOST = 'https://eu.i.posthog.com/i/v0/e'
+  delete process.env.CAPGO_DISABLE_POSTHOG
+  delete process.env.CAPGO_DISABLE_TELEMETRY
+  delete process.env.POSTHOG_API_KEY
+  delete process.env.POSTHOG_API_HOST
+
+  const error = new Error('boom')
+  error.stack = `Error: boom\n    at runUpload (${cwd()}/src/index.ts:10:5)`
+
+  const sent = await capturePosthogException({
+    error,
+    functionName: 'bundle upload',
+    kind: 'unhandled_error',
+    status: 1,
+  })
+
+  assert.equal(sent, true)
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].url, 'https://eu.i.posthog.com/i/v0/e/')
+
+  const body = JSON.parse(requests[0].init.body)
+  assert.equal(body.token, 'posthog-key')
+  assert.equal(body.event, '$exception')
+  assert.equal(body.properties.runtime, 'cli')
+  assert.equal(body.properties.function_name, 'bundle upload')
+  assert.equal(body.properties.error_kind, 'unhandled_error')
+  assert.equal(body.properties.status, 1)
+  assert.match(body.properties.distinct_id, /^cli:[^:]+:bundle upload$/)
+  assert.match(body.properties.$exception_fingerprint, /cli:[^:]+:bundle upload:unhandled_error:Error:runUpload:/)
+  assert.equal(body.properties.$exception_list[0].type, 'Error')
+  assert.equal(body.properties.$exception_list[0].value, 'boom')
+  assert.equal(body.properties.$exception_list[0].mechanism.handled, true)
+  assert.equal(body.properties.$exception_list[0].stacktrace.frames[0].filename, '<cwd>/src/index.ts')
+  assert.equal(requests[0].init.signal instanceof AbortSignal, true)
+
+  requests.length = 0
+  process.env.CAPGO_DISABLE_TELEMETRY = 'true'
+  const disabledSent = await capturePosthogException({
+    error,
+    functionName: 'bundle upload',
+    kind: 'unhandled_error',
+    status: 1,
+  })
+
+  assert.equal(disabledSent, false)
+  assert.equal(requests.length, 0)
+
+  delete process.env.CAPGO_DISABLE_TELEMETRY
+  process.env.CAPGO_CLI_POSTHOG_API_HOST = '://bad-host'
+  const invalidHostSent = await capturePosthogException({
+    error,
+    functionName: 'bundle upload',
+    kind: 'unhandled_error',
+    status: 1,
+  })
+
+  assert.equal(invalidHostSent, false)
+  assert.equal(requests.length, 0)
+
+  const root = new Command('@capgo/cli')
+  const bundle = root.command('bundle')
+  const upload = bundle.command('upload')
+  assert.equal(getCommandPath(upload), 'bundle upload')
+  assert.equal(getCommandPath(root), 'unknown')
+
+  assert.equal(shouldCapturePosthogException({ code: 'commander.helpDisplayed' }), false)
+  assert.equal(shouldCapturePosthogException({ code: 'ENOENT' }), true)
+  assert.equal(shouldCapturePosthogException(new Error('boom')), true)
+
+  console.log('CLI PostHog exception capture tests passed')
+}
+finally {
+  globalThis.fetch = originalFetch
+  restoreEnv()
+}


### PR DESCRIPTION
## Summary (AI generated)

- Added a CLI `capturePosthogException` helper that sends handled `$exception` events to PostHog with stack frames, fingerprints, CLI version, Node/runtime metadata, and sanitized local paths.
- Wired the helper into the top-level Commander error boundary while skipping normal Commander help/version/usage control-flow errors.
- Added a focused CLI test and included it in the CLI test sequence.

## Motivation (AI generated)

The backend now captures server exceptions in PostHog. CLI failures were still only printed locally, which made recurring CLI crash patterns harder to see and group.

## Business Impact (AI generated)

This improves visibility into real CLI runtime failures so Capgo can identify broken workflows faster and reduce support/debug time for CLI users.

## Test Plan (AI generated)

- [x] `bun run test:posthog-exception`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:mcp`
- [x] `bun run test:bundle`
- [x] `node dist/index.js --version`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI exception reporting to capture and optionally send error telemetry for unhandled errors.

* **Tests**
  * Added tests validating exception capture, payload contents, redaction, and telemetry gating.

* **Chores**
  * Added CLI test script and updated test runner; improved CLI error handling and reporting behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2088)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->