### PR TITLE
fix: redact plugin request logs

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -14,6 +14,7 @@ import { sendNotifOrgCached } from '../utils/notifications.ts'
 import { sendNotifToOrgMembersCached } from '../utils/org_email_notifications.ts'
 import { closeClient, deleteChannelDevicePg, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getChannelDeviceOverridePg, getChannelsPg, getCompatibleChannelsPg, getDrizzleClient, getMainChannelsPg, getPgClient, setReplicationLagHeader, upsertChannelDevicePg } from '../utils/pg.ts'
 import { convertQueryToBody, makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
+import { summarizePluginRequestForLog } from '../utils/plugin_request_log.ts'
 import { channelSelfGetRequestSchema, channelSelfRequestSchema, isDevicePlatform } from '../utils/plugin_validation.ts'
 import { buildRateLimitInfo } from '../utils/rateLimitInfo.ts'
 import { sendStatsAndDevice } from '../utils/stats.ts'
@@ -140,7 +141,7 @@ function isChannelSelfLocalChannelStorageVersion(c: Context, body: DeviceLink, o
 }
 
 async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient>, body: DeviceLink): Promise<Response> {
-  cloudlog({ requestId: c.get('requestId'), message: 'post channel self body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post channel self request', request: summarizePluginRequestForLog(body) })
   const { app_id, device_id, channel } = body
 
   const cachedAppStatus = await getAppStatus(c, app_id)
@@ -300,7 +301,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
 }
 
 async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient>, body: DeviceLink): Promise<Response> {
-  cloudlog({ requestId: c.get('requestId'), message: 'put channel self body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'put channel self request', request: summarizePluginRequestForLog(body) })
   const { app_id, defaultChannel, device_id } = body
 
   const cachedAppStatus = await getAppStatus(c, app_id)
@@ -380,7 +381,7 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
 }
 
 async function deleteOverride(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient>, body: DeviceLink): Promise<Response> {
-  cloudlog({ requestId: c.get('requestId'), message: 'delete channel self body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'delete channel self request', request: summarizePluginRequestForLog(body) })
   const {
     app_id,
     device_id,
@@ -502,7 +503,7 @@ async function parseChannelSelfPluginRequest(
   schema: StandardSchema<DeviceLink>,
   requireDevice = true,
 ): Promise<{ response: Response } | { body: DeviceLink, bodyParsed: DeviceLink }> {
-  cloudlog({ requestId: c.get('requestId'), message: logMessage, body })
+  cloudlog({ requestId: c.get('requestId'), message: logMessage, request: summarizePluginRequestForLog(body) })
 
   if (isLimited(c, body.app_id)) {
     return { response: simpleRateLimit(body) }

--- a/supabase/functions/_backend/plugins/updates.ts
+++ b/supabase/functions/_backend/plugins/updates.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono/tiny'
 import { BRES, parseBody, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { parsePluginBody } from '../utils/plugin_parser.ts'
+import { summarizePluginRequestForLog } from '../utils/plugin_request_log.ts'
 import { updateRequestSchema } from '../utils/plugin_validation.ts'
 import { update } from '../utils/update.ts'
 
@@ -19,7 +20,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', async (c) => {
   const body = await parseBody<AppInfos>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post updates body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post updates request', request: summarizePluginRequestForLog(body) })
   if (isLimited(c, body.app_id)) {
     return simpleRateLimit(body)
   }

--- a/supabase/functions/_backend/utils/plugin_request_log.ts
+++ b/supabase/functions/_backend/utils/plugin_request_log.ts
@@ -2,6 +2,9 @@ import type { AppInfos, AppStats } from './types.ts'
 
 type PluginRequestLogBody = Partial<AppInfos & AppStats & { channel?: string }>
 
+/**
+ * Builds a metadata-only representation of plugin request bodies for logs.
+ */
 export function summarizePluginRequestForLog(body: PluginRequestLogBody | null | undefined) {
   return {
     app_id: body?.app_id,

--- a/supabase/functions/_backend/utils/plugin_request_log.ts
+++ b/supabase/functions/_backend/utils/plugin_request_log.ts
@@ -1,0 +1,21 @@
+import type { AppInfos, AppStats } from './types.ts'
+
+type PluginRequestLogBody = Partial<AppInfos & AppStats & { channel?: string }>
+
+export function summarizePluginRequestForLog(body: PluginRequestLogBody | null | undefined) {
+  return {
+    app_id: body?.app_id,
+    platform: body?.platform,
+    plugin_version: body?.plugin_version,
+    version_build: body?.version_build,
+    version_name: body?.version_name,
+    version_os: body?.version_os,
+    is_prod: body?.is_prod,
+    is_emulator: body?.is_emulator,
+    has_device_id: typeof body?.device_id === 'string' && body.device_id.trim() !== '',
+    has_custom_id: typeof body?.custom_id === 'string' && body.custom_id.trim() !== '',
+    has_key_id: typeof body?.key_id === 'string' && body.key_id.trim() !== '',
+    has_channel: typeof body?.channel === 'string' && body.channel.trim() !== '',
+    has_default_channel: typeof body?.defaultChannel === 'string' && body.defaultChannel.trim() !== '',
+  }
+}

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -17,6 +17,7 @@ import { cloudlog } from './logging.ts'
 import { sendNotifOrgCached } from './notifications.ts'
 import { closeClient, getAppOwnerPostgres, getDrizzleClient, getPgClient, requestInfosPostgres, setReplicationLagHeader } from './pg.ts'
 import { makeDevice } from './plugin_parser.ts'
+import { summarizePluginRequestForLog } from './plugin_request_log.ts'
 import { s3 } from './s3.ts'
 import { createStatsBandwidth, createStatsMau, createStatsVersion, onPremStats, sendStatsAndDevice } from './stats.ts'
 import { isUpdateEnumerationLimited, recordUpdateEnumerationMiss, updateEnumerationLimitedResponse } from './updateOracleGuard.ts'
@@ -98,7 +99,7 @@ export async function updateWithPG(
   body: AppInfos,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
 ) {
-  cloudlog({ requestId: c.get('requestId'), message: 'body', body, date: new Date().toISOString() })
+  cloudlog({ requestId: c.get('requestId'), message: 'update request', request: summarizePluginRequestForLog(body), date: new Date().toISOString() })
   const {
     version_name,
     version_build,

--- a/tests/plugin-request-logging.unit.test.ts
+++ b/tests/plugin-request-logging.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { summarizePluginRequestForLog } from '../supabase/functions/_backend/utils/plugin_request_log.ts'
 
 describe('plugin request logging', () => {
-  it('keeps public plugin request logs metadata-only', () => {
+  it.concurrent('keeps public plugin request logs metadata-only', () => {
     const summary = summarizePluginRequestForLog({
       app_id: 'com.example.app',
       device_id: 'device-secret-123',
@@ -43,7 +43,7 @@ describe('plugin request logging', () => {
     expect(serialized).not.toContain('production')
   })
 
-  it('handles empty plugin requests without throwing', () => {
+  it.concurrent('handles empty plugin requests without throwing', () => {
     expect(summarizePluginRequestForLog(undefined)).toMatchObject({
       has_device_id: false,
       has_custom_id: false,

--- a/tests/plugin-request-logging.unit.test.ts
+++ b/tests/plugin-request-logging.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { summarizePluginRequestForLog } from '../supabase/functions/_backend/utils/plugin_request_log.ts'
+
+describe('plugin request logging', () => {
+  it('keeps public plugin request logs metadata-only', () => {
+    const summary = summarizePluginRequestForLog({
+      app_id: 'com.example.app',
+      device_id: 'device-secret-123',
+      custom_id: 'customer@example.com',
+      key_id: 'key-id-abc',
+      channel: 'private-beta',
+      defaultChannel: 'production',
+      platform: 'ios',
+      plugin_version: '8.0.0',
+      version_build: '1.2.3',
+      version_name: '1.2.3',
+      version_os: '17.0',
+      is_prod: true,
+      is_emulator: false,
+    })
+
+    expect(summary).toEqual({
+      app_id: 'com.example.app',
+      platform: 'ios',
+      plugin_version: '8.0.0',
+      version_build: '1.2.3',
+      version_name: '1.2.3',
+      version_os: '17.0',
+      is_prod: true,
+      is_emulator: false,
+      has_device_id: true,
+      has_custom_id: true,
+      has_key_id: true,
+      has_channel: true,
+      has_default_channel: true,
+    })
+
+    const serialized = JSON.stringify(summary)
+    expect(serialized).not.toContain('device-secret-123')
+    expect(serialized).not.toContain('customer@example.com')
+    expect(serialized).not.toContain('key-id-abc')
+    expect(serialized).not.toContain('private-beta')
+    expect(serialized).not.toContain('production')
+  })
+
+  it('handles empty plugin requests without throwing', () => {
+    expect(summarizePluginRequestForLog(undefined)).toMatchObject({
+      has_device_id: false,
+      has_custom_id: false,
+      has_key_id: false,
+      has_channel: false,
+      has_default_channel: false,
+    })
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- replace raw `/updates` and `/channel_self` plugin request body logs with metadata-only summaries
- carry the same metadata-only summary into the downstream update utility log so the parsed update body is not retained there either
- keep operational fields such as app id, platform, plugin version, native version, and boolean presence flags
- avoid retaining raw device IDs, custom IDs, key IDs, channel names, or default channel names in routine cloud logs

## Test
- `npx --yes vitest@4.1.5 run tests/plugin-request-logging.unit.test.ts --config <temp minimal config>`
- `git diff --check`
- `npx --yes esbuild@0.27.2 supabase/functions/_backend/utils/update.ts --bundle --platform=node --format=esm --packages=external --outfile=NUL`

I used a minimal Vitest config locally because this environment does not have Bun installed.