### PR TITLE
fix: redact queue consumer request logs

### DIFF
--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -435,7 +435,7 @@ async function extractErrorDetails(response: Response): Promise<{
     return {
       bodyPreview,
       errorCode: typeof errorCode === 'string' ? errorCode : null,
-      errorMessage: typeof errorMessage === 'string' ? errorMessage : null,
+      errorMessage: typeof errorMessage === 'string' ? sanitizeDiscordResponseBody(errorMessage) : null,
     }
   }
   return {

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -538,7 +538,7 @@ export async function http_post_helper(
       method: 'POST',
       headers,
       body: JSON.stringify(body),
-      // signal: controller.signal,
+      signal: controller.signal,
     })
     return response
   }

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -54,6 +54,8 @@ interface FailureDetail {
   cf_id: string
 }
 
+type QueuePostTargetKind = 'cloudflare' | 'cloudflare_legacy' | 'cloudflare_pp' | 'supabase'
+
 function extractMessageBody(message: Message): Record<string, unknown> {
   if (message.message?.payload !== undefined)
     return (message.message.payload ?? {}) as Record<string, unknown>
@@ -161,6 +163,54 @@ function sanitizeDiscordResponseBody(value: string): string {
 // Helper function to generate UUID v4
 function generateUUID(): string {
   return crypto.randomUUID()
+}
+
+function getQueuePostTargetKind(functionType: string | null | undefined, cfPpUrl: string, cfUrl: string): QueuePostTargetKind {
+  const normalizedType = (functionType ?? '').trim()
+
+  if (normalizedType === 'cloudflare_pp' && cfPpUrl)
+    return 'cloudflare_pp'
+  if (normalizedType === 'cloudflare' && cfUrl)
+    return 'cloudflare'
+  if (normalizedType === '' && cfUrl)
+    return 'cloudflare_legacy'
+  return 'supabase'
+}
+
+function getQueuePayloadLogMetadata(body: unknown): {
+  payloadKeys: number
+  payloadSize: number
+  payloadType: string
+} {
+  let payloadSize = 0
+  try {
+    payloadSize = JSON.stringify(body)?.length ?? 0
+  }
+  catch {
+    payloadSize = 0
+  }
+
+  return {
+    payloadKeys: body && typeof body === 'object' && !Array.isArray(body) ? Object.keys(body).length : 0,
+    payloadSize,
+    payloadType: Array.isArray(body) ? 'array' : typeof body,
+  }
+}
+
+function getQueuePostLogMetadata(functionName: string, targetKind: QueuePostTargetKind, body: unknown): {
+  functionName: string
+  message: string
+  payloadKeys: number
+  payloadSize: number
+  payloadType: string
+  targetKind: QueuePostTargetKind
+} {
+  return {
+    functionName,
+    message: `[${functionName}] Making queued HTTP POST request.`,
+    targetKind,
+    ...getQueuePayloadLogMetadata(body),
+  }
 }
 
 async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queueName: string, batchSize: number = DEFAULT_BATCH_SIZE) {
@@ -457,15 +507,15 @@ export async function http_post_helper(
   let url: string
   const cfPpUrl = getEnv(c, 'CLOUDFLARE_PP_FUNCTION_URL')
   const cfUrl = getEnv(c, 'CLOUDFLARE_FUNCTION_URL')
-  const normalizedType = (function_type ?? '').trim()
+  const targetKind = getQueuePostTargetKind(function_type, cfPpUrl, cfUrl)
 
-  if (normalizedType === 'cloudflare_pp' && cfPpUrl) {
+  if (targetKind === 'cloudflare_pp') {
     url = `${cfPpUrl}/triggers/${function_name}`
   }
-  else if (normalizedType === 'cloudflare' && cfUrl) {
+  else if (targetKind === 'cloudflare') {
     url = `${cfUrl}/triggers/${function_name}`
   }
-  else if (normalizedType === '' && cfUrl) {
+  else if (targetKind === 'cloudflare_legacy') {
     // Backward compatibility: older queue messages may not have function_type set.
     // If a Cloudflare URL is configured, prefer it.
     url = `${cfUrl}/triggers/${function_name}`
@@ -480,7 +530,10 @@ export async function http_post_helper(
   // 15 second timeout, as the queue consumer is running every 10 seconds and the visibility timeout is 60 seconds
 
   try {
-    cloudlog({ requestId: c.get('requestId'), message: `[${function_name}] Making HTTP POST request to "${url}" with body:`, body })
+    cloudlog({
+      requestId: c.get('requestId'),
+      ...getQueuePostLogMetadata(function_name, targetKind, body),
+    })
     const response = await fetch(url, {
       method: 'POST',
       headers,
@@ -627,5 +680,8 @@ export const __queueConsumerTestUtils__ = {
   extractErrorDetails,
   extractMessageBody,
   getActionableQueueFailures,
+  getQueuePayloadLogMetadata,
+  getQueuePostLogMetadata,
+  getQueuePostTargetKind,
   sanitizeDiscordResponseBody,
 }

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -56,6 +56,21 @@ interface FailureDetail {
 
 type QueuePostTargetKind = 'cloudflare' | 'cloudflare_legacy' | 'cloudflare_pp' | 'supabase'
 
+interface QueuePostErrorDetails {
+  errorCode: string | null
+  errorMessage: string | null
+  bodyPreview: string | null
+}
+
+interface QueuePostProcessResult extends Message {
+  httpResponse: Response
+  errorDetails: QueuePostErrorDetails
+  cfId: string
+  payloadSize: number
+}
+
+type QueuePostHelper = typeof http_post_helper
+
 function extractMessageBody(message: Message): Record<string, unknown> {
   if (message.message?.payload !== undefined)
     return (message.message.payload ?? {}) as Record<string, unknown>
@@ -213,6 +228,93 @@ function getQueuePostLogMetadata(functionName: string, targetKind: QueuePostTarg
   }
 }
 
+function getQueuePostExceptionResult(error: unknown): Pick<QueuePostProcessResult, 'errorDetails' | 'httpResponse'> {
+  const cause = error instanceof Error && error.cause && typeof error.cause === 'object'
+    ? error.cause as Record<string, unknown>
+    : null
+  const errorCode = typeof cause?.error === 'string' ? cause.error : 'queue_dispatch_error'
+  const rawMessage = typeof cause?.message === 'string'
+    ? cause.message
+    : error instanceof Error
+      ? error.message
+      : String(error)
+  const errorStatus = typeof (error as { status?: unknown })?.status === 'number'
+    ? (error as { status: number }).status
+    : 500
+  const status = errorCode === 'request_timeout'
+    ? 408
+    : errorStatus >= 400 && errorStatus <= 599
+      ? errorStatus
+      : 500
+  const statusText = errorCode === 'request_timeout' ? 'Request Timeout' : 'Queue Dispatch Error'
+
+  return {
+    httpResponse: new Response(null, {
+      status,
+      statusText,
+    }),
+    errorDetails: {
+      bodyPreview: null,
+      errorCode,
+      errorMessage: sanitizeDiscordResponseBody(rawMessage),
+    },
+  }
+}
+
+async function processQueueMessage(
+  c: Context,
+  queueName: string,
+  message: Message,
+  postHelper: QueuePostHelper = http_post_helper,
+): Promise<QueuePostProcessResult> {
+  const function_name = message.message?.function_name ?? 'unknown'
+  const function_type = message.message?.function_type ?? 'supabase'
+  const body = extractMessageBody(message)
+  if (message.message?.payload === undefined && Object.keys(body).length > 0) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Using legacy queue message body shape for ${function_name}.`,
+      msgId: message.msg_id,
+    })
+  }
+  const cfId = generateUUID()
+  const payloadSize = JSON.stringify(body).length
+
+  try {
+    const httpResponse = await postHelper(c, function_name, function_type, body, cfId)
+    const errorDetails = await extractErrorDetails(httpResponse)
+
+    return {
+      httpResponse,
+      errorDetails,
+      cfId,
+      payloadSize,
+      ...message,
+    }
+  }
+  catch (error) {
+    const { httpResponse, errorDetails } = getQueuePostExceptionResult(error)
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Queued HTTP POST failed for ${function_name}.`,
+      msgId: message.msg_id,
+      functionName: function_name,
+      functionType: function_type,
+      errorCode: errorDetails.errorCode,
+      errorMessage: errorDetails.errorMessage,
+      errorName: error instanceof Error ? error.name : typeof error,
+    })
+
+    return {
+      httpResponse,
+      errorDetails,
+      cfId,
+      payloadSize,
+      ...message,
+    }
+  }
+}
+
 async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queueName: string, batchSize: number = DEFAULT_BATCH_SIZE) {
   const messages = await readQueue(c, db, queueName, batchSize)
 
@@ -235,29 +337,7 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
   }
 
   // Process messages that have been read less than 5 times
-  const results = await Promise.all(messagesToProcess.map(async (message) => {
-    const function_name = message.message?.function_name ?? 'unknown'
-    const function_type = message.message?.function_type ?? 'supabase'
-    const body = extractMessageBody(message)
-    if (message.message?.payload === undefined && Object.keys(body).length > 0) {
-      cloudlog({
-        requestId: c.get('requestId'),
-        message: `[${queueName}] Using legacy queue message body shape for ${function_name}.`,
-        msgId: message.msg_id,
-      })
-    }
-    const cfId = generateUUID()
-    const httpResponse = await http_post_helper(c, function_name, function_type, body, cfId)
-    const errorDetails = await extractErrorDetails(httpResponse)
-
-    return {
-      httpResponse,
-      errorDetails,
-      cfId,
-      payloadSize: JSON.stringify(body).length,
-      ...message,
-    }
-  }))
+  const results = await Promise.all(messagesToProcess.map(message => processQueueMessage(c, queueName, message)))
 
   // Update all messages with their CF IDs
   const cfIdUpdates = results.map(result => ({
@@ -391,11 +471,7 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
   }
 }
 
-async function extractErrorDetails(response: Response): Promise<{
-  errorCode: string | null
-  errorMessage: string | null
-  bodyPreview: string | null
-}> {
+async function extractErrorDetails(response: Response): Promise<QueuePostErrorDetails> {
   if (response.status < 400) {
     return {
       bodyPreview: null,
@@ -680,8 +756,10 @@ export const __queueConsumerTestUtils__ = {
   extractErrorDetails,
   extractMessageBody,
   getActionableQueueFailures,
+  getQueuePostExceptionResult,
   getQueuePayloadLogMetadata,
   getQueuePostLogMetadata,
   getQueuePostTargetKind,
+  processQueueMessage,
   sanitizeDiscordResponseBody,
 }

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -105,6 +105,37 @@ describe('queue_consumer legacy message compatibility', () => {
     ])).toEqual([])
   })
 
+  it.concurrent('summarizes queued POST logs without raw payload values', () => {
+    const payload = {
+      customerId: 'cus_secret_123',
+      email: 'alice@capgo.app',
+      token: 'sk_live_secret_123',
+    }
+    const metadata = __queueConsumerTestUtils__.getQueuePostLogMetadata('cron_sync_sub', 'cloudflare', payload)
+    const serializedMetadata = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      functionName: 'cron_sync_sub',
+      payloadKeys: 3,
+      payloadSize: JSON.stringify(payload).length,
+      payloadType: 'object',
+      targetKind: 'cloudflare',
+    })
+    expect(serializedMetadata).not.toContain('alice@capgo.app')
+    expect(serializedMetadata).not.toContain('cus_secret_123')
+    expect(serializedMetadata).not.toContain('sk_live_secret_123')
+    expect(serializedMetadata).not.toContain('customerId')
+    expect(serializedMetadata).not.toContain('email')
+    expect(serializedMetadata).not.toContain('token')
+  })
+
+  it.concurrent('classifies queued POST targets without exposing configured URLs', () => {
+    expect(__queueConsumerTestUtils__.getQueuePostTargetKind('cloudflare_pp', 'https://pp.example.com', 'https://cf.example.com')).toBe('cloudflare_pp')
+    expect(__queueConsumerTestUtils__.getQueuePostTargetKind('cloudflare', 'https://pp.example.com', 'https://cf.example.com')).toBe('cloudflare')
+    expect(__queueConsumerTestUtils__.getQueuePostTargetKind('', '', 'https://cf.example.com')).toBe('cloudflare_legacy')
+    expect(__queueConsumerTestUtils__.getQueuePostTargetKind('cloudflare', '', '')).toBe('supabase')
+  })
+
   it.concurrent('redacts sensitive data before queue failures are sent to Discord', () => {
     const sanitized = __queueConsumerTestUtils__.sanitizeDiscordResponseBody(JSON.stringify({
       authorization: 'Bearer abcdefghijklmnopqrstuvwxyz1234567890',

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -170,4 +170,23 @@ describe('queue_consumer legacy message compatibility', () => {
       errorMessage: 'builder unavailable',
     })
   })
+
+  it.concurrent('redacts sensitive data from extracted JSON error messages', async () => {
+    const token = 'abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGH'
+    const response = new Response(JSON.stringify({
+      message: `invalid token ${token} for user alice@capgo.app`,
+    }), {
+      headers: {
+        'content-type': 'application/json',
+      },
+      status: 401,
+      statusText: 'Unauthorized',
+    })
+
+    const details = await __queueConsumerTestUtils__.extractErrorDetails(response)
+
+    expect(details.errorMessage).toBe('invalid token [REDACTED_TOKEN] for user [REDACTED_EMAIL]')
+    expect(details.errorMessage).not.toContain(token)
+    expect(details.errorMessage).not.toContain('alice@capgo.app')
+  })
 })

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { __queueConsumerTestUtils__, MAX_QUEUE_READS, messagesArraySchema } from '../supabase/functions/_backend/triggers/queue_consumer.ts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { __queueConsumerTestUtils__, http_post_helper, MAX_QUEUE_READS, messagesArraySchema } from '../supabase/functions/_backend/triggers/queue_consumer.ts'
 import { parseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
 
 describe('queue_consumer legacy message compatibility', () => {
@@ -188,5 +188,63 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(details.errorMessage).toBe('invalid token [REDACTED_TOKEN] for user [REDACTED_EMAIL]')
     expect(details.errorMessage).not.toContain(token)
     expect(details.errorMessage).not.toContain('alice@capgo.app')
+  })
+})
+
+describe('queue_consumer HTTP POST helper timeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('aborts slow queue POST targets after the timeout elapses', async () => {
+    vi.useFakeTimers()
+
+    const body = { queued: true }
+    let capturedSignal: AbortSignal | undefined
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+      const signal = init?.signal as AbortSignal | undefined
+      capturedSignal = signal
+      if (!signal)
+        return Promise.reject(new Error('missing abort signal'))
+
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'))
+        }, { once: true })
+      })
+    })
+
+    const context = {
+      env: {
+        API_SECRET: 'test-api-secret',
+        CLOUDFLARE_FUNCTION_URL: '',
+        CLOUDFLARE_PP_FUNCTION_URL: '',
+        SUPABASE_URL: 'https://supabase.example.com',
+      },
+      get: (key: string) => key === 'requestId' ? 'req-queue-timeout' : undefined,
+    }
+
+    const request = http_post_helper(context as any, 'slow_function', 'supabase', body, 'cf-1')
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      )
+
+    expect(capturedSignal).toBeInstanceOf(AbortSignal)
+    expect(capturedSignal?.aborted).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      body: JSON.stringify(body),
+      method: 'POST',
+      signal: capturedSignal,
+    }))
+
+    await vi.advanceTimersByTimeAsync(15000)
+
+    expect(capturedSignal?.aborted).toBe(true)
+    const error = await request
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('Request Timeout (Internal QUEUE handling error)')
   })
 })

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -191,6 +191,72 @@ describe('queue_consumer legacy message compatibility', () => {
   })
 })
 
