### PR TITLE
fix: redact user trigger record logs

### DIFF
--- a/supabase/functions/_backend/triggers/on_user_create.ts
+++ b/supabase/functions/_backend/triggers/on_user_create.ts
@@ -2,7 +2,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { cloudlog, summarizeRecordForLog } from '../utils/logging.ts'
 import { createApiKey } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { syncUserPreferenceTags } from '../utils/user_preferences.ts'
@@ -11,7 +11,13 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'user create trigger record',
+    record: summarizeRecordForLog(record, {
+      presenceFields: ['id', 'email', 'image_url', 'created_via_invite'],
+    }),
+  })
   await createApiKey(c, record.id)
   cloudlog({ requestId: c.get('requestId'), message: 'createCustomer stripe' })
   await syncUserPreferenceTags(c, record.email, record)

--- a/supabase/functions/_backend/triggers/on_user_delete.ts
+++ b/supabase/functions/_backend/triggers/on_user_delete.ts
@@ -4,7 +4,7 @@ import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
 import { unsubscribeBento } from '../utils/bento.ts'
 import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
-import { cloudlog, summarizeRecordForLog } from '../utils/logging.ts'
+import { cloudlog, summarizePresenceForLog, summarizeRecordForLog } from '../utils/logging.ts'
 import { cancelSubscription } from '../utils/stripe.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 
@@ -339,11 +339,21 @@ async function deleteUserImages(
         .storage
         .from('images')
         .remove(filePaths)
-      cloudlog({ requestId: c.get('requestId'), message: 'deleted user images', count: files.length, user_id: userId })
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'deleted user images',
+        count: files.length,
+        ...summarizePresenceForLog('user_id', userId),
+      })
     }
   }
   catch (error) {
-    cloudlog({ requestId: c.get('requestId'), message: 'error deleting user images', error, user_id: userId })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'error deleting user images',
+      error,
+      ...summarizePresenceForLog('user_id', userId),
+    })
   }
 }
 
@@ -440,7 +450,7 @@ async function deleteUser(c: Context, record: Database['public']['Tables']['user
     requestId: c.get('requestId'),
     context: 'user deletion completed',
     duration_ms: duration,
-    user_id: record.id,
+    ...summarizePresenceForLog('user_id', record.id),
   })
 
   return c.json(BRES)

--- a/supabase/functions/_backend/triggers/on_user_delete.ts
+++ b/supabase/functions/_backend/triggers/on_user_delete.ts
@@ -4,7 +4,7 @@ import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
 import { unsubscribeBento } from '../utils/bento.ts'
 import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { cloudlog, summarizeRecordForLog } from '../utils/logging.ts'
 import { cancelSubscription } from '../utils/stripe.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 
@@ -448,7 +448,13 @@ async function deleteUser(c: Context, record: Database['public']['Tables']['user
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'DELETE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'user delete trigger record',
+    record: summarizeRecordForLog(record, {
+      presenceFields: ['id', 'email', 'image_url'],
+    }),
+  })
 
   if (!record?.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'no user id' })

--- a/supabase/functions/_backend/triggers/on_user_update.ts
+++ b/supabase/functions/_backend/triggers/on_user_update.ts
@@ -3,7 +3,7 @@ import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cleanStoredImageMetadata } from '../utils/image.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { cloudlog, summarizeRecordForLog } from '../utils/logging.ts'
 import { createApiKey } from '../utils/supabase.ts'
 import { syncUserPreferenceTags } from '../utils/user_preferences.ts'
 
@@ -12,14 +12,24 @@ export const app = new Hono<MiddlewareKeyVariables>()
 app.post('/', middlewareAPISecret, triggerValidator('users', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
   const oldRecord = c.get('oldRecord') as Database['public']['Tables']['users']['Row'] | undefined
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'user update trigger record',
+    record: summarizeRecordForLog(record, {
+      presenceFields: ['id', 'email', 'image_url'],
+    }),
+  })
   if (!record.email) {
     cloudlog({ requestId: c.get('requestId'), message: 'No email' })
     return c.json(BRES)
   }
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No id' })
-    throw simpleError('no_id', 'No id', { record })
+    throw simpleError('no_id', 'No id', {
+      record: summarizeRecordForLog(record, {
+        presenceFields: ['id', 'email', 'image_url'],
+      }),
+    })
   }
   await createApiKey(c, record.id)
   await syncUserPreferenceTags(c, record.email, record, oldRecord, oldRecord?.email)

--- a/supabase/functions/_backend/utils/logging.ts
+++ b/supabase/functions/_backend/utils/logging.ts
@@ -26,6 +26,16 @@ export function serializeError(err: unknown) {
   }
 }
 
