### PR TITLE
fix(api): redact query details in Hono logs

### DIFF
--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -12,6 +12,7 @@ import { logger } from 'hono/logger'
 import { requestId } from 'hono/request-id'
 import { Hono } from 'hono/tiny'
 import { timingSafeEqual } from 'hono/utils/buffer'
+import { redactQueryForLog, redactUrlForLog } from './log_redaction.ts'
 import { cloudlog } from './logging.ts'
 import { onError } from './on_error.ts'
 import { getEnv } from './utils.ts'
@@ -157,7 +158,7 @@ export async function getBodyOrQuery<T>(c: Context<MiddlewareKeyVariables, any, 
     }
   }
   if (!body || Object.keys(body).length === 0) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find body', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find body', query: redactQueryForLog(c.req.query()) })
     throw simpleError('invalid_json_parse_body', 'Invalid JSON body')
   }
   if ((body as any).device_id) {
@@ -169,7 +170,7 @@ export async function getBodyOrQuery<T>(c: Context<MiddlewareKeyVariables, any, 
 export const middlewareAuth = honoFactory.createMiddleware(async (c, next) => {
   const authorization = c.req.header('authorization')
   if (!authorization) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorization', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorization', query: redactQueryForLog(c.req.query()) })
     return quickError(401, 'no_jwt_apikey_or_subkey', 'No JWT, apikey or subkey provided')
   }
   c.set('authorization', authorization)
@@ -198,11 +199,11 @@ export const middlewareAPISecret = honoFactory.createMiddleware(async (c, next) 
 
   // timingSafeEqual is here to prevent a timing attack
   if (!authorizationSecret || !API_SECRET) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorizationSecret or API_SECRET', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorizationSecret or API_SECRET', query: redactQueryForLog(c.req.query()) })
     throw simpleError('cannot_find_authorization_secret', 'Cannot find authorization')
   }
   if (!await timingSafeEqual(authorizationSecret, API_SECRET)) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Invalid API secret', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Invalid API secret', query: redactQueryForLog(c.req.query()) })
     throw simpleError('invalid_api_secret', 'Invalid API secret')
   }
   c.set('APISecret', authorizationSecret)
@@ -267,7 +268,7 @@ export function createHono(functionName: string, _version: string) {
 
 export function createAllCatch(appGlobal: Hono<MiddlewareKeyVariables>, functionName: string) {
   appGlobal.all('*', (c) => {
-    cloudlog({ requestId: c.get('requestId'), functionName, message: 'Not found', url: c.req.url })
+    cloudlog({ requestId: c.get('requestId'), functionName, message: 'Not found', url: redactUrlForLog(c.req.url) })
     return c.json({ error: 'not_found', message: 'Not found' }, 404)
   })
   appGlobal.onError(onError(functionName))

--- a/supabase/functions/_backend/utils/log_redaction.ts
+++ b/supabase/functions/_backend/utils/log_redaction.ts
@@ -1,0 +1,41 @@
+const SENSITIVE_QUERY_KEY_PARTS = [
+  'apikey',
+  'authorization',
+  'authcode',
+  'capgkey',
+  'capgoapi',
+  'jwt',
+  'oauthcode',
+  'password',
+  'secret',
+  'session',
+  'token',
+]
+
+const SENSITIVE_QUERY_KEYS = new Set(['code', 'key'])
+
+function isSensitiveQueryKey(key: string) {
+  const compactKey = key.toLowerCase().replace(/[-_]/g, '')
+  return SENSITIVE_QUERY_KEYS.has(compactKey) || SENSITIVE_QUERY_KEY_PARTS.some(part => compactKey.includes(part))
+}
+
+export function redactQueryForLog(query: Record<string, string>) {
+  return Object.fromEntries(Object.entries(query).map(([key, value]) => [
+    key,
+    isSensitiveQueryKey(key) ? '[REDACTED]' : value,
+  ]))
+}
+
+export function redactUrlForLog(urlValue: string) {
+  try {
+    const url = new URL(urlValue)
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (isSensitiveQueryKey(key))
+        url.searchParams.set(key, '[REDACTED]')
+    }
+    return url.toString()
+  }
+  catch {
+    return urlValue
+  }
+}

--- a/tests/hono-log-redaction.unit.test.ts
+++ b/tests/hono-log-redaction.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { redactQueryForLog, redactUrlForLog } from '../supabase/functions/_backend/utils/log_redaction.ts'
+
+describe('hono log redaction', () => {
+  it.concurrent('redacts sensitive query parameters before logging', () => {
+    expect(redactQueryForLog({
+      access_token: 'access-token-value',
+      refresh_token: 'refresh-token-value',
+      apikey: 'api-key-value',
+      code: 'auth-code-value',
+      page: '2',
+    })).toEqual({
+      access_token: '[REDACTED]',
+      refresh_token: '[REDACTED]',
+      apikey: '[REDACTED]',
+      code: '[REDACTED]',
+      page: '2',
+    })
+  })
+
+  it.concurrent('redacts sensitive URL query parameters before logging', () => {
+    const redacted = redactUrlForLog('https://api.capgo.test/private?refresh_token=refresh-token-value&page=2')
+
+    expect(redacted).not.toContain('refresh-token-value')
+    expect(redacted).toContain('refresh_token=%5BREDACTED%5D')
+    expect(redacted).toContain('page=2')
+  })
+
+  it.concurrent('redacts sensitive key format variations', () => {
+    expect(redactQueryForLog({
+      'API_KEY': 'api-key-value',
+      'api-key-token': 'mixed-separator-value',
+      'apiKey': 'camel-case-value',
+      'bearer-token': 'bearer-token-value',
+      'client_secret': 'client-secret-value',
+      'jwtToken': 'jwt-token-value',
+      'oauth_code': 'oauth-code-value',
+    })).toEqual({
+      'API_KEY': '[REDACTED]',
+      'api-key-token': '[REDACTED]',
+      'apiKey': '[REDACTED]',
+      'bearer-token': '[REDACTED]',
+      'client_secret': '[REDACTED]',
+      'jwtToken': '[REDACTED]',
+      'oauth_code': '[REDACTED]',
+    })
+  })
+
+  it.concurrent('preserves non-sensitive partial key matches', () => {
+    expect(redactQueryForLog({
+      codename: 'project-x',
+      keyword: 'search-term',
+      somecodeParam: 'non-secret-code-label',
+    })).toEqual({
+      codename: 'project-x',
+      keyword: 'search-term',
+      somecodeParam: 'non-secret-code-label',
+    })
+  })
+
+  it.concurrent('handles empty queries and invalid URLs', () => {
+    expect(redactQueryForLog({})).toEqual({})
+    expect(redactUrlForLog('not-a-valid-url')).toBe('not-a-valid-url')
+    expect(redactUrlForLog('http://[::1')).toBe('http://[::1')
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared helper for redacting sensitive query parameter values before log output
- use it for Hono missing-body, missing-auth, API-secret, and not-found URL logs
- preserve non-sensitive query values so operational debugging still works

## Tests
- npm exec --package vitest@4.1.5 -- vitest run tests/hono-log-redaction.unit.test.ts --config /private/tmp/vitest-empty.config.ts
- npm exec --package typescript@6.0.3 -- tsc --noEmit --ignoreConfig --target es2022 --module esnext supabase/functions/_backend/utils/log_redaction.ts

Refs #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sensitive query parameters and URL data (API keys, tokens, passwords) in request logs are now redacted to prevent accidental exposure of confidential information.

* **Tests**
  * Added unit tests for log redaction functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->