### PR TITLE
fix(frontend): require secure scan update URLs

### DIFF
--- a/src/pages/scan.vue
+++ b/src/pages/scan.vue
@@ -160,7 +160,7 @@ async function submitManualUrl() {
 
   if (!isNativePlatform) {
     toast.success(`Opening ${new URL(updateUrl).host}`)
-    window.location.assign(updateUrl)
+    globalThis.location.assign(updateUrl)
     return
   }
 

--- a/src/pages/scan.vue
+++ b/src/pages/scan.vue
@@ -12,6 +12,7 @@ import IconArrowPath from '~icons/heroicons/arrow-path-20-solid'
 import IconLink from '~icons/heroicons/link-20-solid'
 import IconQrCode from '~icons/heroicons/qr-code-20-solid'
 import IconShieldCheck from '~icons/heroicons/shield-check-20-solid'
+import { normalizeUpdateUrl } from '~/services/updateUrls'
 import { useDisplayStore } from '~/stores/display'
 
 const router = useRouter()
@@ -27,32 +28,10 @@ const manualUrl = ref('')
 
 let downloadListener: Awaited<ReturnType<typeof CapacitorUpdater.addListener>> | null = null
 
-function isValidUrl(value: string) {
-  if (!value)
-    return false
-
-  if (typeof URL.canParse === 'function')
-    return URL.canParse(value)
-
-  try {
-    const parsedUrl = new URL(value)
-    return !!parsedUrl.href
-  }
-  catch {
-    return false
-  }
-}
-
 const isFallbackMode = computed(() => !isNativePlatform || !!errorMessage.value)
 const progressPercentage = computed(() => Math.round(downloadProgress.value))
-const normalizedManualUrl = computed(() => {
-  const value = manualUrl.value.trim()
-  if (!value)
-    return ''
-
-  return /^https?:\/\//i.test(value) ? value : `https://${value}`
-})
-const canSubmitManualUrl = computed(() => !isLoading.value && isValidUrl(normalizedManualUrl.value))
+const normalizedManualUrl = computed(() => normalizeUpdateUrl(manualUrl.value))
+const canSubmitManualUrl = computed(() => !isLoading.value && !!normalizedManualUrl.value)
 const manualActionLabel = computed(() => (isNativePlatform ? 'Download update' : 'Open update URL'))
 const scannerStatusLabel = computed(() => {
   if (isLoading.value)
@@ -64,10 +43,11 @@ const scannerStatusLabel = computed(() => {
   return 'Ready'
 })
 const downloadHost = computed(() => {
-  if (!scannedUrl.value || !isValidUrl(scannedUrl.value))
+  const updateUrl = normalizeUpdateUrl(scannedUrl.value)
+  if (!updateUrl)
     return ''
 
-  return new URL(scannedUrl.value).host
+  return new URL(updateUrl).host
 })
 
 onMounted(async () => {
@@ -122,15 +102,16 @@ async function startScanner() {
 }
 
 async function handleBarcodeScan(scannedValue: string) {
-  if (!isValidUrl(scannedValue)) {
-    errorMessage.value = 'The scanned QR code does not contain a valid update URL.'
-    toast.error('Scanned QR code is not a valid URL')
+  const updateUrl = normalizeUpdateUrl(scannedValue)
+  if (!updateUrl) {
+    errorMessage.value = 'The scanned QR code does not contain a secure update URL.'
+    toast.error('Scanned QR code is not a secure update URL')
     return
   }
 
-  scannedUrl.value = scannedValue
-  manualUrl.value = scannedValue
-  await downloadUpdate(scannedValue)
+  scannedUrl.value = updateUrl
+  manualUrl.value = updateUrl
+  await downloadUpdate(updateUrl)
 }
 
 async function downloadUpdate(updateUrl: string) {
@@ -169,20 +150,21 @@ async function downloadUpdate(updateUrl: string) {
 
 async function submitManualUrl() {
   if (!canSubmitManualUrl.value) {
-    toast.error('Enter a valid update URL')
+    toast.error('Enter a secure update URL')
     return
   }
 
+  const updateUrl = normalizedManualUrl.value
   errorMessage.value = ''
-  scannedUrl.value = normalizedManualUrl.value
+  scannedUrl.value = updateUrl
 
   if (!isNativePlatform) {
-    toast.success(`Opening ${new URL(normalizedManualUrl.value).host}`)
-    window.location.assign(normalizedManualUrl.value)
+    toast.success(`Opening ${new URL(updateUrl).host}`)
+    window.location.assign(updateUrl)
     return
   }
 
-  await downloadUpdate(normalizedManualUrl.value)
+  await downloadUpdate(updateUrl)
 }
 
 async function retryScanning() {

--- a/src/services/updateUrls.ts
+++ b/src/services/updateUrls.ts
@@ -1,4 +1,5 @@
-const explicitSchemePattern = /^[a-z][a-z\d+.-]*:/i
+const explicitWebUrlPattern = /^https?:\/\//i
+const explicitSchemeUrlPattern = /^[a-z][a-z\d+.-]*:\/\//i
 const localHttpHosts = new Set(['localhost', '127.0.0.1', '::1'])
 
 function isLocalHttpHost(hostname: string): boolean {
@@ -14,7 +15,10 @@ export function normalizeUpdateUrl(value: string): string {
   if (!trimmed || trimmed.startsWith('//') || trimmed.includes('\\'))
     return ''
 
-  const urlValue = explicitSchemePattern.test(trimmed) ? trimmed : `https://${trimmed}`
+  if (explicitSchemeUrlPattern.test(trimmed) && !explicitWebUrlPattern.test(trimmed))
+    return ''
+
+  const urlValue = explicitWebUrlPattern.test(trimmed) ? trimmed : `https://${trimmed}`
 
   let parsedUrl: URL
   try {

--- a/src/services/updateUrls.ts
+++ b/src/services/updateUrls.ts
@@ -2,7 +2,11 @@ const explicitSchemePattern = /^[a-z][a-z\d+.-]*:/i
 const localHttpHosts = new Set(['localhost', '127.0.0.1', '::1'])
 
 function isLocalHttpHost(hostname: string): boolean {
-  return localHttpHosts.has(hostname) || hostname.endsWith('.localhost')
+  const normalizedHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname
+
+  return localHttpHosts.has(normalizedHostname) || normalizedHostname.endsWith('.localhost')
 }
 
 export function normalizeUpdateUrl(value: string): string {

--- a/src/services/updateUrls.ts
+++ b/src/services/updateUrls.ts
@@ -1,0 +1,37 @@
+const explicitSchemePattern = /^[a-z][a-z\d+.-]*:/i
+const localHttpHosts = new Set(['localhost', '127.0.0.1', '::1'])
+
+function isLocalHttpHost(hostname: string): boolean {
+  return localHttpHosts.has(hostname) || hostname.endsWith('.localhost')
+}
+
+export function normalizeUpdateUrl(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.startsWith('//') || trimmed.includes('\\'))
+    return ''
+
+  const urlValue = explicitSchemePattern.test(trimmed) ? trimmed : `https://${trimmed}`
+
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(urlValue)
+  }
+  catch {
+    return ''
+  }
+
+  if (parsedUrl.username || parsedUrl.password)
+    return ''
+
+  if (parsedUrl.protocol === 'https:')
+    return parsedUrl.toString()
+
+  if (parsedUrl.protocol === 'http:' && isLocalHttpHost(parsedUrl.hostname))
+    return parsedUrl.toString()
+
+  return ''
+}
+
+export function isAllowedUpdateUrl(value: string): boolean {
+  return normalizeUpdateUrl(value) !== ''
+}

--- a/tests/update-urls.unit.test.ts
+++ b/tests/update-urls.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAllowedUpdateUrl, normalizeUpdateUrl } from '~/services/updateUrls'
+
+describe('update URL validation', () => {
+  it.concurrent('accepts HTTPS update URLs and normalizes schemeless hosts', () => {
+    expect(normalizeUpdateUrl('https://updates.example.com/bundle.zip')).toBe('https://updates.example.com/bundle.zip')
+    expect(normalizeUpdateUrl('updates.example.com/bundle.zip')).toBe('https://updates.example.com/bundle.zip')
+    expect(isAllowedUpdateUrl('https://updates.example.com/bundle.zip')).toBe(true)
+  })
+
+  it.concurrent('allows local HTTP URLs for development', () => {
+    expect(normalizeUpdateUrl('http://localhost:5173/bundle.zip')).toBe('http://localhost:5173/bundle.zip')
+    expect(normalizeUpdateUrl('http://preview.localhost/bundle.zip')).toBe('http://preview.localhost/bundle.zip')
+  })
+
+  it.concurrent('rejects insecure or non-web update targets', () => {
+    expect(isAllowedUpdateUrl('http://updates.example.com/bundle.zip')).toBe(false)
+    expect(isAllowedUpdateUrl('javascript:alert(1)')).toBe(false)
+    expect(isAllowedUpdateUrl('file:///tmp/bundle.zip')).toBe(false)
+    expect(isAllowedUpdateUrl('ftp://updates.example.com/bundle.zip')).toBe(false)
+  })
+
+  it.concurrent('rejects ambiguous browser-normalized URLs', () => {
+    expect(isAllowedUpdateUrl('//updates.example.com/bundle.zip')).toBe(false)
+    expect(isAllowedUpdateUrl('https://user:pass@updates.example.com/bundle.zip')).toBe(false)
+    expect(isAllowedUpdateUrl('https:\\\\updates.example.com\\bundle.zip')).toBe(false)
+  })
+})

--- a/tests/update-urls.unit.test.ts
+++ b/tests/update-urls.unit.test.ts
@@ -12,6 +12,7 @@ describe('update URL validation', () => {
   it.concurrent('allows local HTTP URLs for development', () => {
     expect(normalizeUpdateUrl('http://localhost:5173/bundle.zip')).toBe('http://localhost:5173/bundle.zip')
     expect(normalizeUpdateUrl('http://preview.localhost/bundle.zip')).toBe('http://preview.localhost/bundle.zip')
+    expect(normalizeUpdateUrl('http://[::1]:5173/bundle.zip')).toBe('http://[::1]:5173/bundle.zip')
   })
 
   it.concurrent('rejects insecure or non-web update targets', () => {

--- a/tests/update-urls.unit.test.ts
+++ b/tests/update-urls.unit.test.ts
@@ -6,6 +6,8 @@ describe('update URL validation', () => {
   it.concurrent('accepts HTTPS update URLs and normalizes schemeless hosts', () => {
     expect(normalizeUpdateUrl('https://updates.example.com/bundle.zip')).toBe('https://updates.example.com/bundle.zip')
     expect(normalizeUpdateUrl('updates.example.com/bundle.zip')).toBe('https://updates.example.com/bundle.zip')
+    expect(normalizeUpdateUrl('updates.example.com:8443/bundle.zip')).toBe('https://updates.example.com:8443/bundle.zip')
+    expect(normalizeUpdateUrl('localhost:5173/bundle.zip')).toBe('https://localhost:5173/bundle.zip')
     expect(isAllowedUpdateUrl('https://updates.example.com/bundle.zip')).toBe(true)
   })
 


### PR DESCRIPTION
## Summary
- normalize scanned and manually entered update URLs before opening or downloading
- require HTTPS update URLs, with localhost HTTP kept for local development
- reject non-web schemes, protocol-relative targets, credentialed URLs, and backslash-normalized inputs
- add unit coverage for accepted and rejected update URL inputs

## Tests
- `npx --yes bun@latest x vitest run tests/update-urls.unit.test.ts`
- `npx --yes bun@latest x eslint src/services/updateUrls.ts src/pages/scan.vue tests/update-urls.unit.test.ts`
- `npx --yes bun@latest run lint`
- `npx --yes bun@latest run typecheck`
- `git diff --check`

/claim #1667