### PR TITLE
feat(admin): store paid plan conversion total

### DIFF
--- a/scripts/backfill_org_conversion_rate_trend.ts
+++ b/scripts/backfill_org_conversion_rate_trend.ts
@@ -37,6 +37,7 @@ type GlobalStatsRow = Pick<
   | 'plan_solo_conversion_rate'
   | 'plan_team'
   | 'plan_team_conversion_rate'
+  | 'plan_total_conversion_rate'
 >
 type OrgCreatedAtRow = Pick<Database['public']['Tables']['orgs']['Row'], 'created_at'>
 
@@ -45,6 +46,7 @@ export interface PlanConversionRates {
   maker: number
   solo: number
   team: number
+  total: number
 }
 
 export interface OrgConversionRateBackfillRow {
@@ -94,11 +96,17 @@ export function calculateOrgConversionRate(paying: number | string | null | unde
 }
 
 function calculatePlanConversionRates(row: GlobalStatsRow, orgs: number): PlanConversionRates {
+  const total = toMetricNumber(row.plan_solo)
+    + toMetricNumber(row.plan_maker)
+    + toMetricNumber(row.plan_team)
+    + toMetricNumber(row.plan_enterprise)
+
   return {
     solo: calculateOrgConversionRate(row.plan_solo, orgs),
     maker: calculateOrgConversionRate(row.plan_maker, orgs),
     team: calculateOrgConversionRate(row.plan_team, orgs),
     enterprise: calculateOrgConversionRate(row.plan_enterprise, orgs),
+    total: calculateOrgConversionRate(total, orgs),
   }
 }
 
@@ -108,6 +116,7 @@ function getCurrentPlanConversionRates(row: GlobalStatsRow): PlanConversionRates
     maker: toMetricNumber(row.plan_maker_conversion_rate),
     team: toMetricNumber(row.plan_team_conversion_rate),
     enterprise: toMetricNumber(row.plan_enterprise_conversion_rate),
+    total: toMetricNumber(row.plan_total_conversion_rate),
   }
 }
 
