### PR TITLE
fix(frontend): avoid client-side replication secret

### DIFF
--- a/src/pages/admin/dashboard/replication.vue
+++ b/src/pages/admin/dashboard/replication.vue
@@ -99,25 +99,19 @@ const checkedAt = computed(() => {
   return formatLocalDateTime(data.value.checked_at)
 })
 
-const internalReplicationSecret = import.meta.env.VITE_REPLICATION_API_SECRET as string | undefined
-
 async function loadReplicationStatus() {
   isLoading.value = true
   errorMessage.value = null
 
   try {
-    const headers: Record<string, string> = {}
-    if (internalReplicationSecret) {
-      headers.apisecret = internalReplicationSecret
-    }
-    else {
-      const supabase = useSupabase()
-      const { data: { session } } = await supabase.auth.getSession()
+    const supabase = useSupabase()
+    const { data: { session } } = await supabase.auth.getSession()
 
-      if (!session?.access_token)
-        throw new Error('No session available and replication secret is not configured')
+    if (!session?.access_token)
+      throw new Error('No session available')
 
-      headers.Authorization = `Bearer ${session.access_token}`
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${session.access_token}`,
     }
 
     const response = await fetch(`${defaultApiHost}/replication`, {


### PR DESCRIPTION
## Summary

- Remove the `VITE_REPLICATION_API_SECRET` fallback from the admin replication dashboard
- Always authenticate browser replication status requests with the current admin Supabase JWT
- Keep the backend `apisecret` path untouched for server-side/internal callers

/claim #1667

## Motivation

`VITE_` variables are bundled into client JavaScript. If a replication API secret is configured there, any browser that can fetch the admin bundle can recover and reuse it. The page already supports admin JWT authorization, so the browser should not ship a reusable shared secret.

## Test Plan

- [x] `git diff --check`
- [x] `bunx eslint src/pages/admin/dashboard/replication.vue`
