### PR TITLE
fix(api): accept x-api-key in middlewareKey

### DIFF
--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -447,9 +447,10 @@ function resolveAuthHeaders(c: Context) {
 
 function resolveKeyHeaders(c: Context) {
   const capgkeyString = c.req.header('capgkey')
+  const xApiKeyString = c.req.header('x-api-key')
   const apikeyString = c.req.header('authorization')
-  const key = capgkeyString ?? apikeyString
-  return { capgkeyString, apikeyString, key }
+  const key = capgkeyString ?? xApiKeyString ?? apikeyString
+  return { capgkeyString, xApiKeyString, apikeyString, key }
 }
 
 async function resolveApiKey(
@@ -622,7 +623,7 @@ export function middlewareKey(rights: Database['public']['Enums']['key_mode'][],
       return simpleRateLimit({ reason: 'too_many_failed_auth_attempts', ...buildRateLimitInfo(ipRateLimited.resetAt) })
     }
 
-    const { capgkeyString, apikeyString, key } = resolveKeyHeaders(c)
+    const { capgkeyString, xApiKeyString, apikeyString, key } = resolveKeyHeaders(c)
     const subkey_id = await getSubkeyId(c)
 
     cloudlog({
@@ -631,6 +632,7 @@ export function middlewareKey(rights: Database['public']['Enums']['key_mode'][],
       method: c.req.method,
       url: c.req.url,
       hasCapgkey: !!capgkeyString,
+      hasXApiKey: !!xApiKeyString,
       hasAuthorization: !!apikeyString,
       hasKey: !!key,
       usePostgres,

--- a/tests/middleware-key-headers.unit.test.ts
+++ b/tests/middleware-key-headers.unit.test.ts
@@ -1,0 +1,107 @@
+import { Hono } from 'hono/tiny'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { middlewareKey } from '../supabase/functions/_backend/utils/hono_middleware.ts'
+
+const {
+  mockCheckKey,
+  mockCheckKeyById,
+  mockIsAPIKeyRateLimited,
+  mockIsIPRateLimited,
+  mockRecordAPIKeyUsage,
+  mockRecordFailedAuth,
+  mockSupabaseAdmin,
+} = vi.hoisted(() => ({
+  mockCheckKey: vi.fn(),
+  mockCheckKeyById: vi.fn(),
+  mockIsAPIKeyRateLimited: vi.fn(),
+  mockIsIPRateLimited: vi.fn(),
+  mockRecordAPIKeyUsage: vi.fn(),
+  mockRecordFailedAuth: vi.fn(),
+  mockSupabaseAdmin: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rate_limit.ts', () => ({
+  isAPIKeyRateLimited: mockIsAPIKeyRateLimited,
+  isIPRateLimited: mockIsIPRateLimited,
+  recordAPIKeyUsage: mockRecordAPIKeyUsage,
+  recordFailedAuth: mockRecordFailedAuth,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  checkKey: mockCheckKey,
+  checkKeyById: mockCheckKeyById,
+  supabaseAdmin: mockSupabaseAdmin,
+}))
+
+const fakeApikey = {
+  id: 123,
+  user_id: 'user-test',
+  key: 'stored-key',
+  key_hash: null,
+  mode: 'all',
+  name: 'unit-test-key',
+  limited_to_orgs: [],
+  limited_to_apps: [],
+  expires_at: null,
+}
+
+function createApp() {
+  const app = new Hono()
+  app.get('/protected', middlewareKey(['all']), (c) => {
+    const auth = c.get('auth') as { authType: string, userId: string }
+    return c.json({
+      authType: auth.authType,
+      capgkey: c.get('capgkey'),
+      userId: auth.userId,
+    })
+  })
+  return app
+}
+
+describe('middlewareKey header resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsIPRateLimited.mockResolvedValue({ limited: false })
+    mockIsAPIKeyRateLimited.mockResolvedValue({ limited: false })
+    mockRecordAPIKeyUsage.mockResolvedValue(undefined)
+    mockRecordFailedAuth.mockResolvedValue(undefined)
+    mockSupabaseAdmin.mockReturnValue({})
+    mockCheckKey.mockResolvedValue(fakeApikey)
+    mockCheckKeyById.mockResolvedValue(null)
+  })
+
+  it('accepts x-api-key as an API key header', async () => {
+    const response = await createApp().request(new Request('http://localhost/protected', {
+      headers: {
+        'x-api-key': 'x-api-key-value',
+      },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockCheckKey).toHaveBeenCalledWith(expect.anything(), 'x-api-key-value', expect.anything(), ['all'])
+    await expect(response.json()).resolves.toEqual({
+      authType: 'apikey',
+      capgkey: 'x-api-key-value',
+      userId: 'user-test',
+    })
+  })
+
+  it('keeps capgkey precedence over x-api-key for legacy clients', async () => {
+    const response = await createApp().request(new Request('http://localhost/protected', {
+      headers: {
+        'capgkey': 'legacy-key-value',
+        'x-api-key': 'x-api-key-value',
+      },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockCheckKey).toHaveBeenCalledWith(expect.anything(), 'legacy-key-value', expect.anything(), ['all'])
+    await expect(response.json()).resolves.toMatchObject({
+      capgkey: 'legacy-key-value',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- make middlewareKey resolve API keys from `x-api-key`, matching middlewareV2, CORS, and the documented new public API header
- keep the existing header precedence for legacy `capgkey` clients
- add a focused unit test for `x-api-key` auth context propagation and legacy precedence

Related to #1667.

## Tests
- `./node_modules/.bin/vitest run tests/middleware-key-headers.unit.test.ts`
- `./node_modules/.bin/eslint supabase/functions/_backend/utils/hono_middleware.ts tests/middleware-key-headers.unit.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API authentication now accepts the `x-api-key` header alongside existing `capgkey` and `authorization` headers. Legacy `capgkey` retains priority for backward compatibility when multiple headers are present.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->