### PR TITLE
Block deleted bundle reads from cache

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -363,8 +363,15 @@ async function assertReadableAppScopedAttachment(c: Context, fileId: unknown): P
         FROM public.app_versions
         WHERE owner_org = $1
           AND app_id = $2
-          AND r2_path = $3
-          AND COALESCE(deleted, false) = true
+          AND deleted = true
+          AND (
+            r2_path = $3
+            OR EXISTS (
+              SELECT 1
+              FROM unnest(manifest) AS manifest_entry
+              WHERE manifest_entry.s3_path = $3
+            )
+          )
         LIMIT 1
       `,
       [scopedPath.owner_org, scopedPath.app_id, fileId],

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -356,6 +356,23 @@ async function assertReadableAppScopedAttachment(c: Context, fileId: unknown): P
     if (!app || app.owner_org !== scopedPath.owner_org) {
       quickError(404, 'not_found', 'Not found')
     }
+
+    const deletedBundlePath = await pgClient.query<{ id: number }>(
+      `
+        SELECT id
+        FROM public.app_versions
+        WHERE owner_org = $1
+          AND app_id = $2
+          AND r2_path = $3
+          AND COALESCE(deleted, false) = true
+        LIMIT 1
+      `,
+      [scopedPath.owner_org, scopedPath.app_id, fileId],
+    )
+
+    if (deletedBundlePath.rows.length > 0) {
+      quickError(404, 'not_found', 'Not found')
+    }
   }
   finally {
     await closeClient(c, pgClient)

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -368,8 +368,9 @@ async function assertReadableAppScopedAttachment(c: Context, fileId: unknown): P
             r2_path = $3
             OR EXISTS (
               SELECT 1
-              FROM unnest(manifest) AS manifest_entry
-              WHERE manifest_entry.s3_path = $3
+              FROM public.manifest m
+              WHERE m.app_version_id = public.app_versions.id
+                AND m.s3_path = $3
             )
           )
         LIMIT 1

--- a/supabase/functions/_backend/private/download_link.ts
+++ b/supabase/functions/_backend/private/download_link.ts
@@ -44,6 +44,7 @@ app.post('/', middlewareAuth, async (c) => {
     .select('*, owner_org ( created_by )')
     .eq('app_id', body.app_id)
     .eq('id', body.id)
+    .eq('deleted', false)
     .single()
 
   const ownerOrg = bundle?.owner_org.created_by

--- a/supabase/migrations/20260511012637_add_app_versions_deleted_r2_path_index.sql
+++ b/supabase/migrations/20260511012637_add_app_versions_deleted_r2_path_index.sql
@@ -1,3 +1,6 @@
 CREATE INDEX IF NOT EXISTS "idx_app_versions_deleted_r2_path"
 ON "public"."app_versions" USING "btree" ("owner_org", "app_id", "r2_path")
 WHERE ("deleted" = true);
+
+CREATE INDEX IF NOT EXISTS "idx_manifest_app_version_id_s3_path"
+ON "public"."manifest" USING "btree" ("app_version_id", "s3_path");

--- a/supabase/migrations/20260511012637_add_app_versions_deleted_r2_path_index.sql
+++ b/supabase/migrations/20260511012637_add_app_versions_deleted_r2_path_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "idx_app_versions_deleted_r2_path"
+ON "public"."app_versions" USING "btree" ("owner_org", "app_id", "r2_path")
+WHERE ("deleted" = true);

--- a/tests/download-link-deleted-bundle.unit.test.ts
+++ b/tests/download-link-deleted-bundle.unit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAllCatch, createHono } from '../supabase/functions/_backend/utils/hono.ts'
+import { version } from '../supabase/functions/_backend/utils/version.ts'
+
+const eqMock = vi.fn()
+const singleMock = vi.fn()
+const getBundleUrlMock = vi.fn()
+
+vi.mock('../supabase/functions/_backend/utils/discord.ts', () => ({
+  sendDiscordAlert500: () => Promise.resolve(),
+  sendDiscordAlert: () => Promise.resolve(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/downloadUrl.ts', () => ({
+  getBundleUrl: getBundleUrlMock,
+  getManifestUrl: vi.fn(() => []),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: vi.fn(() => Promise.resolve(true)),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: eqMock,
+      })),
+    })),
+  })),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../supabase/functions/_backend/utils/hono.ts')>()
+  return {
+    ...actual,
+    middlewareAuth: async (c: any, next: () => Promise<void>) => {
+      c.set('authorization', 'Bearer test-token')
+      c.set('auth', { userId: 'test-user' })
+      await next()
+    },
+    useCors: async (_c: any, next: () => Promise<void>) => {
+      await next()
+    },
+  }
+})
+
+describe('private download_link deleted bundle guard', () => {
+  it('filters deleted bundles before creating download URLs', async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    const query = {
+      eq: eqMock,
+      single: singleMock,
+    }
+    eqMock.mockReturnValue(query)
+    singleMock.mockResolvedValue({
+      data: null,
+      error: { message: 'no rows' },
+    })
+
+    const { app: downloadLink } = await import('../supabase/functions/_backend/private/download_link.ts')
+    const appGlobal = createHono('private', version)
+    appGlobal.route('/download_link', downloadLink)
+    createAllCatch(appGlobal, 'private')
+
+    const response = await appGlobal.fetch(
+      new Request('http://localhost/download_link', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          app_id: 'test-app',
+          id: 123,
+          storage_provider: 'r2',
+        }),
+      }),
+    )
+
+    const body = await response.json() as { error: string }
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('cannot_get_bundle')
+    expect(eqMock).toHaveBeenCalledWith('deleted', false)
+    expect(getBundleUrlMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/download-link-deleted-bundle.unit.test.ts
+++ b/tests/download-link-deleted-bundle.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAllCatch, createHono } from '../supabase/functions/_backend/utils/hono.ts'
 import { version } from '../supabase/functions/_backend/utils/version.ts'
 
@@ -46,10 +46,11 @@ vi.mock('../supabase/functions/_backend/utils/hono.ts', async (importOriginal) =
 })
 
 describe('private download_link deleted bundle guard', () => {
-  it('filters deleted bundles before creating download URLs', async () => {
-    vi.resetModules()
+  beforeEach(() => {
     vi.clearAllMocks()
+  })
 
+  it('filters deleted bundles before creating download URLs', async () => {
     const query = {
       eq: eqMock,
       single: singleMock,

--- a/tests/files-app-read-guard.unit.test.ts
+++ b/tests/files-app-read-guard.unit.test.ts
@@ -149,6 +149,47 @@ describe('files app-scoped read guard', () => {
     expect(bucketPut).not.toHaveBeenCalled()
   })
 
+  it('returns 404 for soft-deleted manifest asset paths before serving cached content', async () => {
+    getAppByAppIdPgMock.mockResolvedValue({ app_id: 'test-app', owner_org: 'test-org' })
+    pgClientMock.query.mockResolvedValue({ rows: [{ id: 123 }] })
+
+    const bucketPut = vi.fn()
+    globalThis.caches = {
+      default: {
+        match: async () => new Response('cached deleted manifest bytes', {
+          headers: {
+            'content-type': 'text/javascript',
+          },
+        }),
+        put: async () => { },
+      },
+    } as any
+
+    const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+    const { createAllCatch, createHono } = await import('../supabase/functions/_backend/utils/hono.ts')
+    const { version } = await import('../supabase/functions/_backend/utils/version.ts')
+
+    const appGlobal = createHono('files', version)
+    appGlobal.route('/', files)
+    createAllCatch(appGlobal, 'files')
+
+    const filePath = 'orgs/test-org/apps/test-app/assets/main.js'
+    const response = await appGlobal.fetch(
+      new Request(new URL(filePath, 'http://localhost/read/attachments/')),
+      {
+        ATTACHMENT_BUCKET: { put: bucketPut },
+      },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(404)
+    expect(pgClientMock.query).toHaveBeenCalledWith(
+      expect.stringContaining('unnest(manifest)'),
+      ['test-org', 'test-app', filePath],
+    )
+    expect(bucketPut).not.toHaveBeenCalled()
+  })
+
   it('serves cached content for non-deleted bundle paths', async () => {
     getAppByAppIdPgMock.mockResolvedValue({ app_id: 'test-app', owner_org: 'test-org' })
     pgClientMock.query.mockResolvedValue({ rows: [] })

--- a/tests/files-app-read-guard.unit.test.ts
+++ b/tests/files-app-read-guard.unit.test.ts
@@ -149,7 +149,7 @@ describe('files app-scoped read guard', () => {
     expect(bucketPut).not.toHaveBeenCalled()
   })
 
-  it('returns 404 for soft-deleted manifest asset paths before serving cached content', async () => {
+  it('returns 404 for soft-deleted persisted manifest asset paths before serving cached content', async () => {
     getAppByAppIdPgMock.mockResolvedValue({ app_id: 'test-app', owner_org: 'test-org' })
     pgClientMock.query.mockResolvedValue({ rows: [{ id: 123 }] })
 
@@ -184,9 +184,10 @@ describe('files app-scoped read guard', () => {
 
     expect(response.status).toBe(404)
     expect(pgClientMock.query).toHaveBeenCalledWith(
-      expect.stringContaining('unnest(manifest)'),
+      expect.stringContaining('FROM public.manifest'),
       ['test-org', 'test-app', filePath],
     )
+    expect(pgClientMock.query.mock.calls[0]?.[0]).not.toContain('unnest(manifest)')
     expect(bucketPut).not.toHaveBeenCalled()
   })
 

--- a/tests/files-app-read-guard.unit.test.ts
+++ b/tests/files-app-read-guard.unit.test.ts
@@ -148,4 +148,46 @@ describe('files app-scoped read guard', () => {
     )
     expect(bucketPut).not.toHaveBeenCalled()
   })
+
+  it('serves cached content for non-deleted bundle paths', async () => {
+    getAppByAppIdPgMock.mockResolvedValue({ app_id: 'test-app', owner_org: 'test-org' })
+    pgClientMock.query.mockResolvedValue({ rows: [] })
+
+    const bucketPut = vi.fn()
+    globalThis.caches = {
+      default: {
+        match: async () => new Response('cached bundle bytes', {
+          headers: {
+            'content-type': 'application/zip',
+          },
+        }),
+        put: async () => { },
+      },
+    } as any
+
+    const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+    const { createAllCatch, createHono } = await import('../supabase/functions/_backend/utils/hono.ts')
+    const { version } = await import('../supabase/functions/_backend/utils/version.ts')
+
+    const appGlobal = createHono('files', version)
+    appGlobal.route('/', files)
+    createAllCatch(appGlobal, 'files')
+
+    const filePath = 'orgs/test-org/apps/test-app/1.0.0.zip'
+    const response = await appGlobal.fetch(
+      new Request(`http://localhost/read/attachments/${filePath}`),
+      {
+        ATTACHMENT_BUCKET: { put: bucketPut },
+      },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('cached bundle bytes')
+    expect(pgClientMock.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM public.app_versions'),
+      ['test-org', 'test-app', filePath],
+    )
+    expect(bucketPut).not.toHaveBeenCalled()
+  })
 })

