### PR TITLE
fix(api): redact webhook error details

### DIFF
--- a/supabase/functions/_backend/public/webhooks/delete.ts
+++ b/supabase/functions/_backend/public/webhooks/delete.ts
@@ -1,10 +1,10 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
 import { type } from 'arktype'
-import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
 import { checkWebhookPermission } from './index.ts'
+import { parseWebhookBody } from './redaction.ts'
 
 const bodySchema = type({
   orgId: 'string',
@@ -12,11 +12,7 @@ const bodySchema = type({
 })
 
 export async function deleteWebhook(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
-  const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(bodySchema, bodyRaw)
 
   await checkWebhookPermission(c, body.orgId, apikey)
 

--- a/supabase/functions/_backend/public/webhooks/deliveries.ts
+++ b/supabase/functions/_backend/public/webhooks/deliveries.ts
@@ -5,16 +5,15 @@ import type {
   WebhookPayload,
 } from '../../utils/webhook.ts'
 import { type } from 'arktype'
-import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey, supabaseWithAuth } from '../../utils/supabase.ts'
 import {
   getDeliveryById,
   getWebhookById,
-  getWebhookUrlValidationError,
   queueWebhookDelivery,
 } from '../../utils/webhook.ts'
 import { checkWebhookPermission, checkWebhookPermissionV2 } from './index.ts'
+import { parseWebhookBody, throwIfInvalidWebhookUrl } from './redaction.ts'
 
 const getDeliveriesSchema = type({
   'orgId': 'string',
@@ -31,11 +30,7 @@ const retryDeliverySchema = type({
 const DELIVERIES_PER_PAGE = 50
 
 export async function getDeliveries(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
-  const bodyParsed = safeParseSchema(getDeliveriesSchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(getDeliveriesSchema, bodyRaw)
 
   await checkWebhookPermission(c, body.orgId, apikey)
 
@@ -108,11 +103,7 @@ export async function getDeliveries(c: Context<MiddlewareKeyVariables, any, any>
 }
 
 export async function retryDelivery(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw: any, auth: AuthInfo): Promise<Response> {
-  const bodyParsed = safeParseSchema(retryDeliverySchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(retryDeliverySchema, bodyRaw)
 
   await checkWebhookPermissionV2(c, body.orgId, auth)
 
@@ -144,9 +135,7 @@ export async function retryDelivery(c: Context<MiddlewareKeyVariables, any, any>
     throw simpleError('webhook_disabled', 'Webhook is disabled')
   }
 
-  const urlError = getWebhookUrlValidationError(c, webhook.url)
-  if (urlError)
-    throw simpleError('invalid_url', urlError, { url: webhook.url })
+  throwIfInvalidWebhookUrl(c, webhook.url)
 
   // Reset delivery status and queue for retry
   await supabase

--- a/supabase/functions/_backend/public/webhooks/get.ts
+++ b/supabase/functions/_backend/public/webhooks/get.ts
@@ -6,6 +6,7 @@ import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
 import { fetchLimit } from '../../utils/utils.ts'
 import { checkWebhookPermission } from './index.ts'
+import { parseWebhookBody } from './redaction.ts'
 
 const bodySchema = type({
   'orgId': 'string',
@@ -28,11 +29,7 @@ const webhookSchema = type({
 const webhooksSchema = webhookSchema.array()
 
 export async function get(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
-  const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(bodySchema, bodyRaw)
 
   await checkWebhookPermission(c, body.orgId, apikey)
 

--- a/supabase/functions/_backend/public/webhooks/post.ts
+++ b/supabase/functions/_backend/public/webhooks/post.ts
@@ -1,11 +1,11 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
 import { type } from 'arktype'
-import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
-import { getWebhookUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
+import { WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
 import { checkWebhookPermission } from './index.ts'
+import { parseWebhookBody, throwIfInvalidWebhookUrl } from './redaction.ts'
 
 const bodySchema = type({
   'orgId': 'string',
@@ -16,11 +16,7 @@ const bodySchema = type({
 })
 
 export async function post(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
-  const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(bodySchema, bodyRaw)
 
   await checkWebhookPermission(c, body.orgId, apikey)
 
@@ -33,9 +29,7 @@ export async function post(c: Context, bodyRaw: any, apikey: Database['public'][
     })
   }
 
-  const urlError = getWebhookUrlValidationError(c, body.url)
-  if (urlError)
-    throw simpleError('invalid_url', urlError, { url: body.url })
+  throwIfInvalidWebhookUrl(c, body.url)
 
   // Create webhook using authenticated client - RLS will enforce access
   // Note: Using type assertion as webhooks table types are not yet generated

--- a/supabase/functions/_backend/public/webhooks/put.ts
+++ b/supabase/functions/_backend/public/webhooks/put.ts
@@ -1,11 +1,11 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
 import { type } from 'arktype'
-import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
-import { getWebhookUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
+import { WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
 import { checkWebhookPermission } from './index.ts'
+import { parseWebhookBody, throwIfInvalidWebhookUrl } from './redaction.ts'
 
 const bodySchema = type({
   'orgId': 'string',
@@ -17,11 +17,7 @@ const bodySchema = type({
 })
 
 export async function put(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
-  const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(bodySchema, bodyRaw)
 
   await checkWebhookPermission(c, body.orgId, apikey)
 
@@ -57,9 +53,7 @@ export async function put(c: Context, bodyRaw: any, apikey: Database['public']['
 
   // Validate URL if provided
   if (body.url) {
-    const urlError = getWebhookUrlValidationError(c, body.url)
-    if (urlError)
-      throw simpleError('invalid_url', urlError, { url: body.url })
+    throwIfInvalidWebhookUrl(c, body.url)
   }
 
   // Build update object

--- a/supabase/functions/_backend/public/webhooks/redaction.ts
+++ b/supabase/functions/_backend/public/webhooks/redaction.ts
@@ -1,0 +1,65 @@
+import type { Context } from 'hono'
+import type { StandardSchema } from '../../utils/ark_validation.ts'
+import { safeParseSchema } from '../../utils/ark_validation.ts'
+import { simpleError } from '../../utils/hono.ts'
+import { getWebhookUrlValidationError } from '../../utils/webhook.ts'
+
+interface ValidationIssueLike {
+  code?: unknown
+}
+
+export function getWebhookValidationErrorMetadata(error: unknown) {
+  const issues = Array.isArray((error as { issues?: unknown[] } | undefined)?.issues)
+    ? (error as { issues: ValidationIssueLike[] }).issues
+    : []
+
+  return {
+    success: false,
+    issueCount: issues.length,
+    issues: issues.slice(0, 10).map(issue => ({
+      ...(typeof issue?.code === 'string' ? { code: issue.code } : {}),
+    })),
+  }
+}
+
+export function parseWebhookBody<T>(schema: StandardSchema<T>, bodyRaw: unknown): T {
+  const bodyParsed = safeParseSchema(schema, bodyRaw)
+  if (!bodyParsed.success) {
+    throw simpleError('invalid_body', 'Invalid body', {
+      parseResult: getWebhookValidationErrorMetadata(bodyParsed.error),
+    })
+  }
+
+  return bodyParsed.data
+}
+
+export function getWebhookUrlMetadata(urlString: unknown) {
+  if (typeof urlString !== 'string') {
+    return { hasUrl: false }
+  }
+
+  try {
+    const url = new URL(urlString)
+    return {
+      hasUrl: true,
+      protocol: url.protocol,
+      hostnameLength: url.hostname.length,
+      pathLength: url.pathname.length,
+      hasSearch: url.search.length > 0,
+      hasHash: url.hash.length > 0,
+    }
+  }
+  catch {
+    return {
+      hasUrl: true,
+      parseable: false,
+      length: urlString.length,
+    }
+  }
+}
+
+export function throwIfInvalidWebhookUrl(c: Context, urlString: string) {
+  const urlError = getWebhookUrlValidationError(c, urlString)
+  if (urlError)
+    throw simpleError('invalid_url', urlError, { url: getWebhookUrlMetadata(urlString) })
+}

--- a/supabase/functions/_backend/public/webhooks/redaction.ts
+++ b/supabase/functions/_backend/public/webhooks/redaction.ts
@@ -25,9 +25,7 @@ export function getWebhookValidationErrorMetadata(error: unknown) {
 export function parseWebhookBody<T>(schema: StandardSchema<T>, bodyRaw: unknown): T {
   const bodyParsed = safeParseSchema(schema, bodyRaw)
   if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', {
-      parseResult: getWebhookValidationErrorMetadata(bodyParsed.error),
-    })
+    throw simpleError('invalid_body', 'Invalid body')
   }
 
   return bodyParsed.data

--- a/supabase/functions/_backend/public/webhooks/test.ts
+++ b/supabase/functions/_backend/public/webhooks/test.ts
@@ -1,17 +1,16 @@
 import type { Context } from 'hono'
 import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import { type } from 'arktype'
-import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseWithAuth } from '../../utils/supabase.ts'
 import {
   createDeliveryRecord,
   createTestPayload,
   deliverWebhook,
-  getWebhookUrlValidationError,
   updateDeliveryResult,
 } from '../../utils/webhook.ts'
 import { checkWebhookPermissionV2 } from './index.ts'
+import { parseWebhookBody, throwIfInvalidWebhookUrl } from './redaction.ts'
 
 const bodySchema = type({
   orgId: 'string',
@@ -19,11 +18,7 @@ const bodySchema = type({
 })
 
 export async function test(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw: any, auth: AuthInfo): Promise<Response> {
-  const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
-  if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
-  }
-  const body = bodyParsed.data
+  const body = parseWebhookBody(bodySchema, bodyRaw)
 
   await checkWebhookPermissionV2(c, body.orgId, auth)
 
@@ -46,9 +41,7 @@ export async function test(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw
     throw simpleError('no_permission', 'Webhook does not belong to this organization', { webhookId: body.webhookId })
   }
 
-  const urlError = getWebhookUrlValidationError(c, webhook.url)
-  if (urlError)
-    throw simpleError('invalid_url', urlError, { url: webhook.url })
+  throwIfInvalidWebhookUrl(c, webhook.url)
 
   // Create test payload
   const payload = createTestPayload(body.orgId)

--- a/tests/webhook-redaction.unit.test.ts
+++ b/tests/webhook-redaction.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { getWebhookUrlMetadata, getWebhookValidationErrorMetadata } from '../supabase/functions/_backend/public/webhooks/redaction.ts'
+import { createSchema, makeIssue, safeParseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
+
+describe('webhook error redaction', () => {
+  it('summarizes validation errors without schema messages or paths', () => {
+    const schema = createSchema(() => ({
+      issues: [
+        makeIssue('Webhook URL https://secret.example.com/hook?token=hidden is invalid', ['url'], 'predicate'),
+        makeIssue('Webhook name secret-name is invalid', ['name'], 'minLength'),
+      ],
+    }))
+    const result = safeParseSchema(schema, {})
+
+    if (result.success)
+      throw new Error('Expected schema validation to fail')
+
+    const serialized = JSON.stringify(getWebhookValidationErrorMetadata(result.error))
+
+    expect(serialized).toBe(JSON.stringify({
+      success: false,
+      issueCount: 2,
+      issues: [
+        { code: 'predicate' },
+        { code: 'minLength' },
+      ],
+    }))
+    expect(serialized).not.toMatch(/secret\.example\.com|token=hidden|secret-name|url/)
+  })
+
+  it('summarizes webhook urls without exposing hosts, paths, or query secrets', () => {
+    const metadata = getWebhookUrlMetadata('https://secret.example.com/webhook/path?token=hidden#fragment')
+
+    expect(metadata).toEqual({
+      hasUrl: true,
+      protocol: 'https:',
+      hostnameLength: 'secret.example.com'.length,
+      pathLength: '/webhook/path'.length,
+      hasSearch: true,
+      hasHash: true,
+    })
+    expect(JSON.stringify(metadata)).not.toMatch(/secret\.example\.com|\/webhook\/path|token=hidden|fragment/)
+  })
+
+  it('summarizes unparsable webhook urls by length only', () => {
+    const metadata = getWebhookUrlMetadata('not a url with secret token')
+
+    expect(metadata).toEqual({
+      hasUrl: true,
+      parseable: false,
+      length: 'not a url with secret token'.length,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('secret token')
+  })
+})


### PR DESCRIPTION
## Summary
- replace webhook schema validation error objects with issue-count/code metadata
- replace invalid webhook URL `moreInfo` values with URL shape metadata
- add focused regression coverage for schema and URL redaction

/claim #1667

## Tests
- `bunx vitest run tests/webhook-redaction.unit.test.ts`
- `bunx eslint supabase/functions/_backend/public/webhooks/delete.ts supabase/functions/_backend/public/webhooks/deliveries.ts supabase/functions/_backend/public/webhooks/get.ts supabase/functions/_backend/public/webhooks/post.ts supabase/functions/_backend/public/webhooks/put.ts supabase/functions/_backend/public/webhooks/test.ts supabase/functions/_backend/public/webhooks/redaction.ts tests/webhook-redaction.unit.test.ts`
- `bun run typecheck`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook URL validation across all endpoints with more consistent error handling.

* **Tests**
  * Added test coverage for webhook URL validation with enhanced error messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->