### PR TITLE
fix(api): redact notification log details

### DIFF
--- a/supabase/functions/_backend/utils/notification_logging.ts
+++ b/supabase/functions/_backend/utils/notification_logging.ts
@@ -1,0 +1,13 @@
+export function getRecipientEmailLogMetadata(email?: string | null) {
+  return {
+    hasRecipientEmail: typeof email === 'string' && email.trim().length > 0,
+  }
+}
+
+export function getEventDataLogMetadata(eventData?: Record<string, unknown> | null) {
+  const eventDataFieldCount = eventData ? Object.keys(eventData).length : 0
+  return {
+    hasEventData: eventDataFieldCount > 0,
+    eventDataFieldCount,
+  }
+}

--- a/supabase/functions/_backend/utils/notifications.ts
+++ b/supabase/functions/_backend/utils/notifications.ts
@@ -6,6 +6,7 @@ import { and, eq } from 'drizzle-orm'
 import { trackBentoEvent } from './bento.ts'
 import { CacheHelper } from './cache.ts'
 import { cloudlog } from './logging.ts'
+import { getEventDataLogMetadata, getRecipientEmailLogMetadata } from './notification_logging.ts'
 import { getDrizzleClient as createDrizzleClient, getPgClient, logPgError } from './pg.ts'
 import * as schema from './postgres_schema.ts'
 import { backgroundTask } from './utils.ts'
@@ -235,12 +236,23 @@ export async function sendNotifOrg(
       cloudlog({ requestId: c.get('requestId'), message: isFirstSend ? 'notif never sent' : 'notif ready to sent', event: eventName, uniqId })
       const res = await trackBentoEvent(c, managementEmail, eventData, eventName)
       if (!res) {
-        cloudlog({ requestId: c.get('requestId'), message: 'trackEvent failed', eventName, email: managementEmail, eventData })
+        cloudlog({
+          requestId: c.get('requestId'),
+          message: 'trackEvent failed',
+          eventName,
+          ...getRecipientEmailLogMetadata(managementEmail),
+          ...getEventDataLogMetadata(eventData),
+        })
         // Note: We already claimed it in DB, but email failed. On next attempt, cron will determine if we retry.
         return false
       }
 
-      cloudlog({ requestId: c.get('requestId'), message: 'send notif done', eventName, email: managementEmail })
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'send notif done',
+        eventName,
+        ...getRecipientEmailLogMetadata(managementEmail),
+      })
       return true
     }
 
@@ -301,11 +313,23 @@ export async function sendNotifOrgOnce(
     const res = await trackBentoEvent(c, recipientEmail, eventData, eventName)
     if (!res) {
       const cleanupSucceeded = await cleanupClaim()
-      cloudlog({ requestId: c.get('requestId'), message: 'trackEvent failed for one-time notif', eventName, email: recipientEmail, eventData })
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'trackEvent failed for one-time notif',
+        eventName,
+        ...getRecipientEmailLogMetadata(recipientEmail),
+        ...getEventDataLogMetadata(eventData),
+      })
       return { sent: false, cleanupFailed: !cleanupSucceeded }
     }
 
-    cloudlog({ requestId: c.get('requestId'), message: 'send one-time notif done', eventName, email: recipientEmail, uniqId })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'send one-time notif done',
+      eventName,
+      uniqId,
+      ...getRecipientEmailLogMetadata(recipientEmail),
+    })
     return { sent: true, cleanupFailed: false }
   }
   catch (e: unknown) {

--- a/supabase/functions/_backend/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/utils/org_email_notifications.ts
@@ -561,7 +561,7 @@ export async function sendNotifToOrgMembers(
     eventName,
     preferenceKey,
     orgId,
-    primaryEmail,
+    hasPrimaryEmail: true,
     additionalRecipients: additionalEmails.length,
     managementEmailIncluded: !!managementEmail,
   })
@@ -664,24 +664,18 @@ export async function sendNotifToOrgMembersOnce(
     sendResults.push({ ...recipient, ...sendResult })
   }
 
-  const sentEmails = sendResults
-    .filter(result => result.sent)
-    .map(result => result.email)
-  const cleanupFailedEmails = sendResults
-    .filter(result => result.cleanupFailed)
-    .map(result => result.email)
-  const alreadyClaimedBeforeRunEmails = sendResults
-    .filter(result => result.wasAlreadyClaimedBeforeRun)
-    .map(result => result.email)
+  const deliveredRecipientCount = sendResults.filter(result => result.sent).length
+  const cleanupFailedRecipientCount = sendResults.filter(result => result.cleanupFailed).length
+  const alreadyClaimedRecipientCount = sendResults.filter(result => result.wasAlreadyClaimedBeforeRun).length
 