--- a/tests/files-app-read-guard.unit.test.ts
+++ b/tests/files-app-read-guard.unit.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getAppByAppIdPgMock = vi.fn()
-const getPgClientMock = vi.fn(() => ({}))
+const pgClientMock = {
+  query: vi.fn(),
+}
+const getPgClientMock = vi.fn(() => pgClientMock)
 
 vi.mock('hono/adapter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('hono/adapter')>()
@@ -32,6 +35,7 @@ describe('files app-scoped read guard', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    pgClientMock.query.mockResolvedValue({ rows: [] })
   })
 
   it('returns 404 for deleted app-scoped files before serving cached content', async () => {
@@ -102,5 +106,46 @@ describe('files app-scoped read guard', () => {
     expect(response.status).toBe(404)
     expect(bucketPut).not.toHaveBeenCalled()
     expect(getAppByAppIdPgMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 for soft-deleted bundle paths before serving cached content', async () => {
+    getAppByAppIdPgMock.mockResolvedValue({ app_id: 'test-app', owner_org: 'test-org' })
+    pgClientMock.query.mockResolvedValue({ rows: [{ id: 123 }] })
+
+    const bucketPut = vi.fn()
+    globalThis.caches = {
+      default: {
+        match: async () => new Response('cached deleted bundle bytes', {
+          headers: {
+            'content-type': 'application/zip',
+          },
+        }),
+        put: async () => { },
+      },
+    } as any
+
+    const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+    const { createAllCatch, createHono } = await import('../supabase/functions/_backend/utils/hono.ts')
+    const { version } = await import('../supabase/functions/_backend/utils/version.ts')
+
+    const appGlobal = createHono('files', version)
+    appGlobal.route('/', files)
+    createAllCatch(appGlobal, 'files')
+
+    const filePath = 'orgs/test-org/apps/test-app/1.0.0.zip'
+    const response = await appGlobal.fetch(
+      new Request(`http://localhost/read/attachments/${filePath}`),
+      {
+        ATTACHMENT_BUCKET: { put: bucketPut },
+      },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(404)
+    expect(pgClientMock.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM public.app_versions'),
+      ['test-org', 'test-app', filePath],
+    )
+    expect(bucketPut).not.toHaveBeenCalled()
   })
 })

--- a/tests/files-local-read-proxy.unit.test.ts
+++ b/tests/files-local-read-proxy.unit.test.ts
@@ -2,7 +2,10 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const createSignedUrlMock = vi.fn()
 const getAppByAppIdPgMock = vi.fn()
-const getPgClientMock = vi.fn(() => ({}))
+const pgClientMock = {
+  query: vi.fn(),
+}
+const getPgClientMock = vi.fn(() => pgClientMock)
 const storageFromMock = vi.fn(() => ({
   createSignedUrl: createSignedUrlMock,
 }))
@@ -46,6 +49,7 @@ describe('files local read proxy', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    pgClientMock.query.mockResolvedValue({ rows: [] })
     globalThis.fetch = originalFetch
   })
 


### PR DESCRIPTION
## Summary

- Block app-scoped attachment reads when the requested path matches a soft-deleted `app_versions.r2_path` or a persisted manifest asset path.
- Run the deleted-bundle check before cache reads and cache-to-R2 restore logic.
- Keep private download links from resolving deleted bundles.
- Add indexes for deleted bundle path lookups and persisted manifest path lookups.
- Add regression coverage for deleted bundle paths, persisted manifest asset paths, and non-deleted cached bundle reads.

/claim #1667

## Test plan

- [x] GitHub CI passed on head `0374e6c`.
- [x] `bunx vitest run tests/files-app-read-guard.unit.test.ts`
- [x] `bunx vitest run tests/files-app-read-guard.unit.test.ts tests/files-local-read-proxy.unit.test.ts tests/download-link-deleted-bundle.unit.test.ts`
- [x] `bunx eslint supabase/functions/_backend/files/files.ts supabase/functions/_backend/private/download_link.ts tests/files-app-read-guard.unit.test.ts tests/files-local-read-proxy.unit.test.ts tests/download-link-deleted-bundle.unit.test.ts`
- [x] `git diff --check`

## Screenshots

Not applicable; backend-only change.

## Checklist

- [x] My code follows the code style of this project and passes the targeted lint checks listed above.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests.