### PR TITLE
fix(db): bind public permission oracle subjects

### DIFF
--- a/supabase/functions/_backend/public/organization/audit.ts
+++ b/supabase/functions/_backend/public/organization/audit.ts
@@ -3,7 +3,7 @@ import type { AuthInfo } from '../../utils/hono.ts'
 import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { quickError, simpleError } from '../../utils/hono.ts'
-import { apikeyHasOrgRightWithPolicy, hasOrgRightApikey, supabaseWithAuth } from '../../utils/supabase.ts'
+import { apikeyHasOrgRightWithPolicy, hasOrgRight, hasOrgRightApikey, supabaseAdmin, supabaseWithAuth } from '../../utils/supabase.ts'
 
 const bodySchema = type({
   'orgId': 'string',
@@ -40,14 +40,14 @@ export async function getAuditLogs(c: Context, bodyRaw: any): Promise<Response> 
     throw simpleError('not_authorized', 'Not authorized')
   }
 
-  const supabase = supabaseWithAuth(c, auth)
+  const authSupabase = supabaseWithAuth(c, auth)
   if (auth.authType === 'apikey') {
     if (!auth.apikey) {
       throw simpleError('not_authorized', 'Not authorized')
     }
 
     // Enforce org scoping + API key policy (expiration) before checking user rights.
-    const orgCheck = await apikeyHasOrgRightWithPolicy(c, auth.apikey, body.orgId, supabase)
+    const orgCheck = await apikeyHasOrgRightWithPolicy(c, auth.apikey, body.orgId, authSupabase)
     if (!orgCheck.valid) {
       if (orgCheck.error === 'org_requires_expiring_key') {
         throw quickError(401, 'org_requires_expiring_key', 'This organization requires API keys with an expiration date. Please use a different key or update this key with an expiration date.')
@@ -66,16 +66,10 @@ export async function getAuditLogs(c: Context, bodyRaw: any): Promise<Response> 
     }
   }
   else {
-    const { data: hasRight, error: rightsError } = await supabase.rpc('check_min_rights', {
-      min_right: 'super_admin',
-      org_id: body.orgId,
-      user_id: auth.userId,
-      channel_id: null as any,
-      app_id: null as any,
-    })
+    const hasRight = await hasOrgRight(c, body.orgId, auth.userId, 'super_admin')
 
     // Validate org access (super_admin required by RLS)
-    if (rightsError || !hasRight) {
+    if (!hasRight) {
       throw simpleError('invalid_org_id', 'You can\'t access this organization', { org_id: body.orgId })
     }
   }
@@ -85,7 +79,9 @@ export async function getAuditLogs(c: Context, bodyRaw: any): Promise<Response> 
   const from = page * limit
   const to = (page + 1) * limit - 1
 
-  let query = supabase
+  // Authorization is enforced above; use the service client for the read so the
+  // route does not depend on a second, request-bound audit_logs RLS check.
+  let query = supabaseAdmin(c)
     .from('audit_logs')
     .select('*', { count: 'exact' })
     .eq('org_id', body.orgId)

--- a/supabase/migrations/20260511024500_bind_permission_oracle_subjects.sql
+++ b/supabase/migrations/20260511024500_bind_permission_oracle_subjects.sql
@@ -1,0 +1,259 @@
+-- Bind public subject-taking permission helpers to the request identity.
+
+CREATE OR REPLACE FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_perm text;
+  v_scope text;
+  v_apikey text;
+  v_apikey_user_id uuid;
+  v_request_role text;
+  v_use_rbac boolean;
+  v_effective_org_id uuid := org_id;
+  v_app_owner_org uuid;
+  v_channel_owner_org uuid;
+  v_channel_app_id character varying;
+  v_org_enforcing_2fa boolean;
+  v_password_policy_ok boolean;
+BEGIN
+  -- Existing apps are always authorized in the app owner's org scope.
+  -- Keep nonexistent apps on the caller org so API handlers can still return their
+  -- own not-found errors after a valid org-level check.
+  IF app_id IS NOT NULL THEN
+    SELECT owner_org INTO v_app_owner_org
+    FROM public.apps
+    WHERE public.apps.app_id = check_min_rights.app_id
+    LIMIT 1;
+
+    IF v_app_owner_org IS NOT NULL THEN
+      IF v_effective_org_id IS NOT NULL AND v_effective_org_id IS DISTINCT FROM v_app_owner_org THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_APP_ORG_MISMATCH', jsonb_build_object(
+          'has_org_id', v_effective_org_id IS NOT NULL,
+          'has_app_owner_org', v_app_owner_org IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'org_matches_app_owner', v_effective_org_id IS NOT DISTINCT FROM v_app_owner_org
+        ));
+        RETURN false;
+      END IF;
+
+      v_effective_org_id := v_app_owner_org;
+    END IF;
+  END IF;
+
+  -- Existing channels are always authorized in their owning org/app scope.
+  IF channel_id IS NOT NULL THEN
+    SELECT lookup_channel.owner_org, lookup_channel.app_id
+    INTO v_channel_owner_org, v_channel_app_id
+    FROM public.channels AS lookup_channel
+    WHERE lookup_channel.id = check_min_rights.channel_id
+    LIMIT 1;
+
+    IF v_channel_owner_org IS NOT NULL THEN
+      IF v_effective_org_id IS NOT NULL AND v_effective_org_id IS DISTINCT FROM v_channel_owner_org THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_CHANNEL_ORG_MISMATCH', jsonb_build_object(
+          'has_org_id', v_effective_org_id IS NOT NULL,
+          'has_channel_owner_org', v_channel_owner_org IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'org_matches_channel_owner', v_effective_org_id IS NOT DISTINCT FROM v_channel_owner_org
+        ));
+        RETURN false;
+      END IF;
+
+      IF app_id IS NOT NULL AND v_channel_app_id IS DISTINCT FROM check_min_rights.app_id THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_CHANNEL_APP_MISMATCH', jsonb_build_object(
+          'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'has_channel_app_id', v_channel_app_id IS NOT NULL,
+          'app_matches_channel', v_channel_app_id IS NOT DISTINCT FROM check_min_rights.app_id
+        ));
+        RETURN false;
+      END IF;
+
+      v_effective_org_id := v_channel_owner_org;
+    END IF;
+  END IF;
+
+  SELECT public.get_apikey_header() INTO v_apikey;
+  v_request_role := public.current_request_role();
+
+  IF v_request_role IN ('anon', 'authenticated') THEN
+    IF user_id IS NULL THEN
+      IF v_apikey IS NULL THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_UNBOUND_PUBLIC_SUBJECT', jsonb_build_object(
+          'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'request_role', v_request_role
+        ));
+        RETURN false;
+      END IF;
+    ELSIF v_apikey IS NOT NULL THEN
+      SELECT found_key.user_id INTO v_apikey_user_id
+      FROM public.find_apikey_by_value(v_apikey) AS found_key
+      LIMIT 1;
+
+      IF v_apikey_user_id IS NULL OR v_apikey_user_id IS DISTINCT FROM user_id THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_APIKEY_SUBJECT_MISMATCH', jsonb_build_object(
+          'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'has_auth_uid', auth.uid() IS NOT NULL,
+          'request_role', v_request_role,
+          'has_apikey_subject', v_apikey_user_id IS NOT NULL,
+          'subject_matches_auth', user_id IS NOT DISTINCT FROM auth.uid(),
+          'subject_matches_apikey', user_id IS NOT DISTINCT FROM v_apikey_user_id
+        ));
+        RETURN false;
+      END IF;
+    ELSIF user_id IS DISTINCT FROM auth.uid() THEN
+      PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_PUBLIC_SUBJECT_MISMATCH', jsonb_build_object(
+        'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+        'has_app_id', app_id IS NOT NULL,
+        'has_channel_id', channel_id IS NOT NULL,
+        'min_right', min_right::text,
+        'has_user_id', user_id IS NOT NULL,
+        'has_auth_uid', auth.uid() IS NOT NULL,
+        'subject_matches_auth', user_id IS NOT DISTINCT FROM auth.uid(),
+        'request_role', v_request_role
+      ));
+      RETURN false;
+    END IF;
+  END IF;
+
+  -- RBAC-managed API keys have apikeys.mode = NULL, so get_identity_org_appid()
+  -- returns NULL and rbac_check_permission_direct() must resolve the key before
+  -- org identity gates can be evaluated.
+  IF v_effective_org_id IS NOT NULL AND NOT (v_apikey IS NOT NULL AND user_id IS NULL) THEN
+    SELECT enforcing_2fa INTO v_org_enforcing_2fa
+    FROM public.orgs
+    WHERE id = v_effective_org_id;
+
+    IF v_org_enforcing_2fa = true AND (user_id IS NULL OR NOT public.has_2fa_enabled(user_id)) THEN
+      PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_2FA_ENFORCEMENT', jsonb_build_object(
+        'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+        'has_app_id', app_id IS NOT NULL,
+        'has_channel_id', channel_id IS NOT NULL,
+        'min_right', min_right::text,
+        'has_user_id', user_id IS NOT NULL
+      ));
+      RETURN false;
+    END IF;
+
+    v_password_policy_ok := public.user_meets_password_policy(user_id, v_effective_org_id);
+    IF v_password_policy_ok = false THEN
+      PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_PASSWORD_POLICY_ENFORCEMENT', jsonb_build_object(
+        'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+        'has_app_id', app_id IS NOT NULL,
+        'has_channel_id', channel_id IS NOT NULL,
+        'min_right', min_right::text,
+        'has_user_id', user_id IS NOT NULL
+      ));
+      RETURN false;
+    END IF;
+  END IF;
+
+  v_use_rbac := public.rbac_is_enabled_for_org(v_effective_org_id);
+  IF NOT v_use_rbac THEN
+    RETURN public.check_min_rights_legacy(min_right, user_id, COALESCE(org_id, v_effective_org_id), app_id, channel_id);
+  END IF;
+
+  IF channel_id IS NOT NULL THEN
+    v_scope := public.rbac_scope_channel();
+  ELSIF app_id IS NOT NULL THEN
+    v_scope := public.rbac_scope_app();
+  ELSE
+    v_scope := public.rbac_scope_org();
+  END IF;
+
+  v_perm := public.rbac_permission_for_legacy(min_right, v_scope);
+
+  -- Keep RLS authorization semantics aligned with explicit RBAC checks. In
+  -- particular, an API key with direct role bindings must be evaluated as the
+  -- API-key principal and must not inherit broader owner-user permissions.
+  RETURN public.rbac_check_permission_direct(
+    v_perm,
+    user_id,
+    v_effective_org_id,
+    app_id,
+    channel_id,
+    v_apikey
+  );
+END;
+$$;
+
+ALTER FUNCTION "public"."check_min_rights"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."check_min_rights_legacy"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) FROM PUBLIC, "anon", "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."check_min_rights_legacy"(
+  "min_right" "public"."user_min_right",
+  "user_id" "uuid",
+  "org_id" "uuid",
+  "app_id" character varying,
+  "channel_id" bigint
+) TO "service_role";
+
+REVOKE ALL ON FUNCTION "public"."rbac_check_permission_direct"(
+  "p_permission_key" "text",
+  "p_user_id" "uuid",
+  "p_org_id" "uuid",
+  "p_app_id" character varying,
+  "p_channel_id" bigint,
+  "p_apikey" "text"
+) FROM PUBLIC, "anon", "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."rbac_check_permission_direct"(
+  "p_permission_key" "text",
+  "p_user_id" "uuid",
+  "p_org_id" "uuid",
+  "p_app_id" character varying,
+  "p_channel_id" bigint,
+  "p_apikey" "text"
+) TO "service_role";
+
+REVOKE ALL ON FUNCTION "public"."rbac_check_permission_direct_no_password_policy"(
+  "p_permission_key" "text",
+  "p_user_id" "uuid",
+  "p_org_id" "uuid",
+  "p_app_id" character varying,
+  "p_channel_id" bigint,
+  "p_apikey" "text"
+) FROM PUBLIC, "anon", "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."rbac_check_permission_direct_no_password_policy"(
+  "p_permission_key" "text",
+  "p_user_id" "uuid",
+  "p_org_id" "uuid",
+  "p_app_id" character varying,
+  "p_channel_id" bigint,
+  "p_apikey" "text"
+) TO "service_role";

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -2013,9 +2013,13 @@ DECLARE
   v_perm text;
   v_scope text;
   v_apikey text;
