### PR TITLE
fix: avoid logging signed bundle URLs

### DIFF
--- a/supabase/functions/_backend/utils/downloadUrl.ts
+++ b/supabase/functions/_backend/utils/downloadUrl.ts
@@ -67,7 +67,7 @@ export async function getBundleUrl(
   if (getRuntimeKey() !== 'workerd') {
     try {
       const signedUrl = await s3.getSignedUrl(c, r2_path, EXPIRATION_SECONDS)
-      cloudlog({ requestId: c.get('requestId'), message: 'getBundleUrl', signedUrl })
+      cloudlog({ requestId: c.get('requestId'), message: 'getBundleUrl', hasDownloadUrl: Boolean(signedUrl), source: 's3' })
       const url = signedUrl
       // Since it's signed url we cannot add extra query params like checksum and device id
       // TODO: switch to our own file endpoint instead of direct s3 signed url

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -259,7 +259,6 @@ export async function updateWithPG(
     })
   }
 
-  // cloudlog(c.get('requestId'), 'signedURL', device_id, version_name, version.name)
   if (version_name === version.name) {
     cloudlog({ requestId: c.get('requestId'), message: 'No new version available', id: device_id, version_name, version: version.name, date: new Date().toISOString() })
     // TODO: check why this event is send with wrong version_name
@@ -445,7 +444,7 @@ export async function updateWithPG(
   cloudlog({ requestId: c.get('requestId'), message: 'bundle_url_timing', duration: `${endBundleUrl - startBundleUrl}ms`, date: new Date().toISOString() })
   //  check signedURL and if it's url
   if ((!signedURL || (!(signedURL.startsWith('http://') || signedURL.startsWith('https://')))) && !manifest.length) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot get bundle signedURL', url: signedURL, id: app_id, date: new Date().toISOString() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot get bundle download URL', hasDownloadUrl: Boolean(signedURL), id: app_id, date: new Date().toISOString() })
     await sendStatsAndDevice(c, device, [{ action: 'cannotGetBundle', versionName: version.name }])
     return updateError200(c, 'no_bundle_url', 'Cannot get bundle url')
   }
@@ -459,7 +458,7 @@ export async function updateWithPG(
     createStatsVersion(c, version.name, app_id, 'get'),
     sendStatsAndDevice(c, device, [{ action: 'get', versionName: version.name }]),
   ])
-  cloudlog({ requestId: c.get('requestId'), message: 'New version available', app_id, version: version.name, signedURL, date: new Date().toISOString() })
+  cloudlog({ requestId: c.get('requestId'), message: 'New version available', app_id, version: version.name, hasDownloadUrl: Boolean(signedURL), manifestEntries: manifest.length, date: new Date().toISOString() })
   const res = resToVersion(plugin_version, signedURL, version as any, manifest, needsMetadata)
   if (!res.url && !res.manifest) {
     cloudlog({ requestId: c.get('requestId'), message: 'No url or manifest', id: app_id, version: version.name, date: new Date().toISOString() })

--- a/tests/download-url-logging.unit.test.ts
+++ b/tests/download-url-logging.unit.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { cloudlogMock, cloudlogErrMock, getSignedUrlMock } = vi.hoisted(() => ({
+  cloudlogMock: vi.fn(),
+  cloudlogErrMock: vi.fn(),
+  getSignedUrlMock: vi.fn(),
+}))
+
+vi.mock('hono/adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('hono/adapter')>()
+  return {
+    ...actual,
+    getRuntimeKey: () => 'node',
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: cloudlogErrMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/s3.ts', () => ({
+  s3: {
+    getSignedUrl: getSignedUrlMock,
+  },
+}))
+
+describe('download URL logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not write presigned bundle URLs to logs', async () => {
+    const signedUrl = 'https://storage.example/bundle.zip?X-Amz-Signature=secret-token'
+    getSignedUrlMock.mockResolvedValue(signedUrl)
+
+    const { getBundleUrl } = await import('../supabase/functions/_backend/utils/downloadUrl.ts')
+
+    const context = {
+      get: vi.fn(() => 'request-id'),
+      req: {
+        url: 'https://api.example/updates',
+        header: vi.fn(),
+      },
+    }
+
+    await expect(getBundleUrl(context as any, 'orgs/org-1/apps/app-1/bundle.zip', 'device-1', 'checksum-1')).resolves.toBe(signedUrl)
+
+    const downloadUrlLog = cloudlogMock.mock.calls[1]?.[0]
+    expect(downloadUrlLog).toHaveProperty('hasDownloadUrl', true)
+    expect(downloadUrlLog).toHaveProperty('source', 's3')
+
+    const loggedPayload = JSON.stringify(downloadUrlLog)
+    expect(loggedPayload).not.toContain(signedUrl)
+    expect(loggedPayload).not.toContain('secret-token')
+  })
+})


### PR DESCRIPTION
## Summary

- Stops backend logs from storing full presigned bundle/download URLs.
- Keeps the existing update response behavior unchanged while retaining non-sensitive log context.
- Adds a regression test to ensure presigned URL tokens are not written through `cloudlog`.

## Security note

This avoids exposing time-limited bundle access URLs in operational logs. The PR intentionally keeps the public description high level.

## Test plan

- [x] `.\node_modules\.bin\vitest.cmd run tests\download-url-logging.unit.test.ts`
- [x] `git diff --check`

/claim #1667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced logging security by preventing sensitive authentication credentials from being exposed in system logs while maintaining visibility into download URL operations.

* **Tests**
  * Added unit tests to verify secure logging behavior for download URL functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->