### PR TITLE
fix(api): redact password compliance logs

### DIFF
--- a/supabase/functions/_backend/private/validate_password_compliance.ts
+++ b/supabase/functions/_backend/private/validate_password_compliance.ts
@@ -12,6 +12,7 @@ import { clearFailedAccountAuth, isAccountRateLimited, isIPRateLimited, recordFa
 import { buildRateLimitInfo } from '../utils/rateLimitInfo.ts'
 import { emptySupabase, supabaseClient, supabaseAdmin as useSupabaseAdmin } from '../utils/supabase.ts'
 import { getEnv } from '../utils/utils.ts'
+import { getPasswordComplianceBodyLogMetadata, getPasswordComplianceSuccessLogMetadata } from './validate_password_compliance_logging.ts'
 
 interface ValidatePasswordCompliance {
   email: string
@@ -154,8 +155,7 @@ app.post('/', async (c) => {
     return simpleRateLimit({ reason: 'too_many_failed_account_auth_attempts', ...buildRateLimitInfo(accountRateLimitStatus.resetAt) })
   }
 
-  const { password: _password, captcha_token: _captchaToken, ...bodyWithoutPassword } = body
-  cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance raw body', rawBody: bodyWithoutPassword })
+  cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance raw body', rawBody: getPasswordComplianceBodyLogMetadata(body) })
 
   const adminClient = useSupabaseAdmin(c)
 
@@ -279,7 +279,7 @@ app.post('/', async (c) => {
     return quickError(500, 'compliance_update_failed', 'Failed to update compliance record', { error: upsertError.message })
   }
 
-  cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance - success', userId, orgId: body.org_id })
+  cloudlog({ requestId: c.get('requestId'), context: 'validate_password_compliance - success', ...getPasswordComplianceSuccessLogMetadata(userId, body.org_id) })
 
   return c.json({
     status: 'ok',

--- a/supabase/functions/_backend/private/validate_password_compliance_logging.ts
+++ b/supabase/functions/_backend/private/validate_password_compliance_logging.ts
@@ -1,0 +1,31 @@
+type PasswordComplianceField = 'email' | 'password' | 'org_id' | 'captcha_token'
+
+function getBodyObject(body: unknown) {
+  if (!body || typeof body !== 'object' || Array.isArray(body))
+    return null
+  return body as Partial<Record<PasswordComplianceField, unknown>> & Record<string, unknown>
+}
+
+function hasStringField(body: Record<string, unknown> | null, field: PasswordComplianceField) {
+  return typeof body?.[field] === 'string'
+}
+
+export function getPasswordComplianceBodyLogMetadata(body: unknown) {
+  const bodyObject = getBodyObject(body)
+
+  return {
+    bodyType: Array.isArray(body) ? 'array' : typeof body,
+    fieldCount: bodyObject ? Object.keys(bodyObject).length : 0,
+    hasEmail: hasStringField(bodyObject, 'email'),
+    hasPassword: hasStringField(bodyObject, 'password'),
+    hasOrgId: hasStringField(bodyObject, 'org_id'),
+    hasCaptchaToken: hasStringField(bodyObject, 'captcha_token'),
+  }
+}
+
+export function getPasswordComplianceSuccessLogMetadata(userId: unknown, orgId: unknown) {
+  return {
+    hasUserId: typeof userId === 'string' && userId.length > 0,
+    hasOrgId: typeof orgId === 'string' && orgId.length > 0,
+  }
+}

--- a/tests/password-compliance-logging.unit.test.ts
+++ b/tests/password-compliance-logging.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getPasswordComplianceBodyLogMetadata, getPasswordComplianceSuccessLogMetadata } from '../supabase/functions/_backend/private/validate_password_compliance_logging.ts'
+
+describe('password compliance logging metadata', () => {
+  it('summarizes request bodies without retaining credentials or identifiers', () => {
+    const metadata = getPasswordComplianceBodyLogMetadata({
+      email: 'member@example.com',
+      password: 'CorrectHorseBatteryStaple123!',
+      org_id: '6f06fb67-b12e-4b20-b593-33b4f4411d09',
+      captcha_token: 'turnstile-secret-token',
+      unexpected: 'raw-extra-value',
+    })
+
+    expect(metadata).toEqual({
+      bodyType: 'object',
+      fieldCount: 5,
+      hasEmail: true,
+      hasPassword: true,
+      hasOrgId: true,
+      hasCaptchaToken: true,
+    })
+
+    const serialized = JSON.stringify(metadata)
+    expect(serialized).not.toContain('member@example.com')
+    expect(serialized).not.toContain('CorrectHorseBatteryStaple123!')
+    expect(serialized).not.toContain('6f06fb67-b12e-4b20-b593-33b4f4411d09')
+    expect(serialized).not.toContain('turnstile-secret-token')
+    expect(serialized).not.toContain('raw-extra-value')
+  })
+
+  it('summarizes malformed request bodies without preserving raw values', () => {
+    expect(getPasswordComplianceBodyLogMetadata(null)).toEqual({
+      bodyType: 'object',
+      fieldCount: 0,
+      hasEmail: false,
+      hasPassword: false,
+      hasOrgId: false,
+      hasCaptchaToken: false,
+    })
+
+    expect(getPasswordComplianceBodyLogMetadata(['member@example.com'])).toEqual({
+      bodyType: 'array',
+      fieldCount: 0,
+      hasEmail: false,
+      hasPassword: false,
+      hasOrgId: false,
+      hasCaptchaToken: false,
+    })
+  })
+
+  it('does not retain user or organization identifiers in success metadata', () => {
+    const metadata = getPasswordComplianceSuccessLogMetadata(
+      '57a6fb0a-fc26-419d-aeb0-9f44f4d0b53a',
+      '6f06fb67-b12e-4b20-b593-33b4f4411d09',
+    )
+
+    expect(metadata).toEqual({
+      hasUserId: true,
+      hasOrgId: true,
+    })
+
+    const serialized = JSON.stringify(metadata)
+    expect(serialized).not.toContain('57a6fb0a-fc26-419d-aeb0-9f44f4d0b53a')
+    expect(serialized).not.toContain('6f06fb67-b12e-4b20-b593-33b4f4411d09')
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- replace validate_password_compliance request logs with metadata-only summaries
- stop retaining raw email, password, captcha token, organization id, and extra request fields in routine cloud logs
- redact the success log so it records identifier presence without user/org ids

## Motivation
This is a small hardening follow-up for the public security rewards thread. The endpoint already avoided logging the password and captcha token directly, but the request log still retained email/org identifiers and the success log retained user/org ids. Those values are not needed for routine diagnostics.

## Test Plan
- `./node_modules/.bin/vitest run tests/password-compliance-logging.unit.test.ts`
- `./node_modules/.bin/vitest run tests/account-rate-limit.unit.test.ts tests/password-compliance-logging.unit.test.ts`
- `./node_modules/.bin/eslint supabase/functions/_backend/private/validate_password_compliance.ts supabase/functions/_backend/private/validate_password_compliance_logging.ts tests/password-compliance-logging.unit.test.ts`
- `git diff --check`