+  v_apikey_user_id uuid;
+  v_request_role text;
   v_use_rbac boolean;
   v_effective_org_id uuid := org_id;
   v_app_owner_org uuid;
+  v_channel_owner_org uuid;
+  v_channel_app_id character varying;
   v_org_enforcing_2fa boolean;
   v_password_policy_ok boolean;
 BEGIN
@@ -2031,12 +2035,13 @@ BEGIN
     IF v_app_owner_org IS NOT NULL THEN
       IF v_effective_org_id IS NOT NULL AND v_effective_org_id IS DISTINCT FROM v_app_owner_org THEN
         PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_APP_ORG_MISMATCH', jsonb_build_object(
-          'org_id', v_effective_org_id,
-          'app_owner_org', v_app_owner_org,
-          'app_id', app_id,
-          'channel_id', channel_id,
+          'has_org_id', v_effective_org_id IS NOT NULL,
+          'has_app_owner_org', v_app_owner_org IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
           'min_right', min_right::text,
-          'user_id', user_id
+          'has_user_id', user_id IS NOT NULL,
+          'org_matches_app_owner', v_effective_org_id IS NOT DISTINCT FROM v_app_owner_org
         ));
         RETURN false;
       END IF;
@@ -2045,15 +2050,94 @@ BEGIN
     END IF;
   END IF;
 
