### PR TITLE
fix: redact Stripe customer log metadata

### DIFF
--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -708,7 +708,14 @@ export interface StripeCustomer {
 }
 
 export async function createCustomer(c: Context, email: string, userId: string, orgId: string, name: string) {
-  cloudlog({ requestId: c.get('requestId'), message: 'createCustomer', email, userId, orgId, name })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'createCustomer',
+    userId,
+    orgId,
+    hasEmail: Boolean(email),
+    hasName: Boolean(name),
+  })
   const baseConsoleUrl = (getEnv(c, 'WEBAPP_URL') || '').replace(TRAILING_SLASHES_REGEX, '')
   const metadata: Record<string, string> = {
     user_id: userId,
@@ -718,7 +725,14 @@ export async function createCustomer(c: Context, email: string, userId: string, 
     metadata.log_as = `${baseConsoleUrl}/log-as/${userId}`
   }
   if (!isStripeConfigured(c)) {
-    cloudlog({ requestId: c.get('requestId'), message: 'createCustomer no stripe key', email, userId, name })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'createCustomer no stripe key',
+      userId,
+      orgId,
+      hasEmail: Boolean(email),
+      hasName: Boolean(name),
+    })
     // create a fake customer id like stripe one and random id
     const randomId = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
     return { id: `cus_${randomId}`, email, name, metadata }

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -707,14 +707,34 @@ export interface StripeCustomer {
   }
 }
 
