### PR TITLE
fix: remove deployment banner debug logs

### DIFF
--- a/src/components/dashboard/DeploymentBanner.vue
+++ b/src/components/dashboard/DeploymentBanner.vue
@@ -144,7 +144,6 @@ async function loadData() {
   defaultChannels.value = []
   latestBundle.value = null
   selectedChannelIds.value = []
-  console.log('[DeploymentBanner] Loading data for app:', props.appId)
 
   try {
     // Step 1: Get default channels configuration (public download channels)
@@ -161,7 +160,6 @@ async function loadData() {
     }))
 
     defaultChannels.value = allowedChannels.filter((channel): channel is DefaultChannel => channel !== null)
-    console.log('[DeploymentBanner] Default channels:', defaultChannels.value)
 
     // Step 2: Get latest bundle (excluding special bundle types)
     // We filter out 'unknown' and 'builtin' bundles as these are not deployable
@@ -175,8 +173,6 @@ async function loadData() {
       .neq('name', 'builtin')
       .order('created_at', { ascending: false })
       .limit(1)
-
-    console.log('[DeploymentBanner] Latest bundle:', bundles?.[0])
 
     latestBundle.value = bundles?.[0] ?? null
   }
@@ -224,21 +220,13 @@ async function executeDeployment() {
   deploying.value = true
 
   try {
-    console.log('[DeploymentBanner] Starting deployment:', {
-      bundleId: bundle.id,
-      bundleName: bundle.name,
-      channelIds: targetIds,
-    })
-
     // Perform the deployment by updating the channel versions in bulk
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('channels')
       .update({ version: bundle.id })
       .in('id', targetIds)
       .eq('app_id', props.appId) // Extra safety: ensure we're updating the right channels
       .select()
-
-    console.log('[DeploymentBanner] Deployment result:', { data, error })
 
     if (error) {
       // Deployment failed - show error and return early


### PR DESCRIPTION
## Summary

- remove routine deployment banner debug logs that retained app ids, channel rows, latest bundle rows, selected channel ids, and deployment result data
- keep deployment loading, permission checks, channel updates, success handling, and error logging unchanged

## Test plan

- `git diff --check`
- `rg -n "console\.log|const \{ data, error \}" src/components/dashboard/DeploymentBanner.vue` returned no matches
- Not run: full lint/typecheck, because this workspace has no local `bun` binary or `node_modules` installed

## Screenshots

Not applicable; this removes debug logging and does not change UI behavior.

## Checklist

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests

/claim #1667