### PR TITLE
fix: redact trigger record logs

### DIFF
--- a/supabase/functions/_backend/triggers/logging.ts
+++ b/supabase/functions/_backend/triggers/logging.ts
@@ -1,0 +1,134 @@
+import type { Context } from 'hono'
+import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { Database } from '../utils/supabase.types.ts'
+import { cloudlog } from '../utils/logging.ts'
+
+type AppRecord = Database['public']['Tables']['apps']['Row']
+type AppVersionRecord = Database['public']['Tables']['app_versions']['Row']
+type ChannelRecord = Database['public']['Tables']['channels']['Row']
+type DeployHistoryRecord = Database['public']['Tables']['deploy_history']['Row']
+type ManifestRecord = Database['public']['Tables']['manifest']['Row']
+type OrgRecord = Database['public']['Tables']['orgs']['Row']
+type UserRecord = Database['public']['Tables']['users']['Row']
+
+export function logTriggerRecord<TRecord>(
+  c: Context<MiddlewareKeyVariables>,
+  message: string,
+  record: TRecord,
+  getMetadata: (record: TRecord) => Record<string, unknown>,
+) {
+  cloudlog({
+    requestId: c.get('requestId'),
+    message,
+    record: getMetadata(record),
+  })
+}
+
+function hasStringValue(value: unknown) {
+  return typeof value === 'string' && value.length > 0
+}
+
+function hasNumberValue(value: unknown) {
+  return typeof value === 'number'
+}
+
+export function getOrgTriggerRecordLogMetadata(record: OrgRecord) {
+  return {
+    hasId: hasStringValue(record.id),
+    hasName: hasStringValue(record.name),
+    hasManagementEmail: hasStringValue(record.management_email),
+    hasCustomerId: hasStringValue(record.customer_id),
+    hasCreatedBy: hasStringValue(record.created_by),
+    hasWebsite: hasStringValue(record.website),
+    hasLogo: hasStringValue(record.logo),
+    hasRequiredEncryptionKey: hasStringValue(record.required_encryption_key),
+    enforces2fa: record.enforcing_2fa,
+    usesNewRbac: record.use_new_rbac,
+    requiresApikeyExpiration: record.require_apikey_expiration,
+  }
+}
+
+export function getAppTriggerRecordLogMetadata(record: AppRecord) {
+  return {
+    hasId: hasStringValue(record.id),
+    hasAppId: hasStringValue(record.app_id),
+    hasOwnerOrg: hasStringValue(record.owner_org),
+    hasUserId: hasStringValue(record.user_id),
+    hasName: hasStringValue(record.name),
+    hasIconUrl: hasStringValue(record.icon_url),
+    hasAndroidStoreUrl: hasStringValue(record.android_store_url),
+    hasIosStoreUrl: hasStringValue(record.ios_store_url),
+    hasLastVersion: hasStringValue(record.last_version),
+    transferHistoryCount: Array.isArray(record.transfer_history) ? record.transfer_history.length : 0,
+  }
+}
+
+export function getAppVersionTriggerRecordLogMetadata(record: AppVersionRecord) {
+  return {
+    hasId: hasNumberValue(record.id),
+    hasAppId: hasStringValue(record.app_id),
+    hasOwnerOrg: hasStringValue(record.owner_org),
+    hasUserId: hasStringValue(record.user_id),
+    hasName: hasStringValue(record.name),
+    hasChecksum: hasStringValue(record.checksum),
+    hasExternalUrl: hasStringValue(record.external_url),
+    hasKeyId: hasStringValue(record.key_id),
+    hasLink: hasStringValue(record.link),
+    hasMinUpdateVersion: hasStringValue(record.min_update_version),
+    hasR2Path: hasStringValue(record.r2_path),
+    hasSessionKey: hasStringValue(record.session_key),
+    manifestCount: Array.isArray(record.manifest) ? record.manifest.length : 0,
+    nativePackagesCount: Array.isArray(record.native_packages) ? record.native_packages.length : 0,
+    deleted: record.deleted,
+  }
+}
+
+export function getChannelTriggerRecordLogMetadata(record: ChannelRecord) {
+  return {
+    hasId: hasNumberValue(record.id),
+    hasAppId: hasStringValue(record.app_id),
+    hasOwnerOrg: hasStringValue(record.owner_org),
+    hasCreatedBy: hasStringValue(record.created_by),
+    hasName: hasStringValue(record.name),
+    hasRbacId: hasStringValue(record.rbac_id),
+    hasVersion: hasNumberValue(record.version),
+    isPublic: record.public,
+  }
+}
+
+export function getDeployHistoryTriggerRecordLogMetadata(record: DeployHistoryRecord) {
+  return {
+    hasId: hasNumberValue(record.id),
+    hasAppId: hasStringValue(record.app_id),
+    hasOwnerOrg: hasStringValue(record.owner_org),
+    hasCreatedBy: hasStringValue(record.created_by),
+    hasChannelId: hasNumberValue(record.channel_id),
+    hasVersionId: hasNumberValue(record.version_id),
+  }
+}
+
+export function getManifestTriggerRecordLogMetadata(record: ManifestRecord) {
+  return {
+    hasId: hasNumberValue(record.id),
+    hasAppVersionId: hasNumberValue(record.app_version_id),
+    hasFileName: hasStringValue(record.file_name),
+    hasFileHash: hasStringValue(record.file_hash),
+    hasS3Path: hasStringValue(record.s3_path),
+    hasFileSize: hasNumberValue(record.file_size),
+  }
+}
+
+export function getUserTriggerRecordLogMetadata(record: UserRecord) {
+  return {
+    hasId: hasStringValue(record.id),
+    hasEmail: hasStringValue(record.email),
+    hasFirstName: hasStringValue(record.first_name),
+    hasLastName: hasStringValue(record.last_name),
+    hasImageUrl: hasStringValue(record.image_url),
+    hasCountry: hasStringValue(record.country),
+    hasBanTime: hasStringValue(record.ban_time),
+    createdViaInvite: record.created_via_invite,
+    notificationsEnabled: record.enable_notifications,
+    optedForNewsletters: record.opt_for_newsletters,
+  }
+}

