### PR TITLE
fix(api): redact Discord error alerts

### DIFF
--- a/supabase/functions/_backend/utils/discord.ts
+++ b/supabase/functions/_backend/utils/discord.ts
@@ -5,69 +5,143 @@ import type { Context } from 'hono'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { getEnv } from './utils.ts'
 
-// Fields that should be completely removed from logs (never logged)
-const REMOVED_FIELDS = ['password']
-// Fields that should show first 4 and last 4 characters
-const PARTIALLY_REDACTED_FIELDS = ['secret', 'token', 'apikey', 'api_key', 'authorization', 'credential', 'private_key']
-
-// Partially redact a value - show first 4 and last 4 characters
-function partialRedact(value: string): string {
-  if (value.length <= 8) {
-    return '***REDACTED***'
-  }
-  return `${value.slice(0, 4)}...${value.slice(-4)}`
+interface DiscordAlert500PayloadInput {
+  body: string
+  environment: string
+  error: Error
+  functionName: string
+  hasClientIp: boolean
+  hasUserAgent: boolean
+  method: string
+  rawHeaders: Record<string, string>
+  requestId: string
+  timestamp: string
+  url: string
 }
 
-// Remove or redact sensitive fields from a string that might contain JSON
-function sanitizeSensitiveFromString(str: string): string {
-  let result = str
-
-  // Completely remove password fields (including the key)
-  for (const field of REMOVED_FIELDS) {
-    // Remove "password":"value", or "password": "value" (with optional trailing comma)
-    const jsonRegexWithComma = new RegExp(`"${field}"\\s*:\\s*"[^"]*"\\s*,?\\s*`, 'gi')
-    result = result.replace(jsonRegexWithComma, '')
-    // Clean up any resulting double commas or leading/trailing commas in objects
-    result = result.replace(/,\s*,/g, ',')
-    result = result.replace(/\{\s*,/g, '{')
-    result = result.replace(/,\s*\}/g, '}')
-  }
-
-  // Partially redact other sensitive fields (show first 4 and last 4 chars)
-  for (const field of PARTIALLY_REDACTED_FIELDS) {
-    const jsonRegex = new RegExp(`("${field}"\\s*:\\s*)"([^"]*)"`, 'gi')
-    result = result.replace(jsonRegex, (_match, prefix, value) => {
-      return `${prefix}"${partialRedact(value)}"`
-    })
-  }
-
-  return result
+function boolLabel(value: boolean) {
+  return value ? 'yes' : 'no'
 }
 
-// Sanitize sensitive headers - remove or redact
-function sanitizeSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
-  const sanitized: Record<string, string> = {}
-  for (const [key, value] of Object.entries(headers)) {
-    const lowerKey = key.toLowerCase()
-    // Skip password-related headers entirely
-    if (REMOVED_FIELDS.some(field => lowerKey.includes(field))) {
-      continue
-    }
-    else if (PARTIALLY_REDACTED_FIELDS.some(field => lowerKey.includes(field))) {
-      sanitized[key] = partialRedact(value)
-    }
-    else {
-      sanitized[key] = value
+function getPathSegmentCount(path: string) {
+  return path.split('/').filter(Boolean).length
+}
+
+function getUrlSummary(rawUrl: string) {
+  try {
+    const parsed = new URL(rawUrl)
+    return {
+      hasQuery: parsed.search.length > 0,
+      hasPath: parsed.pathname.length > 0,
+      pathSegmentCount: getPathSegmentCount(parsed.pathname),
     }
   }
-  return sanitized
+  catch {
+    const [path = ''] = rawUrl.split('?')
+    return {
+      hasQuery: rawUrl.includes('?'),
+      hasPath: path.length > 0,
+      pathSegmentCount: getPathSegmentCount(path),
+    }
+  }
+}
+
+function getHeaderSummary(headers: Record<string, string>) {
+  const headerNames = Object.keys(headers).map(headerName => headerName.toLowerCase())
+  return {
+    count: headerNames.length,
+    hasApiKey: headerNames.some(headerName =>
+      headerName === 'capgkey'
+      || headerName === 'x-api-key'
+      || headerName.includes('apikey')
+      || headerName.includes('api-key'),
+    ),
+    hasAuthorization: headerNames.includes('authorization'),
+    hasCookie: headerNames.includes('cookie') || headerNames.includes('set-cookie'),
+  }
+}
+
+function getSafeErrorName(error: Error) {
+  const errorName = error?.name ?? 'Error'
+  if (/^[\w .:-]{1,80}$/.test(errorName))
+    return errorName
+  return 'Error'
+}
+
+function getDiscordPayloadLogMetadata(payload: RESTPostAPIWebhookWithTokenJSONBody) {
+  const body = typeof payload === 'string'
+    ? { content: payload }
+    : payload
+  const maybeBody = body as {
+    content?: unknown
+    embeds?: unknown
+  }
+
+  return {
+    embedCount: Array.isArray(maybeBody.embeds) ? maybeBody.embeds.length : 0,
+    hasContent: typeof maybeBody.content === 'string' && maybeBody.content.length > 0,
+    payloadType: typeof payload,
+  }
+}
+
+function buildDiscordAlert500Payload(input: DiscordAlert500PayloadInput): RESTPostAPIWebhookWithTokenJSONBody {
+  const urlSummary = getUrlSummary(input.url)
+  const headerSummary = getHeaderSummary(input.rawHeaders)
+  const errorMessage = input.error?.message ?? ''
+  const errorStack = input.error?.stack ?? ''
+
+  return {
+    content: `🚨 **${input.functionName}** Error Alert`,
+    embeds: [
+      {
+        title: `❌ ${input.functionName} Function Failed`,
+        description: `**Error:** ${getSafeErrorName(input.error)}`,
+        color: 0xFF0000, // Red color
+        timestamp: input.timestamp,
+        fields: [
+          {
+            name: '🔍 Request Details',
+            value: `**Method:** ${input.method}\n**Path present:** ${boolLabel(urlSummary.hasPath)}\n**Path segments:** ${urlSummary.pathSegmentCount}\n**Has query:** ${boolLabel(urlSummary.hasQuery)}\n**Request ID:** ${input.requestId}`,
+            inline: false,
+          },
+          {
+            name: '🌐 Client Info',
+            value: `**IP present:** ${boolLabel(input.hasClientIp)}\n**User-Agent present:** ${boolLabel(input.hasUserAgent)}`,
+            inline: false,
+          },
+          {
+            name: '📝 Request Body',
+            value: `**Present:** ${boolLabel(input.body.length > 0)}\n**Character length:** ${input.body.length}`,
+            inline: false,
+          },
+          {
+            name: '🔧 Headers',
+            value: `**Count:** ${headerSummary.count}\n**Authorization present:** ${boolLabel(headerSummary.hasAuthorization)}\n**Cookie present:** ${boolLabel(headerSummary.hasCookie)}\n**API key present:** ${boolLabel(headerSummary.hasApiKey)}`,
+            inline: false,
+          },
+          {
+            name: '💥 Error Summary',
+            value: `**Message present:** ${boolLabel(errorMessage.length > 0)}\n**Message length:** ${errorMessage.length}\n**Stack present:** ${boolLabel(errorStack.length > 0)}`,
+            inline: false,
+          },
+        ],
+        footer: {
+          text: `Function: ${input.functionName} | Environment: ${input.environment || 'unknown'}`,
+        },
+      },
+    ],
+  }
 }
 
 export async function sendDiscordAlert(c: Context, payload: RESTPostAPIWebhookWithTokenJSONBody): Promise<boolean> {
   const webhookUrl = getEnv(c, 'DISCORD_ALERT')
 
   if (!webhookUrl) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Discord not set', payload: JSON.stringify(payload) })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Discord not set',
+      payload: getDiscordPayloadLogMetadata(payload),
+    })
     return true
   }
 
@@ -100,63 +174,32 @@ export async function sendDiscordAlert(c: Context, payload: RESTPostAPIWebhookWi
 export function sendDiscordAlert500(c: Context, functionName: string, body: string, e: Error) {
   const requestId = c.get('requestId') ?? 'unknown'
   const timestamp = new Date().toISOString()
-  const userAgent = c.req.header('user-agent') ?? 'unknown'
-  const ip = c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for') ?? 'unknown'
+  const userAgent = c.req.header('user-agent')
+  const ip = c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for')
   const method = c.req.method
   const url = c.req.url
   const rawHeaders = Object.fromEntries((c.req.raw.headers as any).entries())
-  const headers = sanitizeSensitiveHeaders(rawHeaders)
-  const errorMessage = e?.message ?? 'Unknown error'
-  const errorStack = e?.stack ?? 'No stack trace'
-  const errorName = e?.name ?? 'Error'
-  // Defense-in-depth: remove/sanitize sensitive fields from body string
-  const safeBody = sanitizeSensitiveFromString(body)
-  return sendDiscordAlert(c, {
-    content: `🚨 **${functionName}** Error Alert`,
-    embeds: [
-      {
-        title: `❌ ${functionName} Function Failed`,
-        description: `**Error:** ${errorName}\n**Message:** ${errorMessage}`,
-        color: 0xFF0000, // Red color
-        timestamp,
-        fields: [
-          {
-            name: '🔍 Request Details',
-            value: `**Method:** ${method}\n**URL:** ${url}\n**Request ID:** ${requestId}`,
-            inline: false,
-          },
-          {
-            name: '🌐 Client Info',
-            value: `**IP:** ${ip}\n**User-Agent:** ${userAgent}`,
-            inline: false,
-          },
-          {
-            name: '📝 Request Body',
-            value: `\`\`\`\n${safeBody}\n\`\`\``,
-            inline: false,
-          },
-          {
-            name: '🔧 Headers',
-            value: `\`\`\`json\n${JSON.stringify(headers, null, 2).substring(0, 1000)}\n\`\`\``,
-            inline: false,
-          },
-          {
-            name: '💥 Error Stack',
-            value: `\`\`\`\n${errorStack.substring(0, 1000)}\n\`\`\``,
-            inline: false,
-          },
-          {
-            name: '🔍 Full Error Object',
-            value: `\`\`\`json\n${JSON.stringify(e, Object.getOwnPropertyNames(e), 2).substring(0, 1000)}\n\`\`\``,
-            inline: false,
-          },
-        ],
-        footer: {
-          text: `Function: ${functionName} | Environment: ${getEnv(c, 'ENVIRONMENT') || 'unknown'}`,
-        },
-      },
-    ],
-  }).catch((e: any) => {
+
+  const payload = buildDiscordAlert500Payload({
+    body,
+    environment: getEnv(c, 'ENVIRONMENT') || 'unknown',
+    error: e,
+    functionName,
+    hasClientIp: !!ip,
+    hasUserAgent: !!userAgent,
+    method,
+    rawHeaders,
+    requestId,
+    timestamp,
+    url,
+  })
+
+  return sendDiscordAlert(c, payload).catch((e: any) => {
     cloudlogErr({ requestId, functionName, message: 'sendDiscordAlert500 failed', error: e })
   })
+}
+
+export const __discordTestUtils__ = {
+  buildDiscordAlert500Payload,
+  getDiscordPayloadLogMetadata,
 }

--- a/supabase/functions/_backend/utils/discord.ts
+++ b/supabase/functions/_backend/utils/discord.ts
@@ -68,6 +68,15 @@ function getSafeErrorName(error: Error) {
   return 'Error'
 }
 
+function getErrorLogMetadata(error: unknown) {
+  const errorMessage = error instanceof Error ? error.message : String(error)
+  return {
+    errorName: error instanceof Error ? getSafeErrorName(error) : 'Error',
+    hasMessage: errorMessage.length > 0,
+    messageLength: errorMessage.length,
+  }
+}
+
 function getDiscordPayloadLogMetadata(payload: RESTPostAPIWebhookWithTokenJSONBody) {
   const body = typeof payload === 'string'
     ? { content: payload }
@@ -166,7 +175,11 @@ export async function sendDiscordAlert(c: Context, payload: RESTPostAPIWebhookWi
     return true
   }
   catch (error) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Discord webhook error', error })
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Discord webhook error',
+      error: getErrorLogMetadata(error),
+    })
     return true
   }
 }
@@ -195,11 +208,17 @@ export function sendDiscordAlert500(c: Context, functionName: string, body: stri
   })
 
   return sendDiscordAlert(c, payload).catch((e: any) => {
-    cloudlogErr({ requestId, functionName, message: 'sendDiscordAlert500 failed', error: e })
+    cloudlogErr({
+      requestId,
+      functionName,
+      message: 'sendDiscordAlert500 failed',
+      error: getErrorLogMetadata(e),
+    })
   })
 }
 
 export const __discordTestUtils__ = {
   buildDiscordAlert500Payload,
+  getErrorLogMetadata,
   getDiscordPayloadLogMetadata,
 }