-  if (cleanupFailedEmails.length > 0) {
+  if (cleanupFailedRecipientCount > 0) {
     cloudlog({
       requestId: c.get('requestId'),
       message: 'sendNotifToOrgMembersOnce: recipient cleanup failed',
       eventName,
       preferenceKey,
       orgId,
-      cleanupFailedRecipients: cleanupFailedEmails,
+      cleanupFailedRecipientsCount: cleanupFailedRecipientCount,
     })
     return false
   }
@@ -698,10 +692,10 @@ export async function sendNotifToOrgMembersOnce(
     eventName,
     preferenceKey,
     orgId,
-    primaryEmail,
+    hasPrimaryEmail: true,
     additionalRecipients: additionalEmails.length,
-    deliveredRecipients: sentEmails.length,
-    alreadyClaimedRecipients: alreadyClaimedBeforeRunEmails.length,
+    deliveredRecipients: deliveredRecipientCount,
+    alreadyClaimedRecipients: alreadyClaimedRecipientCount,
     firstOrgSend,
     managementEmailIncluded: !!managementEmail,
   })

--- a/tests/notification-logging.unit.test.ts
+++ b/tests/notification-logging.unit.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { cloudlogMock, logPgErrorMock, trackBentoEventMock } = vi.hoisted(() => ({
+  cloudlogMock: vi.fn(),
+  logPgErrorMock: vi.fn(),
+  trackBentoEventMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
+  trackBentoEvent: trackBentoEventMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  getDrizzleClient: vi.fn(),
+  getPgClient: vi.fn(),
+  logPgError: logPgErrorMock,
+}))
+
+describe('notification log metadata', () => {
+  beforeEach(() => {
+    cloudlogMock.mockReset()
+    logPgErrorMock.mockReset()
+    trackBentoEventMock.mockReset()
+  })
+
+  it('summarizes recipient email presence without retaining the address', async () => {
+    const { getRecipientEmailLogMetadata } = await import('../supabase/functions/_backend/utils/notification_logging.ts')
+
+    const metadata = getRecipientEmailLogMetadata('admin@example.com')
+
+    expect(metadata).toEqual({ hasRecipientEmail: true })
+    expect(JSON.stringify(metadata)).not.toContain('admin@example.com')
+  })
+
+  it('summarizes event data shape without retaining values', async () => {
+    const { getEventDataLogMetadata } = await import('../supabase/functions/_backend/utils/notification_logging.ts')
+
+    const metadata = getEventDataLogMetadata({
+      email: 'invitee@example.com',
+      token: 'secret-token',
+    })
+
+    expect(metadata).toEqual({
+      hasEventData: true,
+      eventDataFieldCount: 2,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('invitee@example.com')
+    expect(JSON.stringify(metadata)).not.toContain('secret-token')
+  })
+
+  it('logs one-time notification failures without retaining recipient or event data values', async () => {
+    const { sendNotifOrgOnce } = await import('../supabase/functions/_backend/utils/notifications.ts')
+    const returningMock = vi.fn().mockResolvedValue([{}])
+    const writeClient = {
+      delete: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue(undefined),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({
+            returning: returningMock,
+          })),
+        })),
+      })),
+    }
+    trackBentoEventMock.mockResolvedValue(false)
+
+    const result = await sendNotifOrgOnce(
+      { get: vi.fn().mockReturnValue('req-notif-log') } as any,
+      'user:invite',
+      { email: 'invitee@example.com', token: 'secret-token' },
+      'org-id',
+      'uniq-id',
+      'recipient@example.com',
+      {} as any,
+      writeClient as any,
+    )
+
+    expect(result).toEqual({ sent: false, cleanupFailed: false })
+    expect(cloudlogMock).toHaveBeenLastCalledWith({
+      requestId: 'req-notif-log',
+      message: 'trackEvent failed for one-time notif',
+      eventName: 'user:invite',
+      hasRecipientEmail: true,
+      hasEventData: true,
+      eventDataFieldCount: 2,
+    })
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('recipient@example.com')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('invitee@example.com')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('secret-token')
+  })
+})

--- a/tests/org-email-notifications-send-once.unit.test.ts
+++ b/tests/org-email-notifications-send-once.unit.test.ts
@@ -308,8 +308,10 @@ describe('sendNotifToOrgMembersOnce', () => {
     expect(claimNotifOrgOnceMock).not.toHaveBeenCalled()
     expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
       message: 'sendNotifToOrgMembersOnce: recipient cleanup failed',
-      cleanupFailedRecipients: ['billing@example.com', 'admin@example.com'],
+      cleanupFailedRecipientsCount: 2,
     }))
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('billing@example.com')
+    expect(JSON.stringify(cloudlogMock.mock.calls)).not.toContain('admin@example.com')
   })
 
   it('reads one-time recipients from the primary client before finalizing the org claim', async () => {


### PR DESCRIPTION
## Summary
- replace notification delivery logs that retained recipient email/event payload values with metadata-only fields
- keep notification sending, throttling, and Bento event payloads unchanged
- add a focused unit test for the one-time notification failure path to ensure raw recipient/event values are not retained in cloudlog calls

## Testing
- ./node_modules/.bin/vitest run tests/notification-logging.unit.test.ts tests/org-email-notifications-send-once.unit.test.ts
- ./node_modules/.bin/eslint supabase/functions/_backend/utils/notification_logging.ts supabase/functions/_backend/utils/notifications.ts supabase/functions/_backend/utils/org_email_notifications.ts tests/notification-logging.unit.test.ts tests/org-email-notifications-send-once.unit.test.ts
- git diff --check

Related to #1667.