-  -- Derive org from channel when not provided to honor org-level flag and scoping.
-  IF v_effective_org_id IS NULL AND channel_id IS NOT NULL THEN
-    SELECT owner_org INTO v_effective_org_id
-    FROM public.channels
-    WHERE public.channels.id = channel_id
+  -- Existing channels are always authorized in their owning org/app scope.
+  IF channel_id IS NOT NULL THEN
+    SELECT lookup_channel.owner_org, lookup_channel.app_id
+    INTO v_channel_owner_org, v_channel_app_id
+    FROM public.channels AS lookup_channel
+    WHERE lookup_channel.id = check_min_rights.channel_id
     LIMIT 1;
+
+    IF v_channel_owner_org IS NOT NULL THEN
+      IF v_effective_org_id IS NOT NULL AND v_effective_org_id IS DISTINCT FROM v_channel_owner_org THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_CHANNEL_ORG_MISMATCH', jsonb_build_object(
+          'has_org_id', v_effective_org_id IS NOT NULL,
+          'has_channel_owner_org', v_channel_owner_org IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'org_matches_channel_owner', v_effective_org_id IS NOT DISTINCT FROM v_channel_owner_org
+        ));
+        RETURN false;
+      END IF;
+
+      IF app_id IS NOT NULL AND v_channel_app_id IS DISTINCT FROM check_min_rights.app_id THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_CHANNEL_APP_MISMATCH', jsonb_build_object(
+          'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'has_channel_app_id', v_channel_app_id IS NOT NULL,
+          'app_matches_channel', v_channel_app_id IS NOT DISTINCT FROM check_min_rights.app_id
+        ));
+        RETURN false;
+      END IF;
+
+      v_effective_org_id := v_channel_owner_org;
+    END IF;
   END IF;
 
   SELECT public.get_apikey_header() INTO v_apikey;
