### PR TITLE
fix: redact Bento log payload details

### DIFF
--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -8,13 +8,25 @@ function summarizeBentoResult(result: unknown) {
 
   const item = result as Record<string, unknown>
   const errors = item.errors
-  const results = item.results
+  const resultItems = item.results
+  let errorCount: number | undefined
+  let resultCount: number | undefined
+
+  if (Array.isArray(errors))
+    errorCount = errors.length
+  else if (errors !== undefined)
+    errorCount = 1
+
+  if (Array.isArray(resultItems))
+    resultCount = resultItems.length
+  else if (typeof resultItems === 'number')
+    resultCount = resultItems
 
   return {
     failed: typeof item.failed === 'number' ? item.failed : undefined,
-    errorCount: Array.isArray(errors) ? errors.length : errors === undefined ? undefined : 1,
+    errorCount,
     hasErrors: Array.isArray(errors) ? errors.length > 0 : errors !== undefined,
-    results: Array.isArray(results) ? results.length : typeof results === 'number' ? results : undefined,
+    results: resultCount,
   }
 }
 

--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -2,6 +2,18 @@ import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
 import { getEnv } from './utils.ts'
 
+function summarizeBentoResult(result: unknown) {
+  if (!result || typeof result !== 'object')
+    return { resultType: typeof result }
+
+  const item = result as Record<string, unknown>
+  return {
+    failed: typeof item.failed === 'number' ? item.failed : undefined,
+    hasErrors: item.errors !== undefined,
+    results: typeof item.results === 'number' ? item.results : undefined,
+  }
+}
+
 export function isBentoConfigured(c: Context) {
   const publishableKey = (getEnv(c, 'BENTO_PUBLISHABLE_KEY') || '').trim()
   const secretKey = (getEnv(c, 'BENTO_SECRET_KEY') || '').trim()
@@ -52,8 +64,7 @@ async function bentoFetch(c: Context, path: string, siteUuid: string, body: any)
   })
 
   if (!response.ok) {
-    const error = await response.text()
-    throw new Error(`Bento API error: ${response.status} ${error}`)
+    throw new Error(`Bento API error: ${response.status}`)
   }
 
   return response.json()
@@ -77,7 +88,7 @@ export async function trackBentoEvent(c: Context, email: string, data: any, even
 
     const res = await bentoFetch(c, 'batch/events', siteUuid, payload) as { results: number, failed: number }
     if (res.failed > 0) {
-      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvent', error: res })
+      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvent', error: summarizeBentoResult(res) })
       return false
     }
     return true
@@ -112,7 +123,14 @@ export async function addTagBento(c: Context, email: string, segments: { segment
       bentoFetch(c, 'fetch/commands', siteUuid, { command }),
     ))
 
-    cloudlog({ requestId: c.get('requestId'), message: 'addTagBento', email, commands, results })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'addTagBento',
+      addTagCount: segments.segments.length,
+      removeTagCount: segments.deleteSegments.length,
+      commandCount: commands.length,
+      results: results.map(summarizeBentoResult),
+    })
     return true
   }
   catch (e) {
@@ -152,7 +170,7 @@ export async function syncBentoSubscriberTags(
       const payload = { subscribers: chunk }
       const res = await bentoFetch(c, 'batch/subscribers', siteUuid, payload) as { results?: number, failed?: number, errors?: unknown }
       if (res?.failed && res.failed > 0) {
-        cloudlogErr({ requestId: c.get('requestId'), message: 'syncBentoSubscriberTags', error: res })
+        cloudlogErr({ requestId: c.get('requestId'), message: 'syncBentoSubscriberTags', error: summarizeBentoResult(res) })
         return false
       }
     }
@@ -177,11 +195,11 @@ export async function unsubscribeBento(c: Context, email: string) {
 
     const result = await bentoFetch(c, 'fetch/commands', siteUuid, { command })
 
-    cloudlog({ requestId: c.get('requestId'), message: 'unsubscribeBento', email, result })
+    cloudlog({ requestId: c.get('requestId'), message: 'unsubscribeBento', result: summarizeBentoResult(result) })
     return true
   }
   catch (e) {
-    cloudlog({ requestId: c.get('requestId'), message: 'unsubscribeBento error', error: e })
+    cloudlogErr({ requestId: c.get('requestId'), message: 'unsubscribeBento error', error: serializeError(e) })
     return false
   }
 }

