### PR TITLE
Reduce update request log exposure

### DIFF
--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -48,6 +48,23 @@ const UPDATE_BLOCKED_CODES = new Set([
   'key_id_mismatch',
 ])
 
+function summarizeUpdateRequest(body: AppInfos) {
+  return {
+    app_id: body.app_id,
+    platform: body.platform,
+    plugin_version: body.plugin_version,
+    version_name: body.version_name,
+    version_os: body.version_os,
+    hasVersionBuild: Boolean(body.version_build),
+    hasDeviceId: Boolean(body.device_id),
+    hasCustomId: Boolean(body.custom_id),
+    hasDefaultChannel: Boolean(body.defaultChannel),
+    hasKeyId: Boolean(body.key_id),
+    is_prod: body.is_prod,
+    is_emulator: body.is_emulator,
+  }
+}
+
 export function getUpdateResponseKind(errorCode: string): UpdateResponseKind {
   if (UPDATE_UP_TO_DATE_CODES.has(errorCode))
     return 'up_to_date'
@@ -98,7 +115,7 @@ export async function updateWithPG(
   body: AppInfos,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
 ) {
-  cloudlog({ requestId: c.get('requestId'), message: 'body', body, date: new Date().toISOString() })
+  cloudlog({ requestId: c.get('requestId'), message: 'update request', body: summarizeUpdateRequest(body), date: new Date().toISOString() })
   const {
     version_name,
     version_build,

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -65,6 +65,21 @@ function summarizeUpdateRequest(body: AppInfos) {
   }
 }
 
+function summarizeUpdateDevice(device: ReturnType<typeof makeDevice>) {
+  return {
+    hasDeviceId: Boolean(device.device_id),
+    hasCustomId: Boolean(device.custom_id),
+    hasAppId: Boolean(device.app_id),
+    hasVersionBuild: Boolean(device.version_build),
+    hasVersionName: Boolean(device.version_name),
+    hasPluginVersion: Boolean(device.plugin_version),
+    hasOsVersion: Boolean(device.os_version),
+    platform: device.platform,
+    is_prod: device.is_prod,
+    is_emulator: device.is_emulator,
+  }
+}
+
 export function getUpdateResponseKind(errorCode: string): UpdateResponseKind {
   if (UPDATE_UP_TO_DATE_CODES.has(errorCode))
     return 'up_to_date'
@@ -228,7 +243,7 @@ export async function updateWithPG(
 
   await backgroundTask(c, createStatsMau(c, device_id, app_id, appOwner.owner_org, platform, version_build))
 
-  cloudlog({ requestId: c.get('requestId'), message: 'vals', platform, device })
+  cloudlog({ requestId: c.get('requestId'), message: 'vals', platform, device: summarizeUpdateDevice(device) })
 
   // Only query link/comment if plugin supports it (v5.35.0+, v6.35.0+, v7.35.0+, v8.35.0+) AND app has expose_metadata enabled
   const needsMetadata = appOwner.expose_metadata && !isDeprecatedPluginVersion(pluginVersion, '5.35.0', '6.35.0', '7.35.0', '8.35.0')


### PR DESCRIPTION
## Summary
- replace the full plugin update request-body log with a compact summary
- keep updater behavior unchanged while avoiding routine retention of device/custom identifiers
- leave enough app/platform/version-shape context for diagnostics

Related to #1667.

## Verification
- `bunx eslint supabase/functions/_backend/utils/update.ts`
- `bun typecheck`
- `git diff --check`