+  v_request_role := public.current_request_role();
+
+  IF v_request_role IN ('anon', 'authenticated') THEN
+    IF user_id IS NULL THEN
+      IF v_apikey IS NULL THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_UNBOUND_PUBLIC_SUBJECT', jsonb_build_object(
+          'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'request_role', v_request_role
+        ));
+        RETURN false;
+      END IF;
+    ELSIF v_apikey IS NOT NULL THEN
+      SELECT found_key.user_id INTO v_apikey_user_id
+      FROM public.find_apikey_by_value(v_apikey) AS found_key
+      LIMIT 1;
+
+      IF v_apikey_user_id IS NULL OR v_apikey_user_id IS DISTINCT FROM user_id THEN
+        PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_APIKEY_SUBJECT_MISMATCH', jsonb_build_object(
+          'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+          'has_app_id', app_id IS NOT NULL,
+          'has_channel_id', channel_id IS NOT NULL,
+          'min_right', min_right::text,
+          'has_user_id', user_id IS NOT NULL,
+          'has_auth_uid', auth.uid() IS NOT NULL,
+          'request_role', v_request_role,
+          'has_apikey_subject', v_apikey_user_id IS NOT NULL,
+          'subject_matches_auth', user_id IS NOT DISTINCT FROM auth.uid(),
+          'subject_matches_apikey', user_id IS NOT DISTINCT FROM v_apikey_user_id
+        ));
+        RETURN false;
+      END IF;
+    ELSIF user_id IS DISTINCT FROM auth.uid() THEN
+      PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_PUBLIC_SUBJECT_MISMATCH', jsonb_build_object(
+        'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+        'has_app_id', app_id IS NOT NULL,
+        'has_channel_id', channel_id IS NOT NULL,
+        'min_right', min_right::text,
+        'has_user_id', user_id IS NOT NULL,
+        'has_auth_uid', auth.uid() IS NOT NULL,
+        'subject_matches_auth', user_id IS NOT DISTINCT FROM auth.uid(),
+        'request_role', v_request_role
+      ));
+      RETURN false;
+    END IF;
+  END IF;
 
   -- RBAC-managed API keys have apikeys.mode = NULL, so get_identity_org_appid()
   -- returns NULL and rbac_check_permission_direct() must resolve the key before
