### PR TITLE
[codex] Fix missed component release recovery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && github.sha || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import process from 'node:process'
+import { TextDecoder } from 'node:util'
 
 export type Component = 'capgo' | 'cli'
 export type ReleaseAs = 'patch' | 'minor' | 'major'
@@ -74,6 +75,38 @@ function runGit(args: string[]): string {
   }).trim()
 }
 
+function stringifyGitErrorOutput(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value instanceof Uint8Array) {
+    return new TextDecoder().decode(value)
+  }
+
+  return ''
+}
+
+function getGitErrorText(error: unknown): string {
+  const parts = []
+
+  if (error instanceof Error) {
+    parts.push(error.message)
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const outputs = error as { stdout?: unknown, stderr?: unknown }
+    parts.push(stringifyGitErrorOutput(outputs.stdout))
+    parts.push(stringifyGitErrorOutput(outputs.stderr))
+  }
+
+  return parts.filter(Boolean).join('\n')
+}
+
+function isNoMatchingTagError(error: unknown): boolean {
+  return /no matching tag|no names found|no tags can describe|fatal: no tag/i.test(getGitErrorText(error))
+}
+
 export function getComponentTagPattern(component: Component): string {
   return `${component}-[0-9]*`
 }
@@ -83,7 +116,11 @@ export function getLatestComponentTag(component: Component, after: string, run: 
     const tag = run(['describe', '--tags', '--match', getComponentTagPattern(component), '--abbrev=0', after])
     return tag || null
   }
-  catch {
+  catch (error) {
+    if (!isNoMatchingTagError(error)) {
+      throw error
+    }
+
     return null
   }
 }

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from 'node:child_process'
+import process from 'node:process'
 
 export type Component = 'capgo' | 'cli'
 export type ReleaseAs = 'patch' | 'minor' | 'major'
+type GitRunner = (args: string[]) => string
 
 const sharedMatchers = [
   /^\.github\/workflows\/bump_version\.yml$/,
@@ -72,32 +74,50 @@ function runGit(args: string[]): string {
   }).trim()
 }
 
