### PR TITLE
fix: remove onboarding debug logs

### DIFF
--- a/src/components/dashboard/StepsApp.vue
+++ b/src/components/dashboard/StepsApp.vue
@@ -12,7 +12,6 @@ import { pushEvent } from '~/services/posthog'
 import { getLocalConfig, isLocal, useSupabase } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useDialogV2Store } from '~/stores/dialogv2'
-import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 
@@ -20,7 +19,6 @@ const props = defineProps<{
   onboarding: boolean
 }>()
 const emit = defineEmits(['done', 'closeStep'])
-const displayStore = useDisplayStore()
 const isLoading = ref(false)
 const isDemoLoading = ref(false)
 const step = ref(0)
@@ -94,7 +92,6 @@ function setLog() {
     pushEvent(`user:onboarding-step-${stepToName(step.value)}`, config.supaHost)
   }
   if (step.value === 2) {
-    console.log('Finished onboarding for app ID:', appId.value)
     emit('done', appId.value)
   }
 }
@@ -102,7 +99,6 @@ function setLog() {
 function scrollToElement(id: string) {
   // Get the element with the id
   const el = document.getElementById(id)
-  console.log('el', el)
   if (el) {
     // Use el.scrollIntoView() to instantly scroll to the element
     el.scrollIntoView({ behavior: 'smooth' })
@@ -190,7 +186,6 @@ async function createDemoApp() {
 
 function clearWatchers() {
   if (pollTimer.value !== null) {
-    console.log('clear poll timer', pollTimer.value)
     clearInterval(pollTimer.value)
     pollTimer.value = null
   }
@@ -200,7 +195,6 @@ async function copyToast(allowed: boolean, _id: string, text?: string) {
     return
   try {
     await navigator.clipboard.writeText(text)
-    console.log('displayStore.messageToast', displayStore.messageToast)
     toast.success(t('copied-to-clipboard'))
   }
   catch (err) {
@@ -229,7 +223,6 @@ async function addNewApiKey() {
   const userId = claimsData?.claims?.sub
 
   if (!userId) {
-    console.log('Not logged in, cannot regenerate API key')
     return
   }
   const { error } = await createDefaultApiKey(supabase, t('api-key'))
@@ -289,14 +282,11 @@ async function getLatestAppId(): Promise<string | undefined> {
 
   if (error || !data || data.length === 0)
     return undefined
-  console.log('data', data)
-  console.log('latest app id', data[0].app_id)
   return data[0].app_id as string
 }
 
 watchEffect(async () => {
   if (step.value === 1 && !realtimeListener.value) {
-    console.log('watch app change step 1 via polling')
     realtimeListener.value = true
     await organizationStore.awaitInitialLoad()
     // establish baseline

--- a/src/components/dashboard/StepsBundle.vue
+++ b/src/components/dashboard/StepsBundle.vue
@@ -10,7 +10,6 @@ import { pushEvent } from '~/services/posthog'
 import { getLocalConfig, isLocal, useSupabase } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useDialogV2Store } from '~/stores/dialogv2'
-import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 
@@ -19,7 +18,6 @@ const props = defineProps<{
   appId: string
 }>()
 const emit = defineEmits(['done', 'closeStep'])
-const displayStore = useDisplayStore()
 const isLoading = ref(false)
 const step = ref(0)
 const clicked = ref(0)
@@ -69,7 +67,6 @@ function stepToName(stepNumber: number): string {
 }
 
 function setLog() {
-  console.log('setLog', props.onboarding, main.user?.id, step.value)
   if (props.onboarding && main.user?.id) {
     sendEvent({
       channel: 'onboarding-bundle',
@@ -87,7 +84,6 @@ function setLog() {
 
 function clearWatchers() {
   if (pollTimer.value !== null) {
-    console.log('clear poll timer', pollTimer.value)
     clearInterval(pollTimer.value)
     pollTimer.value = null
   }
@@ -96,7 +92,6 @@ function clearWatchers() {
 function scrollToElement(id: string) {
   // Get the element with the id
   const el = document.getElementById(id)
-  console.log('el', el)
   if (el) {
     // Use el.scrollIntoView() to instantly scroll to the element
     el.scrollIntoView({ behavior: 'smooth' })
@@ -108,7 +103,6 @@ async function copyToast(allowed: boolean, id: string, text?: string) {
     return
   try {
     await navigator.clipboard.writeText(text)
-    console.log('displayStore.messageToast', displayStore.messageToast)
     toast.success(t('copied-to-clipboard'))
   }
   catch (err) {
@@ -142,7 +136,6 @@ async function addNewApiKey() {
   const userId = claimsData?.claims?.sub
 
   if (!userId) {
-    console.log('Not logged in, cannot regenerate API key')
     return
   }
   const { error } = await createDefaultApiKey(supabase, t('api-key'))
@@ -224,7 +217,6 @@ function onInviteSuccess() {
 
 watchEffect(async () => {
   if (step.value === 1 && !realtimeListener.value) {
-    console.log('watch app change step 1 via polling')
     realtimeListener.value = true
     await organizationStore.awaitInitialLoad()
 


### PR DESCRIPTION
Summary
- Remove routine console.log debug output from dashboard app/bundle onboarding flows.
- Drop the now-unused display store imports that only supported those debug logs.

Security / privacy
- The removed browser-console logs could retain user IDs, app IDs, selected Supabase rows, DOM elements, timer IDs, and toast state during onboarding.
- Behavior is unchanged; warnings/errors for failed operations are still retained.

Test plan
- git diff --check
- rg -n "displayStore|useDisplayStore|console\\.log" src/components/dashboard/StepsBundle.vue src/components/dashboard/StepsApp.vue

/claim #1667
