### PR TITLE
fix(api): redact organization member logs

### DIFF
--- a/supabase/functions/_backend/public/organization/members/delete.ts
+++ b/supabase/functions/_backend/public/organization/members/delete.ts
@@ -7,6 +7,7 @@ import { BRES, quickError, simpleError } from '../../../utils/hono.ts'
 import { cloudlog } from '../../../utils/logging.ts'
 import { checkPermission } from '../../../utils/rbac.ts'
 import { supabaseAdmin, supabaseApikey } from '../../../utils/supabase.ts'
+import { getOrganizationMemberDeleteLogMetadata } from './logging.ts'
 
 const deleteBodySchema = type({
   orgId: 'string',
@@ -38,8 +39,6 @@ export async function deleteMember(c: Context<MiddlewareKeyVariables>, bodyRaw: 
 
   // Use authenticated client for the delete operation - RLS will enforce org access
   const supabase = supabaseApikey(c, c.get('capgkey') as string)
-  cloudlog({ requestId: c.get('requestId'), message: 'userData.id', data: userData.id })
-  cloudlog({ requestId: c.get('requestId'), message: 'body.orgId', data: body.orgId })
   const { data: deletedMembership, error } = await supabase
     .from('org_users')
     .delete()
@@ -69,6 +68,10 @@ export async function deleteMember(c: Context<MiddlewareKeyVariables>, bodyRaw: 
     throw simpleError('error_deleting_role_bindings', 'Error deleting role bindings for user', { error: rbacError })
   }
 
-  cloudlog({ requestId: c.get('requestId'), message: 'User deleted from organization', data: { user_id: userData.id, org_id: body.orgId } })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'User deleted from organization',
+    data: getOrganizationMemberDeleteLogMetadata(body, userData.id),
+  })
   return c.json(BRES)
 }

--- a/supabase/functions/_backend/public/organization/members/get.ts
+++ b/supabase/functions/_backend/public/organization/members/get.ts
@@ -8,6 +8,7 @@ import { cloudlog } from '../../../utils/logging.ts'
 import { checkPermission } from '../../../utils/rbac.ts'
 import { createSignedImageUrl } from '../../../utils/storage.ts'
 import { apikeyHasOrgRightWithPolicy, supabaseApikey } from '../../../utils/supabase.ts'
+import { getOrganizationMembersLogMetadata, getOrganizationMembersQueryLogMetadata } from './logging.ts'
 
 const bodySchema = type({
   orgId: 'string',
@@ -51,7 +52,11 @@ export async function get(c: Context<MiddlewareKeyVariables>, bodyRaw: any, apik
       guild_id: body.orgId,
     })
 
-  cloudlog({ requestId: c.get('requestId'), message: 'data', data, error })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Organization members query result',
+    data: getOrganizationMembersQueryLogMetadata(data, error),
+  })
   if (error) {
     throw simpleError('cannot_get_organization_members', 'Cannot get organization members', { error })
   }
@@ -74,6 +79,10 @@ export async function get(c: Context<MiddlewareKeyVariables>, bodyRaw: any, apik
     }
   }))
 
-  cloudlog({ requestId: c.get('requestId'), message: 'Members', data: signedMembers })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Organization members prepared',
+    data: getOrganizationMembersLogMetadata(signedMembers),
+  })
   return c.json(signedMembers)
 }

