### PR TITLE
fix: stop logging organization admin identifiers

### DIFF
--- a/src/pages/settings/organization/Members.vue
+++ b/src/pages/settings/organization/Members.vue
@@ -677,8 +677,6 @@ async function showInviteModal() {
 }
 
 async function sendInvitation(email: string, type: Database['public']['Enums']['user_min_right'] | string): Promise<boolean> {
-  console.log(`Invite ${email} with perm ${type}`)
-
   const orgId = currentOrganization.value?.gid
   if (!orgId) {
     toast.error('Organization ID not found.')

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -643,7 +643,6 @@ export const useOrganizationStore = defineStore('organization', () => {
 
     // Verify user has super_admin or owner role for this organization
     const currentOrg = _organizations.value.get(orgId)
-    console.log('Delete org check:', { orgId, currentOrg, role: currentOrg?.role, userId: currentUserId })
     if (!currentOrg || !canDeleteOrganization(orgId)) {
       console.error('Permission denied:', { role: currentOrg?.role, required: ['super_admin', 'owner', 'org_super_admin'] })
       return { data: null, error: new Error('Insufficient permissions') }


### PR DESCRIPTION
## Summary

- Stop logging invitee email/permission values from the organization members invite flow.
- Stop logging organization/user context from the organization deletion permission check.
- Related public hardening thread: #1667.

## Motivation

Both logs are client-side debug breadcrumbs and are not needed for normal behavior. They can retain organization identifiers, user identifiers, current organization details, invitee email addresses, and role choices in browser logs.

## Test Plan

- [x] `git diff --check`
- [ ] `bunx eslint src/pages/settings/organization/Members.vue src/stores/organization.ts` (not run locally: `bunx` is not installed in this environment)

## Checklist

- [x] Change kept to removing debug logs only.
- [x] Invite and delete organization behavior unchanged.
- [x] No private technical details included.

/claim #1667
