### PR TITLE
fix: redact private devices request logs

### DIFF
--- a/supabase/functions/_backend/private/devices.ts
+++ b/supabase/functions/_backend/private/devices.ts
@@ -10,7 +10,7 @@ import { appIdSchema, cursorSchema, deviceIdSchema, hasInvalidQueryLimitInput, h
 import { checkPermission } from '../utils/rbac.ts'
 import { countDevices, readDevices } from '../utils/stats.ts'
 
-interface DataDevice {
+export interface DataDevice {
   appId: string
   count?: boolean
   versionName?: string
@@ -43,6 +43,21 @@ const devicesBodySchema = type({
   'limit?': queryLimitSchema,
 })
 
+export function getPrivateDevicesRequestLogMetadata(body: DataDevice) {
+  const deviceIds = body.devicesId ?? body.deviceIds ?? []
+  return {
+    hasAppId: typeof body.appId === 'string' && body.appId.trim().length > 0,
+    count: body.count ?? false,
+    hasVersionName: typeof body.versionName === 'string' && body.versionName.trim().length > 0,
+    deviceIdsCount: deviceIds.length,
+    hasSearch: typeof body.search === 'string' && body.search.trim().length > 0,
+    customIdMode: body.customIdMode ?? false,
+    orderCount: body.order?.length ?? 0,
+    hasCursor: typeof body.cursor === 'string' && body.cursor.trim().length > 0,
+    limit: body.limit,
+  }
+}
+
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
@@ -59,7 +74,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   if (hasUnsafeDevicesQueryText(body)) {
     throw simpleError('invalid_body', 'Invalid body')
   }
-  cloudlog({ requestId: c.get('requestId'), message: 'post devices body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post devices request', request: getPrivateDevicesRequestLogMetadata(body) })
   if (!(await checkPermission(c, 'app.read_devices', { appId: body.appId }))) {
     throw simpleError('app_access_denied', 'You can\'t access this app', { app_id: body.appId })
   }

--- a/tests/private-devices-request-logging.unit.test.ts
+++ b/tests/private-devices-request-logging.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { getPrivateDevicesRequestLogMetadata } from '../supabase/functions/_backend/private/devices.ts'
+
+describe('private devices request log metadata', () => {
+  it.concurrent('summarizes device filters without retaining request values', () => {
+    const metadata = getPrivateDevicesRequestLogMetadata({
+      appId: 'com.example.secret',
+      count: true,
+      versionName: '1.2.3-sensitive-build',
+      devicesId: ['device-secret-1', 'device-secret-2'],
+      search: 'private-user-search',
+      customIdMode: true,
+      order: [{ key: 'device_id', sortable: 'asc' }],
+      cursor: 'cursor-secret',
+      limit: 50,
+    })
+
+    expect(metadata).toEqual({
+      hasAppId: true,
+      count: true,
+      hasVersionName: true,
+      deviceIdsCount: 2,
+      hasSearch: true,
+      customIdMode: true,
+      orderCount: 1,
+      hasCursor: true,
+      limit: 50,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('com.example.secret')
+    expect(JSON.stringify(metadata)).not.toContain('1.2.3-sensitive-build')
+    expect(JSON.stringify(metadata)).not.toContain('device-secret-1')
+    expect(JSON.stringify(metadata)).not.toContain('private-user-search')
+    expect(JSON.stringify(metadata)).not.toContain('cursor-secret')
+  })
+
+  it.concurrent('handles empty optional filters', () => {
+    expect(getPrivateDevicesRequestLogMetadata({ appId: 'com.example.app' })).toEqual({
+      hasAppId: true,
+      count: false,
+      hasVersionName: false,
+      deviceIdsCount: 0,
+      hasSearch: false,
+      customIdMode: false,
+      orderCount: 0,
+      hasCursor: false,
+      limit: undefined,
+    })
+  })
+})


### PR DESCRIPTION
/claim #1667

Summary:
- Replace the /private/devices raw request-body cloudlog with shape-only metadata.
- Keep device listing/count behavior unchanged while avoiding routine retention of app IDs, device IDs, version filters, search text, order values, and cursors.
- Add focused unit coverage for the log metadata helper.

Test plan:
- git diff --check
- Not run locally: bun and node_modules are unavailable in this checkout.