### PR TITLE
[codex] docs(webhook): document validation boundaries

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -535,6 +535,10 @@ async function runChannelSelfWithPgClient(
   }
 }
 
+// Plugin endpoints are intentionally public device endpoints: their responses are
+// considered public data, so we do not require Capgo JWT/API-key auth or add
+// checks beyond Supabase/platform protections. Endpoint-specific validation, plan
+// checks, and rate limits still apply.
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', async (c) => {

--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -142,6 +142,10 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   return { success: true }
 }
 
+// Plugin endpoints are intentionally public device endpoints: their responses are
+// considered public data, so we do not require Capgo JWT/API-key auth or add
+// checks beyond Supabase/platform protections. Endpoint-specific validation, plan
+// checks, and rate limits still apply.
 export const app = new Hono<MiddlewareKeyVariables>()
 
 async function parseBodyRaw(c: Context): Promise<AppStats | AppStats[]> {

--- a/supabase/functions/_backend/plugins/updates.ts
+++ b/supabase/functions/_backend/plugins/updates.ts
@@ -11,6 +11,10 @@ import {
   isLimited,
 } from '../utils/utils.ts'
 
+// Plugin endpoints are intentionally public device endpoints: their responses are
+// considered public data, so we do not require Capgo JWT/API-key auth or add
+// checks beyond Supabase/platform protections. Endpoint-specific validation, plan
+// checks, and rate limits still apply.
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', async (c) => {

--- a/supabase/functions/_backend/utils/webhook.ts
+++ b/supabase/functions/_backend/utils/webhook.ts
@@ -76,6 +76,9 @@ export function getWebhookUrlValidationError(c: Context, urlString: string): str
   if (allowLocalWebhookUrls(c))
     return null
 
+  // We intentionally stop at syntactic/public-host checks: webhook delivery runs
+  // entirely from serverless infrastructure, so private/internal addresses are not
+  // reachable by design.
   const hostname = normalizeHostname(url.hostname)
   if (isLocalhostHostname(hostname))
     return 'Webhook URL must point to a public host'


### PR DESCRIPTION
## Summary (AI generated)

- Added an inline comment documenting the intentional webhook URL validation boundary.
- Clarified that delivery relies on serverless network isolation, Supabase/platform auth boundaries, and public plugin endpoint data assumptions.

## Motivation (AI generated)

The webhook validation helper needed a clear code-level note explaining why Capgo does not perform deeper private/internal address or webhook-specific auth checks.

## Business Impact (AI generated)

This reduces future implementation drift around webhook validation and helps keep behavior aligned with Capgo's serverless and public plugin endpoint model.

## Test Plan (AI generated)

- [x] Ran `bun lint:backend`
- [x] Commit hook ran CLI build and Vue typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification comments to backend plugins and utilities to document authentication and validation approaches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2090)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->