### PR TITLE
fix(api): redact stripe billing logs

### DIFF
--- a/supabase/functions/_backend/private/stripe_billing_context.ts
+++ b/supabase/functions/_backend/private/stripe_billing_context.ts
@@ -1,0 +1,42 @@
+import type { Context } from 'hono'
+import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import { simpleError } from '../utils/hono.ts'
+import { cloudlog } from '../utils/logging.ts'
+import { checkPermission } from '../utils/rbac.ts'
+import { supabaseClient } from '../utils/supabase.ts'
+
+type AppContext = Context<MiddlewareKeyVariables, any, any>
+type StripeBillingArea = 'checkout' | 'portal'
+
+export async function resolveStripeBillingCustomer(
+  c: AppContext,
+  area: StripeBillingArea,
+  orgId: string,
+) {
+  const authorization = c.get('authorization')
+  if (!authorization)
+    throw simpleError('not_authorized', 'Not authorized')
+
+  const authContext = c.get('auth')
+  if (!authContext?.userId)
+    throw simpleError('not_authorized', 'Not authorized')
+
+  const supabase = supabaseClient(c, authorization)
+
+  cloudlog({ requestId: c.get('requestId'), message: `stripe ${area} auth context`, auth: { authenticated: true } })
+  const { data: org, error: dbError } = await supabase
+    .from('orgs')
+    .select('customer_id')
+    .eq('id', orgId)
+    .single()
+  if (dbError || !org)
+    throw simpleError('not_authorized', 'Not authorized')
+  if (!org.customer_id)
+    throw simpleError('no_customer', 'No customer')
+
+  if (!await checkPermission(c, 'org.update_billing', { orgId }))
+    throw simpleError('not_authorize', 'Not authorize')
+
+  cloudlog({ requestId: c.get('requestId'), message: `stripe ${area} org lookup result`, org: { found: true, hasCustomerId: Boolean(org.customer_id) } })
+  return org.customer_id
+}

--- a/supabase/functions/_backend/private/stripe_checkout.ts
+++ b/supabase/functions/_backend/private/stripe_checkout.ts
@@ -17,13 +17,25 @@ interface CheckoutData {
   orgId: string
 }
 
+function getCheckoutRequestLogMetadata(body: CheckoutData) {
+  return {
+    hasPriceId: Boolean(body.priceId),
+    hasClientReferenceId: Boolean(body.clientReferenceId),
+    recurrence: body.recurrence,
+    hasAttributionId: Boolean(body.attributionId),
+    hasSuccessUrl: Boolean(body.successUrl),
+    hasCancelUrl: Boolean(body.cancelUrl),
+    hasOrgId: Boolean(body.orgId),
+  }
+}
+
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<CheckoutData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout request', request: getCheckoutRequestLogMetadata(body) })
 
   if (!body.orgId)
     throw simpleError('no_org_id_provided', 'No org_id provided')
@@ -40,7 +52,7 @@ app.post('/', middlewareAuth, async (c) => {
   // Use authenticated client - RLS will enforce access based on JWT
   const supabase = supabaseClient(c, authorization)
 
-  cloudlog({ requestId: c.get('requestId'), message: 'auth', auth: authContext.userId })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe checkout auth context', auth: { authenticated: true } })
   const { data: org, error: dbError } = await supabase
     .from('orgs')
     .select('customer_id')
@@ -54,7 +66,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
     throw simpleError('not_authorize', 'Not authorize')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'user', org })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe checkout org lookup result', org: { found: true, hasCustomerId: Boolean(org.customer_id) } })
   const checkout = await createCheckout(c, org.customer_id, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId)
   return c.json({ url: checkout.url })
 })

