### PR TITLE
fix(api): redact failed version delete logs

### DIFF
--- a/supabase/functions/_backend/private/delete_failed_version.ts
+++ b/supabase/functions/_backend/private/delete_failed_version.ts
@@ -13,11 +13,19 @@ interface DataUpload {
   name: string
 }
 
+export function getDeleteFailedVersionBodyMetadata(body: Partial<DataUpload>) {
+  return {
+    hasAppId: typeof body.app_id === 'string' && body.app_id.length > 0,
+    hasName: typeof body.name === 'string' && body.name.length > 0,
+  }
+}
+
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.delete('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
   const body = await parseBody<DataUpload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'delete failed version body', body })
+  const bodyMetadata = getDeleteFailedVersionBodyMetadata(body)
+  cloudlog({ requestId: c.get('requestId'), message: 'delete failed version body', ...bodyMetadata })
   const apikey = c.get('apikey')
   const capgkey = c.get('capgkey') as string
   if (apikey && typeof apikey === 'object') {
@@ -44,10 +52,10 @@ app.delete('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
   }
 
   if (!body.app_id) {
-    return quickError(400, 'error_app_id_missing', 'Error bundle name missing', { body })
+    return quickError(400, 'error_app_id_missing', 'Error bundle name missing', bodyMetadata)
   }
   if (!body.name) {
-    return quickError(400, 'error_bundle_name_missing', 'Error bundle name missing', { body })
+    return quickError(400, 'error_bundle_name_missing', 'Error bundle name missing', bodyMetadata)
   }
 
   const { data: version, error: errorVersion } = await supabaseApikey(c, capgkey)

--- a/tests/delete-failed-version-redaction.unit.test.ts
+++ b/tests/delete-failed-version-redaction.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { getDeleteFailedVersionBodyMetadata } from '../supabase/functions/_backend/private/delete_failed_version.ts'
+
+describe('delete failed version request metadata', () => {
+  it('summarizes request body presence without retaining raw values', () => {
+    const metadata = getDeleteFailedVersionBodyMetadata({
+      app_id: 'com.example.secret-app',
+      name: '1.2.3-private-build',
+    })
+
+    expect(metadata).toEqual({
+      hasAppId: true,
+      hasName: true,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('com.example.secret-app')
+    expect(JSON.stringify(metadata)).not.toContain('1.2.3-private-build')
+  })
+
+  it('marks missing body fields without including the original body', () => {
+    expect(getDeleteFailedVersionBodyMetadata({ app_id: 'com.example.app' })).toEqual({
+      hasAppId: true,
+      hasName: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- stop logging the raw delete_failed_version request body
- return metadata-only validation details for missing request fields
- add focused coverage for the body metadata helper

## Tests
- bunx vitest run tests/delete-failed-version-redaction.unit.test.ts
- bunx eslint supabase/functions/_backend/private/delete_failed_version.ts tests/delete-failed-version-redaction.unit.test.ts
- git diff --check

/claim #1667