--- a/supabase/functions/_backend/triggers/on_app_create.ts
+++ b/supabase/functions/_backend/triggers/on_app_create.ts
@@ -12,12 +12,13 @@ import * as schema from '../utils/postgres_schema.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
+import { getAppTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['apps']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'app insert trigger record', record, getAppTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No id' })
@@ -54,7 +55,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
   if (!appExists) {
     ownerOrg = ownerOrg ?? (record.owner_org ?? undefined)
     if (!ownerOrg) {
-      cloudlog({ requestId: c.get('requestId'), message: 'App missing and no owner_org in webhook payload, skipping', record })
+      logTriggerRecord(c, 'App missing and no owner_org in webhook payload, skipping', record, getAppTriggerRecordLogMetadata)
       return c.json(BRES)
     }
 
@@ -83,7 +84,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
       throw simpleError('error_fetching_organization', 'Error fetching organization', { error })
     }
 
-    cloudlog({ requestId: c.get('requestId'), message: 'App missing, skipping onboarding and default versions', record })
+    logTriggerRecord(c, 'App missing, skipping onboarding and default versions', record, getAppTriggerRecordLogMetadata)
     return c.json(BRES)
   }
 
@@ -99,7 +100,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
 
   // Can't proceed with onboarding/default versions without an org id.
   if (!ownerOrg) {
-    cloudlog({ requestId: c.get('requestId'), message: 'App missing or no owner_org, skipping onboarding and default versions', record })
+    logTriggerRecord(c, 'App missing or no owner_org, skipping onboarding and default versions', record, getAppTriggerRecordLogMetadata)
     return c.json(BRES)
   }
 

--- a/supabase/functions/_backend/triggers/on_app_delete.ts
+++ b/supabase/functions/_backend/triggers/on_app_delete.ts
@@ -5,12 +5,13 @@ import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { s3 } from '../utils/s3.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import { getAppTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('apps', 'DELETE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['apps']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'app delete trigger record', record, getAppTriggerRecordLogMetadata)
 
   if (!record?.app_id) {
     cloudlog({ requestId: c.get('requestId'), message: 'no app id' })

--- a/supabase/functions/_backend/triggers/on_app_update.ts
+++ b/supabase/functions/_backend/triggers/on_app_update.ts
@@ -4,12 +4,13 @@ import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cleanStoredImageMetadata } from '../utils/image.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { getAppTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('apps', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['apps']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'app update trigger record', record, getAppTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No app id' })

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -6,6 +6,7 @@ import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../uti
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { retryWithBackoff } from '../utils/retry.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import { getChannelTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -95,7 +96,7 @@ async function getCurrentPublicWinner(
 
 app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['channels']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'channel update trigger record', record, getChannelTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No id' })

