### PR TITLE
fix(frontend): harden external window opens

### DIFF
--- a/src/components/BundlePreviewFrame.vue
+++ b/src/components/BundlePreviewFrame.vue
@@ -4,6 +4,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import IconExternalLink from '~icons/lucide/external-link'
 import IconSmartphone from '~icons/lucide/smartphone'
+import { openExternalLink } from '~/services/externalLinks'
 import { buildChannelPreviewSubdomain, buildPreviewSubdomain } from '../../shared/preview-subdomain.ts'
 
 const props = defineProps<{
@@ -114,9 +115,7 @@ function generateQRCode() {
 watch(previewUrl, generateQRCode)
 
 function openExternal() {
-  if (!previewUrl.value)
-    return
-  window.open(previewUrl.value, '_blank')
+  openExternalLink(previewUrl.value ?? undefined)
 }
 </script>
 

--- a/src/components/tables/BundleTable.vue
+++ b/src/components/tables/BundleTable.vue
@@ -656,6 +656,7 @@ watch(props, async () => {
           <a
             href="https://capgo.app/docs/webapp/bundles/#delete-a-bundle"
             target="_blank"
+            rel="noopener noreferrer"
             class="ml-1 text-blue-500 underline hover:text-blue-600"
           >
             {{ t('here') }}

--- a/src/pages/app/[app].bundle.[bundle].vue
+++ b/src/pages/app/[app].bundle.[bundle].vue
@@ -1111,6 +1111,7 @@ async function deleteBundle() {
           <a
             href="https://capgo.app/docs/webapp/bundles/#delete-a-bundle"
             target="_blank"
+            rel="noopener noreferrer"
             class="ml-1 text-blue-500 underline hover:text-blue-600"
           >
             {{ t('here') }}
@@ -1141,6 +1142,7 @@ async function deleteBundle() {
           <a
             href="https://capgo.app/docs/webapp/bundles/#delete-a-bundle"
             target="_blank"
+            rel="noopener noreferrer"
             class="ml-1 text-blue-500 underline hover:text-blue-600"
           >
             {{ t('here') }}

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -18,6 +18,7 @@ import IconWarning from '~icons/lucide/alert-triangle'
 import IconExternalLink from '~icons/lucide/external-link'
 import IconDown from '~icons/material-symbols/keyboard-arrow-down-rounded'
 import { formatDate, formatLocalDate } from '~/services/date'
+import { openExternalLink } from '~/services/externalLinks'
 import { checkPermissions } from '~/services/permissions'
 import { checkCompatibilityNativePackages, defaultApiHost, isCompatible, useSupabase } from '~/services/supabase'
 import { isInternalVersionName } from '~/services/versions'
@@ -496,11 +497,7 @@ async function onSelectAutoUpdate(value: Database['public']['Enums']['disable_up
 }
 
 function openLink(url?: string): void {
-  if (url) {
-    const win = window.open(url, '_blank')
-    if (win)
-      win.opener = null
-  }
+  openExternalLink(url)
 }
 
 // Get the platform to use for testing based on channel settings

--- a/src/pages/app/modules.vue
+++ b/src/pages/app/modules.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import IconNext from '~icons/ic/round-keyboard-arrow-right'
+import { openExternalLink } from '~/services/externalLinks'
 import { useDisplayStore } from '~/stores/display'
 
 const { t } = useI18n()
@@ -25,8 +26,7 @@ Object.keys(dependencies).forEach((dep) => {
   }
 })
 function openLink(url?: string) {
-  if (url)
-    window.open(url, '_blank')
+  openExternalLink(url)
 }
 // console.log('modules', modules.value)
 displayStore.NavTitle = t('module-heading')

--- a/src/pages/invitation.vue
+++ b/src/pages/invitation.vue
@@ -9,6 +9,7 @@ import IconShield from '~icons/lucide/shield-check'
 import IconX from '~icons/lucide/x'
 import { authGhostButtonClass, authInsetCardClass, authPrimaryButtonClass, authSecondaryButtonClass } from '~/components/auth/pageStyles'
 import Toggle from '~/components/Toggle.vue'
+import { openExternalLink } from '~/services/externalLinks'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 
@@ -166,11 +167,11 @@ function joinCapgo() {
 
 // Open ToS and Privacy Policy in new tabs
 function openTos() {
-  window.open('https://capgo.app/tos/', '_blank')
+  openExternalLink('https://capgo.app/tos/')
 }
 
 function openPrivacy() {
-  window.open('https://capgo.app/privacy/', '_blank')
+  openExternalLink('https://capgo.app/privacy/')
 }
 </script>
 

--- a/src/services/externalLinks.ts
+++ b/src/services/externalLinks.ts
@@ -1,10 +1,10 @@
 const externalWindowFeatures = 'noopener,noreferrer'
 
 export function openExternalLink(url?: string): void {
-  if (!url || typeof window === 'undefined')
+  if (!url || typeof globalThis.window === 'undefined')
     return
 
-  const openedWindow = window.open(url, '_blank', externalWindowFeatures)
+  const openedWindow = globalThis.window.open(url, '_blank', externalWindowFeatures)
   if (openedWindow)
     openedWindow.opener = null
 }

--- a/src/services/externalLinks.ts
+++ b/src/services/externalLinks.ts
@@ -1,7 +1,7 @@
 const externalWindowFeatures = 'noopener,noreferrer'
 
 export function openExternalLink(url?: string): void {
-  if (!url || typeof globalThis.window === 'undefined')
+  if (!url || globalThis.window === undefined)
     return
 
   const openedWindow = globalThis.window.open(url, '_blank', externalWindowFeatures)

--- a/src/services/externalLinks.ts
+++ b/src/services/externalLinks.ts
@@ -1,0 +1,10 @@
+const externalWindowFeatures = 'noopener,noreferrer'
+
+export function openExternalLink(url?: string): void {
+  if (!url || typeof window === 'undefined')
+    return
+
+  const openedWindow = window.open(url, '_blank', externalWindowFeatures)
+  if (openedWindow)
+    openedWindow.opener = null
+}

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -3,6 +3,7 @@ import { Capacitor } from '@capacitor/core'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { useDialogV2Store } from '~/stores/dialogv2'
+import { openExternalLink } from './externalLinks'
 import { useSupabase } from './supabase'
 
 async function presentActionSheetOpen(url: string) {
@@ -20,7 +21,7 @@ async function presentActionSheetOpen(url: string) {
         text: t('continue'),
         id: 'continue-button',
         handler: async () => {
-          window.open(url, '_blank')
+          openExternalLink(url)
         },
       },
     ],
@@ -32,7 +33,7 @@ export function openBlank(link: string) {
   if (Capacitor.getPlatform() === 'ios')
     presentActionSheetOpen(link)
   else
-    window.open(link, '_blank')
+    openExternalLink(link)
 }
 export async function openPortal(orgId: string, t: ComposerTranslation) {
   let url = ''

--- a/tests/external-links.unit.test.ts
+++ b/tests/external-links.unit.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { openExternalLink } from '~/services/externalLinks'
+
+describe('external link navigation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('opens external links without sharing the opener', () => {
+    const popup = { opener: { location: 'https://app.capgo.test' } }
+    const open = vi.fn(() => popup)
+    vi.stubGlobal('window', { open })
+
+    openExternalLink('https://preview.capgo.test/')
+
+    expect(open).toHaveBeenCalledWith('https://preview.capgo.test/', '_blank', 'noopener,noreferrer')
+    expect(popup.opener).toBeNull()
+  })
+
+  it('does not open an empty link', () => {
+    const open = vi.fn()
+    vi.stubGlobal('window', { open })
+
+    openExternalLink('')
+
+    expect(open).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- centralize external `window.open` calls behind a helper that always uses `noopener,noreferrer` and clears `opener` when a popup object is returned
- use the helper for bundle preview, channel/package links, and module dependency links
- add missing `rel="noopener noreferrer"` to bundle docs links that open in a new tab

## Validation
- `npx --yes bun@latest x vitest run tests/external-links.unit.test.ts`
- `npx --yes bun@latest x eslint src/services/externalLinks.ts tests/external-links.unit.test.ts src/components/BundlePreviewFrame.vue src/pages/app/modules.vue 'src/pages/app/[app].channel.[channel].vue' src/components/tables/BundleTable.vue 'src/pages/app/[app].bundle.[bundle].vue'`
- `npx --yes bun@latest run lint`
- `npx --yes bun@latest run typecheck`
- `git diff --check`

/claim #1667