### PR TITLE
fix(db): align API-key oracle grants in schema dump

### DIFF
--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -20915,7 +20915,6 @@ GRANT ALL ON FUNCTION "public"."get_org_owner_id"("apikey" "text", "app_id" "tex
 REVOKE ALL ON FUNCTION "public"."get_org_perm_for_apikey"("apikey" "text", "app_id" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."get_org_perm_for_apikey"("apikey" "text", "app_id" "text") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."get_org_perm_for_apikey"("apikey" "text", "app_id" "text") TO "service_role";
-GRANT ALL ON FUNCTION "public"."get_org_perm_for_apikey"("apikey" "text", "app_id" "text") TO "anon";
 
 
 
@@ -21036,14 +21035,12 @@ REVOKE ALL ON FUNCTION "public"."get_update_stats"() FROM PUBLIC;
 REVOKE ALL ON FUNCTION "public"."get_user_id"("apikey" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."get_user_id"("apikey" "text") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."get_user_id"("apikey" "text") TO "service_role";
-GRANT ALL ON FUNCTION "public"."get_user_id"("apikey" "text") TO "anon";
 
 
 
 REVOKE ALL ON FUNCTION "public"."get_user_id"("apikey" "text", "app_id" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."get_user_id"("apikey" "text", "app_id" "text") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."get_user_id"("apikey" "text", "app_id" "text") TO "service_role";
-GRANT ALL ON FUNCTION "public"."get_user_id"("apikey" "text", "app_id" "text") TO "anon";
 
 
 
@@ -22891,7 +22888,6 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INS
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "anon";
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "authenticated";
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "service_role";
-
 
 
 


### PR DESCRIPTION
## Summary
- remove stale `anon` grants for API-key oracle RPCs from `supabase/schemas/prod.sql`
- align the schema dump with `20260427105909_fix_apikey_helper_rpc_public_execute.sql` and the existing pgTAP expectations
- keep `authenticated` and `service_role` execute grants unchanged

/claim #1667

## Test plan
- [x] `git diff --check`
- [x] confirmed no remaining `anon` grants for `get_user_id(text)`, `get_user_id(text,text)`, or `get_org_perm_for_apikey(text,text)` in `supabase/schemas/prod.sql`
- [ ] `npx --yes bun@latest run lint:sql -- supabase/schemas/prod.sql` could not run locally because `sqlfluff` is not installed in this environment

## Notes
No new migration is needed here: the migration chain already revokes these grants. This patch fixes the schema dump so fresh schema-based resets do not reintroduce the anonymous RPC surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API access restrictions to require authentication for certain backend functions that were previously accessible to anonymous users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->