--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -7,10 +7,14 @@ function summarizeBentoResult(result: unknown) {
     return { resultType: typeof result }
 
   const item = result as Record<string, unknown>
+  const errors = item.errors
+  const results = item.results
+
   return {
     failed: typeof item.failed === 'number' ? item.failed : undefined,
-    hasErrors: item.errors !== undefined,
-    results: typeof item.results === 'number' ? item.results : undefined,
+    errorCount: Array.isArray(errors) ? errors.length : errors === undefined ? undefined : 1,
+    hasErrors: Array.isArray(errors) ? errors.length > 0 : errors !== undefined,
+    results: Array.isArray(results) ? results.length : typeof results === 'number' ? results : undefined,
   }
 }
 

--- a/tests/bento-log-redaction.unit.test.ts
+++ b/tests/bento-log-redaction.unit.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cloudlogErrMock,
+  cloudlogMock,
+  fetchMock,
+  getEnvMock,
+} = vi.hoisted(() => ({
+  cloudlogErrMock: vi.fn(),
+  cloudlogMock: vi.fn(),
+  fetchMock: vi.fn(),
+  getEnvMock: vi.fn((c: { env?: Record<string, string> }, key: string) => c.env?.[key] ?? ''),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: cloudlogErrMock,
+  serializeError: (error: unknown) => ({ message: error instanceof Error ? error.message : String(error) }),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  getEnv: getEnvMock,
+}))
+
+function createContext() {
+  return {
+    env: {
+      BENTO_PUBLISHABLE_KEY: 'pub-key',
+      BENTO_SECRET_KEY: 'secret-key',
+      BENTO_SITE_UUID: 'site-uuid',
+    },
+    get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+  } as any
+}
+
+beforeEach(() => {
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify({
+      errors: [{ email: 'alice@example.com', message: 'subscriber failed' }],
+      failed: 0,
+      results: 1,
+    }), { status: 200 })),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  cloudlogErrMock.mockReset()
+  cloudlogMock.mockReset()
+  fetchMock.mockReset()
+  getEnvMock.mockClear()
+})
+
+describe('bento log redaction', () => {
+  it('keeps add tag logs free of recipient emails and command payloads', async () => {
+    const { addTagBento } = await import('../supabase/functions/_backend/utils/bento.ts')
+
+    await expect(addTagBento(createContext(), 'alice@example.com', {
+      deleteSegments: ['trial'],
+      segments: ['paying'],
+    })).resolves.toBe(true)
+
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      addTagCount: 1,
+      commandCount: 2,
+      message: 'addTagBento',
+      removeTagCount: 1,
+      results: [
+        expect.objectContaining({ failed: 0, hasErrors: true, results: 1 }),
+        expect.objectContaining({ failed: 0, hasErrors: true, results: 1 }),
+      ],
+    }))
+
+    const logged = JSON.stringify(cloudlogMock.mock.calls)
+    expect(logged).not.toContain('alice@example.com')
+    expect(logged).not.toContain('remove_tag')
+    expect(logged).not.toContain('add_tag')
+    expect(logged).not.toContain('subscriber failed')
+  })
+
+  it('keeps unsubscribe logs free of recipient emails and result payloads', async () => {
+    const { unsubscribeBento } = await import('../supabase/functions/_backend/utils/bento.ts')
+
+    await expect(unsubscribeBento(createContext(), 'alice@example.com')).resolves.toBe(true)
+
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'unsubscribeBento',
+      result: expect.objectContaining({ failed: 0, hasErrors: true, results: 1 }),
+    }))
+
+    const logged = JSON.stringify(cloudlogMock.mock.calls)
+    expect(logged).not.toContain('alice@example.com')
+    expect(logged).not.toContain('subscriber failed')
+  })
+
+  it('does not include third-party error bodies in Bento failure logs', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('alice@example.com could not be updated', {
+      status: 400,
+    }))
+
+    const { addTagBento } = await import('../supabase/functions/_backend/utils/bento.ts')
+
+    await expect(addTagBento(createContext(), 'alice@example.com', {
+      deleteSegments: [],
+      segments: ['paying'],
+    })).resolves.toBe(false)
+
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'addTagBento error',
+    }))
+
+    const logged = JSON.stringify(cloudlogErrMock.mock.calls)
+    expect(logged).toContain('Bento API error: 400')
+    expect(logged).not.toContain('alice@example.com')
+    expect(logged).not.toContain('could not be updated')
+  })
+})

