### PR TITLE
fix(api): redact captcha verification logs

### DIFF
--- a/supabase/functions/_backend/utils/captcha.ts
+++ b/supabase/functions/_backend/utils/captcha.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import type { SafeParseSchemaResult } from './ark_validation.ts'
 import { type } from 'arktype'
 import { safeParseSchema } from './ark_validation.ts'
 import { simpleError } from './hono.ts'
@@ -7,6 +8,17 @@ import { cloudlog } from './logging.ts'
 const captchaSchema = type({
   success: 'boolean',
 })
+
+interface CaptchaResult {
+  success: boolean
+}
+
+function getCaptchaLogMetadata(captchaResultData: SafeParseSchemaResult<CaptchaResult>) {
+  return {
+    parsed: captchaResultData.success,
+    success: captchaResultData.success ? captchaResultData.data.success : undefined,
+  }
+}
 
 export async function verifyCaptchaToken(c: Context, token: string, captchaSecret: string) {
   const url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
@@ -26,7 +38,11 @@ export async function verifyCaptchaToken(c: Context, token: string, captchaSecre
   if (!captchaResultData.success) {
     throw simpleError('invalid_captcha', 'Invalid captcha result')
   }
-  cloudlog({ requestId: c.get('requestId'), context: 'captcha_result', captchaResultData })
+  cloudlog({
+    requestId: c.get('requestId'),
+    context: 'captcha_result',
+    captchaResult: getCaptchaLogMetadata(captchaResultData),
+  })
   if (captchaResultData.data.success !== true) {
     throw simpleError('invalid_captcha', 'Invalid captcha result')
   }

--- a/tests/captcha-log-redaction.unit.test.ts
+++ b/tests/captcha-log-redaction.unit.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cloudlogMock,
+  fetchMock,
+} = vi.hoisted(() => ({
+  cloudlogMock: vi.fn(),
+  fetchMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+}))
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+  } as any
+}
+
+beforeEach(() => {
+  cloudlogMock.mockReset()
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('captcha log redaction', () => {
+  it('logs only metadata for successful captcha responses', async () => {
+    const { verifyCaptchaToken } = await import('../supabase/functions/_backend/utils/captcha.ts')
+    fetchMock.mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        action: 'signup',
+        cdata: 'raw-cdata-value',
+        challenge_ts: '2026-05-11T00:00:00Z',
+        hostname: 'tenant.capgo.app',
+        success: true,
+        token: 'turnstile-response-token',
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await verifyCaptchaToken(createContext(), 'turnstile-response-token', 'turnstile-secret-key')
+
+    const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+      expect.objectContaining({
+        body: expect.any(URLSearchParams),
+        method: 'POST',
+      }),
+    )
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: 'request-id',
+      context: 'captcha_result',
+      captchaResult: {
+        parsed: true,
+        success: true,
+      },
+    })
+    expect(serializedLogs).not.toContain('raw-cdata-value')
+    expect(serializedLogs).not.toContain('tenant.capgo.app')
+    expect(serializedLogs).not.toContain('turnstile-response-token')
+    expect(serializedLogs).not.toContain('turnstile-secret-key')
+  })
+
+  it('logs only metadata before rejecting failed captcha responses', async () => {
+    const { verifyCaptchaToken } = await import('../supabase/functions/_backend/utils/captcha.ts')
+    fetchMock.mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        'error-codes': ['invalid-input-response'],
+        'success': false,
+        'token': 'failed-turnstile-response-token',
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      verifyCaptchaToken(createContext(), 'failed-turnstile-response-token', 'turnstile-secret-key'),
+    ).rejects.toThrow('Invalid captcha result')
+
+    const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
+
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: 'request-id',
+      context: 'captcha_result',
+      captchaResult: {
+        parsed: true,
+        success: false,
+      },
+    })
+    expect(serializedLogs).not.toContain('invalid-input-response')
+    expect(serializedLogs).not.toContain('failed-turnstile-response-token')
+    expect(serializedLogs).not.toContain('turnstile-secret-key')
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw captcha verification result logging with parsed/success metadata only
- add unit coverage for successful and failed Turnstile responses to ensure response details, tokens, secrets, hostnames, and error codes are not retained in logs

/claim #1667

## Test plan
- ./node_modules/.bin/vitest run tests/captcha-log-redaction.unit.test.ts
- ./node_modules/.bin/eslint supabase/functions/_backend/utils/captcha.ts tests/captcha-log-redaction.unit.test.ts
- git diff --check

Note: attempted `./node_modules/.bin/vitest run tests/private-error-cases.test.ts tests/captcha-log-redaction.unit.test.ts`, but local Supabase was not running and the suite failed to connect to 127.0.0.1:54321 before exercising this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Captcha verification logs now sanitize sensitive credentials and tokens to prevent accidental exposure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->