### PR TITLE
fix: redact private endpoint log payloads

### DIFF
--- a/supabase/functions/_backend/private/invite_new_user_to_org.ts
+++ b/supabase/functions/_backend/private/invite_new_user_to_org.ts
@@ -85,7 +85,13 @@ async function validateInvite(c: Context, rawBody: any) {
   }
 
   const body = validationResult.data
-  cloudlog({ requestId: c.get('requestId'), context: 'invite_new_user_to_org validated body', body })
+  cloudlog({
+    requestId: c.get('requestId'),
+    context: 'invite_new_user_to_org validated body',
+    orgId: body.org_id,
+    inviteType: body.invite_type,
+    hasCaptchaToken: Boolean(body.captcha_token),
+  })
 
   const authorization = c.get('authorization')
   if (!authorization)

--- a/supabase/functions/_backend/private/invite_new_user_to_org.ts
+++ b/supabase/functions/_backend/private/invite_new_user_to_org.ts
@@ -161,7 +161,7 @@ async function validateInvite(c: Context, rawBody: any) {
 
 app.post('/', middlewareAuth, async (c) => {
   const rawBody = await parseBody<any>(c)
-  cloudlog({ requestId: c.get('requestId'), context: 'invite_new_user_to_org raw body', rawBody })
+  cloudlog({ requestId: c.get('requestId'), context: 'invite_new_user_to_org request' })
 
   const res = await validateInvite(c, rawBody)
   if (!res.inviteCreatorUser) {

--- a/supabase/functions/_backend/private/stripe_checkout.ts
+++ b/supabase/functions/_backend/private/stripe_checkout.ts
@@ -23,7 +23,14 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<CheckoutData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout body', body })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'post stripe checkout body',
+    orgId: body.orgId,
+    recurrence: body.recurrence,
+    hasClientReferenceId: Boolean(body.clientReferenceId),
+    hasAttributionId: Boolean(body.attributionId),
+  })
 
   if (!body.orgId)
     throw simpleError('no_org_id_provided', 'No org_id provided')
@@ -54,7 +61,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
     throw simpleError('not_authorize', 'Not authorize')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'user', org })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe checkout org loaded', orgId: body.orgId, hasCustomerId: Boolean(org.customer_id) })
   const checkout = await createCheckout(c, org.customer_id, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId)
   return c.json({ url: checkout.url })
 })

--- a/supabase/functions/_backend/private/stripe_portal.ts
+++ b/supabase/functions/_backend/private/stripe_portal.ts
@@ -17,7 +17,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<PortalData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal request' })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('not_authorized', 'Not authorized')
@@ -44,7 +44,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
     throw simpleError('not_authorize', 'Not authorize')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'org', org })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe portal org loaded', hasCustomer: Boolean(org.customer_id) })
   const link = await createPortal(c, org.customer_id, body.callbackUrl)
   return c.json({ url: link.url })
 })

--- a/supabase/functions/_backend/private/upload_link.ts
+++ b/supabase/functions/_backend/private/upload_link.ts
@@ -19,7 +19,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
   const body = await parseBody<DataUpload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post upload link body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post upload link request' })
   const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
   const capgkey = c.get('capgkey') as string
   cloudlog({


### PR DESCRIPTION
## Summary
- stop logging full request bodies for private Stripe portal, upload-link, and invite endpoints
- keep metadata-only diagnostics for request tracing
- avoid recording Stripe customer rows in routine logs

## Motivation
This is a small public hardening follow-up for #1667. These endpoints are authenticated/private and the existing logs included request payloads or customer row data that are not needed for normal debugging.

## Business Impact
- Lowers accidental sensitive-data exposure in logs
- Keeps behavior and API responses unchanged
- Preserves enough log signal for request tracing

## Test Plan
- `bunx eslint supabase/functions/_backend/private/stripe_portal.ts supabase/functions/_backend/private/upload_link.ts supabase/functions/_backend/private/invite_new_user_to_org.ts`
- `git diff --check`

## Checklist
- [x] No behavioral/API contract changes
- [x] Focused security hardening
- [x] Local lint passes