--- a/supabase/functions/_backend/private/stripe_checkout.ts
+++ b/supabase/functions/_backend/private/stripe_checkout.ts
@@ -2,10 +2,9 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { Hono } from 'hono/tiny'
 import { middlewareAuth, parseBody, simpleError, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { checkPermission } from '../utils/rbac.ts'
 import { createCheckout } from '../utils/stripe.ts'
-import { supabaseClient } from '../utils/supabase.ts'
 import { getEnv } from '../utils/utils.ts'
+import { resolveStripeBillingCustomer } from './stripe_billing_context.ts'
 
 interface CheckoutData {
   priceId: string
@@ -40,33 +39,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!body.orgId)
     throw simpleError('no_org_id_provided', 'No org_id provided')
 
-  const authorization = c.get('authorization')
-  if (!authorization)
-    throw simpleError('not_authorized', 'Not authorized')
-
-  // Get user ID from auth context (already validated by middlewareAuth)
-  const authContext = c.get('auth')
-  if (!authContext?.userId)
-    throw simpleError('not_authorized', 'Not authorized')
-
-  // Use authenticated client - RLS will enforce access based on JWT
-  const supabase = supabaseClient(c, authorization)
-
-  cloudlog({ requestId: c.get('requestId'), message: 'stripe checkout auth context', auth: { authenticated: true } })
-  const { data: org, error: dbError } = await supabase
-    .from('orgs')
-    .select('customer_id')
-    .eq('id', body.orgId)
-    .single()
-  if (dbError || !org)
-    throw simpleError('not_authorized', 'Not authorized')
-  if (!org.customer_id)
-    throw simpleError('no_customer', 'No customer')
-
-  if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
-    throw simpleError('not_authorize', 'Not authorize')
-
-  cloudlog({ requestId: c.get('requestId'), message: 'stripe checkout org lookup result', org: { found: true, hasCustomerId: Boolean(org.customer_id) } })
-  const checkout = await createCheckout(c, org.customer_id, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId)
+  const customerId = await resolveStripeBillingCustomer(c, 'checkout', body.orgId)
+  const checkout = await createCheckout(c, customerId, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId)
   return c.json({ url: checkout.url })
 })

--- a/supabase/functions/_backend/private/stripe_portal.ts
+++ b/supabase/functions/_backend/private/stripe_portal.ts
@@ -11,13 +11,20 @@ interface PortalData {
   orgId: string
 }
 
+function getPortalRequestLogMetadata(body: PortalData) {
+  return {
+    hasCallbackUrl: Boolean(body.callbackUrl),
+    hasOrgId: Boolean(body.orgId),
+  }
+}
+
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<PortalData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal request', request: getPortalRequestLogMetadata(body) })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('not_authorized', 'Not authorized')
@@ -30,7 +37,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!authContext?.userId)
     throw simpleError('not_authorized', 'Not authorized')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'auth', auth: authContext.userId })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe portal auth context', auth: { authenticated: true } })
   const { data: org, error: dbError } = await supabase
     .from('orgs')
     .select('customer_id')
@@ -44,7 +51,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
     throw simpleError('not_authorize', 'Not authorize')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'org', org })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe portal org lookup result', org: { found: true, hasCustomerId: Boolean(org.customer_id) } })
   const link = await createPortal(c, org.customer_id, body.callbackUrl)
   return c.json({ url: link.url })
 })

