### PR TITLE
fix(frontend): validate redirect query targets

### DIFF
--- a/src/pages/accountDisabled.vue
+++ b/src/pages/accountDisabled.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { authGhostButtonClass, authPrimaryButtonClass, authSecondaryButtonClass } from '~/components/auth/pageStyles'
+import { getSafeRedirectPath } from '~/services/redirects'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { useMainStore } from '~/stores/main'
@@ -27,10 +28,9 @@ const isRestoring = ref(false)
 let intervalId: NodeJS.Timeout | null = null
 
 const restoreTarget = computed(() => {
-  const target = typeof route.query.to === 'string' ? route.query.to : ''
-  if (target.startsWith('/') && target !== '/accountDisabled')
-    return target
-  return '/dashboard'
+  return getSafeRedirectPath(route.query.to, '/dashboard', {
+    blockedPrefixes: ['/accountDisabled'],
+  })
 })
 
 async function handleRestore() {

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -14,6 +14,7 @@ import iconEmail from '~icons/oui/email?raw'
 import iconPassword from '~icons/ph/key?raw'
 import mfaIcon from '~icons/simple-icons/2fas?raw'
 import { hideLoader } from '~/services/loader'
+import { getSafeRedirectPath } from '~/services/redirects'
 import { autoAuth, defaultApiHost, hashEmail, useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 
@@ -166,12 +167,7 @@ onBeforeUnmount(() => {
 })
 
 async function nextLogin() {
-  if (route.query.to && typeof route.query.to === 'string') {
-    await router.replace(route.query.to)
-  }
-  else {
-    await router.replace('/dashboard')
-  }
+  await router.replace(getSafeRedirectPath(route.query.to))
   setTimeout(async () => {
     isLoading.value = false
   }, 500)
@@ -342,8 +338,9 @@ async function handleSsoLogin() {
 
   try {
     const redirectUrl = new URL('/sso-callback', window.location.origin)
-    if (route.query.to && typeof route.query.to === 'string') {
-      redirectUrl.searchParams.set('to', route.query.to)
+    const redirectTarget = getSafeRedirectPath(route.query.to, '')
+    if (redirectTarget) {
+      redirectUrl.searchParams.set('to', redirectTarget)
     }
 
     const { data, error } = await supabase.auth.signInWithSSO({

--- a/src/pages/onboarding/organization.vue
+++ b/src/pages/onboarding/organization.vue
@@ -9,6 +9,7 @@ import IconUsers from '~icons/lucide/users-round'
 import IconBack from '~icons/material-symbols/arrow-back-ios-rounded'
 import InviteTeammateModal from '~/components/dashboard/InviteTeammateModal.vue'
 import { uploadOrgLogoFile } from '~/services/photos'
+import { getSafeRedirectPath } from '~/services/redirects'
 import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
@@ -241,9 +242,9 @@ async function goBack() {
     return
   }
 
-  const fallbackPath = typeof route.query.to === 'string' && route.query.to && !route.query.to.startsWith('/onboarding/')
-    ? route.query.to
-    : '/login'
+  const fallbackPath = getSafeRedirectPath(route.query.to, '/login', {
+    blockedPrefixes: ['/onboarding'],
+  })
   await router.push(fallbackPath)
 }
 
@@ -267,12 +268,16 @@ async function logoutFromOnboarding() {
 }
 
 async function syncRouteQuery(nextStep: OnboardingStep, orgId = createdOrgId.value) {
+  const redirectTarget = getSafeRedirectPath(route.query.to, '', {
+    blockedPrefixes: ['/onboarding'],
+  })
+
   await router.replace({
     path: '/onboarding/organization',
     query: {
       ...(orgId ? { org: orgId } : {}),
       ...(typeof route.query.source === 'string' ? { source: route.query.source } : {}),
-      ...(typeof route.query.to === 'string' ? { to: route.query.to } : {}),
+      ...(redirectTarget ? { to: redirectTarget } : {}),
       step: nextStep,
     },
   })

--- a/src/pages/resend_email.vue
+++ b/src/pages/resend_email.vue
@@ -8,6 +8,7 @@ import { toast } from 'vue-sonner'
 import iconEmail from '~icons/oui/email?raw'
 import { authGhostButtonClass, authInsetCardClass, authPanelClass, authPrimaryButtonClass } from '~/components/auth/pageStyles'
 import { getRecentEmailOtpVerification, sendEmailOtpVerification, verifyEmailOtp } from '~/services/emailOtp'
+import { getSafeRedirectPath } from '~/services/redirects'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { useMainStore } from '~/stores/main'
@@ -25,7 +26,9 @@ const otpVerificationLoading = ref(false)
 const currentUserId = ref('')
 const currentUserEmail = ref('')
 const emailVerificationBlockingReason = computed(() => route.query.reason === 'email_not_verified')
-const returnTo = computed(() => (typeof route.query.return_to === 'string' ? route.query.return_to : ''))
+const rawReturnTo = computed(() => (typeof route.query.return_to === 'string' ? route.query.return_to : ''))
+const returnTo = computed(() => getSafeRedirectPath(rawReturnTo.value, '/settings/account'))
+const returnToLabel = computed(() => rawReturnTo.value ? returnTo.value : '')
 const usesEmailOtpFlow = computed(() => emailVerificationBlockingReason.value && !!currentUserId.value && !!currentUserEmail.value)
 
 async function submit(form: { email: string }) {
@@ -56,7 +59,7 @@ async function loadDeleteEmailVerificationState() {
 
     const { isVerified } = await getRecentEmailOtpVerification(supabase, currentUserId.value)
     if (isVerified)
-      await router.replace(returnTo.value || '/settings/account')
+      await router.replace(returnTo.value)
   }
   catch (error) {
     console.error('Cannot load email verification state', error)
@@ -102,7 +105,7 @@ async function verifyOtpCode() {
     return
   }
 
-  await router.replace(returnTo.value || '/settings/account')
+  await router.replace(returnTo.value)
 }
 
 onMounted(async () => {
@@ -131,8 +134,8 @@ onMounted(async () => {
         <p class="mt-2 text-sm leading-6">
           {{ t('email-not-verified-banner-body') }}
         </p>
-        <p v-if="returnTo" class="mt-3 text-xs font-medium tracking-[0.12em] uppercase">
-          {{ t('attempted-destination') }} {{ returnTo }}
+        <p v-if="returnToLabel" class="mt-3 text-xs font-medium tracking-[0.12em] uppercase">
+          {{ t('attempted-destination') }} {{ returnToLabel }}
         </p>
       </div>
 

--- a/src/pages/sso-callback.vue
+++ b/src/pages/sso-callback.vue
@@ -8,6 +8,7 @@ import IconLoader from '~icons/lucide/loader-2'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import { authGhostButtonClass, authSecondaryButtonClass } from '~/components/auth/pageStyles'
 import { useSSOProvisioning } from '~/composables/useSSOProvisioning'
+import { getSafeRedirectPath } from '~/services/redirects'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 
@@ -18,25 +19,6 @@ const { t } = useI18n()
 const isLoading = ref(true)
 const errorMessage = ref('')
 const { provisionUser, error: provisionError } = useSSOProvisioning()
-
-function validateRedirectPath(path: string | undefined): string {
-  // Default fallback
-  if (!path) {
-    return '/dashboard'
-  }
-
-  // Only allow relative paths starting with / but not //
-  if (!path.startsWith('/') || path.startsWith('//')) {
-    return '/dashboard'
-  }
-
-  // Reject paths containing scheme-like patterns (http:, https:, javascript:, etc.)
-  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
-    return '/dashboard'
-  }
-
-  return path
-}
 
 function getSsoCallbackParams() {
   const hashParams = new URLSearchParams(globalThis.location.hash.replace('#', ''))
@@ -135,10 +117,7 @@ async function completeSsoLogin() {
       }
     }
 
-    // Validate redirect path to prevent open redirect
-    const redirectTo = route.query.to as string | undefined
-    const validatedPath = validateRedirectPath(redirectTo)
-    router.replace(validatedPath)
+    router.replace(getSafeRedirectPath(route.query.to))
   }
   catch (err) {
     isLoading.value = false

--- a/src/services/redirects.ts
+++ b/src/services/redirects.ts
@@ -1,0 +1,59 @@
+interface SafeRedirectOptions {
+  blockedPaths?: string[]
+  blockedPrefixes?: string[]
+}
+
+const defaultRedirectPath = '/dashboard'
+const redirectBaseUrl = 'https://app.capgo.local'
+
+function hasControlCharacter(path: string): boolean {
+  return Array.from(path).some((char) => {
+    const codePoint = char.charCodeAt(0)
+    return codePoint <= 31 || codePoint === 127
+  })
+}
+
+export function isSafeRedirectPath(path: string): boolean {
+  if (!path || path !== path.trim())
+    return false
+
+  if (!path.startsWith('/') || path.startsWith('//'))
+    return false
+
+  if (path.includes('\\') || hasControlCharacter(path))
+    return false
+
+  try {
+    const parsedUrl = new URL(path, redirectBaseUrl)
+    return parsedUrl.origin === redirectBaseUrl && parsedUrl.pathname.startsWith('/')
+  }
+  catch {
+    return false
+  }
+}
+
+function hasBlockedPrefix(path: string, prefix: string): boolean {
+  return path === prefix
+    || path.startsWith(`${prefix}/`)
+    || path.startsWith(`${prefix}?`)
+    || path.startsWith(`${prefix}#`)
+}
+
+function isBlockedRedirectPath(path: string, options: SafeRedirectOptions): boolean {
+  return options.blockedPaths?.includes(path) === true
+    || options.blockedPrefixes?.some(prefix => hasBlockedPrefix(path, prefix)) === true
+}
+
+export function getSafeRedirectPath(target: unknown, fallback = defaultRedirectPath, options: SafeRedirectOptions = {}): string {
+  const fallbackPath = fallback === '' || isSafeRedirectPath(fallback)
+    ? fallback
+    : defaultRedirectPath
+
+  if (typeof target !== 'string')
+    return fallbackPath
+
+  if (!isSafeRedirectPath(target) || isBlockedRedirectPath(target, options))
+    return fallbackPath
+
+  return target
+}

--- a/src/services/redirects.ts
+++ b/src/services/redirects.ts
@@ -8,13 +8,14 @@ const redirectBaseUrl = 'https://app.capgo.local'
 
 function hasControlCharacter(path: string): boolean {
   return Array.from(path).some((char) => {
-    const codePoint = char.charCodeAt(0)
+    const codePoint = char.codePointAt(0) ?? 0
     return codePoint <= 31 || codePoint === 127
   })
 }
 
 export function isSafeRedirectPath(path: string): boolean {
-  if (!path || path !== path.trim())
+  const trimmedPath = path.trim()
+  if (trimmedPath.length === 0 || path !== trimmedPath)
     return false
 
   if (!path.startsWith('/') || path.startsWith('//'))

--- a/src/services/redirects.ts
+++ b/src/services/redirects.ts
@@ -45,7 +45,8 @@ function isBlockedRedirectPath(path: string, options: SafeRedirectOptions): bool
 }
 
 export function getSafeRedirectPath(target: unknown, fallback = defaultRedirectPath, options: SafeRedirectOptions = {}): string {
-  const fallbackPath = fallback === '' || isSafeRedirectPath(fallback)
+  const fallbackPath = fallback === ''
+    || (isSafeRedirectPath(fallback) && !isBlockedRedirectPath(fallback, options))
     ? fallback
     : defaultRedirectPath
 

--- a/tests/redirects.unit.test.ts
+++ b/tests/redirects.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getSafeRedirectPath, isSafeRedirectPath } from '../src/services/redirects.ts'
+import { getSafeRedirectPath, isSafeRedirectPath } from '~/services/redirects'
 
 describe('redirect path validation', () => {
   it.concurrent('accepts same-origin application paths', () => {
@@ -30,6 +30,12 @@ describe('redirect path validation', () => {
     expect(getSafeRedirectPath('/onboarding/organization', '/login', {
       blockedPrefixes: ['/onboarding'],
     })).toBe('/login')
+    expect(getSafeRedirectPath('/settings/account', '/onboarding/organization', {
+      blockedPrefixes: ['/onboarding'],
+    })).toBe('/settings/account')
+    expect(getSafeRedirectPath('/onboarding/organization', '/onboarding/organization', {
+      blockedPrefixes: ['/onboarding'],
+    })).toBe('/dashboard')
     expect(getSafeRedirectPath('/accountDisabled?restored=1', '/dashboard', {
       blockedPrefixes: ['/accountDisabled'],
     })).toBe('/dashboard')

--- a/tests/redirects.unit.test.ts
+++ b/tests/redirects.unit.test.ts
@@ -22,6 +22,7 @@ describe('redirect path validation', () => {
 
   it.concurrent('falls back when a query redirect is unsafe', () => {
     expect(getSafeRedirectPath('//example.com/phish')).toBe('/dashboard')
+    expect(getSafeRedirectPath(undefined, '//example.com/phish')).toBe('/dashboard')
     expect(getSafeRedirectPath('/settings/account')).toBe('/settings/account')
     expect(getSafeRedirectPath(undefined, '/login')).toBe('/login')
   })

--- a/tests/redirects.unit.test.ts
+++ b/tests/redirects.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSafeRedirectPath, isSafeRedirectPath } from '../src/services/redirects.ts'
+
+describe('redirect path validation', () => {
+  it.concurrent('accepts same-origin application paths', () => {
+    expect(isSafeRedirectPath('/dashboard')).toBe(true)
+    expect(isSafeRedirectPath('/settings/account?tab=security#email')).toBe(true)
+  })
+
+  it.concurrent('rejects absolute and protocol-relative targets', () => {
+    expect(isSafeRedirectPath('https://example.com/phish')).toBe(false)
+    expect(isSafeRedirectPath('//example.com/phish')).toBe(false)
+    expect(isSafeRedirectPath('javascript:alert(1)')).toBe(false)
+  })
+
+  it.concurrent('rejects ambiguous browser-normalized targets', () => {
+    expect(isSafeRedirectPath('/\\example.com/phish')).toBe(false)
+    expect(isSafeRedirectPath('/dashboard\n//example.com')).toBe(false)
+    expect(isSafeRedirectPath(' /dashboard')).toBe(false)
+  })
+
+  it.concurrent('falls back when a query redirect is unsafe', () => {
+    expect(getSafeRedirectPath('//example.com/phish')).toBe('/dashboard')
+    expect(getSafeRedirectPath('/settings/account')).toBe('/settings/account')
+    expect(getSafeRedirectPath(undefined, '/login')).toBe('/login')
+  })
+
+  it.concurrent('blocks caller-specific redirect loops', () => {
+    expect(getSafeRedirectPath('/onboarding/organization', '/login', {
+      blockedPrefixes: ['/onboarding'],
+    })).toBe('/login')
+    expect(getSafeRedirectPath('/accountDisabled?restored=1', '/dashboard', {
+      blockedPrefixes: ['/accountDisabled'],
+    })).toBe('/dashboard')
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- add a shared safe redirect helper for same-origin app paths
- apply it to login, SSO callback, resend email, account restore, and onboarding redirect targets
- cover absolute, protocol-relative, browser-normalized, and loop targets with unit tests

## Tests
- npx --yes bun@latest x vitest run tests/redirects.unit.test.ts tests/sso-enforcement-redirect.unit.test.ts
- npx --yes bun@latest run lint
- npx --yes bun@latest run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized redirect-path sanitizer used across auth and onboarding flows.

* **Bug Fixes**
  * Enhanced redirect safety to block unsafe or unwanted destinations (including certain path prefixes) after login, SSO, onboarding, and verification.
  * Prevented potential redirect loops and removed inconsistent fallback behaviors.

* **Tests**
  * Added unit tests covering redirect validation and fallback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2158)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->