### PR TITLE
fix: disable Drizzle query logging by default

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -373,8 +373,8 @@ export function getPgClient(c: Context, readOnly = false) {
   return pool
 }
 
-export function getDrizzleClient(db: ReturnType<typeof getPgClient>) {
-  return drizzle({ client: db, logger: true })
+export function getDrizzleClient(db: ReturnType<typeof getPgClient>, logger = false) {
+  return drizzle({ client: db, logger })
 }
 
 // Helper to extract detailed error information from pg errors


### PR DESCRIPTION
## Summary

- Disable Drizzle SQL query logging by default for shared backend DB clients.
- Keep query logging available as an explicit opt-in argument for focused debugging.
- Related public hardening thread: #1667.

## Motivation

The shared `getDrizzleClient` helper currently enables Drizzle logging for every backend caller. That can put SQL text and parameters into application logs across normal request paths. Query logging is useful for local debugging, but it should not be the default for production-facing shared clients.

## Business Impact

This reduces accidental sensitive-data exposure in logs with a very small runtime change. Existing callers keep using the same helper and can still opt into query logging when needed.

## Test Plan

- [x] `bunx eslint supabase/functions/_backend/utils/pg.ts`
- [x] `git diff --check`
- [x] GitHub checks: Run tests, Run Playwright tests, Socket Security, SonarCloud, CodSpeed

## Checklist

- [x] Kept the change scoped to the shared Drizzle client helper.
- [x] Preserved opt-in query logging for focused debugging.
- [x] Confirmed no migration or documentation update is required for this behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database logging configuration for backend operations, reducing verbosity by default while maintaining the ability to enable detailed logging when needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->