--- a/supabase/functions/_backend/public/organization/members/logging.ts
+++ b/supabase/functions/_backend/public/organization/members/logging.ts
@@ -1,0 +1,76 @@
+interface OrganizationMemberInviteBody {
+  orgId?: unknown
+  email?: unknown
+  invite_type?: unknown
+}
+
+interface OrganizationMemberDeleteBody {
+  orgId?: unknown
+  email?: unknown
+}
+
+interface OrganizationMemberLogEntry {
+  image_url?: unknown
+  is_tmp?: unknown
+}
+
+// Supabase/Postgres error identifiers are short symbolic tokens; drop anything else.
+const SAFE_ERROR_FIELD_PATTERN = /^\w{1,32}$/
+
+function hasStringValue(value: unknown) {
+  return typeof value === 'string' && value.length > 0
+}
+
+function getSafeErrorField(value: unknown) {
+  return typeof value === 'string' && SAFE_ERROR_FIELD_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+function getErrorLogMetadata(error: unknown) {
+  if (!error)
+    return { hasError: false }
+
+  if (typeof error === 'object') {
+    const issue = error as { code?: unknown, name?: unknown }
+    return {
+      hasError: true,
+      errorCode: getSafeErrorField(issue.code),
+      errorName: getSafeErrorField(issue.name),
+    }
+  }
+
+  return { hasError: true }
+}
+
+export function getOrganizationInviteLogMetadata(body: OrganizationMemberInviteBody) {
+  return {
+    hasOrgId: hasStringValue(body.orgId),
+    hasEmail: hasStringValue(body.email),
+    hasInviteType: typeof body.invite_type === 'string',
+  }
+}
+
+export function getOrganizationMemberDeleteLogMetadata(body: OrganizationMemberDeleteBody, userId?: unknown) {
+  return {
+    hasOrgId: hasStringValue(body.orgId),
+    hasEmail: hasStringValue(body.email),
+    hasUserId: hasStringValue(userId),
+  }
+}
+
+export function getOrganizationMembersQueryLogMetadata(data: unknown, error: unknown) {
+  return {
+    hasData: Array.isArray(data) && data.length > 0,
+    memberCount: Array.isArray(data) ? data.length : 0,
+    ...getErrorLogMetadata(error),
+  }
+}
+
+export function getOrganizationMembersLogMetadata(members: OrganizationMemberLogEntry[]) {
+  return {
+    memberCount: members.length,
+    temporaryMemberCount: members.filter(member => member.is_tmp === true).length,
+    hasSignedImages: members.some(member => hasStringValue(member.image_url)),
+  }
+}

--- a/supabase/functions/_backend/public/organization/members/post.ts
+++ b/supabase/functions/_backend/public/organization/members/post.ts
@@ -7,6 +7,7 @@ import { BRES, simpleError } from '../../../utils/hono.ts'
 import { cloudlog } from '../../../utils/logging.ts'
 import { checkPermission } from '../../../utils/rbac.ts'
 import { supabaseApikey } from '../../../utils/supabase.ts'
+import { getOrganizationInviteLogMetadata } from './logging.ts'
 
 const inviteBodySchema = type({
   orgId: 'string',
@@ -93,6 +94,10 @@ export async function post(c: Context<MiddlewareKeyVariables>, bodyRaw: any, _ap
   if (data && data !== 'OK') {
     throw simpleError('error_inviting_user_to_organization', 'Error inviting user to organization', { data })
   }
-  cloudlog({ requestId: c.get('requestId'), message: 'User invited to organization', data: { email: body.email, org_id: body.orgId } })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'User invited to organization',
+    data: getOrganizationInviteLogMetadata(body),
+  })
   return c.json(BRES)
 }

--- a/tests/organization-members-logging.unit.test.ts
+++ b/tests/organization-members-logging.unit.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  apikeyHasOrgRightWithPolicyMock,
+  checkPermissionMock,
+  cloudlogMock,
+  createSignedImageUrlMock,
+  supabaseAdminMock,
+  supabaseApikeyMock,
+} = vi.hoisted(() => ({
+  apikeyHasOrgRightWithPolicyMock: vi.fn(),
+  checkPermissionMock: vi.fn(),
+  cloudlogMock: vi.fn(),
+  createSignedImageUrlMock: vi.fn(),
+  supabaseAdminMock: vi.fn(),
+  supabaseApikeyMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
+  BRES: { status: 'ok' },
+  quickError: (status: number, error: string, message: string, details: Record<string, unknown> = {}) => {
+    const issue = new Error(message) as Error & { details?: Record<string, unknown>, status?: number }
+    issue.status = status
+    issue.details = { error, ...details }
+    throw issue
+  },
+  simpleError: (error: string, message: string, details: Record<string, unknown> = {}) => {
+    const issue = new Error(message) as Error & { details?: Record<string, unknown>, status?: number }
+    issue.status = 400
+    issue.details = { error, ...details }
+    throw issue
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/storage.ts', () => ({
+  createSignedImageUrl: (...args: unknown[]) => createSignedImageUrlMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  apikeyHasOrgRightWithPolicy: (...args: unknown[]) => apikeyHasOrgRightWithPolicyMock(...args),
+  supabaseAdmin: (...args: unknown[]) => supabaseAdminMock(...args),
+  supabaseApikey: (...args: unknown[]) => supabaseApikeyMock(...args),
+}))
+
+const ORG_ID = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+const USER_ID = '86a84313-9b9f-46d0-9cbb-09d67f18c8f6'
+const MEMBER_ID = '73ad0d23-ce1f-40ca-a9e8-d3a73eaa1ff2'
+const INVITE_ID = 'b814fd2d-7f5c-4526-a2e4-a52534616b52'
+const MEMBER_EMAIL = 'member@example.com'
+const INVITE_EMAIL = 'invitee@example.com'
+const SIGNED_IMAGE_URL = 'https://storage.example.com/image.png?token=secret-token'
+
+function createContext() {
+  return {
+    get: vi.fn((key: string) => {
+      if (key === 'requestId')
+        return 'request-test'
+      if (key === 'capgkey')
+        return 'capgkey-secret'
+      if (key === 'auth')
+        return undefined
+      return undefined
+    }),
+    json: vi.fn((body: unknown) => Response.json(body)),
+  }
+}
+
+function buildInviteSupabaseClient(useNewRbac = false) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table !== 'orgs')
+        throw new Error(`Unexpected table: ${table}`)
+
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { use_new_rbac: useNewRbac }, error: null }),
+      }
+    }),
+    rpc: vi.fn().mockResolvedValue({ data: 'OK', error: null }),
+  }
+}
+
+function buildDeleteSupabaseClient() {
+  return {
+    from: vi.fn((table: string) => {
+      if (table !== 'org_users')
+        throw new Error(`Unexpected table: ${table}`)
+
+      return {
+        delete: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: { org_id: ORG_ID, user_id: USER_ID }, error: null }),
+        select: vi.fn().mockReturnThis(),
+      }
+    }),
+  }
+}
+
+function buildAdminClient() {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'users') {
+        return {
+          eq: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { id: USER_ID }, error: null }),
+        }
+      }
+
+      if (table === 'role_bindings') {
+        return {
+          delete: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          error: null,
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    }),
+  }
+}
+
+function buildGetMembersSupabaseClient() {
+  return {
+    rpc: vi.fn().mockResolvedValue({
+      data: [
+        {
+          email: MEMBER_EMAIL,
+          image_url: 'org/member/avatar.png',
+          is_tmp: false,
+          role: 'admin',
+          uid: MEMBER_ID,
+        },
+        {
+          email: INVITE_EMAIL,
+          image_url: null,
+          is_tmp: true,
+          role: 'invite_read',
+          uid: INVITE_ID,
+        },
+      ],
+      error: null,
+    }),
+  }
+}
+
+function expectLogsToExcludeSensitiveValues() {
+  const logs = JSON.stringify(cloudlogMock.mock.calls)
+  expect(logs).not.toContain(ORG_ID)
+  expect(logs).not.toContain(USER_ID)
+  expect(logs).not.toContain(MEMBER_ID)
+  expect(logs).not.toContain(INVITE_ID)
+  expect(logs).not.toContain(MEMBER_EMAIL)
+  expect(logs).not.toContain(INVITE_EMAIL)
+  expect(logs).not.toContain('capgkey-secret')
+  expect(logs).not.toContain('secret-token')
+}
+
+describe('organization members logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apikeyHasOrgRightWithPolicyMock.mockResolvedValue({ valid: true })
+    checkPermissionMock.mockResolvedValue(true)
+    createSignedImageUrlMock.mockResolvedValue(SIGNED_IMAGE_URL)
+    supabaseAdminMock.mockReturnValue(buildAdminClient())
+  })
+
+  it('does not log invited email or organization id when inviting a member', async () => {
+    supabaseApikeyMock.mockReturnValue(buildInviteSupabaseClient())
+    const { post } = await import('../supabase/functions/_backend/public/organization/members/post.ts')
+
+    const response = await post(createContext() as any, {
+      email: INVITE_EMAIL,
+      invite_type: 'read',
+      orgId: ORG_ID,
+    }, { key: 'api-key' } as any)
+
+    expect(response.status).toBe(200)
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        hasEmail: true,
+        hasInviteType: true,
+        hasOrgId: true,
+      }),
+      message: 'User invited to organization',
+    }))
+    expectLogsToExcludeSensitiveValues()
+  })
+
+  it('does not log deleted member email, user id, or organization id', async () => {
+    supabaseApikeyMock.mockReturnValue(buildDeleteSupabaseClient())
+    const { deleteMember } = await import('../supabase/functions/_backend/public/organization/members/delete.ts')
+
+    const response = await deleteMember(createContext() as any, {
+      email: MEMBER_EMAIL,
+      orgId: ORG_ID,
+    }, { key: 'api-key' } as any)
+
+    expect(response.status).toBe(200)
+    expect(cloudlogMock).toHaveBeenCalledTimes(1)
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        hasEmail: true,
+        hasOrgId: true,
+        hasUserId: true,
+      }),
+      message: 'User deleted from organization',
+    }))
+    expectLogsToExcludeSensitiveValues()
+  })
+
+  it('does not log member emails, ids, or signed image URLs when listing members', async () => {
+    supabaseApikeyMock.mockReturnValue(buildGetMembersSupabaseClient())
+    const { get } = await import('../supabase/functions/_backend/public/organization/members/get.ts')
+
+    const response = await get(createContext() as any, { orgId: ORG_ID }, {
+      key: 'api-key',
+      user_id: USER_ID,
+    } as any)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([
+      expect.objectContaining({ email: MEMBER_EMAIL, image_url: SIGNED_IMAGE_URL, uid: MEMBER_ID }),
+      expect.objectContaining({ email: INVITE_EMAIL, image_url: '', uid: INVITE_ID }),
+    ])
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        hasData: true,
+        hasError: false,
+        memberCount: 2,
+      }),
+      message: 'Organization members query result',
+    }))
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        hasSignedImages: true,
+        memberCount: 2,
+        temporaryMemberCount: 1,
+      }),
+      message: 'Organization members prepared',
+    }))
+    expectLogsToExcludeSensitiveValues()
+  })
+})


### PR DESCRIPTION
## Summary
- replace organization member invite/delete/list cloudlogs with metadata-only summaries
- stop retaining raw member emails, user ids, org ids, and signed image URLs in routine organization member logs
- add focused regression coverage for invite, delete, and list member log payloads

## Tests
- ./node_modules/.bin/vitest run tests/organization-members-logging.unit.test.ts
- ./node_modules/.bin/eslint supabase/functions/_backend/public/organization/members/logging.ts supabase/functions/_backend/public/organization/members/post.ts supabase/functions/_backend/public/organization/members/delete.ts supabase/functions/_backend/public/organization/members/get.ts tests/organization-members-logging.unit.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for organization member operations to ensure sensitive data is not exposed in system logs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2142)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->