### PR TITLE
chore: redact notification recipient details from logs

### DIFF
--- a/supabase/functions/_backend/utils/notifications.ts
+++ b/supabase/functions/_backend/utils/notifications.ts
@@ -63,7 +63,7 @@ function setNotifCacheStatus(c: Context, orgId: string, eventName: string, uniqI
 }
 
 function getEventDataSummary(eventData: EventData) {
-  const fields = Object.keys(eventData).sort()
+  const fields = Object.keys(eventData).sort((a, b) => a.localeCompare(b))
   return {
     fieldCount: fields.length,
     fields,

--- a/supabase/functions/_backend/utils/notifications.ts
+++ b/supabase/functions/_backend/utils/notifications.ts
@@ -328,7 +328,7 @@ export async function sendNotifOrgOnce(
       return { sent: false, cleanupFailed: !cleanupSucceeded }
     }
 
-    cloudlog({ requestId: c.get('requestId'), message: 'send one-time notif done', eventName, uniqId, ...getNotificationLogDetails(recipientEmail) })
+    cloudlog({ requestId: c.get('requestId'), message: 'send one-time notif done', eventName, ...getNotificationLogDetails(recipientEmail) })
     return { sent: true, cleanupFailed: false }
   }
   catch (e: unknown) {

--- a/supabase/functions/_backend/utils/notifications.ts
+++ b/supabase/functions/_backend/utils/notifications.ts
@@ -14,6 +14,14 @@ interface EventData {
   [key: string]: any
 }
 
+interface NotificationLogDetails {
+  eventDataSummary?: {
+    fieldCount: number
+    fields: string[]
+  }
+  recipientEmailPresent: boolean
+}
+
 export interface SendNotifOrgOnceResult {
   cleanupFailed: boolean
   sent: boolean
@@ -52,6 +60,21 @@ function setNotifCacheStatus(c: Context, orgId: string, eventName: string, uniqI
       return
     await cacheEntry.helper.putJson(cacheEntry.request, { sendable }, ttlSeconds)
   })
+}
+
+function getEventDataSummary(eventData: EventData) {
+  const fields = Object.keys(eventData).sort()
+  return {
+    fieldCount: fields.length,
+    fields,
+  }
+}
+
+function getNotificationLogDetails(recipientEmail: string, eventData?: EventData): NotificationLogDetails {
+  return {
+    recipientEmailPresent: Boolean(recipientEmail),
+    ...(eventData ? { eventDataSummary: getEventDataSummary(eventData) } : {}),
+  }
 }
 
 /**
@@ -235,12 +258,12 @@ export async function sendNotifOrg(
       cloudlog({ requestId: c.get('requestId'), message: isFirstSend ? 'notif never sent' : 'notif ready to sent', event: eventName, uniqId })
       const res = await trackBentoEvent(c, managementEmail, eventData, eventName)
       if (!res) {
-        cloudlog({ requestId: c.get('requestId'), message: 'trackEvent failed', eventName, email: managementEmail, eventData })
+        cloudlog({ requestId: c.get('requestId'), message: 'trackEvent failed', eventName, ...getNotificationLogDetails(managementEmail, eventData) })
         // Note: We already claimed it in DB, but email failed. On next attempt, cron will determine if we retry.
         return false
       }
 
-      cloudlog({ requestId: c.get('requestId'), message: 'send notif done', eventName, email: managementEmail })
+      cloudlog({ requestId: c.get('requestId'), message: 'send notif done', eventName, ...getNotificationLogDetails(managementEmail) })
       return true
     }
 
@@ -301,11 +324,11 @@ export async function sendNotifOrgOnce(
     const res = await trackBentoEvent(c, recipientEmail, eventData, eventName)
     if (!res) {
       const cleanupSucceeded = await cleanupClaim()
-      cloudlog({ requestId: c.get('requestId'), message: 'trackEvent failed for one-time notif', eventName, email: recipientEmail, eventData })
+      cloudlog({ requestId: c.get('requestId'), message: 'trackEvent failed for one-time notif', eventName, ...getNotificationLogDetails(recipientEmail, eventData) })
       return { sent: false, cleanupFailed: !cleanupSucceeded }
     }
 
-    cloudlog({ requestId: c.get('requestId'), message: 'send one-time notif done', eventName, email: recipientEmail, uniqId })
+    cloudlog({ requestId: c.get('requestId'), message: 'send one-time notif done', eventName, uniqId, ...getNotificationLogDetails(recipientEmail) })
     return { sent: true, cleanupFailed: false }
   }
   catch (e: unknown) {

--- a/tests/notifications-send-once.unit.test.ts
+++ b/tests/notifications-send-once.unit.test.ts
@@ -142,4 +142,32 @@ describe.sequential('sendNotifOrgOnce', () => {
     expect(cloudlogPayload).not.toContain('billing@example.com')
     expect(cloudlogPayload).not.toContain('keep-me-out')
   })
+
+  it('does not log recipient email or unique recipient identifier when Bento succeeds', async () => {
+    trackBentoEventMock.mockResolvedValue(true)
+    const { client } = createWriteClient()
+
+    const { sendNotifOrgOnce } = await import('../supabase/functions/_backend/utils/notifications.ts')
+
+    const sent = await sendNotifOrgOnce(
+      createContext(),
+      'user:need_onboarding',
+      { org_id: 'org-123' },
+      'org-123',
+      'org-123:recipient-email-hash',
+      'billing@example.com',
+      {} as any,
+      client,
+    )
+
+    expect(sent).toEqual({ sent: true, cleanupFailed: false })
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventName: 'user:need_onboarding',
+      message: 'send one-time notif done',
+      recipientEmailPresent: true,
+    }))
+    const cloudlogPayload = JSON.stringify(cloudlogMock.mock.calls)
+    expect(cloudlogPayload).not.toContain('billing@example.com')
+    expect(cloudlogPayload).not.toContain('org-123:recipient-email-hash')
+  })
 })

--- a/tests/notifications-send-once.unit.test.ts
+++ b/tests/notifications-send-once.unit.test.ts
@@ -110,4 +110,36 @@ describe.sequential('sendNotifOrgOnce', () => {
       expect.any(Error),
     )
   })
+
+  it('does not log recipient email or raw event data when Bento returns false', async () => {
+    trackBentoEventMock.mockResolvedValue(false)
+    const { client } = createWriteClient()
+
+    const { sendNotifOrgOnce } = await import('../supabase/functions/_backend/utils/notifications.ts')
+
+    const sent = await sendNotifOrgOnce(
+      createContext(),
+      'user:need_onboarding',
+      { org_id: 'org-123', sensitive_value: 'keep-me-out' },
+      'org-123',
+      'org-123:recipient',
+      'billing@example.com',
+      {} as any,
+      client,
+    )
+
+    expect(sent).toEqual({ sent: false, cleanupFailed: false })
+    expect(cloudlogMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventDataSummary: {
+        fieldCount: 2,
+        fields: ['org_id', 'sensitive_value'],
+      },
+      eventName: 'user:need_onboarding',
+      message: 'trackEvent failed for one-time notif',
+      recipientEmailPresent: true,
+    }))
+    const cloudlogPayload = JSON.stringify(cloudlogMock.mock.calls)
+    expect(cloudlogPayload).not.toContain('billing@example.com')
+    expect(cloudlogPayload).not.toContain('keep-me-out')
+  })
 })


### PR DESCRIPTION
## Summary
- Redacts notification recipient email addresses from Bento delivery logs
- Replaces raw notification eventData logging with a field-count/key summary
- Adds coverage to ensure one-time notification failures do not log recipient email or raw event values

## Testing
- bunx vitest run tests/notifications-send-once.unit.test.ts
- bunx eslint supabase/functions/_backend/utils/notifications.ts tests/notifications-send-once.unit.test.ts
- git diff --check

Related to #1667.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced structured notification logging with enhanced privacy controls; logs now summarize event data and omit recipient email and sensitive field values.

* **Tests**
  * Added test verifying logging preserves privacy when event tracking indicates no send (ensures sensitive details are excluded).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2156)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2156)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->