--- a/tests/bento-log-redaction.unit.test.ts
+++ b/tests/bento-log-redaction.unit.test.ts
@@ -80,6 +80,70 @@ describe('bento log redaction', () => {
     expect(logged).not.toContain('subscriber failed')
   })
 
+  it('keeps failed event logs free of recipient emails, event details, and Bento error bodies', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      errors: [{ email: 'alice@example.com', message: 'event rejected' }],
+      failed: 1,
+      results: [{ email: 'alice@example.com', status: 'failed' }],
+    }), { status: 200 }))
+
+    const { trackBentoEvent } = await import('../supabase/functions/_backend/utils/bento.ts')
+
+    await expect(trackBentoEvent(createContext(), 'alice@example.com', {
+      plan: 'enterprise',
+      userId: 'user-123',
+    }, 'subscription_created')).resolves.toBe(false)
+
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        errorCount: 1,
+        failed: 1,
+        hasErrors: true,
+        results: 1,
+      }),
+      message: 'trackBentoEvent',
+    }))
+
+    const logged = JSON.stringify(cloudlogErrMock.mock.calls)
+    expect(logged).not.toContain('alice@example.com')
+    expect(logged).not.toContain('event rejected')
+    expect(logged).not.toContain('enterprise')
+    expect(logged).not.toContain('subscription_created')
+    expect(logged).not.toContain('user-123')
+  })
+
+  it('keeps subscriber sync failure logs free of recipient emails and tag payloads', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      errors: [{ email: 'alice@example.com', message: 'subscriber rejected' }],
+      failed: 1,
+      results: [{ email: 'alice@example.com', status: 'failed' }],
+    }), { status: 200 }))
+
+    const { syncBentoSubscriberTags } = await import('../supabase/functions/_backend/utils/bento.ts')
+
+    await expect(syncBentoSubscriberTags(createContext(), {
+      deleteSegments: ['trial'],
+      email: 'alice@example.com',
+      segments: ['paying'],
+    })).resolves.toBe(false)
+
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        errorCount: 1,
+        failed: 1,
+        hasErrors: true,
+        results: 1,
+      }),
+      message: 'syncBentoSubscriberTags',
+    }))
+
+    const logged = JSON.stringify(cloudlogErrMock.mock.calls)
+    expect(logged).not.toContain('alice@example.com')
+    expect(logged).not.toContain('subscriber rejected')
+    expect(logged).not.toContain('paying')
+    expect(logged).not.toContain('trial')
+  })
+
   it('keeps unsubscribe logs free of recipient emails and result payloads', async () => {
     const { unsubscribeBento } = await import('../supabase/functions/_backend/utils/bento.ts')
 

--- a/tests/bento-log-redaction.unit.test.ts
+++ b/tests/bento-log-redaction.unit.test.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -22,15 +23,22 @@ vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
   getEnv: getEnvMock,
 }))
 
-function createContext() {
-  return {
+interface BentoMockContext {
+  env: Record<string, string>
+  get: (key: string) => string | undefined
+}
+
+function createContext(): Context {
+  const context = {
     env: {
       BENTO_PUBLISHABLE_KEY: 'pub-key',
       BENTO_SECRET_KEY: 'secret-key',
       BENTO_SITE_UUID: 'site-uuid',
     },
     get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
-  } as any
+  } satisfies BentoMockContext
+
+  return context as unknown as Context
 }
 
 beforeEach(() => {


### PR DESCRIPTION
/claim #1667

## Summary
- Redacts Bento email-automation logs so recipient emails, tag names, command payloads, third-party result bodies, and third-party error text are not retained in application logs.
- Replaces raw Bento responses with compact status/count summaries while keeping useful failure signals for debugging.
- Keeps runtime behavior unchanged: Bento requests, return values, and success/failure handling remain the same apart from safer log/error surfaces.

## Scope
- Public-safe log-retention hardening only.
- No live Bento requests were made during verification.
- Tests use mocked Bento responses and mocked log sinks to assert sensitive values are absent from emitted logs.

## Verification
- Focused Vitest coverage for `tests/bento-log-redaction.unit.test.ts`: 5 tests passed locally.
- `git diff --check` passed.
- CI is green after the latest push: `changes`, `Run tests`, `Run Playwright tests`, `Check dead code`, Socket Security, SonarCloud, CodeRabbit, and CodSpeed all pass.

## Notes
This PR is intentionally narrow: it fixes one concrete retention surface and adds regression coverage for the sensitive values that should not appear in routine logs.