### PR TITLE
fix(api): redact plugin parser error details

### DIFF
--- a/supabase/functions/_backend/utils/plugin_parser.ts
+++ b/supabase/functions/_backend/utils/plugin_parser.ts
@@ -7,6 +7,22 @@ import { fixSemver } from '../utils/utils.ts'
 import { safeParseSchema } from './ark_validation.ts'
 import { simpleError } from './hono.ts'
 
+const PLUGIN_BODY_FIELDS = [
+  'app_id',
+  'channel',
+  'custom_id',
+  'defaultChannel',
+  'device_id',
+  'is_emulator',
+  'is_prod',
+  'key_id',
+  'platform',
+  'plugin_version',
+  'version_build',
+  'version_name',
+  'version_os',
+] as const
+
 export interface DeviceLink extends AppInfos {
   channel?: string
 }
@@ -20,6 +36,42 @@ function normalizeCustomId(customId: unknown): string | undefined {
 
 function getInvalidCode(c: Context) {
   return c.req.method === 'GET' || c.req.method === 'DELETE' ? 'invalid_query_parameters' : 'invalid_json_body'
+}
+
+export function getPluginBodyMetadata(body: unknown) {
+  if (!body || typeof body !== 'object') {
+    return {
+      fieldCount: 0,
+      hasBody: false,
+      presentFields: [],
+      unknownFieldCount: 0,
+    }
+  }
+
+  const keys = Object.keys(body)
+  const knownFields = new Set<string>(PLUGIN_BODY_FIELDS)
+  return {
+    fieldCount: keys.length,
+    hasBody: true,
+    presentFields: PLUGIN_BODY_FIELDS.filter(field => keys.includes(field)),
+    unknownFieldCount: keys.filter(key => !knownFields.has(key)).length,
+  }
+}
+
+export function getPluginParseFailureMetadata(parseResult: ReturnType<typeof safeParseSchema>) {
+  if (parseResult.success) {
+    return {
+      success: true,
+    }
+  }
+
+  return {
+    success: false,
+    issueCount: parseResult.error.issues.length,
+    issues: parseResult.error.issues.slice(0, 5).map(issue => ({
+      code: issue.code,
+    })),
+  }
 }
 
 export function makeDevice(devBody: AppInfos | DeviceLink | AppStats, allowCustomID = true): DeviceWithoutCreatedAt {
@@ -45,19 +97,19 @@ export function makeDevice(devBody: AppInfos | DeviceLink | AppStats, allowCusto
 
 export function parsePluginBody<T extends AppInfos | DeviceLink | AppStats>(c: Context, body: T, schema: StandardSchema<T>, requireDevice = true) {
   if (Object.keys(body ?? {}).length === 0) {
-    throw simpleError(getInvalidCode(c), 'Cannot parse body', { body })
+    throw simpleError(getInvalidCode(c), 'Cannot parse body', { body: getPluginBodyMetadata(body) })
   }
   if (requireDevice && !body.device_id) {
-    throw simpleError('missing_device_id', 'Cannot find device_id', { body })
+    throw simpleError('missing_device_id', 'Cannot find device_id', { body: getPluginBodyMetadata(body) })
   }
   if (!body.app_id) {
-    throw simpleError('missing_app_id', 'Cannot find app_id', { body })
+    throw simpleError('missing_app_id', 'Cannot find app_id', { body: getPluginBodyMetadata(body) })
   }
   // Only validate version_build if it's provided (not required for GET /channel_self)
   if (body.version_build) {
     const coerce = tryParse(fixSemver(body.version_build))
     if (!coerce) {
-      throw simpleError('semver_error', `Native version: ${body.version_build} doesn't follow semver convention, please check https://capgo.app/semver_tester/ to learn more about semver usage in Capgo`, { version_build: body.version_build })
+      throw simpleError('semver_error', 'Native version doesn\'t follow semver convention, please check https://capgo.app/semver_tester/ to learn more about semver usage in Capgo', { body: getPluginBodyMetadata(body) })
     }
     body.version_build = format(coerce)
   }
@@ -69,7 +121,7 @@ export function parsePluginBody<T extends AppInfos | DeviceLink | AppStats>(c: C
   }
   const parseResult = safeParseSchema(schema, body)
   if (!parseResult.success) {
-    throw simpleError(getInvalidCode(c), 'Cannot parse body', { parseResult })
+    throw simpleError(getInvalidCode(c), 'Cannot parse body', { parseResult: getPluginParseFailureMetadata(parseResult) })
   }
   return parseResult.data
 }

--- a/tests/plugin-parser-redaction.unit.test.ts
+++ b/tests/plugin-parser-redaction.unit.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import { createSchema, makeIssue } from '../supabase/functions/_backend/utils/ark_validation.ts'
+import { getPluginBodyMetadata, getPluginParseFailureMetadata, parsePluginBody } from '../supabase/functions/_backend/utils/plugin_parser.ts'
+
+function createContext(method = 'POST') {
+  return {
+    req: {
+      method,
+    },
+  } as any
+}
+
+function getThrownCause(action: () => unknown) {
+  try {
+    action()
+  }
+  catch (error) {
+    return (error as Error & { cause?: any }).cause
+  }
+  throw new Error('Expected action to throw')
+}
+
+describe('plugin parser redaction', () => {
+  it('summarizes request bodies without exposing plugin identifiers', () => {
+    const metadata = getPluginBodyMetadata({
+      app_id: 'com.secret.app',
+      custom_id: 'custom-secret',
+      device_id: 'device-secret',
+      key_id: 'key-secret',
+      version_build: '1.2.3',
+      unexpected_secret: 'raw-value',
+    })
+
+    expect(metadata).toEqual({
+      fieldCount: 6,
+      hasBody: true,
+      presentFields: ['app_id', 'custom_id', 'device_id', 'key_id', 'version_build'],
+      unknownFieldCount: 1,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('com.secret.app')
+    expect(JSON.stringify(metadata)).not.toContain('device-secret')
+    expect(JSON.stringify(metadata)).not.toContain('key-secret')
+    expect(JSON.stringify(metadata)).not.toContain('raw-value')
+  })
+
+  it('uses body metadata for missing device errors', () => {
+    const cause = getThrownCause(() => parsePluginBody(
+      createContext(),
+      {
+        app_id: 'com.secret.app',
+        custom_id: 'custom-secret',
+        version_build: '1.2.3',
+      } as any,
+      createSchema(value => ({ value: value as any })),
+    ))
+
+    expect(cause.error).toBe('missing_device_id')
+    expect(cause.moreInfo).toEqual({
+      body: {
+        fieldCount: 3,
+        hasBody: true,
+        presentFields: ['app_id', 'custom_id', 'version_build'],
+        unknownFieldCount: 0,
+      },
+    })
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('com.secret.app')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('custom-secret')
+  })
+
+  it('redacts invalid semver values from error details', () => {
+    const cause = getThrownCause(() => parsePluginBody(
+      createContext(),
+      {
+        app_id: 'com.secret.app',
+        device_id: 'device-secret',
+        version_build: 'secret-build',
+      } as any,
+      createSchema(value => ({ value: value as any })),
+    ))
+
+    expect(cause.error).toBe('semver_error')
+    expect(cause.message).not.toContain('secret-build')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('secret-build')
+  })
+
+  it('summarizes schema parse failures without raw issue messages or body values', () => {
+    const schema = createSchema(() => ({
+      issues: [
+        makeIssue('Secret value device-secret is invalid', ['device_id'], 'invalid'),
+        makeIssue('App com.secret.app is invalid', ['app_id'], 'invalid'),
+      ],
+    }))
+    const parseResult = schema['~standard'].validate({}) as any
+    const metadata = getPluginParseFailureMetadata({
+      success: false,
+      error: {
+        issues: parseResult.issues,
+      },
+    } as any)
+
+    expect(metadata).toEqual({
+      success: false,
+      issueCount: 2,
+      issues: [
+        { code: 'invalid' },
+        { code: 'invalid' },
+      ],
+    })
+    expect(JSON.stringify(metadata)).not.toContain('device-secret')
+    expect(JSON.stringify(metadata)).not.toContain('com.secret.app')
+  })
+
+  it('does not expose user-controlled issue path segments', () => {
+    const metadata = getPluginParseFailureMetadata({
+      success: false,
+      error: {
+        issues: [
+          makeIssue('Invalid metadata key', ['metadata', 'secret-metadata-key'], 'invalid'),
+        ],
+      },
+    } as any)
+
+    expect(metadata).toEqual({
+      success: false,
+      issueCount: 1,
+      issues: [
+        { code: 'invalid' },
+      ],
+    })
+    expect(JSON.stringify(metadata)).not.toContain('secret-metadata-key')
+  })
+
+  it('uses parse failure metadata in thrown validation errors', () => {
+    const schema = createSchema(() => ({
+      issues: [
+        makeIssue('Secret value device-secret is invalid', ['device_id'], 'invalid'),
+      ],
+    }))
+
+    const cause = getThrownCause(() => parsePluginBody(
+      createContext(),
+      {
+        app_id: 'com.secret.app',
+        device_id: 'device-secret',
+        version_build: '1.2.3',
+      } as any,
+      schema as any,
+    ))
+
+    expect(cause.error).toBe('invalid_json_body')
+    expect(cause.moreInfo).toEqual({
+      parseResult: {
+        success: false,
+        issueCount: 1,
+        issues: [
+          { code: 'invalid' },
+        ],
+      },
+    })
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('device-secret')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('com.secret.app')
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw plugin parser request bodies in error details with metadata-only field summaries
- stop returning/logging raw schema parse results, issue messages, or issue paths from plugin validation failures
- remove invalid native version values from semver error messages and details
- add focused coverage for body, semver, schema issue, and dynamic path redaction

/claim #1667

## Tests
- bunx vitest run tests/plugin-parser-redaction.unit.test.ts tests/plugin-validation.test.ts
- bunx eslint supabase/functions/_backend/utils/plugin_parser.ts tests/plugin-parser-redaction.unit.test.ts
- bun run typecheck
- git diff --check