--- a/supabase/functions/_backend/triggers/on_deploy_history_create.ts
+++ b/supabase/functions/_backend/triggers/on_deploy_history_create.ts
@@ -9,12 +9,13 @@ import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
+import { getDeployHistoryTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('deploy_history', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['deploy_history']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'deploy history insert trigger record', record, getDeployHistoryTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No id' })

--- a/supabase/functions/_backend/triggers/on_manifest_create.ts
+++ b/supabase/functions/_backend/triggers/on_manifest_create.ts
@@ -8,6 +8,7 @@ import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { isRetryablePostgrestResult, retryWithBackoff } from '../utils/retry.ts'
 import { s3 } from '../utils/s3.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import { getManifestTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 const SIZE_RETRY_ATTEMPTS = 3
 const SIZE_RETRY_DELAY_MS = 500
@@ -103,7 +104,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('manifest', 'INSERT'), (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['manifest']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'manifest insert trigger record', record, getManifestTriggerRecordLogMetadata)
 
   if (!record.app_version_id || !record.s3_path) {
     cloudlog({ requestId: c.get('requestId'), message: 'no app_version_id or s3_path' })

--- a/supabase/functions/_backend/triggers/on_org_update.ts
+++ b/supabase/functions/_backend/triggers/on_org_update.ts
@@ -4,12 +4,13 @@ import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cleanStoredImageMetadata } from '../utils/image.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { getOrgTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('orgs', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['orgs']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'org update trigger record', record, getOrgTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No org id' })

--- a/supabase/functions/_backend/triggers/on_organization_create.ts
+++ b/supabase/functions/_backend/triggers/on_organization_create.ts
@@ -7,12 +7,13 @@ import { groupIdentifyPosthog } from '../utils/posthog.ts'
 import { createStripeCustomer, finalizePendingStripeCustomer } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
+import { getOrgTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['orgs']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'org insert trigger record', record, getOrgTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No id' })

--- a/supabase/functions/_backend/triggers/on_organization_delete.ts
+++ b/supabase/functions/_backend/triggers/on_organization_delete.ts
@@ -5,19 +5,20 @@ import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { cancelSubscription } from '../utils/stripe.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import { getOrgTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('orgs', 'DELETE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['orgs']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'org delete trigger record', record, getOrgTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'no org id' })
     return c.json(BRES)
   }
 
-  cloudlog({ requestId: c.get('requestId'), message: 'org delete', record })
+  logTriggerRecord(c, 'org delete', record, getOrgTriggerRecordLogMetadata)
 
   // Cancel subscription if customer_id exists
   if (record.customer_id) {

--- a/supabase/functions/_backend/triggers/on_user_create.ts
+++ b/supabase/functions/_backend/triggers/on_user_create.ts
@@ -6,12 +6,13 @@ import { cloudlog } from '../utils/logging.ts'
 import { createApiKey } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { syncUserPreferenceTags } from '../utils/user_preferences.ts'
+import { getUserTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'user insert trigger record', record, getUserTriggerRecordLogMetadata)
   await createApiKey(c, record.id)
   cloudlog({ requestId: c.get('requestId'), message: 'createCustomer stripe' })
   await syncUserPreferenceTags(c, record.email, record)

--- a/supabase/functions/_backend/triggers/on_user_delete.ts
+++ b/supabase/functions/_backend/triggers/on_user_delete.ts
@@ -7,6 +7,7 @@ import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { cancelSubscription } from '../utils/stripe.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import { getUserTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -448,7 +449,7 @@ async function deleteUser(c: Context, record: Database['public']['Tables']['user
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'DELETE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'user delete trigger record', record, getUserTriggerRecordLogMetadata)
 
   if (!record?.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'no user id' })

--- a/supabase/functions/_backend/triggers/on_user_update.ts
+++ b/supabase/functions/_backend/triggers/on_user_update.ts
@@ -6,13 +6,14 @@ import { cleanStoredImageMetadata } from '../utils/image.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { createApiKey } from '../utils/supabase.ts'
 import { syncUserPreferenceTags } from '../utils/user_preferences.ts'