-function getCommitShas(before: string, after: string): string[] {
+export function getComponentTagPattern(component: Component): string {
+  return `${component}-[0-9]*`
+}
+
+export function getLatestComponentTag(component: Component, after: string, run: GitRunner = runGit): string | null {
+  try {
+    const tag = run(['describe', '--tags', '--match', getComponentTagPattern(component), '--abbrev=0', after])
+    return tag || null
+  }
+  catch {
+    return null
+  }
+}
+
+export function getReleaseRangeBase(component: Component, before: string, after: string, run: GitRunner = runGit): string {
+  return getLatestComponentTag(component, after, run) ?? before
+}
+
+function getCommitShas(before: string, after: string, run: GitRunner = runGit): string[] {
   const isZero = before === '' || /^0+$/.test(before)
 
   if (!isZero) {
-    const commits = runGit(['rev-list', '--reverse', `${before}..${after}`])
+    const commits = run(['rev-list', '--reverse', `${before}..${after}`])
     return commits ? commits.split('\n').filter(Boolean) : []
   }
 
-  const parents = runGit(['rev-list', '--parents', '-n', '1', after]).split(' ')
+  const parents = run(['rev-list', '--parents', '-n', '1', after]).split(' ')
   if (parents.length > 1) {
-    const commits = runGit(['rev-list', '--reverse', `${after}^..${after}`])
+    const commits = run(['rev-list', '--reverse', `${after}^..${after}`])
     return commits ? commits.split('\n').filter(Boolean) : []
   }
 
   return [after]
 }
 
-function getChangedFiles(commit: string): string[] {
-  const files = runGit(['show', '--format=', '--name-only', commit])
+function getChangedFiles(commit: string, run: GitRunner = runGit): string[] {
+  const files = run(['show', '--format=', '--name-only', commit])
   return files ? files.split('\n').filter(Boolean) : []
 }
 
-function getCommitMessage(commit: string): { subject: string, body: string } {
+function getCommitMessage(commit: string, run: GitRunner = runGit): { subject: string, body: string } {
   return {
-    subject: runGit(['log', '-1', '--format=%s', commit]),
-    body: runGit(['log', '-1', '--format=%b', commit]),
+    subject: run(['log', '-1', '--format=%s', commit]),
+    body: run(['log', '-1', '--format=%b', commit]),
   }
 }
 
@@ -132,20 +152,21 @@ export function toReleaseAs(severity: number): ReleaseAs {
   return 'patch'
 }
 
-export function resolveReleaseScope(component: Component, before: string, after: string) {
-  const commits = getCommitShas(before, after)
+export function resolveReleaseScope(component: Component, before: string, after: string, run: GitRunner = runGit) {
+  const releaseBase = getReleaseRangeBase(component, before, after, run)
+  const commits = getCommitShas(releaseBase, after, run)
 
   let shouldRelease = false
   let highestSeverity = 0
 
   for (const commit of commits) {
-    const files = getChangedFiles(commit)
+    const files = getChangedFiles(commit, run)
     if (!matchesComponent(component, files)) {
       continue
     }
 
     shouldRelease = true
-    const message = getCommitMessage(commit)
+    const message = getCommitMessage(commit, run)
     highestSeverity = Math.max(highestSeverity, getSeverity(message.subject, message.body))
   }
 

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { matchesComponent } from '../scripts/release-scope.ts'
+import { getReleaseRangeBase, matchesComponent, resolveReleaseScope } from '../scripts/release-scope.ts'
 
 describe('release scope matching', () => {
   it.concurrent('treats shared release infrastructure as affecting both components', () => {
@@ -41,5 +41,55 @@ describe('release scope matching', () => {
 
     expect(matchesComponent('capgo', files)).toBe(false)
     expect(matchesComponent('cli', files)).toBe(false)
+  })
+
+  it.concurrent('uses the latest component tag instead of only the pushed range', () => {
+    const run = (args: string[]) => {
+      if (args[0] === 'describe') {
+        expect(args).toEqual(['describe', '--tags', '--match', 'cli-[0-9]*', '--abbrev=0', 'HEAD'])
+        return 'cli-7.95.15'
+      }
+
+      throw new Error(`Unexpected git call: ${args.join(' ')}`)
+    }
+
+    expect(getReleaseRangeBase('cli', 'previous-push-sha', 'HEAD', run)).toBe('cli-7.95.15')
+  })
+
+  it.concurrent('falls back to the pushed range when no component tag exists', () => {
+    const run = (args: string[]) => {
+      if (args[0] === 'describe') {
+        throw new Error('no matching tag')
+      }
+
+      throw new Error(`Unexpected git call: ${args.join(' ')}`)
+    }
+
+    expect(getReleaseRangeBase('capgo', 'previous-push-sha', 'HEAD', run)).toBe('previous-push-sha')
+  })
+
+  it.concurrent('keeps missed CLI changes releasable after a later Capgo-only push', () => {
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'describe --tags --match cli-[0-9]* --abbrev=0 head-capgo-only': 'cli-7.95.15',
+        'rev-list --reverse cli-7.95.15..head-capgo-only': 'cli-change\ncapgo-change',
+        'show --format= --name-only cli-change': 'cli/src/posthog.ts',
+        'show --format= --name-only capgo-change': 'src/pages/index.vue',
+        'log -1 --format=%s cli-change': 'feat(cli): capture exceptions',
+        'log -1 --format=%b cli-change': '',
+      }
+
+      if (key in responses) {
+        return responses[key]
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    expect(resolveReleaseScope('cli', 'capgo-change-parent', 'head-capgo-only', run)).toEqual({
+      shouldRelease: true,
+      releaseAs: 'minor',
+    })
   })
 })

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -59,13 +59,27 @@ describe('release scope matching', () => {
   it.concurrent('falls back to the pushed range when no component tag exists', () => {
     const run = (args: string[]) => {
       if (args[0] === 'describe') {
-        throw new Error('no matching tag')
+        throw Object.assign(new Error('git describe failed'), {
+          stderr: 'fatal: No names found, cannot describe anything.',
+        })
       }
 
       throw new Error(`Unexpected git call: ${args.join(' ')}`)
     }
 
     expect(getReleaseRangeBase('capgo', 'previous-push-sha', 'HEAD', run)).toBe('previous-push-sha')
+  })
+
+  it.concurrent('rethrows unexpected git describe failures', () => {
+    const run = (args: string[]) => {
+      if (args[0] === 'describe') {
+        throw new Error('fatal: bad revision HEAD')
+      }
+
+      throw new Error(`Unexpected git call: ${args.join(' ')}`)
+    }
+
+    expect(() => getReleaseRangeBase('cli', 'previous-push-sha', 'HEAD', run)).toThrow('fatal: bad revision HEAD')
   })
 
   it.concurrent('keeps missed CLI changes releasable after a later Capgo-only push', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Make release scope resolution compare each component against its latest matching tag instead of only the latest push range.
- Prevent reusable release test runs from cancelling other release test runs on `main`.
- Add release-scope regression coverage for missed CLI changes after a later Capgo-only push.

## Motivation (AI generated)

A cancelled CLI release test run could lose the CLI release forever because the next successful main push only inspected its own push range. The Capgo release could still ship and include CLI changes in the generated changelog, but no `cli-*` tag or npm publish would happen.

## Business Impact (AI generated)

This keeps Capgo and CLI releases aligned when both products changed, so CLI fixes do not silently miss npm publication after CI cancellation or later main pushes. It reduces manual release recovery and avoids users waiting for already-merged CLI fixes.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/release-scope.test.ts`
- [x] `bunx eslint --no-ignore scripts/release-scope.ts tests/release-scope.test.ts`
- [x] `git diff --check`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow concurrency grouping logic for reusable workflows.
  * Improved internal release scope script with dependency-injected Git execution for enhanced testability.
  * Expanded test coverage for release scope scenarios, including tag selection and fallback handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2095)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->