### PR TITLE
fix: stop logging Stripe session links

### DIFF
--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -28,7 +28,6 @@ async function presentActionSheetOpen(url: string) {
   return dialogStore.onDialogDismiss()
 }
 export function openBlank(link: string) {
-  console.log('openBlank', link)
   if (Capacitor.getPlatform() === 'ios')
     presentActionSheetOpen(link)
   else


### PR DESCRIPTION
## Summary

- Stop printing Stripe checkout and billing portal session links in the browser console.
- Keep the existing iOS confirmation dialog and new-tab behavior unchanged.
- Related public hardening thread: #1667.

## Motivation

`openBlank()` is used for Stripe portal and checkout URLs returned by private billing endpoints. Those session links are generated for a specific billing action, so routine client logs should not retain the full URL before opening it.

## Test Plan

- [x] `git diff --check`
- [ ] `bunx eslint src/services/stripe.ts` (not run locally: `bunx` is not installed in this environment)

## Checklist

- [x] Change kept scoped to one debug log removal.
- [x] Billing portal and checkout navigation behavior unchanged.
- [x] No private technical details included.

/claim #1667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary debug logging from Stripe utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->