+function hasLogValue(value: unknown) {
+  return value !== undefined && value !== null && value !== ''
+}
+
+export function summarizePresenceForLog(field: string, value: unknown) {
+  return {
+    [`has_${field}`]: hasLogValue(value),
+  }
+}
+
 export function summarizeRecordForLog<T extends object>(
   record: T | null | undefined,
   options: {
@@ -46,7 +56,7 @@ export function summarizeRecordForLog<T extends object>(
 
   for (const field of options.presenceFields ?? []) {
     const value = recordValues[field]
-    summary[`has_${field}`] = value !== undefined && value !== null && value !== ''
+    summary[`has_${field}`] = hasLogValue(value)
   }
 
   return summary

--- a/supabase/functions/_backend/utils/logging.ts
+++ b/supabase/functions/_backend/utils/logging.ts
@@ -26,6 +26,32 @@ export function serializeError(err: unknown) {
   }
 }
 
+export function summarizeRecordForLog<T extends object>(
+  record: T | null | undefined,
+  options: {
+    presenceFields?: string[]
+  } = {},
+) {
+  const summary: Record<string, unknown> = {
+    fieldCount: 0,
+    hasRecord: !!record,
+  }
+
+  if (!record) {
+    return summary
+  }
+
+  const recordValues = record as Record<string, unknown>
+  summary.fieldCount = Object.keys(recordValues).length
+
+  for (const field of options.presenceFields ?? []) {
+    const value = recordValues[field]
+    summary[`has_${field}`] = value !== undefined && value !== null && value !== ''
+  }
+
+  return summary
+}
+
 export function cloudlogErr(message: any) {
   if (getRuntimeKey() === 'workerd') {
     console.error(message)

--- a/tests/logging-record-summary.unit.test.ts
+++ b/tests/logging-record-summary.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { summarizeRecordForLog } from '../supabase/functions/_backend/utils/logging.ts'
+import { summarizePresenceForLog, summarizeRecordForLog } from '../supabase/functions/_backend/utils/logging.ts'
 
 describe('summarizeRecordForLog', () => {
   it.concurrent('keeps field presence while redacting raw profile fields', () => {
@@ -33,5 +33,12 @@ describe('summarizeRecordForLog', () => {
       fieldCount: 0,
       hasRecord: false,
     })
+  })
+
+  it.concurrent('summarizes standalone identifiers without retaining raw values', () => {
+    const summary = summarizePresenceForLog('user_id', 'user-123')
+
+    expect(summary).toEqual({ has_user_id: true })
+    expect(JSON.stringify(summary)).not.toContain('user-123')
   })
 })

--- a/tests/logging-record-summary.unit.test.ts
+++ b/tests/logging-record-summary.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeRecordForLog } from '../supabase/functions/_backend/utils/logging.ts'
+
+describe('summarizeRecordForLog', () => {
+  it.concurrent('keeps field presence while redacting raw profile fields', () => {
+    const summary = summarizeRecordForLog({
+      app_metadata: { provider: 'github' },
+      email: 'alice@example.com',
+      id: 'user-123',
+      image_url: 'users/user-123/avatar.png',
+      raw_user_meta_data: { full_name: 'Alice Example' },
+    }, {
+      presenceFields: ['id', 'email', 'image_url', 'raw_user_meta_data'],
+    })
+
+    expect(summary).toEqual({
+      fieldCount: 5,
+      hasRecord: true,
+      has_email: true,
+      has_id: true,
+      has_image_url: true,
+      has_raw_user_meta_data: true,
+    })
+    expect(JSON.stringify(summary)).not.toContain('alice@example.com')
+    expect(JSON.stringify(summary)).not.toContain('avatar.png')
+    expect(JSON.stringify(summary)).not.toContain('Alice Example')
+  })
+
+  it.concurrent('handles missing records without leaking values', () => {
+    expect(summarizeRecordForLog(undefined, {
+      presenceFields: ['id', 'email'],
+    })).toEqual({
+      fieldCount: 0,
+      hasRecord: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- stop user create/update/delete triggers from writing full webhook records to routine logs
- add a shared `summarizeRecordForLog` helper that keeps selected IDs and presence flags without retaining emails, avatar paths, or profile metadata
- use the same summary in the user-update `no_id` error details

/claim #1667

## Test plan

- `bunx vitest run tests/logging-record-summary.unit.test.ts`
- `bunx eslint supabase/functions/_backend/utils/logging.ts supabase/functions/_backend/triggers/on_user_create.ts supabase/functions/_backend/triggers/on_user_update.ts supabase/functions/_backend/triggers/on_user_delete.ts tests/logging-record-summary.unit.test.ts`
- `git diff --check`

## Screenshots

N/A - backend log hardening only.

## Checklist

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved logging for user create/update/delete flows to emit compact, non-sensitive summaries of user data while preserving existing behavior.

* **Tests**
  * Added unit tests ensuring log summaries omit raw sensitive values and correctly report presence flags and field counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2144)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->