### PR TITLE
[codex] Hide active status from org members

### DIFF
--- a/src/pages/settings/organization/Members.vue
+++ b/src/pages/settings/organization/Members.vue
@@ -191,34 +191,21 @@ function getMemberRoleLabel(member: OrganizationMemberRow) {
   return member.role.replaceAll('_', ' ')
 }
 
-function getMemberStatusLabel(member: OrganizationMemberRow) {
-  return isInviteMember(member) ? t('sso-status-pending') : t('sso-status-active')
-}
-
-function getMemberStatusClasses(member: OrganizationMemberRow) {
-  if (isInviteMember(member)) {
-    return {
-      pill: 'border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-400/25 dark:bg-amber-500/8 dark:text-amber-200',
-      dot: 'bg-amber-400 dark:bg-amber-300',
-    }
-  }
-
-  return {
-    pill: 'border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-400/25 dark:bg-emerald-500/8 dark:text-emerald-200',
-    dot: 'bg-emerald-500 dark:bg-emerald-300',
-  }
-}
-
 function renderRoleCell(member: OrganizationMemberRow) {
-  const statusClasses = getMemberStatusClasses(member)
-
-  return h('div', { class: 'flex flex-wrap items-center gap-2 min-w-0 whitespace-normal' }, [
+  const content = [
     h('span', { class: 'truncate text-slate-700 dark:text-slate-200' }, getMemberRoleLabel(member)),
-    h('span', { class: `inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium rounded-full border shrink-0 ${statusClasses.pill}` }, [
-      h('span', { class: `w-1.5 h-1.5 rounded-full ${statusClasses.dot}` }),
-      h('span', getMemberStatusLabel(member)),
-    ]),
-  ])
+  ]
+
+  if (isInviteMember(member)) {
+    content.push(
+      h('div', { class: 'inline-flex items-center gap-1 rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[0.625rem] font-medium text-amber-700 shrink-0 dark:border-amber-400/25 dark:bg-amber-500/8 dark:text-amber-200' }, [
+        h('span', { class: 'size-1.5 rounded-full bg-amber-400 dark:bg-amber-300' }),
+        h('span', t('sso-status-pending')),
+      ]),
+    )
+  }
+
+  return h('div', { class: 'flex flex-wrap items-center gap-2 min-w-0 whitespace-normal' }, content)
 }
 
 async function checkRbacEnabled() {


### PR DESCRIPTION
## Summary (AI generated)

- Removed the Active badge from joined users in the organization members table.
- Kept the Pending badge for invite rows so invitations are still distinguishable.

## Motivation (AI generated)

The Active label on users who already joined the organization was misleading because it looked like a meaningful account state rather than normal membership.

## Business Impact (AI generated)

This reduces confusion for organization admins reviewing members and keeps the table focused on actionable states that require attention.

## Test Plan (AI generated)

- [x] bun lint
- [x] bun typecheck
- [x] commit hook typecheck passed
- [x] GitHub CI passed: Run tests, Run Playwright tests, CodeQL, SonarCloud, Socket, CodSpeed
- [x] Review expected UI behavior: navigate to Settings > Organization > Members; joined members should show only their role; invite rows should still show the Pending badge next to the role
- [x] No screenshot attached because this PR only changes conditional rendering for an existing table cell and CI Playwright coverage passed