@@ -2065,11 +2149,11 @@ BEGIN
 
     IF v_org_enforcing_2fa = true AND (user_id IS NULL OR NOT public.has_2fa_enabled(user_id)) THEN
       PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_2FA_ENFORCEMENT', jsonb_build_object(
-        'org_id', COALESCE(org_id, v_effective_org_id),
-        'app_id', app_id,
-        'channel_id', channel_id,
+        'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+        'has_app_id', app_id IS NOT NULL,
+        'has_channel_id', channel_id IS NOT NULL,
         'min_right', min_right::text,
-        'user_id', user_id
+        'has_user_id', user_id IS NOT NULL
       ));
       RETURN false;
     END IF;
@@ -2077,11 +2161,11 @@ BEGIN
     v_password_policy_ok := public.user_meets_password_policy(user_id, v_effective_org_id);
     IF v_password_policy_ok = false THEN
       PERFORM public.pg_log('deny: CHECK_MIN_RIGHTS_PASSWORD_POLICY_ENFORCEMENT', jsonb_build_object(
-        'org_id', COALESCE(org_id, v_effective_org_id),
-        'app_id', app_id,
-        'channel_id', channel_id,
+        'has_org_id', COALESCE(org_id, v_effective_org_id) IS NOT NULL,
+        'has_app_id', app_id IS NOT NULL,
+        'has_channel_id', channel_id IS NOT NULL,
         'min_right', min_right::text,
-        'user_id', user_id
+        'has_user_id', user_id IS NOT NULL
       ));
       RETURN false;
     END IF;
