### PR TITLE
fix: redact private stats request logs

### DIFF
--- a/supabase/functions/_backend/private/stats.ts
+++ b/supabase/functions/_backend/private/stats.ts
@@ -9,6 +9,7 @@ import { toCsv } from '../utils/csv.ts'
 import { parseBody, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareV2 } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { summarizePrivateStatsRequestForLog } from '../utils/private_stats_request_log.ts'
 import { appIdSchema, deviceIdSchema, hasInvalidQueryLimitInput, hasUnsafeStatsQueryText, MAX_QUERY_LIMIT, queryLimitSchema, safeQueryDateSchema, safeQueryTextSchema, statsActionSchema } from '../utils/privateAnalyticsValidation.ts'
 import { checkPermission } from '../utils/rbac.ts'
 import { readStats } from '../utils/stats.ts'
@@ -142,7 +143,7 @@ async function getValidatedStatsRequestBody<T extends StatsBody | ExportBody>(
   }
   const startDate = normalizeRangeDate(body.rangeStart)
   const endDate = normalizeRangeDate(body.rangeEnd)
-  cloudlog({ requestId: c.get('requestId'), message: logMessage, body })
+  cloudlog({ requestId: c.get('requestId'), message: logMessage, body: summarizePrivateStatsRequestForLog(body) })
   const hasAppReadLogsPermission = await checkPermission(c, 'app.read_logs', { appId: body.appId })
   if (!hasAppReadLogsPermission) {
     throw simpleError('app_access_denied', 'You can\'t access this app', { app_id: body.appId })

--- a/supabase/functions/_backend/utils/private_stats_request_log.ts
+++ b/supabase/functions/_backend/utils/private_stats_request_log.ts
@@ -1,0 +1,31 @@
+export interface PrivateStatsRequestLogBody {
+  appId?: string
+  devicesId?: unknown[]
+  search?: unknown
+  order?: unknown[]
+  rangeStart?: string | number
+  rangeEnd?: string | number
+  limit?: number
+  actions?: unknown[]
+  format?: string
+  filename?: unknown
+}
+
+export function summarizePrivateStatsRequestForLog(body: PrivateStatsRequestLogBody | undefined) {
+  const devicesId = Array.isArray(body?.devicesId) ? body.devicesId : []
+  const order = Array.isArray(body?.order) ? body.order : []
+  const actions = Array.isArray(body?.actions) ? body.actions : []
+
+  return {
+    app_id: body?.appId,
+    range_start: body?.rangeStart,
+    range_end: body?.rangeEnd,
+    limit: body?.limit,
+    format: body?.format,
+    device_filter_count: devicesId.length,
+    order_count: order.length,
+    action_count: actions.length,
+    has_search: typeof body?.search === 'string' && body.search.length > 0,
+    has_filename: typeof body?.filename === 'string' && body.filename.trim().length > 0,
+  }
+}

--- a/tests/private-stats-request-logging.unit.test.ts
+++ b/tests/private-stats-request-logging.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { summarizePrivateStatsRequestForLog } from '../supabase/functions/_backend/utils/private_stats_request_log.ts'
+
+describe('private stats request logging', () => {
+  it.concurrent('keeps analytics request logs metadata-only', () => {
+    const summary = summarizePrivateStatsRequestForLog({
+      appId: 'com.example.app',
+      devicesId: ['device-secret-123', 'device-secret-456'],
+      search: 'customer@example.com',
+      order: [
+        { key: 'device_id', sortable: 'asc' },
+      ],
+      rangeStart: '2026-01-01T00:00:00.000Z',
+      rangeEnd: '2026-01-02T00:00:00.000Z',
+      limit: 500,
+      actions: ['app_moved_to_foreground'],
+      format: 'csv',
+      filename: 'customer@example.com.csv',
+    })
+
+    expect(summary).toEqual({
+      app_id: 'com.example.app',
+      range_start: '2026-01-01T00:00:00.000Z',
+      range_end: '2026-01-02T00:00:00.000Z',
+      limit: 500,
+      format: 'csv',
+      device_filter_count: 2,
+      order_count: 1,
+      action_count: 1,
+      has_search: true,
+      has_filename: true,
+    })
+
+    const serialized = JSON.stringify(summary)
+    expect(serialized).not.toContain('device-secret-123')
+    expect(serialized).not.toContain('device-secret-456')
+    expect(serialized).not.toContain('customer@example.com')
+    expect(serialized).not.toContain('app_moved_to_foreground')
+  })
+
+  it.concurrent('handles empty private stats requests without throwing', () => {
+    expect(summarizePrivateStatsRequestForLog(undefined)).toMatchObject({
+      device_filter_count: 0,
+      order_count: 0,
+      action_count: 0,
+      has_search: false,
+      has_filename: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw `/private/stats` and `/private/stats/export` request-body logging with metadata-only summaries
- avoid logging raw device filters, search text, export filenames, order entries, or action values before the app log-read permission check completes
- add focused unit coverage for the stats request log summarizer

## Test
- `npx --yes vitest@4.1.5 run tests/private-stats-request-logging.unit.test.ts --config $tmp`

/claim #1667