+describe('queue_consumer batch failure handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('turns queued POST exceptions into failed message results without rejecting the batch', async () => {
+    const context = {
+      get: (key: string) => key === 'requestId' ? 'req-queue-batch' : undefined,
+    }
+    const timeoutError = new Error('Request Timeout (Internal QUEUE handling error)')
+    Object.defineProperty(timeoutError, 'cause', {
+      value: {
+        error: 'request_timeout',
+        message: 'Request Timeout (Internal QUEUE handling error)',
+      },
+    })
+
+    const postHelper = vi.fn()
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValueOnce(new Response(null, {
+        status: 204,
+        statusText: 'No Content',
+      }))
+
+    const [failedResult, successResult] = await Promise.all([
+      __queueConsumerTestUtils__.processQueueMessage(context as any, 'test_queue', {
+        msg_id: 10,
+        read_ct: MAX_QUEUE_READS,
+        message: {
+          function_name: 'slow_function',
+          payload: { queued: true },
+        },
+      }, postHelper),
+      __queueConsumerTestUtils__.processQueueMessage(context as any, 'test_queue', {
+        msg_id: 11,
+        read_ct: 1,
+        message: {
+          function_name: 'fast_function',
+          payload: { queued: true },
+        },
+      }, postHelper),
+    ])
+
+    expect(postHelper).toHaveBeenCalledTimes(2)
+    expect(failedResult).toMatchObject({
+      msg_id: 10,
+      errorDetails: {
+        bodyPreview: null,
+        errorCode: 'request_timeout',
+        errorMessage: 'Request Timeout (Internal QUEUE handling error)',
+      },
+    })
+    expect(failedResult.httpResponse.status).toBe(408)
+    expect(failedResult.httpResponse.statusText).toBe('Request Timeout')
+    expect(successResult).toMatchObject({
+      msg_id: 11,
+      errorDetails: {
+        bodyPreview: null,
+        errorCode: null,
+        errorMessage: null,
+      },
+    })
+    expect(successResult.httpResponse.status).toBe(204)
+  })
+})
+
 describe('queue_consumer HTTP POST helper timeout', () => {
   afterEach(() => {
     vi.useRealTimers()

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -196,7 +196,7 @@ describe('queue_consumer batch failure handling', () => {
     vi.restoreAllMocks()
   })
 
-  it('turns queued POST exceptions into failed message results without rejecting the batch', async () => {
+  it.concurrent('turns queued POST exceptions into failed message results without rejecting the batch', async () => {
     const context = {
       get: (key: string) => key === 'requestId' ? 'req-queue-batch' : undefined,
     }
@@ -263,7 +263,7 @@ describe('queue_consumer HTTP POST helper timeout', () => {
     vi.restoreAllMocks()
   })
 
-  it('aborts slow queue POST targets after the timeout elapses', async () => {
+  it.concurrent('aborts slow queue POST targets after the timeout elapses', async () => {
     vi.useFakeTimers()
 
     const body = { queued: true }
@@ -292,10 +292,9 @@ describe('queue_consumer HTTP POST helper timeout', () => {
     }
 
     const request = http_post_helper(context as any, 'slow_function', 'supabase', body, 'cf-1')
-      .then(
-        () => undefined,
-        (error: unknown) => error,
-      )
+    const rejection = expect(request).rejects.toMatchObject({
+      message: 'Request Timeout (Internal QUEUE handling error)',
+    })
 
     expect(capturedSignal).toBeInstanceOf(AbortSignal)
     expect(capturedSignal?.aborted).toBe(false)
@@ -309,8 +308,6 @@ describe('queue_consumer HTTP POST helper timeout', () => {
     await vi.advanceTimersByTimeAsync(15000)
 
     expect(capturedSignal?.aborted).toBe(true)
-    const error = await request
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('Request Timeout (Internal QUEUE handling error)')
+    await rejection
   })
 })


### PR DESCRIPTION
/claim #1667

## Summary
- stop logging the full queue trigger URL and raw queued POST payload before dispatch
- keep debug-safe metadata only: target kind, function name, payload type, payload size, and top-level key count
- add regression coverage proving queued POST log metadata does not include payload keys or sensitive values

## Why
Queued trigger payloads can contain customer identifiers, emails, tokens, or webhook data. The previous pre-dispatch log wrote the resolved endpoint and entire payload into backend logs. This keeps operational visibility while reducing sensitive data exposure.

## Tests
- `git diff --check`
- `npx.cmd --yes vitest run tests/queue-consumer-message-shape.unit.test.ts` *(blocked locally because this checkout has no installed dependencies; Vitest could not resolve `vite`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved queue processing and structured POST logging for clearer diagnostics and more reliable message dispatching.

* **Bug Fixes**
  * Tighter sanitization of error payloads to prevent leaking sensitive values; better handling of per-message failures so one bad message won't fail entire batches.
  * Enforced request timeouts to abort stalled POSTs.

* **Tests**
  * Expanded tests for logging metadata, target classification, error redaction, batch failure handling, and timeout behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2138)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->