--- a/tests/discord-alert-redaction.unit.test.ts
+++ b/tests/discord-alert-redaction.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { __discordTestUtils__ } from '../supabase/functions/_backend/utils/discord.ts'
+
+describe('discord alert redaction', () => {
+  it.concurrent('keeps raw request and error details out of 500 alert payloads', () => {
+    const error = new Error('failed for alice@capgo.app with token super-secret-error-token')
+    error.name = 'SensitiveError'
+    error.stack = 'Error: failed\n    at secret-token-stack-frame'
+
+    const payload = __discordTestUtils__.buildDiscordAlert500Payload({
+      body: JSON.stringify({
+        api_key: 'capg_super_secret_key',
+        device_id: 'device-secret-id',
+        email: 'alice@capgo.app',
+        password: 'correct horse battery staple',
+        token: 'body-token-secret',
+      }),
+      environment: 'production',
+      error,
+      functionName: 'privateEndpoint',
+      hasClientIp: true,
+      hasUserAgent: true,
+      method: 'POST',
+      rawHeaders: {
+        'authorization': 'Bearer raw-authorization-token',
+        'cookie': 'session=raw-cookie-value',
+        'x-api-key': 'raw-api-key-value',
+      },
+      requestId: 'request-id',
+      timestamp: '2026-05-11T00:00:00.000Z',
+      url: 'https://api.capgo.app/functions/v1/secret-url-token?token=url-token&email=alice@capgo.app',
+    })
+
+    const serialized = JSON.stringify(payload)
+
+    expect(serialized).toContain('**Path present:** yes')
+    expect(serialized).toContain('**Path segments:** 3')
+    expect(serialized).toContain('**Has query:** yes')
+    expect(serialized).toContain('**Authorization present:** yes')
+    expect(serialized).toContain('**Cookie present:** yes')
+    expect(serialized).toContain('**API key present:** yes')
+    expect(serialized).toContain('SensitiveError')
+    expect(serialized).not.toContain('alice@capgo.app')
+    expect(serialized).not.toContain('body-token-secret')
+    expect(serialized).not.toContain('capg_super_secret_key')
+    expect(serialized).not.toContain('correct horse battery staple')
+    expect(serialized).not.toContain('device-secret-id')
+    expect(serialized).not.toContain('raw-api-key-value')
+    expect(serialized).not.toContain('raw-authorization-token')
+    expect(serialized).not.toContain('raw-cookie-value')
+    expect(serialized).not.toContain('secret-url-token')
+    expect(serialized).not.toContain('secret-token-stack-frame')
+    expect(serialized).not.toContain('url-token')
+  })
+
+  it.concurrent('summarizes disabled Discord payload logs without serializing payload content', () => {
+    const metadata = __discordTestUtils__.getDiscordPayloadLogMetadata({
+      content: 'contains token raw-token-value',
+      embeds: [
+        {
+          description: 'contains password raw-password-value',
+          title: 'sensitive payload',
+        },
+      ],
+    } as any)
+
+    const serialized = JSON.stringify(metadata)
+
+    expect(metadata).toEqual({
+      embedCount: 1,
+      hasContent: true,
+      payloadType: 'object',
+    })
+    expect(serialized).not.toContain('raw-token-value')
+    expect(serialized).not.toContain('raw-password-value')
+  })
+})