--- a/supabase/functions/_backend/private/stripe_portal.ts
+++ b/supabase/functions/_backend/private/stripe_portal.ts
@@ -1,10 +1,9 @@
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { Hono } from 'hono/tiny'
-import { middlewareAuth, parseBody, simpleError, useCors } from '../utils/hono.ts'
+import { middlewareAuth, parseBody, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { checkPermission } from '../utils/rbac.ts'
 import { createPortal } from '../utils/stripe.ts'
-import { supabaseClient } from '../utils/supabase.ts'
+import { resolveStripeBillingCustomer } from './stripe_billing_context.ts'
 
 interface PortalData {
   callbackUrl: string
@@ -25,33 +24,7 @@ app.use('/', useCors)
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<PortalData>(c)
   cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal request', request: getPortalRequestLogMetadata(body) })
-  const authorization = c.get('authorization')
-  if (!authorization)
-    throw simpleError('not_authorized', 'Not authorized')
-
-  // Use authenticated client - RLS will enforce access based on JWT
-  const supabase = supabaseClient(c, authorization)
-
-  // Get current user ID from JWT
-  const authContext = c.get('auth')
-  if (!authContext?.userId)
-    throw simpleError('not_authorized', 'Not authorized')
-
-  cloudlog({ requestId: c.get('requestId'), message: 'stripe portal auth context', auth: { authenticated: true } })
-  const { data: org, error: dbError } = await supabase
-    .from('orgs')
-    .select('customer_id')
-    .eq('id', body.orgId)
-    .single()
-  if (dbError || !org)
-    throw simpleError('not_authorized', 'Not authorized')
-  if (!org.customer_id)
-    throw simpleError('no_customer', 'No customer')
-
-  if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
-    throw simpleError('not_authorize', 'Not authorize')
-
-  cloudlog({ requestId: c.get('requestId'), message: 'stripe portal org lookup result', org: { found: true, hasCustomerId: Boolean(org.customer_id) } })
-  const link = await createPortal(c, org.customer_id, body.callbackUrl)
+  const customerId = await resolveStripeBillingCustomer(c, 'portal', body.orgId)
+  const link = await createPortal(c, customerId, body.callbackUrl)
   return c.json({ url: link.url })
 })

--- a/tests/stripe-portal-log-redaction.unit.test.ts
+++ b/tests/stripe-portal-log-redaction.unit.test.ts
@@ -15,6 +15,42 @@ const mockedModules = [
   '../supabase/functions/_backend/utils/supabase.ts',
 ]
 
