### PR TITLE
[codex] Fix admin global stats date joins

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1270,8 +1270,15 @@ export async function getAdminGlobalStatsTrend(
         COALESCE(NULLIF(to_jsonb(gs) ->> 'builder_active_paying_clients_60d', '')::int, 0)::int AS builder_active_paying_clients_60d,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'live_updates_active_paying_clients_60d', '')::int, 0)::int AS live_updates_active_paying_clients_60d
       FROM global_stats gs
-      LEFT JOIN global_stats prev ON prev.date_id = (gs.date_id::date - 1)::text
-      WHERE gs.date_id <= ${endDateOnly}
+      LEFT JOIN global_stats prev ON prev.date_id = (
+        CASE
+          WHEN gs.date_id ~ '^\\d{4}-\\d{2}-\\d{2}$'
+            THEN (gs.date_id::date - 1)::text
+          ELSE NULL
+        END
+      )
+      WHERE gs.date_id ~ '^\\d{4}-\\d{2}-\\d{2}$'
+        AND gs.date_id <= ${endDateOnly}
       )
       SELECT *
       FROM stats

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1272,12 +1272,20 @@ export async function getAdminGlobalStatsTrend(
       FROM global_stats gs
       LEFT JOIN global_stats prev ON prev.date_id = (
         CASE
-          WHEN gs.date_id ~ '^\\d{4}-\\d{2}-\\d{2}$'
-            THEN (gs.date_id::date - 1)::text
+          WHEN gs.date_id ~ '^\\d{4}-\\d{2}-\\d{2}$' THEN
+            CASE
+              WHEN to_char(to_date(gs.date_id, 'YYYY-MM-DD'), 'YYYY-MM-DD') = gs.date_id
+                THEN (to_date(gs.date_id, 'YYYY-MM-DD') - 1)::text
+              ELSE NULL
+            END
           ELSE NULL
         END
       )
-      WHERE gs.date_id ~ '^\\d{4}-\\d{2}-\\d{2}$'
+      WHERE CASE
+          WHEN gs.date_id ~ '^\\d{4}-\\d{2}-\\d{2}$'
+            THEN to_char(to_date(gs.date_id, 'YYYY-MM-DD'), 'YYYY-MM-DD') = gs.date_id
+          ELSE false
+        END
         AND gs.date_id <= ${endDateOnly}
       )
       SELECT *


### PR DESCRIPTION
## Summary (AI generated)

- Guard the admin global stats previous-day join so `date_id` is only cast when it matches `YYYY-MM-DD`.
- Filter malformed `global_stats.date_id` rows out of the trend query instead of letting one bad row empty the chart response.

## Motivation (AI generated)

Admin charts started returning `success: true` with an empty `global_stats_trend` dataset after the recent release added a `date_id::date` self-join. Because `date_id` is stored as text, any non-date historic row can make the query throw, and the helper catches that error by returning an empty array.

## Business Impact (AI generated)

Restores admin dashboard trend charts used to monitor platform health, revenue, usage, and conversion metrics without requiring a production data cleanup first.

## Test Plan (AI generated)

- [x] `bun test tests/admin-stats.unit.test.ts`
- [x] `bun lint`
- [x] `bun lint:backend`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed global statistics trending calculations to ensure only properly formatted dates are processed, improving data accuracy and preventing calculation errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->