### PR TITLE
fix(frontend): keep invitation tokens out of URLs

### DIFF
--- a/src/pages/invitation.vue
+++ b/src/pages/invitation.vue
@@ -137,13 +137,18 @@ async function submitForm() {
       throw new Error(error.message || 'Failed to accept invitation')
     }
 
-    // Store tokens in local storage or cookies
     if (data?.access_token && data?.refresh_token) {
-      // Login successful, redirect to dashboard
-      // window.location.href = '/dashboard';
-      router.push(`/login?access_token=${data.access_token}&refresh_token=${data.refresh_token}`)
+      const { error: sessionError } = await supabase.auth.setSession({
+        access_token: data.access_token,
+        refresh_token: data.refresh_token,
+      })
 
-      // MagicCapgo12@#
+      if (sessionError) {
+        captchaComponent.value?.reset()
+        throw new Error(sessionError.message || 'Failed to start session')
+      }
+
+      await router.replace('/dashboard')
     }
     else {
       captchaComponent.value?.reset()

--- a/src/pages/invitation.vue
+++ b/src/pages/invitation.vue
@@ -76,10 +76,22 @@ const organizationInitials = computed(() => {
     .join('')
 })
 
+function scrubInviteMagicStringFromUrl() {
+  const url = new URL(window.location.href)
+  url.searchParams.delete('invite_magic_string')
+  window.history.replaceState(window.history.state, '', url.toString())
+}
+
 onMounted(async () => {
   const supabase = useSupabase()
-  if (route.query.invite_magic_string) {
-    inviteMagicString.value = route.query.invite_magic_string as string
+  const inviteMagicLookup = Array.isArray(route.query.invite_magic_string)
+    ? route.query.invite_magic_string[0]
+    : route.query.invite_magic_string
+
+  if (inviteMagicLookup) {
+    inviteMagicString.value = inviteMagicLookup
+    scrubInviteMagicStringFromUrl()
+
     const { data, error } = await supabase.rpc('get_invite_by_magic_lookup', {
       lookup: inviteMagicString.value,
     }).single()


### PR DESCRIPTION
## Summary

- Set the Supabase session directly after accepting an invitation
- Redirect accepted invitees to the dashboard with `router.replace` instead of forwarding access/refresh tokens through `/login?...`
- Preserve existing captcha reset and error handling when the invitation or session setup fails

/claim #1667

## Motivation

The invitation flow currently receives Supabase access and refresh tokens from `private/accept_invitation`, then places both tokens in the browser URL query string while navigating to `/login`. Even though the login page later scrubs the URL, those tokens can be exposed to browser history, logs, screenshots, extensions, or client-side telemetry during the redirect. The invitation page already has the Supabase client, so it can establish the session without placing credentials in navigation state.

## Test Plan

- [x] `git diff --check`
- [x] `bunx eslint src/pages/invitation.vue`
