### PR TITLE
[codex] Show native build runner wait time

### DIFF
--- a/cli/src/types/supabase.types.ts
+++ b/cli/src/types/supabase.types.ts
@@ -490,6 +490,7 @@ export type Database = {
           owner_org: string
           platform: string
           requested_by: string
+          runner_wait_seconds: number
           status: string
           updated_at: string
           upload_expires_at: string
@@ -508,6 +509,7 @@ export type Database = {
           owner_org: string
           platform: string
           requested_by: string
+          runner_wait_seconds?: number
           status?: string
           updated_at?: string
           upload_expires_at: string
@@ -526,6 +528,7 @@ export type Database = {
           owner_org?: string
           platform?: string
           requested_by?: string
+          runner_wait_seconds?: number
           status?: string
           updated_at?: string
           upload_expires_at?: string

--- a/messages/en.json
+++ b/messages/en.json
@@ -433,6 +433,7 @@
   "build-step-android-setup-title": "Save Android signing credentials",
   "build-step-ios-setup-subtitle": "Run the guided CLI setup for certificates, profiles, and App Store Connect.",
   "build-step-ios-setup-title": "Set up iOS signing",
+  "runner-wait-time": "Wait Time",
   "build-step-request-subtitle-platform": "Request a {platform} build with the CLI.",
   "build-setup-invite-title": "Set up native builds",
   "build-setup-invite-subtitle": "You don't have any builds yet. Pick a platform to get started with Capgo native builds.",

--- a/src/components/tables/BuildTable.vue
+++ b/src/components/tables/BuildTable.vue
@@ -199,6 +199,21 @@ function getStatusColor(status: string): string {
   }
 }
 
+function formatWaitTime(seconds: number | null | undefined): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds ?? 0))
+  if (safeSeconds < 60)
+    return `${safeSeconds}s`
+
+  const minutes = Math.floor(safeSeconds / 60)
+  const remainingSeconds = safeSeconds % 60
+  if (minutes < 60)
+    return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
+
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}
+
 columns.value = [
   {
     label: t('created-at'),
@@ -218,6 +233,12 @@ columns.value = [
       const mode = elem.build_mode || ''
       return `${platform} ${mode}`.trim() || '-'
     },
+  },
+  {
+    label: t('runner-wait-time'),
+    key: 'runner_wait_seconds',
+    class: 'truncate max-w-24',
+    displayFunction: (elem: Element) => formatWaitTime(elem.runner_wait_seconds),
   },
   {
     label: t('status'),

--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -183,7 +183,6 @@ function formatCurrency(value: number) {
 function formatMetricAmount(metric: Database['public']['Enums']['credit_metric_type'], value: number) {
   // Apply ceil to round up the metric value
   const ceiledValue = Math.ceil(value)
-  const min = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(ceiledValue)
   switch (metric) {
     case 'mau':
       return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(ceiledValue)} ${t('users')}`

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -490,6 +490,7 @@ export type Database = {
           owner_org: string
           platform: string
           requested_by: string
+          runner_wait_seconds: number
           status: string
           updated_at: string
           upload_expires_at: string
@@ -508,6 +509,7 @@ export type Database = {
           owner_org: string
           platform: string
           requested_by: string
+          runner_wait_seconds?: number
           status?: string
           updated_at?: string
           upload_expires_at: string
@@ -526,6 +528,7 @@ export type Database = {
           owner_org?: string
           platform?: string
           requested_by?: string
+          runner_wait_seconds?: number
           status?: string
           updated_at?: string
           upload_expires_at?: string

--- a/supabase/functions/_backend/public/app/demo.ts
+++ b/supabase/functions/_backend/public/app/demo.ts
@@ -770,6 +770,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
           buildNumber: build.version.replace(/\./g, ''),
         },
         builder_job_id: build.status === 'succeeded' ? `demo-job-${buildId.slice(0, 8)}` : null,
+        runner_wait_seconds: build.status === 'succeeded' ? 20 + build.daysAgo * 3 : 0,
         created_at: createdAt,
         upload_expires_at: expiresAt,
         upload_path: `builds/${appId}/${build.platform}/${build.version}`,

--- a/supabase/functions/_backend/public/build/status.ts
+++ b/supabase/functions/_backend/public/build/status.ts
@@ -3,6 +3,7 @@ import type { Database } from '../../utils/supabase.types.ts'
 import {
   BUILD_TIMEOUT_STATUS,
   calculateBuildRuntimeSeconds,
+  calculateRunnerWaitSeconds,
   calculateTimeoutCompletedAt,
   capBuildRuntimeSeconds,
   formatBuildTimeoutError,
@@ -26,6 +27,7 @@ interface BuilderStatusResponse {
     status: string
     started_at: number | null
     completed_at: number | null
+    runner_wait_ms?: number | null
     error: string | null
   }
   machine: Record<string, unknown> | null
@@ -162,6 +164,7 @@ export async function getBuildStatus(
 
   const builderJob = await builderResponse.json() as BuilderStatusResponse
   const runtimeSeconds = calculateBuildRuntimeSeconds(builderJob.job.started_at, builderJob.job.completed_at)
+  const runnerWaitSeconds = calculateRunnerWaitSeconds(builderJob.job.runner_wait_ms)
   const timedOut = shouldApplyBuildTimeout(
     builderJob.job.started_at,
     builderJob.job.completed_at,
@@ -196,6 +199,7 @@ export async function getBuildStatus(
     builder_status: builderJob.job.status,
     started_at: builderJob.job.started_at,
     completed_at: effectiveCompletedAt,
+    runner_wait_seconds: runnerWaitSeconds,
     timeout_seconds: timeoutSeconds,
     timed_out: timedOut,
   })
@@ -209,6 +213,7 @@ export async function getBuildStatus(
     .update({
       status: effectiveStatus,
       last_error: effectiveError,
+      runner_wait_seconds: runnerWaitSeconds,
       updated_at: new Date().toISOString(),
     })
     .eq('builder_job_id', job_id)
@@ -256,6 +261,7 @@ export async function getBuildStatus(
     machine: builderJob.machine || null,
     started_at: builderJob.job.started_at,
     completed_at: effectiveCompletedAt,
+    runner_wait_seconds: runnerWaitSeconds,
     build_time_seconds: timeoutApplied
       ? effectiveBuildTimeSeconds
       : builderJob.job.started_at && builderJob.job.completed_at

--- a/supabase/functions/_backend/triggers/cron_reconcile_build_status.ts
+++ b/supabase/functions/_backend/triggers/cron_reconcile_build_status.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono/tiny'
 import {
   BUILD_TIMEOUT_STATUS,
   calculateBuildRuntimeSeconds,
+  calculateRunnerWaitSeconds,
   calculateTimeoutCompletedAt,
   capBuildRuntimeSeconds,
   formatBuildTimeoutError,
@@ -21,6 +22,7 @@ interface BuilderStatusResponse {
     status: string
     started_at: number | null
     completed_at: number | null
+    runner_wait_ms?: number | null
     error: string | null
   }
   machine: Record<string, unknown> | null
@@ -150,6 +152,7 @@ app.post('/', middlewareAPISecret, async (c) => {
       const appTimeout = appTimeouts.get(build.app_id)
       const timeoutSeconds = normalizeBuildTimeoutSeconds(appTimeout?.timeoutSeconds)
       const runtimeSeconds = calculateBuildRuntimeSeconds(builderJob.job.started_at, builderJob.job.completed_at)
+      const runnerWaitSeconds = calculateRunnerWaitSeconds(builderJob.job.runner_wait_ms)
       const buildTimedOut = shouldApplyBuildTimeout(
         builderJob.job.started_at,
         builderJob.job.completed_at,
@@ -211,6 +214,7 @@ app.post('/', middlewareAPISecret, async (c) => {
         .update({
           status: effectiveStatus,
           last_error: effectiveError,
+          runner_wait_seconds: runnerWaitSeconds,
           updated_at: new Date().toISOString(),
         })
         .eq('id', build.id)

--- a/supabase/functions/_backend/utils/build_timeout.ts
+++ b/supabase/functions/_backend/utils/build_timeout.ts
@@ -38,6 +38,13 @@ export function calculateBuildRuntimeSeconds(
   return Math.max(0, Math.floor((endMs - startedAt) / 1000))
 }
 
+export function calculateRunnerWaitSeconds(runnerWaitMs: number | null | undefined): number {
+  if (typeof runnerWaitMs !== 'number' || !Number.isFinite(runnerWaitMs))
+    return 0
+
+  return Math.max(0, Math.floor(runnerWaitMs / 1000))
+}
+
 export function calculateTimeoutCompletedAt(startedAt: number, timeoutSeconds: number): number {
   return startedAt + normalizeBuildTimeoutSeconds(timeoutSeconds) * 1000
 }

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -490,6 +490,7 @@ export type Database = {
           owner_org: string
           platform: string
           requested_by: string
+          runner_wait_seconds: number
           status: string
           updated_at: string
           upload_expires_at: string
@@ -508,6 +509,7 @@ export type Database = {
           owner_org: string
           platform: string
           requested_by: string
+          runner_wait_seconds?: number
           status?: string
           updated_at?: string
           upload_expires_at: string
@@ -526,6 +528,7 @@ export type Database = {
           owner_org?: string
           platform?: string
           requested_by?: string
+          runner_wait_seconds?: number
           status?: string
           updated_at?: string
           upload_expires_at?: string

--- a/supabase/migrations/20260510183000_add_build_runner_wait_seconds.sql
+++ b/supabase/migrations/20260510183000_add_build_runner_wait_seconds.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.build_requests
+ADD COLUMN IF NOT EXISTS runner_wait_seconds bigint NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.build_requests.runner_wait_seconds IS 'Self-hosted runner wait time reported by builder, in seconds. Informational only; not used for billing.';

--- a/tests/build-timeout.unit.test.ts
+++ b/tests/build-timeout.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   calculateBuildRuntimeSeconds,
+  calculateRunnerWaitSeconds,
   calculateTimeoutCompletedAt,
   capBuildRuntimeSeconds,
   DEFAULT_BUILD_TIMEOUT_SECONDS,
@@ -24,6 +25,12 @@ describe('build timeout helpers', () => {
     expect(calculateBuildRuntimeSeconds(1_000, 31_999)).toBe(30)
     expect(calculateBuildRuntimeSeconds(31_000, 1_000)).toBe(0)
     expect(calculateBuildRuntimeSeconds(null, 31_000)).toBeNull()
+  })
+
+  it.concurrent('normalizes runner wait stats without affecting runtime', () => {
+    expect(calculateRunnerWaitSeconds(61_999)).toBe(61)
+    expect(calculateRunnerWaitSeconds(-1)).toBe(0)
+    expect(calculateRunnerWaitSeconds(null)).toBe(0)
   })
 
   it.concurrent('detects running and completed builds past their timeout', () => {


### PR DESCRIPTION
## Summary
- Add a build_requests.runner_wait_seconds column for builder self-hosted runner wait stats.
- Persist runner wait from /build/status and stale-build reconciliation without changing billable build_time_seconds.
- Show wait time in the native builds table.
- Fix an existing unused local in Credits.vue so typecheck passes.

## Validation
- bunx vitest run tests/build-timeout.unit.test.ts
- bun run typecheck
- bun lint
- bun lint:backend
- bun run lint:deadcode
- bash scripts/check-supabase-migration-order.sh

Companion builder PR: https://github.com/Cap-go/capgo_builder/pull/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build requests now track and display runner wait time, showing how long builds spend waiting for self-hosted runners to become available. This informational metric provides insights into runner resource availability.

* **Tests**
  * Added unit tests for runner wait time calculation and normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2097)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->