+export function getCreateCustomerLogMetadata(email: string, userId: string, orgId: string, name: string) {
+  return {
+    hasUserId: Boolean(userId),
+    hasOrgId: Boolean(orgId),
+    hasEmail: Boolean(email),
+    hasName: Boolean(name),
+  }
+}
+
+export function getCreateStripeCustomerInfoLogMetadata(
+  orgId: string | null | undefined,
+  selectedPlan: { id?: number | string | null, name?: string | null, stripe_id?: string | null },
+  customerId: string | null | undefined,
+) {
+  return {
+    planName: selectedPlan.name,
+    hasPlanId: Boolean(selectedPlan.id),
+    hasStripeProductId: Boolean(selectedPlan.stripe_id),
+    hasCustomerId: Boolean(customerId),
+    hasOrgId: Boolean(orgId),
+  }
+}
+
 export async function createCustomer(c: Context, email: string, userId: string, orgId: string, name: string) {
   cloudlog({
     requestId: c.get('requestId'),
     message: 'createCustomer',
-    userId,
-    orgId,
-    hasEmail: Boolean(email),
-    hasName: Boolean(name),
+    ...getCreateCustomerLogMetadata(email, userId, orgId, name),
   })
   const baseConsoleUrl = (getEnv(c, 'WEBAPP_URL') || '').replace(TRAILING_SLASHES_REGEX, '')
   const metadata: Record<string, string> = {
@@ -728,10 +748,7 @@ export async function createCustomer(c: Context, email: string, userId: string, 
     cloudlog({
       requestId: c.get('requestId'),
       message: 'createCustomer no stripe key',
-      userId,
-      orgId,
-      hasEmail: Boolean(email),
-      hasName: Boolean(name),
+      ...getCreateCustomerLogMetadata(email, userId, orgId, name),
     })
     // create a fake customer id like stripe one and random id
     const randomId = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -960,7 +960,15 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
     cloudlog({ requestId: c.get('requestId'), message: 'no default plan' })
     throw new Error('no default plan')
   }
-  cloudlog({ requestId: c.get('requestId'), message: 'createInfo', plan: selectedPlan, customer })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'createInfo',
+    planName: selectedPlan.name,
+    planId: selectedPlan.id,
+    stripeProductId: selectedPlan.stripe_id,
+    hasCustomerId: Boolean(customer.id),
+    orgId: org.id,
+  })
   const { error: createInfoError } = await supabaseAdmin(c)
     .from('stripe_info')
     .insert({

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -7,7 +7,7 @@ import { createClient } from '@supabase/supabase-js'
 import { buildNormalizedDeviceForWrite, hasComparableDeviceChanged, nullableString } from './deviceComparison.ts'
 import { simpleError } from './hono.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
-import { createCustomer } from './stripe.ts'
+import { createCustomer, getCreateStripeCustomerInfoLogMetadata } from './stripe.ts'
 import { Constants } from './supabase.types.ts'
 import { getEnv, isStripeConfigured } from './utils.ts'
 
@@ -963,11 +963,7 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
   cloudlog({
     requestId: c.get('requestId'),
     message: 'createInfo',
-    planName: selectedPlan.name,
-    planId: selectedPlan.id,
-    stripeProductId: selectedPlan.stripe_id,
-    hasCustomerId: Boolean(customer.id),
-    orgId: org.id,
+    ...getCreateStripeCustomerInfoLogMetadata(org.id, selectedPlan, customer.id),
   })
   const { error: createInfoError } = await supabaseAdmin(c)
     .from('stripe_info')

--- a/tests/stripe-customer-log-redaction.unit.test.ts
+++ b/tests/stripe-customer-log-redaction.unit.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getCreateCustomerLogMetadata, getCreateStripeCustomerInfoLogMetadata } from '../supabase/functions/_backend/utils/stripe.ts'
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin: vi.fn(),
+}))
+
+describe('stripe customer log redaction', () => {
+  it.concurrent('keeps customer creation cloudlog payloads free of durable identifiers', () => {
+    const identifiers = {
+      customerId: 'cus_secret_customer_123',
+      email: 'billing-owner@example.com',
+      name: 'Secret Billing Org',
+      orgId: 'org_secret_456',
+      planId: 123,
+      productId: 'prod_secret_product_789',
+      userId: 'user_secret_abc',
+    }
+
+    const payloads = [
+      {
+        requestId: 'request-id',
+        message: 'createCustomer',
+        ...getCreateCustomerLogMetadata(identifiers.email, identifiers.userId, identifiers.orgId, identifiers.name),
+      },
+      {
+        requestId: 'request-id',
+        message: 'createCustomer no stripe key',
+        ...getCreateCustomerLogMetadata(identifiers.email, identifiers.userId, identifiers.orgId, identifiers.name),
+      },
+      {
+        requestId: 'request-id',
+        message: 'createInfo',
+        ...getCreateStripeCustomerInfoLogMetadata(
+          identifiers.orgId,
+          {
+            id: identifiers.planId,
+            name: 'Solo',
+            stripe_id: identifiers.productId,
+          },
+          identifiers.customerId,
+        ),
+      },
+    ]
+
+    expect(payloads[0]).toMatchObject({
+      hasEmail: true,
+      hasName: true,
+      hasOrgId: true,
+      hasUserId: true,
+    })
+    expect(payloads[1]).toMatchObject({
+      hasEmail: true,
+      hasName: true,
+      hasOrgId: true,
+      hasUserId: true,
+    })
+    expect(payloads[2]).toMatchObject({
+      hasCustomerId: true,
+      hasOrgId: true,
+      hasPlanId: true,
+      hasStripeProductId: true,
+      planName: 'Solo',
+    })
+
+    const serializedPayloads = JSON.stringify(payloads)
+
+    expect(serializedPayloads).not.toContain(identifiers.customerId)
+    expect(serializedPayloads).not.toContain(identifiers.email)
+    expect(serializedPayloads).not.toContain(identifiers.name)
+    expect(serializedPayloads).not.toContain(identifiers.orgId)
+    expect(serializedPayloads).not.toContain(String(identifiers.planId))
+    expect(serializedPayloads).not.toContain(identifiers.productId)
+    expect(serializedPayloads).not.toContain(identifiers.userId)
+  })
+})


### PR DESCRIPTION
## Summary

- stop logging raw customer email/name values during Stripe customer creation
- replace the full Stripe customer object in the stripe_info creation log with metadata-only fields
- keep Stripe customer creation, pending-customer fallback, and stripe_info writes unchanged

## Security rationale

This is a small public hardening follow-up for #1667. The existing logs include billing identity data (`email`, `name`) and the full Stripe customer object when creating org billing records. Those values are not needed for routine request tracing and can be reduced to presence flags and stable internal IDs.

## Test plan

- `git diff --check`

Not run locally: `bunx` is not installed on this Windows environment, and the checkout does not have `node_modules`, so lint/type checks are left to CI.

/claim #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal observability through restructured logging payloads to capture key system identifiers more efficiently.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->