### PR TITLE
Reduce organization member log exposure

### DIFF
--- a/supabase/functions/_backend/public/organization/members/delete.ts
+++ b/supabase/functions/_backend/public/organization/members/delete.ts
@@ -38,8 +38,12 @@ export async function deleteMember(c: Context<MiddlewareKeyVariables>, bodyRaw: 
 
   // Use authenticated client for the delete operation - RLS will enforce org access
   const supabase = supabaseApikey(c, c.get('capgkey') as string)
-  cloudlog({ requestId: c.get('requestId'), message: 'userData.id', data: userData.id })
-  cloudlog({ requestId: c.get('requestId'), message: 'body.orgId', data: body.orgId })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Deleting organization member',
+    hasOrgId: !!body.orgId,
+    userResolved: !!userData.id,
+  })
   const { data: deletedMembership, error } = await supabase
     .from('org_users')
     .delete()
@@ -69,6 +73,11 @@ export async function deleteMember(c: Context<MiddlewareKeyVariables>, bodyRaw: 
     throw simpleError('error_deleting_role_bindings', 'Error deleting role bindings for user', { error: rbacError })
   }
 
-  cloudlog({ requestId: c.get('requestId'), message: 'User deleted from organization', data: { user_id: userData.id, org_id: body.orgId } })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'User deleted from organization',
+    hasOrgId: !!body.orgId,
+    deleted: !!deletedMembership,
+  })
   return c.json(BRES)
 }

--- a/supabase/functions/_backend/public/organization/members/get.ts
+++ b/supabase/functions/_backend/public/organization/members/get.ts
@@ -21,6 +21,24 @@ const memberSchema = type({
   is_tmp: 'boolean',
 }).array()
 
+interface MemberForLog {
+  image_url?: string | null
+  is_tmp: boolean
+  role: string
+}
+
+function summarizeMembersForLog(members: MemberForLog[]) {
+  return {
+    count: members.length,
+    withImage: members.filter(member => !!member.image_url).length,
+    tmpCount: members.filter(member => member.is_tmp).length,
+    roles: members.reduce<Record<string, number>>((acc, member) => {
+      acc[member.role] = (acc[member.role] ?? 0) + 1
+      return acc
+    }, {}),
+  }
+}
+
 export async function get(c: Context<MiddlewareKeyVariables>, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
   const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
   if (!bodyParsed.success) {
@@ -51,7 +69,14 @@ export async function get(c: Context<MiddlewareKeyVariables>, bodyRaw: any, apik
       guild_id: body.orgId,
     })
 
-  cloudlog({ requestId: c.get('requestId'), message: 'data', data, error })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'organization members query',
+    hasOrgId: !!body.orgId,
+    hasData: Array.isArray(data),
+    memberCount: Array.isArray(data) ? data.length : 0,
+    hasError: !!error,
+  })
   if (error) {
     throw simpleError('cannot_get_organization_members', 'Cannot get organization members', { error })
   }
@@ -74,6 +99,11 @@ export async function get(c: Context<MiddlewareKeyVariables>, bodyRaw: any, apik
     }
   }))
 
-  cloudlog({ requestId: c.get('requestId'), message: 'Members', data: signedMembers })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'organization members response',
+    hasOrgId: !!body.orgId,
+    ...summarizeMembersForLog(parsed.data),
+  })
   return c.json(signedMembers)
 }

--- a/supabase/functions/_backend/public/organization/members/post.ts
+++ b/supabase/functions/_backend/public/organization/members/post.ts
@@ -93,6 +93,12 @@ export async function post(c: Context<MiddlewareKeyVariables>, bodyRaw: any, _ap
   if (data && data !== 'OK') {
     throw simpleError('error_inviting_user_to_organization', 'Error inviting user to organization', { data })
   }
-  cloudlog({ requestId: c.get('requestId'), message: 'User invited to organization', data: { email: body.email, org_id: body.orgId } })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'User invited to organization',
+    hasOrgId: !!body.orgId,
+    inviteType: body.invite_type,
+    emailPresent: !!body.email,
+  })
   return c.json(BRES)
 }


### PR DESCRIPTION
## Summary
- replace full organization-member query/response logs with metadata-only summaries
- avoid logging invited member emails and deleted member user IDs in org member routes
- keep API behavior unchanged while preserving count/error/role diagnostics

## Security impact
Organization member routes currently log full member arrays, emails, user ids, and signed image URLs during routine list/invite/delete flows. This change keeps those values out of retained logs and records only operational metadata needed for debugging.

Linked to #1667.

## Verification
- `bunx eslint supabase/functions/_backend/public/organization/members/get.ts supabase/functions/_backend/public/organization/members/post.ts supabase/functions/_backend/public/organization/members/delete.ts`
- `bun typecheck`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging infrastructure for organization member management operations (member deletion, retrieval, and invitations) to improve system observability and debugging capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->