@@ -120,6 +129,7 @@ function havePlanRatesChanged(currentRates: PlanConversionRates, nextRates: Plan
     || hasRateChanged(currentRates.maker, nextRates.maker)
     || hasRateChanged(currentRates.team, nextRates.team)
     || hasRateChanged(currentRates.enterprise, nextRates.enterprise)
+    || hasRateChanged(currentRates.total, nextRates.total)
 }
 
 function buildOrgCountsByDateId(dateIds: string[], orgRows: OrgCreatedAtRow[]) {
@@ -181,7 +191,8 @@ async function fetchGlobalStatsRows(supabase: SupabaseClient, fromDateId: string
         plan_solo_conversion_rate,
         plan_maker_conversion_rate,
         plan_team_conversion_rate,
-        plan_enterprise_conversion_rate
+        plan_enterprise_conversion_rate,
+        plan_total_conversion_rate
       `)
       .order('date_id', { ascending: true })
       .range(offset, offset + DEFAULT_PAGE_SIZE - 1)
@@ -240,6 +251,7 @@ async function updateConversionRate(supabase: SupabaseClient, row: OrgConversion
     .from('global_stats')
     .update({
       org_conversion_rate: row.next_rate,
+      plan_total_conversion_rate: row.next_plan_rates.total,
       plan_solo_conversion_rate: row.next_plan_rates.solo,
       plan_maker_conversion_rate: row.next_plan_rates.maker,
       plan_team_conversion_rate: row.next_plan_rates.team,
@@ -291,7 +303,7 @@ async function main(args = process.argv.slice(2), runtimeEnv: Record<string, str
   if (sampleRows.length > 0) {
     console.log('Sample updates:')
     for (const row of sampleRows) {
-      console.log(`${row.date_id}: total ${row.current_rate}% -> ${row.next_rate}% (${row.paying}/${row.orgs}); plans ${row.current_plan_rates.solo}/${row.current_plan_rates.maker}/${row.current_plan_rates.team}/${row.current_plan_rates.enterprise}% -> ${row.next_plan_rates.solo}/${row.next_plan_rates.maker}/${row.next_plan_rates.team}/${row.next_plan_rates.enterprise}%`)
+      console.log(`${row.date_id}: org ${row.current_rate}% -> ${row.next_rate}% (${row.paying}/${row.orgs}); paid plans ${row.current_plan_rates.total}% -> ${row.next_plan_rates.total}%; plans ${row.current_plan_rates.solo}/${row.current_plan_rates.maker}/${row.current_plan_rates.team}/${row.current_plan_rates.enterprise}% -> ${row.next_plan_rates.solo}/${row.next_plan_rates.maker}/${row.next_plan_rates.team}/${row.next_plan_rates.enterprise}%`)
     }
   }
 

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -33,6 +33,7 @@ const globalStatsTrendData = ref<Array<{
   users_active: number
   paying: number
   org_conversion_rate: number
+  plan_total_conversion_rate: number
   plan_solo_conversion_rate: number
   plan_maker_conversion_rate: number
   plan_team_conversion_rate: number
@@ -178,10 +179,10 @@ const planConversionSeries = computed(() => {
 
   return [
     {
-      label: 'Total Conversion (%)',
+      label: 'All Paid Plans (%)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
-        value: item.org_conversion_rate || 0,
+        value: item.plan_total_conversion_rate || 0,
       })),
       color: '#3b82f6', // blue
     },
@@ -697,7 +698,7 @@ displayStore.defaultBack = '/dashboard'
 
           <div class="grid grid-cols-1 gap-6">
             <ChartCard
-              title="Plan Conversion Rate"
+              title="Paid Plan Conversion Rate"
               :is-loading="isLoadingGlobalStatsTrend"
               :has-data="planConversionSeries.length > 0"
             >

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -67,6 +67,7 @@ interface PlanConversionRates {
   maker: number
   solo: number
   team: number
+  total: number
 }
 interface DailyRevenueChangeSummary {
   churnMrr: number
@@ -130,12 +131,17 @@ function calculateConversionRate(converted: number | null | undefined, totalOrgs
   return Number((((converted ?? 0) * 100) / totalOrgs).toFixed(1))
 }
 
+function getPaidPlanTotal(plans: PlanTotal) {
+  return (plans.Solo ?? 0) + (plans.Maker ?? 0) + (plans.Team ?? 0) + (plans.Enterprise ?? 0)
+}
+
 function getPlanConversionRates(plans: PlanTotal, totalOrgs: number): PlanConversionRates {
   return {
     solo: calculateConversionRate(plans.Solo, totalOrgs),
     maker: calculateConversionRate(plans.Maker, totalOrgs),
     team: calculateConversionRate(plans.Team, totalOrgs),
     enterprise: calculateConversionRate(plans.Enterprise, totalOrgs),
+    total: calculateConversionRate(getPaidPlanTotal(plans), totalOrgs),
   }
 }
 
@@ -1069,6 +1075,7 @@ app.post('/', middlewareAPISecret, async (c) => {
     stars,
     paying: customers.total,
     org_conversion_rate,
+    plan_total_conversion_rate: planConversionRates.total,
     plan_solo_conversion_rate: planConversionRates.solo,
     plan_maker_conversion_rate: planConversionRates.maker,
     plan_team_conversion_rate: planConversionRates.team,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1086,6 +1086,7 @@ export interface AdminGlobalStatsTrend {
   users_active: number
   paying: number
   org_conversion_rate: number
+  plan_total_conversion_rate: number
   plan_solo_conversion_rate: number
   plan_maker_conversion_rate: number
   plan_team_conversion_rate: number
@@ -1179,6 +1180,7 @@ export async function getAdminGlobalStatsTrend(
         users_active::int,
         paying::int,
         org_conversion_rate::float,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'plan_total_conversion_rate', '')::float, 0)::float AS plan_total_conversion_rate,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'plan_solo_conversion_rate', '')::float, 0)::float AS plan_solo_conversion_rate,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'plan_maker_conversion_rate', '')::float, 0)::float AS plan_maker_conversion_rate,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'plan_team_conversion_rate', '')::float, 0)::float AS plan_team_conversion_rate,
@@ -1289,6 +1291,7 @@ export async function getAdminGlobalStatsTrend(
       users_active: Number(row.users_active) || 0,
       paying: Number(row.paying) || 0,
       org_conversion_rate: Number(row.org_conversion_rate) || 0,
+      plan_total_conversion_rate: Number(row.plan_total_conversion_rate) || 0,
       plan_solo_conversion_rate: Number(row.plan_solo_conversion_rate) || 0,
       plan_maker_conversion_rate: Number(row.plan_maker_conversion_rate) || 0,
       plan_team_conversion_rate: Number(row.plan_team_conversion_rate) || 0,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1287,6 +1287,7 @@ export type Database = {
           plan_solo_yearly: number
           plan_team: number | null
           plan_team_conversion_rate: number
+          plan_total_conversion_rate: number
           plan_team_monthly: number
           plan_team_yearly: number
           plugin_major_breakdown: Json
@@ -1367,6 +1368,7 @@ export type Database = {
           plan_solo_yearly?: number
           plan_team?: number | null
           plan_team_conversion_rate?: number
+          plan_total_conversion_rate?: number
           plan_team_monthly?: number
           plan_team_yearly?: number
           plugin_major_breakdown?: Json
@@ -1447,6 +1449,7 @@ export type Database = {
           plan_solo_yearly?: number
           plan_team?: number | null
           plan_team_conversion_rate?: number
+          plan_total_conversion_rate?: number
           plan_team_monthly?: number
           plan_team_yearly?: number
           plugin_major_breakdown?: Json

--- a/supabase/migrations/20260510235542_add_plan_total_conversion_rate.sql
+++ b/supabase/migrations/20260510235542_add_plan_total_conversion_rate.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.global_stats
+ADD COLUMN IF NOT EXISTS plan_total_conversion_rate double precision DEFAULT 0 NOT NULL;
+
+COMMENT ON COLUMN public.global_stats.plan_total_conversion_rate IS 'Percentage of organizations converted to any paid plan ((plan_solo + plan_maker + plan_team + plan_enterprise) / orgs * 100)';

--- a/tests/admin-stripe-backfill-scripts.unit.test.ts
+++ b/tests/admin-stripe-backfill-scripts.unit.test.ts
@@ -25,6 +25,7 @@ describe('admin Stripe backfill scripts', () => {
         plan_solo_conversion_rate: 0,
         plan_team: 0,
         plan_team_conversion_rate: 0,
+        plan_total_conversion_rate: 0,
       },
       {
         date_id: '2026-04-02',
@@ -38,6 +39,7 @@ describe('admin Stripe backfill scripts', () => {
         plan_solo_conversion_rate: 15,
         plan_team: 0,
         plan_team_conversion_rate: 0,
+        plan_total_conversion_rate: 25,
       },
     ] as any, [
       ...Array.from({ length: 200 }, () => ({ created_at: '2026-04-01T12:00:00.000Z' })),
@@ -54,6 +56,7 @@ describe('admin Stripe backfill scripts', () => {
           maker: 0,
           solo: 0,
           team: 0,
+          total: 0,
         },
         current_rate: 0,
         next_plan_rates: {
@@ -61,6 +64,7 @@ describe('admin Stripe backfill scripts', () => {
           maker: 5,
           solo: 7.5,
           team: 0,
+          total: 12.5,
         },
         next_rate: 12.5,
         changed: true,
@@ -74,6 +78,7 @@ describe('admin Stripe backfill scripts', () => {
           maker: 10,
           solo: 15,
           team: 0,
+          total: 25,
         },
         current_rate: 25,
         next_plan_rates: {
@@ -81,6 +86,7 @@ describe('admin Stripe backfill scripts', () => {
           maker: 10,
           solo: 15,
           team: 0,
+          total: 25,
         },
         next_rate: 25,
         changed: false,
@@ -102,6 +108,7 @@ describe('admin Stripe backfill scripts', () => {
         plan_solo_conversion_rate: 15,
         plan_team: 0,
         plan_team_conversion_rate: 0,
+        plan_total_conversion_rate: 19.5,
       },
     ] as any, Array.from({ length: 200 }, () => ({ created_at: '2026-04-01T12:00:00.000Z' })))
 
@@ -115,6 +122,7 @@ describe('admin Stripe backfill scripts', () => {
           maker: 4.5,
           solo: 15,
           team: 0,
+          total: 19.5,
         },
         current_rate: 20,
         next_plan_rates: {
@@ -122,6 +130,7 @@ describe('admin Stripe backfill scripts', () => {
           maker: 5,
           solo: 15,
           team: 0,
+          total: 20,
         },
         next_rate: 20,
         changed: true,


### PR DESCRIPTION
## Summary (AI generated)

- Add a stored `plan_total_conversion_rate` metric to `global_stats`.
- Use that metric as the total line in the paid plan conversion chart, alongside Solo, Maker, Team, and Enterprise lines.
- Update the historical backfill script and focused unit coverage for the new total.

## Motivation (AI generated)

The admin dashboard needs a percentage conversion chart that shows total paid plan conversion and plan-by-plan conversion over time.

## Business Impact (AI generated)

This makes it easier to compare which paid plans convert best and whether total paid plan conversion is improving or degrading.

## Test Plan (AI generated)

- [x] `bunx eslint --no-ignore src/pages/admin/dashboard/revenue.vue supabase/functions/_backend/triggers/logsnag_insights.ts supabase/functions/_backend/utils/pg.ts scripts/backfill_org_conversion_rate_trend.ts tests/admin-stripe-backfill-scripts.unit.test.ts`
- [x] `bun test tests/admin-stripe-backfill-scripts.unit.test.ts`
- [x] `bun typecheck`
- [x] `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added overall paid plan conversion rate metric to track aggregate conversion across all paid plans.
  * Updated admin revenue dashboard to display "Paid Plan Conversion Rate" with aggregated conversion data.

* **Tests**
  * Enhanced test coverage for overall conversion rate calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->