### PR TITLE
fix: redact Stripe webhook event logs

### DIFF
--- a/supabase/functions/_backend/utils/stripe_event.ts
+++ b/supabase/functions/_backend/utils/stripe_event.ts
@@ -104,6 +104,20 @@ function invoiceUpcoming(event: Stripe.InvoiceUpcomingEvent, data: Database['pub
   return data
 }
 
+function getStripeEventLogMetadata(event: Stripe.Event) {
+  const stripeObject = event.data?.object as { object?: unknown } | undefined
+
+  return {
+    eventId: event.id,
+    eventType: event.type,
+    objectType: typeof stripeObject?.object === 'string' ? stripeObject.object : undefined,
+    apiVersion: event.api_version,
+    livemode: event.livemode,
+    created: event.created,
+    hasPreviousAttributes: !!event.data?.previous_attributes,
+  }
+}
+
 export function extractDataEvent(c: Context, event: Stripe.Event): StripeData {
   let data: Database['public']['Tables']['stripe_info']['Insert'] = {
     product_id: undefined as any, // Changed from '' to undefined to avoid FK constraint violations
@@ -122,7 +136,7 @@ export function extractDataEvent(c: Context, event: Stripe.Event): StripeData {
   let previousPriceId: string | undefined
   let previousProductId: string | undefined
 
-  cloudlog({ requestId: c.get('requestId'), message: 'event', event: JSON.stringify(event, null, 2) })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe event received', ...getStripeEventLogMetadata(event) })
   if (!event?.data?.object) {
     return { data, isUpgrade, previousPriceId, previousProductId }
   }
@@ -153,7 +167,7 @@ export function extractDataEvent(c: Context, event: Stripe.Event): StripeData {
     data.status = 'updated'
   }
   else {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Other event', event })
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Other event', ...getStripeEventLogMetadata(event) })
   }
   return { data, isUpgrade, previousPriceId, previousProductId }
 }

--- a/tests/stripe-event-logging.unit.test.ts
+++ b/tests/stripe-event-logging.unit.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cloudlogErrMock,
+  cloudlogMock,
+} = vi.hoisted(() => ({
+  cloudlogErrMock: vi.fn(),
+  cloudlogMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: cloudlogErrMock,
+}))
+
+const mockContext = {
+  get: (key: string) => key === 'requestId' ? 'req-stripe-event-log' : undefined,
+} as any
+
+afterEach(() => {
+  cloudlogErrMock.mockReset()
+  cloudlogMock.mockReset()
+  vi.resetModules()
+})
+
+describe('stripe event logging', () => {
+  it('logs safe event metadata without retaining customer payload values', async () => {
+    const { extractDataEvent } = await import('../supabase/functions/_backend/utils/stripe_event.ts')
+
+    const event = {
+      api_version: '2024-04-10',
+      created: 1_711_925_200,
+      data: {
+        object: {
+          id: 'cus_private_123',
+          object: 'customer',
+          email: 'billing-owner@example.com',
+          name: 'Billing Owner',
+          metadata: {
+            invite_code: 'private-invite-code',
+          },
+        },
+      },
+      id: 'evt_safe_metadata',
+      livemode: true,
+      type: 'customer.updated',
+    } as any
+
+    const stripeData = extractDataEvent(mockContext, event)
+
+    expect(stripeData.data.customer_id).toBe('cus_private_123')
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: 'req-stripe-event-log',
+      message: 'stripe event received',
+      eventId: 'evt_safe_metadata',
+      eventType: 'customer.updated',
+      objectType: 'customer',
+      apiVersion: '2024-04-10',
+      livemode: true,
+      created: 1_711_925_200,
+      hasPreviousAttributes: false,
+    })
+
+    const loggedPayload = JSON.stringify(cloudlogMock.mock.calls)
+    expect(loggedPayload).not.toContain('billing-owner@example.com')
+    expect(loggedPayload).not.toContain('Billing Owner')
+    expect(loggedPayload).not.toContain('private-invite-code')
+    expect(loggedPayload).not.toContain('cus_private_123')
+  })
+
+  it('keeps fallback event logs metadata-only for unsupported event types', async () => {
+    const { extractDataEvent } = await import('../supabase/functions/_backend/utils/stripe_event.ts')
+
+    const event = {
+      created: 1_711_925_201,
+      data: {
+        object: {
+          id: 'src_private_456',
+          object: 'source',
+          owner: {
+            email: 'source-owner@example.com',
+          },
+        },
+      },
+      id: 'evt_other_metadata',
+      livemode: false,
+      type: 'source.chargeable',
+    } as any
+
+    extractDataEvent(mockContext, event)
+
+    expect(cloudlogErrMock).toHaveBeenCalledWith({
+      requestId: 'req-stripe-event-log',
+      message: 'Other event',
+      eventId: 'evt_other_metadata',
+      eventType: 'source.chargeable',
+      objectType: 'source',
+      apiVersion: undefined,
+      livemode: false,
+      created: 1_711_925_201,
+      hasPreviousAttributes: false,
+    })
+
+    const loggedPayload = JSON.stringify([
+      ...cloudlogMock.mock.calls,
+      ...cloudlogErrMock.mock.calls,
+    ])
+    expect(loggedPayload).not.toContain('source-owner@example.com')
+    expect(loggedPayload).not.toContain('src_private_456')
+  })
+})


### PR DESCRIPTION
## Summary

- Replace full Stripe webhook event logging with metadata-only event logs.
- Apply the same redaction to the fallback unsupported-event error path.
- Add regression coverage proving customer/source payload values are not retained in log calls.

## Security rationale

Stripe webhook events can contain customer profile fields, owner email addresses, metadata, and other billing context that is not needed for routine observability. Logging only event type/id/object metadata keeps debugging signal while reducing sensitive data exposure.

## Test plan

- `git diff --check`
- `npx.cmd vitest run tests/stripe-event-logging.unit.test.ts` (not completed locally: checkout is missing `vite`/project dependencies)
- `npx.cmd eslint supabase/functions/_backend/utils/stripe_event.ts tests/stripe-event-logging.unit.test.ts` (not completed locally: checkout is missing `@antfu/eslint-config`)

/claim #1667