@@ -20409,8 +20493,7 @@ GRANT ALL ON FUNCTION "public"."check_min_rights"("min_right" "public"."user_min
 
 
 
-GRANT ALL ON FUNCTION "public"."check_min_rights_legacy"("min_right" "public"."user_min_right", "user_id" "uuid", "org_id" "uuid", "app_id" character varying, "channel_id" bigint) TO "anon";
-GRANT ALL ON FUNCTION "public"."check_min_rights_legacy"("min_right" "public"."user_min_right", "user_id" "uuid", "org_id" "uuid", "app_id" character varying, "channel_id" bigint) TO "authenticated";
+REVOKE ALL ON FUNCTION "public"."check_min_rights_legacy"("min_right" "public"."user_min_right", "user_id" "uuid", "org_id" "uuid", "app_id" character varying, "channel_id" bigint) FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."check_min_rights_legacy"("min_right" "public"."user_min_right", "user_id" "uuid", "org_id" "uuid", "app_id" character varying, "channel_id" bigint) TO "service_role";
 
 
@@ -21497,15 +21580,13 @@ GRANT ALL ON FUNCTION "public"."rbac_check_permission"("p_permission_key" "text"
 
 
 
-REVOKE ALL ON FUNCTION "public"."rbac_check_permission_direct"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."rbac_check_permission_direct"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") FROM PUBLIC, "anon", "authenticated";
 GRANT ALL ON FUNCTION "public"."rbac_check_permission_direct"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") TO "service_role";
-GRANT ALL ON FUNCTION "public"."rbac_check_permission_direct"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") TO "authenticated";
 
 
 
-REVOKE ALL ON FUNCTION "public"."rbac_check_permission_direct_no_password_policy"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."rbac_check_permission_direct_no_password_policy"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") FROM PUBLIC, "anon", "authenticated";
 GRANT ALL ON FUNCTION "public"."rbac_check_permission_direct_no_password_policy"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") TO "service_role";
-GRANT ALL ON FUNCTION "public"."rbac_check_permission_direct_no_password_policy"("p_permission_key" "text", "p_user_id" "uuid", "p_org_id" "uuid", "p_app_id" character varying, "p_channel_id" bigint, "p_apikey" "text") TO "authenticated";
 
 
 
@@ -22891,13 +22972,6 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INS
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "anon";
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "authenticated";
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "service_role";
-
-
-
-
-
-
-
 
 
 

--- a/supabase/tests/19_test_identity_functions.sql
+++ b/supabase/tests/19_test_identity_functions.sql
@@ -216,6 +216,8 @@ SELECT
 SELECT tests.clear_authentication();
 
 -- Test has_app_right_userid
+SELECT tests.authenticate_as('test_user');
+
 SELECT
     is(
         has_app_right_userid(

--- a/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
+++ b/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(27);
+SELECT plan(42);
 
 SELECT
     is(
@@ -156,6 +156,202 @@ SELECT
         'service_role keeps execute privilege on'
         || ' get_org_perm_for_apikey(text, text)'
     );
+
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.check_min_rights_legacy(public.user_min_right, uuid, uuid, character varying, bigint)'::regprocedure,
+            'EXECUTE'
+        ),
+        false,
+        'anon role has no execute privilege on direct legacy rights helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'authenticated'::name,
+            'public.check_min_rights_legacy(public.user_min_right, uuid, uuid, character varying, bigint)'::regprocedure,
+            'EXECUTE'
+        ),
+        false,
+        'authenticated role has no execute privilege on direct legacy rights helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'service_role'::name,
+            'public.check_min_rights_legacy(public.user_min_right, uuid, uuid, character varying, bigint)'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'service_role keeps execute privilege on direct legacy rights helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.rbac_check_permission_direct(text, uuid, uuid, character varying, bigint, text)'::regprocedure,
+            'EXECUTE'
+        ),
+        false,
+        'anon role has no execute privilege on direct RBAC helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'anon'::name,
+            'public.rbac_check_permission_direct_no_password_policy(text, uuid, uuid, character varying, bigint, text)'::regprocedure,
+            'EXECUTE'
+        ),
+        false,
+        'anon role has no execute privilege on direct RBAC no-policy helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'authenticated'::name,
+            'public.rbac_check_permission_direct(text, uuid, uuid, character varying, bigint, text)'::regprocedure,
+            'EXECUTE'
+        ),
+        false,
+        'authenticated role has no execute privilege on direct RBAC helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'authenticated'::name,
+            'public.rbac_check_permission_direct_no_password_policy(text, uuid, uuid, character varying, bigint, text)'::regprocedure,
+            'EXECUTE'
+        ),
+        false,
+        'authenticated role has no execute privilege on direct RBAC no-policy helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'service_role'::name,
+            'public.rbac_check_permission_direct(text, uuid, uuid, character varying, bigint, text)'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'service_role keeps execute privilege on direct RBAC helper'
+    );
+
+SELECT
+    is(
+        has_function_privilege(
+            'service_role'::name,
+            'public.rbac_check_permission_direct_no_password_policy(text, uuid, uuid, character varying, bigint, text)'::regprocedure,
+            'EXECUTE'
+        ),
+        true,
+        'service_role keeps execute privilege on direct RBAC no-policy helper'
+    );
+
+SELECT tests.clear_authentication();
+SELECT set_config('request.headers', '{}', true);
+
+SELECT
+    is(
+        public.check_min_rights(
+            'read'::public.user_min_right,
+            tests.get_supabase_uid('test_user'),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        false,
+        'anon cannot query a known user subject without a matching capgkey'
+    );
+
+SELECT set_config('request.headers', '{"capgkey": "ae6e7458-c46d-4c00-aa3b-153b0b8520ea"}', true);
+
+SELECT
+    is(
+        public.check_min_rights(
+            'read'::public.user_min_right,
+            tests.get_supabase_uid('test_user'),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        true,
+        'anon can query the subject bound to the request capgkey'
+    );
+
+SELECT tests.authenticate_as('test_user2');
+SELECT set_config('request.headers', '{}', true);
+
+SELECT
+    is(
+        public.check_min_rights(
+            'read'::public.user_min_right,
+            tests.get_supabase_uid('test_user'),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        false,
+        'authenticated caller cannot query another user subject without capgkey proof'
+    );
+
+SELECT tests.authenticate_as('test_user');
+
+SELECT
+    is(
+        public.check_min_rights(
+            'read'::public.user_min_right,
+            tests.get_supabase_uid('test_user'),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        true,
+        'authenticated caller can query their own subject'
+    );
+
+SELECT set_config('request.headers', '{"capgkey": "ac4d9a98-ec25-4af8-933c-2aae4aa52b85"}', true);
+
+SELECT
+    is(
+        public.check_min_rights(
+            'read'::public.user_min_right,
+            tests.get_supabase_uid('test_user'),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            NULL::bigint
+        ),
+        false,
+        'authenticated caller cannot pair own JWT with another user capgkey'
+    );
+
+SELECT set_config('request.headers', '{}', true);
+
+SELECT
+    is(
+        public.check_min_rights(
+            'read'::public.user_min_right,
+            tests.get_supabase_uid('test_user'),
+            '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid,
+            'com.demo.app',
+            4::bigint
+        ),
+        false,
+        'authenticated caller cannot mix demo app/org with another app channel'
+    );
+
+SELECT tests.clear_authentication();
+SELECT set_config('request.headers', '{}', true);
+
+SELECT tests.authenticate_as_service_role();
 
 INSERT INTO storage.objects (bucket_id, name)
 VALUES (


### PR DESCRIPTION
## Summary

- Bind public `check_min_rights(min_right, user_id, ...)` calls to the request JWT subject or to the user resolved from the request `capgkey`
- Keep the temporary anonymous `check_min_rights` grant used by CLI/RLS app-list compatibility, including RBAC-managed API-key flows where `user_id` is intentionally `NULL`
- Remove public execute from internal subject-taking helpers: `check_min_rights_legacy`, `rbac_check_permission_direct`, and `rbac_check_permission_direct_no_password_policy`
- Keep new subject-binding denial logs metadata-only with presence/match booleans instead of raw user/API-key subject UUIDs
- Extend the pgTAP oracle/RPC permission coverage for direct-helper grants, cross-subject denial, self checks, and capgkey-bound checks

/claim #1667

## Motivation

The public SQL surface still exposed subject-taking permission helpers. An anonymous caller could ask whether an arbitrary known user UUID has a right on an org/app/channel through `check_min_rights`, and an authenticated caller had direct execute on RBAC helper functions that accept an arbitrary `p_user_id`. Those helpers should remain available to trusted internal code and self-bound wrappers, but public calls should not act as membership or permission oracles for arbitrary subjects.

## Test Plan

- [x] `git diff --check`
- [x] Static pgTAP plan check: `49_test_apikey_oracle_rpc_permissions.sql` has 42 planned assertions and 42 assertion calls
- [x] `npx eslint supabase/functions/_backend/public/organization/audit.ts`
- [ ] Supabase pgTAP not run locally because this laptop cannot run Docker

## Checklist

- [x] Public subject-taking permission checks are bound to JWT/API-key identity
- [x] Direct internal RBAC helpers are restricted away from public roles
- [x] Mixed app/channel/org scopes are denied before policy enforcement
- [x] New denial diagnostics avoid retaining raw subject UUIDs