+import { getUserTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
   const oldRecord = c.get('oldRecord') as Database['public']['Tables']['users']['Row'] | undefined
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'user update trigger record', record, getUserTriggerRecordLogMetadata)
   if (!record.email) {
     cloudlog({ requestId: c.get('requestId'), message: 'No email' })
     return c.json(BRES)

--- a/supabase/functions/_backend/triggers/on_version_create.ts
+++ b/supabase/functions/_backend/triggers/on_version_create.ts
@@ -10,6 +10,7 @@ import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
+import { getAppVersionTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 // Special bundle names that should not trigger email notifications
 const SKIP_EMAIL_BUNDLE_NAMES = ['unknown', 'builtin']
@@ -18,7 +19,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['app_versions']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'app version insert trigger record', record, getAppVersionTriggerRecordLogMetadata)
 
   if (!record.id) {
     cloudlog({ requestId: c.get('requestId'), message: 'No id' })

--- a/supabase/functions/_backend/triggers/on_version_delete.ts
+++ b/supabase/functions/_backend/triggers/on_version_delete.ts
@@ -3,13 +3,14 @@ import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { getAppVersionTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 import { deleteIt } from './on_version_update.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'DELETE'), (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['app_versions']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'app version delete trigger record', record, getAppVersionTriggerRecordLogMetadata)
 
   if (!record.app_id || !record.user_id) {
     cloudlog({ requestId: c.get('requestId'), message: 'no app_id or user_id' })

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -11,6 +11,7 @@ import { getPath, s3 } from '../utils/s3.ts'
 import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { backgroundTask } from '../utils/utils.ts'
+import { getAppVersionTriggerRecordLogMetadata, logTriggerRecord } from './logging.ts'
 
 /**
  * Resolves `owner_org` for an app version row.
@@ -341,10 +342,10 @@ export const app = new Hono<MiddlewareKeyVariables>()
 app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['app_versions']['Row']
   const oldRecord = c.get('oldRecord') as Database['public']['Tables']['app_versions']['Row']
-  cloudlog({ requestId: c.get('requestId'), message: 'record', record })
+  logTriggerRecord(c, 'app version update trigger record', record, getAppVersionTriggerRecordLogMetadata)
 
   if (!record.app_id) {
-    cloudlog({ requestId: c.get('requestId'), message: 'no app_id', record })
+    logTriggerRecord(c, 'no app_id', record, getAppVersionTriggerRecordLogMetadata)
     return c.json(BRES)
   }
   // check if version was soft-deleted (deleted_at was set)
@@ -352,7 +353,7 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
     return deleteIt(c, record)
 
   if (!record.r2_path && !record.manifest) {
-    cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', record })
+    logTriggerRecord(c, 'no r2_path and no manifest, skipping update', record, getAppVersionTriggerRecordLogMetadata)
     return c.json(BRES)
   }
 

--- a/tests/trigger-record-logging.unit.test.ts
+++ b/tests/trigger-record-logging.unit.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getAppTriggerRecordLogMetadata,
+  getAppVersionTriggerRecordLogMetadata,
+  getChannelTriggerRecordLogMetadata,
+  getDeployHistoryTriggerRecordLogMetadata,
+  getManifestTriggerRecordLogMetadata,
+  getOrgTriggerRecordLogMetadata,
+  getUserTriggerRecordLogMetadata,
+} from '../supabase/functions/_backend/triggers/logging.ts'
+
+describe('trigger record logging metadata', () => {
+  it.concurrent('summarizes organization trigger records without raw values', () => {
+    const metadata = getOrgTriggerRecordLogMetadata({
+      created_at: '2026-05-11T00:00:00Z',
+      created_by: 'user-secret-id',
+      customer_id: 'cus_secret_123',
+      email_preferences: { marketing: true },
+      enforce_encrypted_bundles: true,
+      enforce_hashed_api_keys: true,
+      enforcing_2fa: true,
+      has_usage_credits: true,
+      id: 'org-secret-id',
+      last_stats_updated_at: null,
+      logo: 'https://cdn.example.com/private-logo.png',
+      management_email: 'admin@example.com',
+      max_apikey_expiration_days: 30,
+      name: 'Private Org Name',
+      password_policy_config: { minLength: 12 },
+      require_apikey_expiration: true,
+      required_encryption_key: 'encryption-key-secret',
+      stats_refresh_requested_at: null,
+      stats_updated_at: null,
+      updated_at: null,
+      use_new_rbac: true,
+      website: 'https://private.example.com',
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      hasCustomerId: true,
+      hasManagementEmail: true,
+      hasRequiredEncryptionKey: true,
+      usesNewRbac: true,
+    })
+    expect(serialized).not.toContain('admin@example.com')
+    expect(serialized).not.toContain('cus_secret_123')
+    expect(serialized).not.toContain('encryption-key-secret')
+    expect(serialized).not.toContain('org-secret-id')
+    expect(serialized).not.toContain('Private Org Name')
+    expect(serialized).not.toContain('user-secret-id')
+  })
+
+  it.concurrent('summarizes app trigger records without raw values', () => {
+    const metadata = getAppTriggerRecordLogMetadata({
+      allow_device_custom_id: true,
+      allow_preview: true,
+      android_store_url: 'https://play.google.com/store/apps/details?id=com.secret.app',
+      app_id: 'com.secret.app',
+      build_timeout_seconds: 120,
+      build_timeout_updated_at: '2026-05-11T00:00:00Z',
+      channel_device_count: 3,
+      created_at: '2026-05-11T00:00:00Z',
+      default_upload_channel: 'production',
+      existing_app: false,
+      expose_metadata: true,
+      icon_url: 'https://cdn.example.com/icon.png',
+      id: 'app-row-secret-id',
+      ios_store_url: 'https://apps.apple.com/app/private',
+      last_version: '1.2.3-secret',
+      manifest_bundle_count: 4,
+      name: 'Secret App',
+      need_onboarding: false,
+      owner_org: 'org-secret-id',
+      retention: 90,
+      stats_refresh_requested_at: null,
+      stats_updated_at: null,
+      transfer_history: [{ from: 'private-source' }],
+      updated_at: null,
+      user_id: 'user-secret-id',
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      hasAppId: true,
+      hasIconUrl: true,
+      hasOwnerOrg: true,
+      transferHistoryCount: 1,
+    })
+    expect(serialized).not.toContain('com.secret.app')
+    expect(serialized).not.toContain('org-secret-id')
+    expect(serialized).not.toContain('Secret App')
+    expect(serialized).not.toContain('user-secret-id')
+    expect(serialized).not.toContain('private-source')
+  })
+
+  it.concurrent('summarizes deploy history trigger records without raw values', () => {
+    const metadata = getDeployHistoryTriggerRecordLogMetadata({
+      app_id: 'com.secret.app',
+      channel_id: 42,
+      created_at: '2026-05-11T00:00:00Z',
+      created_by: 'user-secret-id',
+      deployed_at: '2026-05-11T00:00:00Z',
+      id: 77,
+      install_stats_email_sent_at: null,
+      owner_org: 'org-secret-id',
+      updated_at: null,
+      version_id: 99,
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      hasAppId: true,
+      hasChannelId: true,
+      hasOwnerOrg: true,
+      hasVersionId: true,
+    })
+    expect(serialized).not.toContain('com.secret.app')
+    expect(serialized).not.toContain('org-secret-id')
+    expect(serialized).not.toContain('user-secret-id')
+  })
+
+  it.concurrent('summarizes app version trigger records without raw values', () => {
+    const metadata = getAppVersionTriggerRecordLogMetadata({
+      app_id: 'com.secret.app',
+      checksum: 'checksum-secret',
+      cli_version: '9.9.9',
+      comment: 'private release note',
+      created_at: '2026-05-11T00:00:00Z',
+      deleted: false,
+      deleted_at: null,
+      external_url: 'https://private.example.com/bundle.zip',
+      id: 99,
+      key_id: 'key-secret-id',
+      link: 'https://storage.example.com/private-link',
+      manifest: [{
+        file_hash: 'manifest-hash-secret',
+        file_name: 'manifest-private.js',
+        s3_path: 'orgs/org-secret/apps/com.secret.app/manifest-private.js',
+      }],
+      manifest_count: 1,
+      min_update_version: '1.0.0-secret',
+      name: '1.2.3-secret',
+      native_packages: [{ package: 'private-package' }],
+      owner_org: 'org-secret-id',
+      r2_path: 'orgs/org-secret/apps/com.secret.app/private.zip',
+      session_key: 'session-key-secret',
+      storage_provider: 'r2-direct',
+      updated_at: null,
+      user_id: 'user-secret-id',
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      hasAppId: true,
+      hasR2Path: true,
+      hasSessionKey: true,
+      manifestCount: 1,
+      nativePackagesCount: 1,
+    })
+    expect(serialized).not.toContain('checksum-secret')
+    expect(serialized).not.toContain('com.secret.app')
+    expect(serialized).not.toContain('org-secret-id')
+    expect(serialized).not.toContain('private-link')
+    expect(serialized).not.toContain('session-key-secret')
+    expect(serialized).not.toContain('user-secret-id')
+  })
+
+  it.concurrent('summarizes channel trigger records without raw values', () => {
+    const metadata = getChannelTriggerRecordLogMetadata({
+      allow_dev: true,
+      allow_device: true,
+      allow_device_self_set: true,
+      allow_emulator: true,
+      allow_prod: true,
+      android: true,
+      app_id: 'com.secret.app',
+      created_at: '2026-05-11T00:00:00Z',
+      created_by: 'user-secret-id',
+      disable_auto_update: 'major',
+      disable_auto_update_under_native: false,
+      electron: true,
+      id: 42,
+      ios: true,
+      name: 'private-channel',
+      owner_org: 'org-secret-id',
+      public: true,
+      rbac_id: 'rbac-secret-id',
+      updated_at: '2026-05-11T00:00:00Z',
+      version: 99,
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      hasAppId: true,
+      hasName: true,
+      hasOwnerOrg: true,
+      isPublic: true,
+    })
+    expect(serialized).not.toContain('com.secret.app')
+    expect(serialized).not.toContain('org-secret-id')
+    expect(serialized).not.toContain('private-channel')
+    expect(serialized).not.toContain('rbac-secret-id')
+    expect(serialized).not.toContain('user-secret-id')
+  })
+
+  it.concurrent('summarizes manifest trigger records without raw values', () => {
+    const metadata = getManifestTriggerRecordLogMetadata({
+      app_version_id: 99,
+      file_hash: 'sha256-secret-hash',
+      file_name: 'private.bundle.js',
+      file_size: 12345,
+      id: 77,
+      s3_path: 'orgs/org-secret/apps/com.secret.app/private.bundle.js',
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      hasAppVersionId: true,
+      hasFileHash: true,
+      hasFileName: true,
+      hasS3Path: true,
+    })
+    expect(serialized).not.toContain('sha256-secret-hash')
+    expect(serialized).not.toContain('private.bundle.js')
+    expect(serialized).not.toContain('org-secret')
+    expect(serialized).not.toContain('com.secret.app')
+  })
+
+  it.concurrent('summarizes user trigger records without raw values', () => {
+    const metadata = getUserTriggerRecordLogMetadata({
+      ban_time: null,
+      country: 'DE',
+      created_at: '2026-05-11T00:00:00Z',
+      created_via_invite: true,
+      email: 'user@example.com',
+      email_preferences: { product: true },
+      enable_notifications: true,
+      first_name: 'Private',
+      id: 'user-secret-id',
+      image_url: 'https://cdn.example.com/private-user.png',
+      last_name: 'User',
+      opt_for_newsletters: false,
+      updated_at: null,
+    })
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toMatchObject({
+      createdViaInvite: true,
+      hasEmail: true,
+      hasId: true,
+      hasImageUrl: true,
+    })
+    expect(serialized).not.toContain('user@example.com')
+    expect(serialized).not.toContain('user-secret-id')
+    expect(serialized).not.toContain('Private')
+    expect(serialized).not.toContain('private-user.png')
+  })
+})


### PR DESCRIPTION
## Summary

- replace raw database trigger record logs with metadata-only summaries across trigger handlers
- keep trigger behavior and side effects unchanged
- add focused unit coverage that sensitive row values are not retained in trigger log metadata

Security note: routine trigger logs previously retained full user/org/app/channel/version/manifest rows, including emails, customer ids, app ids, bundle paths, manifest details, and profile fields. This keeps only presence/count/status metadata in those initial trigger logs.

## Test plan

- `git diff --cached --check`
- GitHub CI is green on the current head, including Run tests, Playwright, dead-code check, SonarCloud, Socket, and CodSpeed
- Not run locally: Bun and node_modules are not installed in this Codex environment; relying on GitHub CI for Vitest/lint/typecheck

## Screenshots

Not applicable; this is backend trigger logging only and does not change UI behavior.

## Checklist

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests

/claim #1667