### PR TITLE
fix(api): avoid logging device request bodies

### DIFF
--- a/supabase/functions/_backend/public/device/index.ts
+++ b/supabase/functions/_backend/public/device/index.ts
@@ -9,7 +9,7 @@ import { buildRateLimitInfo } from '../../utils/rateLimitInfo.ts'
 import { backgroundTask } from '../../utils/utils.ts'
 import { deleteOverride } from './delete.ts'
 import { get } from './get.ts'
-import { logDeviceRequestContext } from './logging.ts'
+import { logDeviceRateLimitRecordError, logDeviceRequestContext } from './logging.ts'
 import { post } from './post.ts'
 
 async function assertDeviceIPRateLimit(c: Context, appId: string) {
@@ -57,7 +57,7 @@ async function recordDeviceRateLimitSafely(
       await recordChannelSelfRequest(c, body.app_id, body.device_id, operation, rateLimitChannel)
     }
     catch (error) {
-      cloudlog({ requestId: c.get('requestId'), message: `Failed to record device ${operation} rate limit`, app_id: body.app_id, device_id: body.device_id, error })
+      logDeviceRateLimitRecordError(c, operation, body, error)
     }
   }
   if (body.app_id) {

--- a/supabase/functions/_backend/public/device/index.ts
+++ b/supabase/functions/_backend/public/device/index.ts
@@ -9,23 +9,8 @@ import { buildRateLimitInfo } from '../../utils/rateLimitInfo.ts'
 import { backgroundTask } from '../../utils/utils.ts'
 import { deleteOverride } from './delete.ts'
 import { get } from './get.ts'
+import { logDeviceRequestContext } from './logging.ts'
 import { post } from './post.ts'
-
-function logDeviceRequestContext(
-  c: Context,
-  operation: 'set' | 'get' | 'delete',
-  body: Partial<DeviceLink>,
-  apikey: Database['public']['Tables']['apikeys']['Row'],
-) {
-  cloudlog({ requestId: c.get('requestId'), message: `device ${operation} body`, body })
-  cloudlog({
-    requestId: c.get('requestId'),
-    message: `device ${operation} apikey context`,
-    apikeyId: apikey.id,
-    userId: apikey.user_id,
-    mode: apikey.mode,
-  })
-}
 
 async function assertDeviceIPRateLimit(c: Context, appId: string) {
   const ipRateLimitStatus = await checkChannelSelfIPRateLimit(c, appId, 'Device API IP rate limited')

--- a/supabase/functions/_backend/public/device/logging.ts
+++ b/supabase/functions/_backend/public/device/logging.ts
@@ -1,0 +1,35 @@
+import type { Context } from 'hono'
+import type { Database } from '../../utils/supabase.types.ts'
+import type { DeviceLink } from './delete.ts'
+import { cloudlog } from '../../utils/logging.ts'
+
+type DeviceOperation = 'set' | 'get' | 'delete'
+
+export function getDeviceRequestLogMetadata(body: Partial<DeviceLink>) {
+  return {
+    hasAppId: typeof body.app_id === 'string' && body.app_id.length > 0,
+    hasDeviceId: typeof body.device_id === 'string' && body.device_id.length > 0,
+    hasChannel: typeof body.channel === 'string' && body.channel.length > 0,
+    fieldCount: Object.keys(body).length,
+  }
+}
+
+export function logDeviceRequestContext(
+  c: Context,
+  operation: DeviceOperation,
+  body: Partial<DeviceLink>,
+  apikey: Database['public']['Tables']['apikeys']['Row'],
+) {
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: `device ${operation} request`,
+    ...getDeviceRequestLogMetadata(body),
+  })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: `device ${operation} apikey context`,
+    apikeyId: apikey.id,
+    userId: apikey.user_id,
+    mode: apikey.mode,
+  })
+}

--- a/supabase/functions/_backend/public/device/logging.ts
+++ b/supabase/functions/_backend/public/device/logging.ts
@@ -33,3 +33,17 @@ export function logDeviceRequestContext(
     mode: apikey.mode,
   })
 }
+
+export function logDeviceRateLimitRecordError(
+  c: Context,
+  operation: DeviceOperation,
+  body: Partial<DeviceLink>,
+  error: unknown,
+) {
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: `Failed to record device ${operation} rate limit`,
+    ...getDeviceRequestLogMetadata(body),
+    error,
+  })
+}

--- a/tests/device-request-logging.unit.test.ts
+++ b/tests/device-request-logging.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { cloudlogMock } = vi.hoisted(() => ({
+  cloudlogMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+}))
+
+describe('device request logging', () => {
+  it('logs request metadata without retaining body values', async () => {
+    const { logDeviceRequestContext } = await import('../supabase/functions/_backend/public/device/logging.ts')
+    const context = { get: vi.fn().mockReturnValue('req-device-log') }
+    const body = {
+      app_id: 'com.private.app',
+      device_id: 'device-secret-123',
+      channel: 'beta-private',
+    }
+
+    logDeviceRequestContext(context as any, 'set', body, {
+      id: 'apikey-id',
+      user_id: 'user-id',
+      mode: 'all',
+      key: 'capg-secret',
+    } as any)
+
+    expect(cloudlogMock).toHaveBeenNthCalledWith(1, {
+      requestId: 'req-device-log',
+      message: 'device set request',
+      hasAppId: true,
+      hasDeviceId: true,
+      hasChannel: true,
+      fieldCount: 3,
+    })
+    expect(cloudlogMock.mock.calls[0][0]).not.toHaveProperty('body')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('com.private.app')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('device-secret-123')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('beta-private')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('capg-secret')
+  })
+})

--- a/tests/device-request-logging.unit.test.ts
+++ b/tests/device-request-logging.unit.test.ts
@@ -39,4 +39,29 @@ describe('device request logging', () => {
     expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('beta-private')
     expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('capg-secret')
   })
+
+  it('logs rate limit record failures without retaining body values', async () => {
+    const { logDeviceRateLimitRecordError } = await import('../supabase/functions/_backend/public/device/logging.ts')
+    const context = { get: vi.fn().mockReturnValue('req-rate-limit-log') }
+    const body = {
+      app_id: 'com.private.app',
+      device_id: 'device-secret-123',
+      channel: 'beta-private',
+    }
+
+    logDeviceRateLimitRecordError(context as any, 'delete', body, new Error('cache write failed'))
+
+    expect(cloudlogMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      requestId: 'req-rate-limit-log',
+      message: 'Failed to record device delete rate limit',
+      hasAppId: true,
+      hasDeviceId: true,
+      hasChannel: true,
+      fieldCount: 3,
+    }))
+    expect(cloudlogMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('body')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('com.private.app')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('device-secret-123')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('beta-private')
+  })
 })


### PR DESCRIPTION
## Summary

- Replace Device API request-body logging with metadata-only request logs.
- Move device log context into a small helper.
- Add a regression test that confirms app id, device id, channel, and API key values are not retained in `cloudlog` calls.

## Motivation

The public Device API currently logs the raw request body for set/get/delete operations. Those values are not needed for routine request tracing and can include stable device identifiers or private channel names. This keeps behavior unchanged while reducing unnecessary sensitive data in operational logs.

## Test Plan

- `./node_modules/.bin/vitest run tests/device-request-logging.unit.test.ts`
- `./node_modules/.bin/eslint supabase/functions/_backend/public/device/index.ts supabase/functions/_backend/public/device/logging.ts tests/device-request-logging.unit.test.ts`
- `git diff --check`

/claim #1667