+function mockOrgLookup(customerId: string) {
+  const singleMock = vi.fn().mockResolvedValue({
+    data: { customer_id: customerId },
+    error: null,
+  })
+  const eqMock = vi.fn(() => ({ single: singleMock }))
+  const selectMock = vi.fn(() => ({ eq: eqMock }))
+  const fromMock = vi.fn(() => ({ select: selectMock }))
+
+  supabaseClientMock.mockReturnValue({ from: fromMock })
+  checkPermissionMock.mockResolvedValue(true)
+}
+
+function expectAuthAndOrgLookupLogs(area: 'checkout' | 'portal') {
+  expect(cloudlogMock).toHaveBeenCalledWith({
+    requestId: undefined,
+    message: `stripe ${area} auth context`,
+    auth: { authenticated: true },
+  })
+  expect(cloudlogMock).toHaveBeenCalledWith({
+    requestId: undefined,
+    message: `stripe ${area} org lookup result`,
+    org: {
+      found: true,
+      hasCustomerId: true,
+    },
+  })
+}
+
+function expectNoLoggedSecrets(...secrets: string[]) {
+  const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
+  for (const secret of secrets) {
+    expect(serializedLogs).not.toContain(secret)
+  }
+}
+
 describe('stripe billing log redaction', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -62,16 +98,7 @@ describe('stripe billing log redaction', () => {
   })
 
   it('does not log portal callback, org, user, or customer identifiers', async () => {
-    const singleMock = vi.fn().mockResolvedValue({
-      data: { customer_id: 'cus_sensitive_customer' },
-      error: null,
-    })
-    const eqMock = vi.fn(() => ({ single: singleMock }))
-    const selectMock = vi.fn(() => ({ eq: eqMock }))
-    const fromMock = vi.fn(() => ({ select: selectMock }))
-
-    supabaseClientMock.mockReturnValue({ from: fromMock })
-    checkPermissionMock.mockResolvedValue(true)
+    mockOrgLookup('cus_sensitive_customer')
     createPortalMock.mockResolvedValue({ url: 'https://billing.stripe.com/session_sensitive' })
 
     const { app: stripePortal } = await import('../supabase/functions/_backend/private/stripe_portal.ts')
@@ -101,38 +128,17 @@ describe('stripe billing log redaction', () => {
         hasOrgId: true,
       },
     })
-    expect(cloudlogMock).toHaveBeenCalledWith({
-      requestId: undefined,
-      message: 'stripe portal auth context',
-      auth: { authenticated: true },
-    })
-    expect(cloudlogMock).toHaveBeenCalledWith({
-      requestId: undefined,
-      message: 'stripe portal org lookup result',
-      org: {
-        found: true,
-        hasCustomerId: true,
-      },
-    })
-
-    const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
-    expect(serializedLogs).not.toContain('callback-secret')
-    expect(serializedLogs).not.toContain('org-sensitive-id')
-    expect(serializedLogs).not.toContain('user-sensitive-id')
-    expect(serializedLogs).not.toContain('cus_sensitive_customer')
+    expectAuthAndOrgLookupLogs('portal')
+    expectNoLoggedSecrets(
+      'callback-secret',
+      'org-sensitive-id',
+      'user-sensitive-id',
+      'cus_sensitive_customer',
+    )
   })
 
   it('does not log checkout URLs or billing identifiers', async () => {
-    const singleMock = vi.fn().mockResolvedValue({
-      data: { customer_id: 'cus_checkout_sensitive_customer' },
-      error: null,
-    })
-    const eqMock = vi.fn(() => ({ single: singleMock }))
-    const selectMock = vi.fn(() => ({ eq: eqMock }))
-    const fromMock = vi.fn(() => ({ select: selectMock }))
-
-    supabaseClientMock.mockReturnValue({ from: fromMock })
-    checkPermissionMock.mockResolvedValue(true)
+    mockOrgLookup('cus_checkout_sensitive_customer')
     createCheckoutMock.mockResolvedValue({ url: 'https://checkout.stripe.com/session_sensitive' })
 
     const { app: stripeCheckout } = await import('../supabase/functions/_backend/private/stripe_checkout.ts')
@@ -177,28 +183,16 @@ describe('stripe billing log redaction', () => {
         hasOrgId: true,
       },
     })
-    expect(cloudlogMock).toHaveBeenCalledWith({
-      requestId: undefined,
-      message: 'stripe checkout auth context',
-      auth: { authenticated: true },
-    })
-    expect(cloudlogMock).toHaveBeenCalledWith({
-      requestId: undefined,
-      message: 'stripe checkout org lookup result',
-      org: {
-        found: true,
-        hasCustomerId: true,
-      },
-    })
-
-    const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
-    expect(serializedLogs).not.toContain('price_sensitive_plan')
-    expect(serializedLogs).not.toContain('client-sensitive-reference')
-    expect(serializedLogs).not.toContain('attribution-sensitive-id')
-    expect(serializedLogs).not.toContain('success-secret')
-    expect(serializedLogs).not.toContain('cancel-secret')
-    expect(serializedLogs).not.toContain('org-checkout-sensitive-id')
-    expect(serializedLogs).not.toContain('user-sensitive-id')
-    expect(serializedLogs).not.toContain('cus_checkout_sensitive_customer')
+    expectAuthAndOrgLookupLogs('checkout')
+    expectNoLoggedSecrets(
+      'price_sensitive_plan',
+      'client-sensitive-reference',
+      'attribution-sensitive-id',
+      'success-secret',
+      'cancel-secret',
+      'org-checkout-sensitive-id',
+      'user-sensitive-id',
+      'cus_checkout_sensitive_customer',
+    )
   })
 })