--- a/tests/discord-alert-redaction.unit.test.ts
+++ b/tests/discord-alert-redaction.unit.test.ts
@@ -1,8 +1,55 @@
-import { describe, expect, it } from 'vitest'
-import { __discordTestUtils__ } from '../supabase/functions/_backend/utils/discord.ts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cloudlogErrMock,
+  cloudlogMock,
+  envState,
+  fetchMock,
+} = vi.hoisted(() => ({
+  cloudlogErrMock: vi.fn(),
+  cloudlogMock: vi.fn(),
+  envState: {
+    discordAlert: '',
+  },
+  fetchMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: cloudlogErrMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  getEnv: (_c: unknown, key: string) => {
+    if (key === 'DISCORD_ALERT')
+      return envState.discordAlert
+    if (key === 'ENVIRONMENT')
+      return 'production'
+    return ''
+  },
+}))
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+  } as any
+}
+
+beforeEach(() => {
+  envState.discordAlert = ''
+  fetchMock.mockReset()
+  cloudlogErrMock.mockReset()
+  cloudlogMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('discord alert redaction', () => {
-  it.concurrent('keeps raw request and error details out of 500 alert payloads', () => {
+  it('keeps raw request and error details out of 500 alert payloads', async () => {
+    const { __discordTestUtils__ } = await import('../supabase/functions/_backend/utils/discord.ts')
     const error = new Error('failed for alice@capgo.app with token super-secret-error-token')
     error.name = 'SensitiveError'
     error.stack = 'Error: failed\n    at secret-token-stack-frame'
@@ -53,8 +100,10 @@ describe('discord alert redaction', () => {
     expect(serialized).not.toContain('url-token')
   })
 
-  it.concurrent('summarizes disabled Discord payload logs without serializing payload content', () => {
-    const metadata = __discordTestUtils__.getDiscordPayloadLogMetadata({
+  it('summarizes disabled Discord payload logs without serializing payload content', async () => {
+    const { sendDiscordAlert } = await import('../supabase/functions/_backend/utils/discord.ts')
+
+    await sendDiscordAlert(createContext(), {
       content: 'contains token raw-token-value',
       embeds: [
         {
@@ -64,14 +113,39 @@ describe('discord alert redaction', () => {
       ],
     } as any)
 
-    const serialized = JSON.stringify(metadata)
+    const serialized = JSON.stringify(cloudlogMock.mock.calls)
 
-    expect(metadata).toEqual({
-      embedCount: 1,
-      hasContent: true,
-      payloadType: 'object',
-    })
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      payload: {
+        embedCount: 1,
+        hasContent: true,
+        payloadType: 'object',
+      },
+    }))
     expect(serialized).not.toContain('raw-token-value')
     expect(serialized).not.toContain('raw-password-value')
+  })
+
+  it('summarizes Discord fetch errors without retaining webhook tokens', async () => {
+    const { sendDiscordAlert } = await import('../supabase/functions/_backend/utils/discord.ts')
+    envState.discordAlert = 'https://discord.com/api/webhooks/app-id/discord-webhook-secret-token'
+    fetchMock.mockRejectedValue(new Error(`connect failed: ${envState.discordAlert}`))
+
+    await sendDiscordAlert(createContext(), {
+      content: 'hello',
+    } as any)
+
+    const serialized = JSON.stringify(cloudlogErrMock.mock.calls)
+
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: {
+        errorName: 'Error',
+        hasMessage: true,
+        messageLength: envState.discordAlert.length + 'connect failed: '.length,
+      },
+      message: 'Discord webhook error',
+    }))
+    expect(serialized).not.toContain('discord-webhook-secret-token')
+    expect(serialized).not.toContain(envState.discordAlert)
   })
 })

--- a/tests/discord-alert-redaction.unit.test.ts
+++ b/tests/discord-alert-redaction.unit.test.ts
@@ -40,7 +40,6 @@ beforeEach(() => {
   fetchMock.mockReset()
   cloudlogErrMock.mockReset()
   cloudlogMock.mockReset()
-  vi.stubGlobal('fetch', fetchMock)
 })
 
 afterEach(() => {
@@ -130,6 +129,7 @@ describe('discord alert redaction', () => {
     const { sendDiscordAlert } = await import('../supabase/functions/_backend/utils/discord.ts')
     envState.discordAlert = 'https://discord.com/api/webhooks/app-id/discord-webhook-secret-token'
     fetchMock.mockRejectedValue(new Error(`connect failed: ${envState.discordAlert}`))
+    vi.stubGlobal('fetch', fetchMock)
 
     await sendDiscordAlert(createContext(), {
       content: 'hello',


### PR DESCRIPTION
## Summary
- replace raw request body, headers, URL, client IP/user-agent, error message, stack, and full error object in Discord 500 alerts with presence/count metadata
- stop logging serialized Discord payload content when DISCORD_ALERT is not configured
- add unit coverage that sensitive body/header/URL/error values are absent from alert payloads

/claim #1667

## Test plan
- ./node_modules/.bin/vitest run tests/discord-alert-redaction.unit.test.ts
- ./node_modules/.bin/vitest run tests/on-error-posthog.unit.test.ts tests/discord-alert-redaction.unit.test.ts
- ./node_modules/.bin/eslint supabase/functions/_backend/utils/discord.ts tests/discord-alert-redaction.unit.test.ts
- git diff --check