### PR TITLE
fix: stop returning api keys in statistics errors

### DIFF
--- a/supabase/functions/_backend/public/statistics/index.ts
+++ b/supabase/functions/_backend/public/statistics/index.ts
@@ -909,12 +909,12 @@ app.get('/org/:org_id', async (c) => {
   }
   if (auth.authType === 'apikey' && auth.apikey!.limited_to_orgs && auth.apikey!.limited_to_orgs.length > 0) {
     if (!auth.apikey!.limited_to_orgs.includes(orgId)) {
-      throw quickError(401, 'invalid_apikey', 'Invalid apikey', { data: auth.apikey!.key })
+      throw quickError(401, 'invalid_apikey', 'Invalid apikey', { apikeyId: auth.apikey!.id })
     }
   }
 
   if (auth.authType === 'apikey' && auth.apikey!.limited_to_apps && auth.apikey!.limited_to_apps.length > 0) {
-    throw quickError(401, 'invalid_apikey', 'Invalid apikey', { data: auth.apikey!.key })
+    throw quickError(401, 'invalid_apikey', 'Invalid apikey', { apikeyId: auth.apikey!.id })
   }
 
   // Use authenticated client - RLS will enforce access


### PR DESCRIPTION
## Summary

- replace the raw API key value in /statistics/org invalid-key error details with the API key id
- keep the existing 401 behavior for out-of-scope org/app-limited keys
- add a regression assertion that the rejected statistics response does not contain the plain statistics API key or a moreInfo.data payload

## Security impact

The previous invalid-key branches could put a valid API key into both the client-visible error JSON and the structured error log. This keeps enough non-secret context for debugging without returning the credential.

/claim #1667

## Test plan

- [x] git diff --check
- [ ] bun run supabase:with-env -- bunx vitest run tests/statistics.test.ts (local bun runtime is unavailable in this checkout environment)