### PR TITLE
fix(rbac): enforce channel promotion overrides

### DIFF
--- a/src/components/dashboard/DeploymentBanner.vue
+++ b/src/components/dashboard/DeploymentBanner.vue
@@ -216,8 +216,10 @@ async function executeDeployment() {
   const bundle = latestBundle.value
   const allowedTargetIds = new Set(deployTargets.value.map(target => target.id))
   const targetIds = selectedChannelIds.value.filter(id => allowedTargetIds.has(id))
-  if (targetIds.length === 0)
+  if (targetIds.length === 0) {
+    toast.error(t('no-permission'))
     return
+  }
 
   deploying.value = true
 

--- a/src/pages/app/[app].bundle.[bundle].vue
+++ b/src/pages/app/[app].bundle.[bundle].vue
@@ -105,6 +105,10 @@ const canEditBundleMetadata = computedAsync(async () => {
   return await checkPermissions('app.upload_bundle', { appId: version.value.app_id })
 }, false)
 
+const selectableChannels = computed(() => {
+  return filteredChannels.value.filter(channel => canPromoteChannel(channel.id))
+})
+
 const canDeleteBundle = computedAsync(async () => {
   if (!version.value?.app_id)
     return false
@@ -227,6 +231,7 @@ async function getUnknownBundleId() {
     .single()
   return data?.id
 }
+
 // add check compatibility here
 async function setChannel(channel: Database['public']['Tables']['channels']['Row'], id: number) {
   if (!canPromoteChannel(channel.id)) {
@@ -238,6 +243,11 @@ async function setChannel(channel: Database['public']['Tables']['channels']['Row
     console.error('Invalid version ID:', id)
     toast.error(t('error-invalid-version'))
     return Promise.reject(new Error('Invalid version ID'))
+  }
+
+  if (!(await checkPermissions('channel.promote_bundle', { channelId: channel.id }))) {
+    toast.error(t('no-permission'))
+    return Promise.reject(new Error('No permission to update channel version'))
   }
 
   return supabase
@@ -1213,12 +1223,12 @@ async function deleteBundle() {
           </div>
 
           <!-- Available Channels -->
-          <div v-if="filteredChannels.length > 0" class="space-y-2">
+          <div v-if="selectableChannels.length > 0" class="space-y-2">
             <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t('available-channels') }}
             </h4>
             <div
-              v-for="chan in filteredChannels"
+              v-for="chan in selectableChannels"
               :key="chan.id"
               class="p-3 transition-colors border rounded-lg cursor-pointer"
               :class="{

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -158,19 +158,23 @@ async function getChannel(force = false) {
 }
 
 async function saveChannelChange<K extends EditableChannelKey>(key: K, val: ChannelUpdate[K]) {
-  if (!canUpdateChannelSettings.value) {
+  const canUpdate = key === 'version'
+    ? canPromoteBundle.value
+    : canUpdateChannelSettings.value
+
+  if (!canUpdate) {
     toast.error(t('no-permission'))
-    return
+    return false
   }
 
   if (!id.value || !channel.value)
-    return
+    return false
 
   // Validate version ID if updating version field
   if (key === 'version' && (val === undefined || val === null || typeof val !== 'number')) {
     console.error('Invalid version ID:', val)
     toast.error(t('error-invalid-version'))
-    return
+    return false
   }
 
   try {
@@ -181,17 +185,20 @@ async function saveChannelChange<K extends EditableChannelKey>(key: K, val: Chan
       .from('channels')
       .update(update)
       .eq('id', id.value)
-    getChannel(true)
     if (error) {
       toast.error(t('error-update-channel'))
       console.error('no channel update', error)
+      return false
     }
     else {
+      await getChannel(true)
       toast.info(t('cloud-replication-delay'))
+      return true
     }
   }
   catch (error) {
     console.error(error)
+    return false
   }
 }
 
@@ -343,19 +350,7 @@ async function handleRevert() {
             return
           }
 
-          const { error: updateError } = await supabase
-            .from('channels')
-            .update({ version: revertVersionId })
-            .eq('id', id.value)
-
-          if (updateError) {
-            console.error(updateError)
-            toast.error(t('error-revert-to-builtin'))
-            return
-          }
-
-          await getChannel(true)
-          toast.info(t('cloud-replication-delay'))
+          await saveChannelChange('version', revertVersionId)
         },
       },
     ],

--- a/supabase/functions/_backend/public/bundle/set_channel.ts
+++ b/supabase/functions/_backend/public/bundle/set_channel.ts
@@ -22,6 +22,11 @@ export async function setChannel(c: Context<MiddlewareKeyVariables>, body: SetCh
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
 
+  // Preserve the existing app-level failure shape for unknown or inaccessible apps.
+  if (!(await checkPermission(c, 'channel.promote_bundle', { appId: body.app_id }))) {
+    throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
+  }
+
   // Get organization info
   const { data: org, error: orgError } = await supabaseApikey(c, apikey.key)
     .from('apps')

--- a/tests/bundle-set-channel-rbac.unit.test.ts
+++ b/tests/bundle-set-channel-rbac.unit.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const checkPermissionMock = vi.fn()
+const supabaseApikeyMock = vi.fn()
+const closeClientMock = vi.fn()
+const logPgErrorMock = vi.fn()
+const queryMock = vi.fn()
+const releaseMock = vi.fn()
+const connectMock = vi.fn()
+const pgClientMock = { connect: connectMock }
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseApikey: (...args: unknown[]) => supabaseApikeyMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: (...args: unknown[]) => closeClientMock(...args),
+  getPgClient: () => pgClientMock,
+  logPgError: (...args: unknown[]) => logPgErrorMock(...args),
+}))
+
+const { setChannel } = await import('../supabase/functions/_backend/public/bundle/set_channel.ts')
+
+function queryBuilderFactory(table: string) {
+  const rows: Record<string, unknown> = {
+    apps: { owner_org: '046a36ac-e03c-4590-9257-bd6c9dba9ee8' },
+    app_versions: { id: 7, name: '1.0.0', app_id: 'com.example.app' },
+    channels: { id: 42, name: 'production', app_id: 'com.example.app' },
+  }
+
+  return {
+    eq: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: rows[table], error: null }),
+  }
+}
+
+function context() {
+  return {
+    get: vi.fn((key: string) => {
+      if (key === 'capgkey')
+        return 'test-apikey'
+      if (key === 'requestId')
+        return 'test-request'
+      return undefined
+    }),
+    json: vi.fn((body: unknown) => Response.json(body)),
+  }
+}
+
+describe('bundle set channel RBAC guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkPermissionMock.mockResolvedValue(true)
+    supabaseApikeyMock.mockReturnValue({
+      from: vi.fn((table: string) => queryBuilderFactory(table)),
+    })
+    queryMock.mockImplementation(async (text: string) => ({
+      rowCount: text.includes('UPDATE public.channels') ? 1 : undefined,
+    }))
+    connectMock.mockResolvedValue({
+      query: queryMock,
+      release: releaseMock,
+    })
+  })
+
+  it('checks promotion permission against the target channel', async () => {
+    const c = context()
+
+    const response = await setChannel(c as any, {
+      app_id: 'com.example.app',
+      version_id: 7,
+      channel_id: 42,
+    }, { key: 'test-apikey' } as any)
+
+    expect(response.status).toBe(200)
+    expect(checkPermissionMock).toHaveBeenNthCalledWith(1, c, 'channel.promote_bundle', {
+      appId: 'com.example.app',
+    })
+    expect(checkPermissionMock).toHaveBeenNthCalledWith(2, c, 'channel.promote_bundle', {
+      appId: 'com.example.app',
+      channelId: 42,
+    })
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('UPDATE public.channels'), [
+      7,
+      42,
+      'com.example.app',
+      '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    ])
+  })
+
+  it('does not update the channel when channel-scoped promotion is denied', async () => {
+    const c = context()
+    checkPermissionMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+
+    await expect(setChannel(c as any, {
+      app_id: 'com.example.app',
+      version_id: 7,
+      channel_id: 42,
+    }, { key: 'test-apikey' } as any)).rejects.toHaveProperty('status', 400)
+
+    expect(checkPermissionMock).toHaveBeenNthCalledWith(1, c, 'channel.promote_bundle', {
+      appId: 'com.example.app',
+    })
+    expect(checkPermissionMock).toHaveBeenNthCalledWith(2, c, 'channel.promote_bundle', {
+      appId: 'com.example.app',
+      channelId: 42,
+    })
+    expect(connectMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Hardened channel promotion entry points so bundle-to-channel writes keep the app-level access guard and still require channel-scoped `channel.promote_bundle` permission.
- Tightened frontend channel-version actions to use promotion permission for version changes and recheck promotion before writing from the bundle page.
- Added unit coverage for the `/bundle/set_channel` RBAC guard sequence and denial behavior.

## Motivation (AI generated)

GHSA-633x-9x77-77gf requires channel-specific promotion overrides to be respected on promotion paths. The current base already includes database trigger enforcement; this PR closes the remaining backend/UI guard coverage around the shortcut flows.

## Business Impact (AI generated)

This reduces the risk that a user with broad app access can promote bundles to channels where a channel-specific deny override should apply, protecting staged rollout and production channel controls.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/bundle-set-channel-rbac.unit.test.ts tests/rbac-permissions.test.ts`
- [x] GitHub CI checks on the updated PR branch
