### PR TITLE
fix: remove channel debug logs

### DIFF
--- a/src/components/tables/ChannelTable.vue
+++ b/src/components/tables/ChannelTable.vue
@@ -85,7 +85,6 @@ async function addChannel(name: string) {
   if (!name || !versionId.value || !main.user)
     return
   try {
-    console.log('addChannel', name, versionId.value, main.user)
     const currentGid = organizationStore.currentOrganization?.gid
     if (!currentGid)
       return
@@ -368,7 +367,6 @@ async function showAddModal() {
         role: 'primary',
         handler: async () => {
           const name = newChannelName.value.trim()
-          console.log('newName', name)
           if (!name) {
             toast.error(t('missing-name'))
             return false


### PR DESCRIPTION
/claim #1667

## Summary
- Remove the channel creation debug log that printed the channel name, selected version id, and full user object.
- Remove the add-channel modal debug log that printed the new channel name.

Safe public context: this keeps channel creation behavior unchanged while avoiding routine browser-console retention of user and channel identifiers.

## Test plan
- Inspected diff; change only deletes two `console.log` statements.
- Not run locally: project lint/typecheck commands require Bun in this environment, and Bun is not installed here.

## Screenshots
Not applicable; no UI behavior changed.

## Checklist
- [x] Scoped change only
- [x] No payment details posted
- [x] No private vulnerability details disclosed