### PR TITLE
fix(api): redact ok request body logs

### DIFF
--- a/supabase/functions/_backend/public/ok.ts
+++ b/supabase/functions/_backend/public/ok.ts
@@ -4,9 +4,39 @@ import { cloudlog } from '../utils/logging.ts'
 
 export const app = honoFactory.createApp()
 
+export function summarizeOkRequestBodyForLog(body: unknown) {
+  if (body === null || body === undefined) {
+    return {
+      bodyType: body === null ? 'null' : 'undefined',
+      hasBody: false,
+    }
+  }
+
+  if (Array.isArray(body)) {
+    return {
+      bodyType: 'array',
+      hasBody: true,
+      itemCount: body.length,
+    }
+  }
+
+  if (typeof body === 'object') {
+    return {
+      bodyType: 'object',
+      hasBody: true,
+      keyCount: Object.keys(body as Record<string, unknown>).length,
+    }
+  }
+
+  return {
+    bodyType: typeof body,
+    hasBody: true,
+  }
+}
+
 app.post('/', async (c) => {
   const body = await parseBody<any>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'body', data: body })
+  cloudlog({ requestId: c.get('requestId'), message: 'body', data: summarizeOkRequestBodyForLog(body) })
   const apiVersion = resolveCapgoApiVersion(c)
 
   return apiVersion.handle({

--- a/tests/ok-request-logging.unit.test.ts
+++ b/tests/ok-request-logging.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeOkRequestBodyForLog } from '../supabase/functions/_backend/public/ok.ts'
+
+describe('ok endpoint request logging', () => {
+  it.concurrent('summarizes request bodies without retaining raw payload values', () => {
+    const summary = summarizeOkRequestBodyForLog({
+      nested: {
+        token: 'secret-token',
+      },
+      password: 'super-secret',
+      username: 'alice@example.com',
+    })
+
+    expect(summary).toEqual({
+      bodyType: 'object',
+      hasBody: true,
+      keyCount: 3,
+    })
+
+    const serialized = JSON.stringify(summary)
+    expect(serialized).not.toContain('secret-token')
+    expect(serialized).not.toContain('super-secret')
+    expect(serialized).not.toContain('alice@example.com')
+    expect(serialized).not.toContain('password')
+    expect(serialized).not.toContain('username')
+  })
+
+  it.concurrent('keeps array and empty body logs metadata-only', () => {
+    expect(summarizeOkRequestBodyForLog(['secret-1', 'secret-2'])).toEqual({
+      bodyType: 'array',
+      hasBody: true,
+      itemCount: 2,
+    })
+
+    expect(summarizeOkRequestBodyForLog(undefined)).toEqual({
+      bodyType: 'undefined',
+      hasBody: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Replace `/ok` POST request-body cloudlog output with a metadata-only summary.
- Keep the endpoint response/version behavior unchanged.
- Add unit coverage that verifies raw request values and field names are not retained in the log summary.

## Motivation (AI generated)

The public `/ok` endpoint accepts arbitrary POST bodies, so routine logs should not store raw payload data that may contain credentials, tokens, emails, or other accidental sensitive values.

## Business Impact (AI generated)

This reduces unnecessary data retention in public endpoint logs while preserving existing health-check/API-version behavior.

## Test Plan (AI generated)

- [x] `npm exec --yes --package=bun -- bunx vitest run tests/ok-request-logging.unit.test.ts`
- [x] `npm exec --yes --package=bun -- bun lint:backend`
- [x] `npm exec --yes --package=bun -- bun typecheck`

Related to #1667

Generated with AI