### PR TITLE
fix: avoid logging full client config fallback

### DIFF
--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -57,7 +57,7 @@ export async function getRemoteConfig() {
   try {
     const response = await fetch(`${defaultApiHost}/private/config`)
     if (!response.ok) {
-      console.log('Local config', localConfig)
+      console.log('Using local config fallback', { status: response.status })
       stripeEnabled.value = localConfig.stripeEnabled ?? stripeEnabled.value
       return localConfig as CapgoConfig
     }
@@ -68,7 +68,7 @@ export async function getRemoteConfig() {
     return merged
   }
   catch {
-    console.log('Local config', localConfig)
+    console.log('Using local config fallback')
     stripeEnabled.value = localConfig.stripeEnabled ?? stripeEnabled.value
     return localConfig as CapgoConfig
   }


### PR DESCRIPTION
## Summary

- Stop printing the full local client config object when remote config fetch falls back.
- Keep fallback behavior unchanged and retain enough status context for debugging.
- Related public hardening thread: #1667.

## Motivation

The fallback path currently logs the whole local config object in the browser console. That object includes deployment configuration such as the Supabase URL and anon key. The anon key is intended for client use, but printing the full config is unnecessary and makes logs noisier than needed.

## Test Plan

- [x] `bunx eslint src/services/supabase.ts`
- [x] `git diff --check`

## Checklist

- [x] Behavior unchanged: local config is still used on failed remote config fetch.
- [x] Fallback logs no longer include the full config object.
- [x] Change kept scoped to client config fallback logging.

/claim #1667