### PR TITLE
fix(frontend): show native build concurrency in pricing

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1478,6 +1478,7 @@
   "plan-feature-soc2-certified": "SOC 2 certified",
   "plan-inactive": "Plan inactive",
   "plan-maker": "Best for small business owners",
+  "plan-native-build-concurrency": "{count} concurrent native builds",
   "plan-page-warn": "Buying a plan will ONLY affect the \"%ORG_NAME%\" organization.",
   "plan-page-warn-2": "Learn more about it.",
   "plan-payasyougo": "Best for scaling enterprises",

--- a/playwright/e2e/subscription-checkout.spec.ts
+++ b/playwright/e2e/subscription-checkout.spec.ts
@@ -141,6 +141,7 @@ test.describe('Subscription Checkout', () => {
       market_desc: 'Emulator current subscription plan',
       mau: 1000,
       name: currentPlanName,
+      native_build_concurrency: 2,
       price_m: 1,
       price_m_id: currentMonthlyPrice.id,
       price_y: 10,
@@ -159,6 +160,7 @@ test.describe('Subscription Checkout', () => {
       market_desc: 'Emulator subscription plan',
       mau: 10000,
       name: planName,
+      native_build_concurrency: 3,
       price_m: 10,
       price_m_id: upgradeMonthlyPrice.id,
       price_y: 96,
@@ -200,6 +202,7 @@ test.describe('Subscription Checkout', () => {
     })
 
     await expect(planCard).toHaveCount(1)
+    await expect(planCard.getByText('3 concurrent native builds')).toBeVisible()
     await expect(planCard.getByRole('button', { name: 'Upgrade' })).toBeEnabled()
     await planCard.locator('[data-test="plan-action-button"]').click()
 

--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -100,6 +100,9 @@ function planFeatures(plan: Database['public']['Tables']['plans']['Row']) {
     : `${plan.bandwidth.toLocaleString()} ${t('plan-bandwidth')}`
 
   const buildTimeFeature = buildTimeDisplay ? planFeature(buildTimeDisplay, true) : null
+  const nativeBuildConcurrencyFeature = plan.native_build_concurrency
+    ? planFeature(t('plan-native-build-concurrency', { count: plan.native_build_concurrency.toLocaleString() }))
+    : null
 
   const planName = plan.name?.toLowerCase() ?? ''
   const extraFeatures = (planFeatureLabelKeysByPlan[planName] ?? [])
@@ -110,6 +113,7 @@ function planFeatures(plan: Database['public']['Tables']['plans']['Row']) {
     planFeature(storageFeature),
     planFeature(bandwidthFeature),
     buildTimeFeature,
+    nativeBuildConcurrencyFeature,
     ...extraFeatures,
   ].filter((feature): feature is PlanFeature => !!feature)
 }


### PR DESCRIPTION
## Summary (AI generated)

- Display each plan's native build concurrency limit in the pricing card feature list.
- Cover the visible pricing row in the subscription checkout Playwright flow.

## Motivation (AI generated)

- The native build concurrency limit is stored in the plan data and enforced by the backend, so pricing should show the same DB-backed value.

## Business Impact (AI generated)

- Makes plan differences clearer before upgrade and reduces confusion around native build capacity.

## Test Plan (AI generated)

- [x] bun lint
- [x] bun typecheck
- [x] bun run test:front playwright/e2e/subscription-checkout.spec.ts