--- a/tests/stripe-portal-log-redaction.unit.test.ts
+++ b/tests/stripe-portal-log-redaction.unit.test.ts
@@ -1,0 +1,122 @@
+import { HTTPException } from 'hono/http-exception'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const cloudlogMock = vi.fn()
+const checkPermissionMock = vi.fn()
+const createPortalMock = vi.fn()
+const supabaseClientMock = vi.fn()
+
+const mockedModules = [
+  '../supabase/functions/_backend/utils/hono.ts',
+  '../supabase/functions/_backend/utils/logging.ts',
+  '../supabase/functions/_backend/utils/rbac.ts',
+  '../supabase/functions/_backend/utils/stripe.ts',
+  '../supabase/functions/_backend/utils/supabase.ts',
+]
+
+describe('stripe portal log redaction', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    vi.doMock('../supabase/functions/_backend/utils/hono.ts', () => ({
+      middlewareAuth: async (c: any, next: () => Promise<void>) => {
+        c.set('authorization', 'Bearer jwt-with-sensitive-user')
+        c.set('auth', {
+          userId: 'user-sensitive-id',
+          authType: 'jwt',
+          apikey: null,
+          jwt: 'Bearer jwt-with-sensitive-user',
+        })
+        await next()
+      },
+      parseBody: async (c: { req: { json: () => Promise<unknown> } }) => await c.req.json(),
+      simpleError: (errorCode: string, message: string) => {
+        throw new HTTPException(400, { message, cause: { error: errorCode } })
+      },
+      useCors: async (_c: unknown, next: () => Promise<void>) => await next(),
+    }))
+
+    vi.doMock('../supabase/functions/_backend/utils/logging.ts', () => ({
+      cloudlog: cloudlogMock,
+    }))
+
+    vi.doMock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+      checkPermission: checkPermissionMock,
+    }))
+
+    vi.doMock('../supabase/functions/_backend/utils/stripe.ts', () => ({
+      createPortal: createPortalMock,
+    }))
+
+    vi.doMock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+      supabaseClient: supabaseClientMock,
+    }))
+  })
+
+  afterEach(() => {
+    mockedModules.forEach(path => vi.doUnmock(path))
+    vi.resetModules()
+  })
+
+  it('does not log portal callback, org, user, or customer identifiers', async () => {
+    const singleMock = vi.fn().mockResolvedValue({
+      data: { customer_id: 'cus_sensitive_customer' },
+      error: null,
+    })
+    const eqMock = vi.fn(() => ({ single: singleMock }))
+    const selectMock = vi.fn(() => ({ eq: eqMock }))
+    const fromMock = vi.fn(() => ({ select: selectMock }))
+
+    supabaseClientMock.mockReturnValue({ from: fromMock })
+    checkPermissionMock.mockResolvedValue(true)
+    createPortalMock.mockResolvedValue({ url: 'https://billing.stripe.com/session_sensitive' })
+
+    const { app: stripePortal } = await import('../supabase/functions/_backend/private/stripe_portal.ts')
+
+    const response = await stripePortal.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        callbackUrl: 'https://app.capgo.app/billing?token=callback-secret',
+        orgId: 'org-sensitive-id',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ url: 'https://billing.stripe.com/session_sensitive' })
+    expect(createPortalMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'cus_sensitive_customer',
+      'https://app.capgo.app/billing?token=callback-secret',
+    )
+
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: undefined,
+      message: 'post stripe portal request',
+      request: {
+        hasCallbackUrl: true,
+        hasOrgId: true,
+      },
+    })
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: undefined,
+      message: 'stripe portal auth context',
+      auth: { authenticated: true },
+    })
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: undefined,
+      message: 'stripe portal org lookup result',
+      org: {
+        found: true,
+        hasCustomerId: true,
+      },
+    })
+
+    const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
+    expect(serializedLogs).not.toContain('callback-secret')
+    expect(serializedLogs).not.toContain('org-sensitive-id')
+    expect(serializedLogs).not.toContain('user-sensitive-id')
+    expect(serializedLogs).not.toContain('cus_sensitive_customer')
+  })
+})

--- a/tests/stripe-portal-log-redaction.unit.test.ts
+++ b/tests/stripe-portal-log-redaction.unit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const cloudlogMock = vi.fn()
 const checkPermissionMock = vi.fn()
+const createCheckoutMock = vi.fn()
 const createPortalMock = vi.fn()
 const supabaseClientMock = vi.fn()
 
@@ -14,7 +15,7 @@ const mockedModules = [
   '../supabase/functions/_backend/utils/supabase.ts',
 ]
 
