### PR TITLE
fix(api): reject hashed limited subkeys

### DIFF
--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -340,8 +340,9 @@ function setApiKeyAuthContext(c: Context, apikey: Database['public']['Tables']['
  * @param c - Hono context used to store auth data.
  * @param userId - The owner of the parent API key.
  * @param subkey - The row representing the validated subkey.
+ * @param subkeySecret - The plaintext subkey secret to propagate to downstream checks.
  */
-function setSubkeyAuthContext(c: Context, userId: string, subkey: Database['public']['Tables']['apikeys']['Row']) {
+function setSubkeyAuthContext(c: Context, userId: string, subkey: Database['public']['Tables']['apikeys']['Row'], subkeySecret: string) {
   c.set('auth', {
     userId,
     authType: 'apikey',
@@ -350,11 +351,7 @@ function setSubkeyAuthContext(c: Context, userId: string, subkey: Database['publ
   })
   c.set('apikey', subkey)
   c.set('subkey', subkey)
-
-  // Prefer the subkey's own secret for downstream RLS/policy checks when it exists.
-  if (subkey.key) {
-    c.set('capgkey', subkey.key)
-  }
+  c.set('capgkey', subkeySecret)
 }
 
 /**
@@ -387,6 +384,29 @@ function validateSubkeyLimits(c: Context, subkey: Database['public']['Tables']['
     return quickError(401, 'invalid_subkey', 'Invalid subkey, no limited apps or orgs')
   }
   return null
+}
+
+/**
+ * Rejects hashed-only subkeys because downstream SQL/RLS paths still require a
+ * plaintext key string and would otherwise fall back to the parent API key.
+ *
+ * @param c - Hono context used for logging.
+ * @param subkey - The candidate subkey row.
+ * @throws quickError when the subkey cannot be safely represented.
+ */
+function assertSubkeyHasPlaintextSecret(
+  c: Context,
+  subkey: Database['public']['Tables']['apikeys']['Row'],
+): asserts subkey is Database['public']['Tables']['apikeys']['Row'] & { key: string } {
+  if (!subkey.key) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Invalid hashed subkey, cannot propagate subkey auth context',
+      subkeyId: subkey.id,
+      subkeyUserId: subkey.user_id,
+    })
+    quickError(401, 'invalid_subkey', 'Invalid subkey')
+  }
 }
 
 /**
@@ -532,7 +552,8 @@ async function foundAPIKey(c: Context, capgkeyString: string, rights: Database['
     if (limitError) {
       return limitError
     }
-    setSubkeyAuthContext(c, apikey.user_id, subkey)
+    assertSubkeyHasPlaintextSecret(c, subkey)
+    setSubkeyAuthContext(c, apikey.user_id, subkey, subkey.key)
   }
 }
 
@@ -657,8 +678,9 @@ export function middlewareKey(rights: Database['public']['Enums']['key_mode'][],
       if (limitError) {
         return limitError
       }
+      assertSubkeyHasPlaintextSecret(c, subkey)
       // Override auth context with subkey for RBAC
-      setSubkeyAuthContext(c, apikey.user_id, subkey)
+      setSubkeyAuthContext(c, apikey.user_id, subkey, subkey.key)
     }
     await next()
   })

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { BASE_URL, fetchWithRetry, getSupabaseClient, headers, NON_OWNER_ORG_ID, ORG_ID, resetAndSeedAppData, resetAppData, resetAppDataStats, USER_ID, USER_ID_2 } from './test-utils.ts'
 
 function isDuplicateAppCreationError(body: any): boolean {
@@ -283,6 +283,88 @@ describe('[GET] /app subkey ownership enforcement', () => {
       method: 'GET',
       headers: { ...headers, ...subkeyHeaders },
     })
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error?: string }
+    expect(data.error).toBe('invalid_subkey')
+  })
+})
+
+describe('/app hashed subkey enforcement', () => {
+  const id = randomUUID()
+  const ALLOWED_APPNAME = `com.hashed-subkey.allowed.${id}`
+  const BLOCKED_APPNAME = `com.hashed-subkey.blocked.${id}`
+  let subkeyId = 0
+
+  async function createAppForTest(appName: string) {
+    const createApp = await fetch(`${BASE_URL}/app`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        owner_org: ORG_ID,
+        app_id: appName,
+        name: `App ${appName}`,
+        icon: 'test-icon',
+      }),
+    })
+    if (createApp.status !== 200) {
+      const body = await createApp.json().catch(() => null) as any
+      const isDuplicate = isDuplicateAppCreationError(body)
+      if (!isDuplicate) {
+        expect(createApp.status, JSON.stringify(body)).toBe(200)
+      }
+    }
+  }
+
+  beforeAll(async () => {
+    await createAppForTest(ALLOWED_APPNAME)
+    const createSubkey = await fetch(`${BASE_URL}/apikey`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        name: 'Hashed Limited Subkey',
+        mode: 'all',
+        limited_to_apps: [ALLOWED_APPNAME],
+        hashed: true,
+      }),
+    })
+    expect(createSubkey.status).toBe(200)
+    const subkeyData = await createSubkey.json() as { id: number }
+    subkeyId = subkeyData.id
+  })
+
+  afterAll(async () => {
+    if (subkeyId) {
+      await getSupabaseClient().from('apikeys').delete().eq('id', subkeyId)
+    }
+    await resetAppData(ALLOWED_APPNAME)
+    await resetAppDataStats(ALLOWED_APPNAME)
+    await resetAppData(BLOCKED_APPNAME)
+    await resetAppDataStats(BLOCKED_APPNAME)
+  })
+
+  it('should reject hashed subkeys on middlewareKey routes', async () => {
+    const response = await fetch(`${BASE_URL}/app/${ALLOWED_APPNAME}`, {
+      method: 'GET',
+      headers: { ...headers, 'x-limited-key-id': String(subkeyId) },
+    })
+
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error?: string }
+    expect(data.error).toBe('invalid_subkey')
+  })
+
+  it('should reject hashed subkeys on middlewareV2 routes', async () => {
+    const response = await fetch(`${BASE_URL}/app`, {
+      method: 'POST',
+      headers: { ...headers, 'x-limited-key-id': String(subkeyId) },
+      body: JSON.stringify({
+        owner_org: ORG_ID,
+        app_id: BLOCKED_APPNAME,
+        name: `App ${BLOCKED_APPNAME}`,
+        icon: 'test-icon',
+      }),
+    })
+
     expect(response.status).toBe(401)
     const data = await response.json() as { error?: string }
     expect(data.error).toBe('invalid_subkey')

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -65,14 +65,16 @@ beforeAll(async () => {
   appScopedKeyId = appScopedKeyData.id
   appScopedKey = appScopedKeyData.key
 
-  const { data: orgScopedSubkeyData, error: orgScopedSubkeyError } = await getSupabaseClient().rpc('create_hashed_apikey_for_user', {
-    p_user_id: USER_ID,
-    p_mode: 'all',
-    p_name: `webhook-org-scoped-subkey-${globalId}`,
-    p_limited_to_orgs: [WEBHOOK_TEST_ORG_ID],
-    p_limited_to_apps: [],
-    p_expires_at: null as unknown as string,
-  })
+  const { data: orgScopedSubkeyData, error: orgScopedSubkeyError } = await getSupabaseClient().from('apikeys').insert({
+    user_id: USER_ID,
+    key: randomUUID(),
+    key_hash: null,
+    mode: 'all',
+    name: `webhook-org-scoped-subkey-${globalId}`,
+    limited_to_orgs: [WEBHOOK_TEST_ORG_ID],
+    limited_to_apps: [],
+    expires_at: null,
+  }).select('id').single()
   if (orgScopedSubkeyError || !orgScopedSubkeyData?.id) {
     throw new Error(`Failed to create org-scoped API subkey for webhook tests: ${orgScopedSubkeyError?.message ?? 'missing key data'}`)
   }


### PR DESCRIPTION
## Summary (AI generated)

- Reject `x-limited-key-id` subkeys that only have a hashed stored secret before rewriting auth context.
- Require plaintext subkey secrets when propagating `capgkey` to downstream RBAC/RLS checks.
- Add regression coverage for both `middlewareKey` and `middlewareV2` app routes.

## Motivation (AI generated)

GHSA-vm62-vgrc-hx56 reported that hashed limited subkeys could leave `capgkey` set to the parent API key, allowing later permission checks to authorize the parent instead of the selected limited subkey.

## Business Impact (AI generated)

This preserves delegated API-key boundaries for whitelabel and integration flows by preventing hashed limited subkeys from silently bypassing app/org scope restrictions.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bun run supabase:with-env -- bunx vitest run tests/app.test.ts --typecheck.enabled=false`
- [x] `bun typecheck`