### PR TITLE
fix(api): redact download link request logs

### DIFF
--- a/supabase/functions/_backend/private/download_link.ts
+++ b/supabase/functions/_backend/private/download_link.ts
@@ -14,13 +14,46 @@ interface DataDownload {
   isManifest?: boolean
 }
 
+export function getDownloadLinkRequestMetadata(body: Partial<DataDownload> | null | undefined) {
+  return {
+    hasAppId: typeof body?.app_id === 'string' && body.app_id.length > 0,
+    hasStorageProvider: typeof body?.storage_provider === 'string' && body.storage_provider.length > 0,
+    hasUserId: typeof body?.user_id === 'string' && body.user_id.length > 0,
+    hasVersionId: body?.id !== undefined && body.id !== null,
+    isManifest: body?.isManifest === true,
+  }
+}
+
+export function getDownloadLinkBundleMetadata(bundle: unknown) {
+  if (!bundle || typeof bundle !== 'object') {
+    return {
+      hasBundle: false,
+    }
+  }
+
+  const bundleRecord = bundle as {
+    checksum?: unknown
+    id?: unknown
+    owner_org?: unknown
+    r2_path?: unknown
+  }
+
+  return {
+    hasBundle: true,
+    hasBundleId: bundleRecord.id !== undefined && bundleRecord.id !== null,
+    hasChecksum: typeof bundleRecord.checksum === 'string' && bundleRecord.checksum.length > 0,
+    hasOwnerOrg: !!bundleRecord.owner_org,
+    hasR2Path: typeof bundleRecord.r2_path === 'string' && bundleRecord.r2_path.length > 0,
+  }
+}
+
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<DataDownload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post download link body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post download link body', body: getDownloadLinkRequestMetadata(body) })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('cannot_find_authorization', 'Cannot find authorization')
@@ -37,7 +70,7 @@ app.post('/', middlewareAuth, async (c) => {
 
   // Auth context is already set by middlewareAuth
   if (!(await checkPermission(c, 'app.read_bundles', { appId: body.app_id })))
-    throw simpleError('app_access_denied', 'You can\'t access this app', { app_id: body.app_id })
+    throw simpleError('app_access_denied', 'You can\'t access this app', { body: getDownloadLinkRequestMetadata(body) })
 
   const { data: bundle, error: getBundleError } = await supabase
     .from('app_versions')
@@ -46,14 +79,14 @@ app.post('/', middlewareAuth, async (c) => {
     .eq('id', body.id)
     .single()
 
-  const ownerOrg = bundle?.owner_org.created_by
+  const ownerOrg = bundle?.owner_org?.created_by
 
   if (getBundleError) {
     throw simpleError('cannot_get_bundle', 'Cannot get bundle', { getBundleError })
   }
 
   if (!ownerOrg) {
-    throw simpleError('cannot_get_owner_org', 'Cannot get owner org', { bundle })
+    throw simpleError('cannot_get_owner_org', 'Cannot get owner org', { bundle: getDownloadLinkBundleMetadata(bundle) })
   }
 
   if (body.isManifest) {

--- a/tests/download-link-redaction.unit.test.ts
+++ b/tests/download-link-redaction.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { getDownloadLinkBundleMetadata, getDownloadLinkRequestMetadata } from '../supabase/functions/_backend/private/download_link.ts'
+
+describe('download link logging metadata', () => {
+  it('summarizes request bodies without exposing request values', () => {
+    const metadata = getDownloadLinkRequestMetadata({
+      app_id: 'com.secret.app',
+      id: 42,
+      isManifest: true,
+      storage_provider: 'r2',
+      user_id: 'user-secret',
+    })
+
+    expect(metadata).toEqual({
+      hasAppId: true,
+      hasStorageProvider: true,
+      hasUserId: true,
+      hasVersionId: true,
+      isManifest: true,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('com.secret.app')
+    expect(JSON.stringify(metadata)).not.toContain('user-secret')
+    expect(JSON.stringify(metadata)).not.toContain('42')
+  })
+
+  it('can be reused in access-denied errors without exposing app ids', () => {
+    const moreInfo = {
+      body: getDownloadLinkRequestMetadata({
+        app_id: 'com.denied.secret',
+        id: 99,
+        storage_provider: 'r2',
+      }),
+    }
+
+    expect(moreInfo).toEqual({
+      body: {
+        hasAppId: true,
+        hasStorageProvider: true,
+        hasUserId: false,
+        hasVersionId: true,
+        isManifest: false,
+      },
+    })
+    expect(JSON.stringify(moreInfo)).not.toContain('com.denied.secret')
+    expect(JSON.stringify(moreInfo)).not.toContain('99')
+  })
+
+  it('summarizes bundle rows without exposing storage details', () => {
+    const metadata = getDownloadLinkBundleMetadata({
+      app_id: 'com.secret.app',
+      checksum: 'secret-checksum',
+      id: 42,
+      owner_org: null,
+      r2_path: 'orgs/secret/apps/com.secret.app/bundle.zip',
+    })
+
+    expect(metadata).toEqual({
+      hasBundle: true,
+      hasBundleId: true,
+      hasChecksum: true,
+      hasOwnerOrg: false,
+      hasR2Path: true,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('com.secret.app')
+    expect(JSON.stringify(metadata)).not.toContain('secret-checksum')
+    expect(JSON.stringify(metadata)).not.toContain('bundle.zip')
+    expect(JSON.stringify(metadata)).not.toContain('42')
+  })
+
+  it('handles missing bundles with metadata only', () => {
+    expect(getDownloadLinkBundleMetadata(null)).toEqual({
+      hasBundle: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw private download_link request body logging with metadata-only booleans
- avoid returning/logging raw app ids on access-denied errors
- avoid returning/logging the raw bundle row when owner_org is missing
- add focused unit coverage for request and bundle metadata redaction

/claim #1667

## Tests
- bunx vitest run tests/download-link-redaction.unit.test.ts
- bunx eslint supabase/functions/_backend/private/download_link.ts tests/download-link-redaction.unit.test.ts
- git diff --check