-describe('stripe portal log redaction', () => {
+describe('stripe billing log redaction', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
@@ -46,6 +47,7 @@ describe('stripe portal log redaction', () => {
     }))
 
     vi.doMock('../supabase/functions/_backend/utils/stripe.ts', () => ({
+      createCheckout: createCheckoutMock,
       createPortal: createPortalMock,
     }))
 
@@ -118,5 +120,85 @@ describe('stripe portal log redaction', () => {
     expect(serializedLogs).not.toContain('org-sensitive-id')
     expect(serializedLogs).not.toContain('user-sensitive-id')
     expect(serializedLogs).not.toContain('cus_sensitive_customer')
+  })
+
+  it('does not log checkout URLs or billing identifiers', async () => {
+    const singleMock = vi.fn().mockResolvedValue({
+      data: { customer_id: 'cus_checkout_sensitive_customer' },
+      error: null,
+    })
+    const eqMock = vi.fn(() => ({ single: singleMock }))
+    const selectMock = vi.fn(() => ({ eq: eqMock }))
+    const fromMock = vi.fn(() => ({ select: selectMock }))
+
+    supabaseClientMock.mockReturnValue({ from: fromMock })
+    checkPermissionMock.mockResolvedValue(true)
+    createCheckoutMock.mockResolvedValue({ url: 'https://checkout.stripe.com/session_sensitive' })
+
+    const { app: stripeCheckout } = await import('../supabase/functions/_backend/private/stripe_checkout.ts')
+
+    const response = await stripeCheckout.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        priceId: 'price_sensitive_plan',
+        clientReferenceId: 'client-sensitive-reference',
+        recurrence: 'month',
+        attributionId: 'attribution-sensitive-id',
+        successUrl: 'https://app.capgo.app/success?session=success-secret',
+        cancelUrl: 'https://app.capgo.app/cancel?session=cancel-secret',
+        orgId: 'org-checkout-sensitive-id',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ url: 'https://checkout.stripe.com/session_sensitive' })
+    expect(createCheckoutMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'cus_checkout_sensitive_customer',
+      'month',
+      'price_sensitive_plan',
+      'https://app.capgo.app/success?session=success-secret',
+      'https://app.capgo.app/cancel?session=cancel-secret',
+      'client-sensitive-reference',
+      'attribution-sensitive-id',
+    )
+
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: undefined,
+      message: 'post stripe checkout request',
+      request: {
+        hasPriceId: true,
+        hasClientReferenceId: true,
+        recurrence: 'month',
+        hasAttributionId: true,
+        hasSuccessUrl: true,
+        hasCancelUrl: true,
+        hasOrgId: true,
+      },
+    })
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: undefined,
+      message: 'stripe checkout auth context',
+      auth: { authenticated: true },
+    })
+    expect(cloudlogMock).toHaveBeenCalledWith({
+      requestId: undefined,
+      message: 'stripe checkout org lookup result',
+      org: {
+        found: true,
+        hasCustomerId: true,
+      },
+    })
+
+    const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
+    expect(serializedLogs).not.toContain('price_sensitive_plan')
+    expect(serializedLogs).not.toContain('client-sensitive-reference')
+    expect(serializedLogs).not.toContain('attribution-sensitive-id')
+    expect(serializedLogs).not.toContain('success-secret')
+    expect(serializedLogs).not.toContain('cancel-secret')
+    expect(serializedLogs).not.toContain('org-checkout-sensitive-id')
+    expect(serializedLogs).not.toContain('user-sensitive-id')
+    expect(serializedLogs).not.toContain('cus_checkout_sensitive_customer')
   })
 })


### PR DESCRIPTION
/claim #1667

## Summary
- replace raw stripe portal and checkout request-body logging with metadata-only logging
- avoid logging raw auth user IDs and Stripe customer IDs during portal and checkout creation
- add unit coverage that callback URLs, checkout redirect URLs, org IDs, user IDs, customer IDs, price IDs, client references, and attribution IDs are not retained in logs

## Test plan
- ./node_modules/.bin/vitest run tests/stripe-portal-log-redaction.unit.test.ts
- ./node_modules/.bin/eslint supabase/functions/_backend/private/stripe_portal.ts supabase/functions/_backend/private/stripe_checkout.ts tests/stripe-portal-log-redaction.unit.test.ts
- git diff --check