### PR TITLE
fix(api): redact create app validation body

### DIFF
--- a/supabase/functions/_backend/public/app/post.ts
+++ b/supabase/functions/_backend/public/app/post.ts
@@ -17,18 +17,45 @@ export interface CreateApp {
   android_store_url?: string
 }
 
+const createAppMetadataFields = [
+  'android_store_url',
+  'app_id',
+  'existing_app',
+  'icon',
+  'ios_store_url',
+  'name',
+  'need_onboarding',
+  'owner_org',
+] as const
+
+export function getCreateAppBodyMetadata(body: unknown) {
+  if (!body || typeof body !== 'object') {
+    return { hasBody: false }
+  }
+
+  const bodyRecord = body as Record<string, unknown>
+  const presentFields = createAppMetadataFields.filter(field => field in bodyRecord)
+
+  return {
+    fieldCount: Object.keys(bodyRecord).length,
+    hasBody: true,
+    presentFields,
+    unknownFieldCount: Math.max(0, Object.keys(bodyRecord).length - presentFields.length),
+  }
+}
+
 export async function post(c: Context<MiddlewareKeyVariables>, body: CreateApp): Promise<Response> {
   if (!body.app_id) {
-    throw simpleError('missing_app_id', 'Missing app_id', { body })
+    throw simpleError('missing_app_id', 'Missing app_id', { body: getCreateAppBodyMetadata(body) })
   }
   if (!isValidAppId(body.app_id)) {
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
   if (!body.name) {
-    throw simpleError('missing_name', 'Missing name', { body })
+    throw simpleError('missing_name', 'Missing name', { body: getCreateAppBodyMetadata(body) })
   }
   if (!body.owner_org) {
-    throw quickError(400, 'missing_owner_org', 'Missing owner_org', { body })
+    throw quickError(400, 'missing_owner_org', 'Missing owner_org', { body: getCreateAppBodyMetadata(body) })
   }
 
   // Check if the user is allowed to create an app in this organization (auth context set by middlewareKey)

--- a/supabase/functions/_backend/public/app/post.ts
+++ b/supabase/functions/_backend/public/app/post.ts
@@ -49,7 +49,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: CreateApp):
     throw simpleError('missing_app_id', 'Missing app_id', { body: getCreateAppBodyMetadata(body) })
   }
   if (!isValidAppId(body.app_id)) {
-    throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
+    throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { body: getCreateAppBodyMetadata(body) })
   }
   if (!body.name) {
     throw simpleError('missing_name', 'Missing name', { body: getCreateAppBodyMetadata(body) })

--- a/tests/create-app-redaction.unit.test.ts
+++ b/tests/create-app-redaction.unit.test.ts
@@ -68,4 +68,25 @@ describe('create app error redaction', () => {
     expect(JSON.stringify(cause.moreInfo)).not.toContain('secret-org-id')
     expect(JSON.stringify(cause.moreInfo)).not.toContain('apps.apple.com')
   })
+
+  it('redacts raw invalid app ids from create-app validation errors', async () => {
+    const cause = await getRejectedCause(() => post({} as any, {
+      app_id: 'https://internal.example/secret-token',
+      name: 'Secret App',
+      owner_org: 'secret-org-id',
+    } as any))
+
+    expect(cause.error).toBe('invalid_app_id')
+    expect(cause.moreInfo).toEqual({
+      body: {
+        fieldCount: 3,
+        hasBody: true,
+        presentFields: ['app_id', 'name', 'owner_org'],
+        unknownFieldCount: 0,
+      },
+    })
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('secret-token')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('internal.example')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('secret-org-id')
+  })
 })

--- a/tests/create-app-redaction.unit.test.ts
+++ b/tests/create-app-redaction.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { getCreateAppBodyMetadata, post } from '../supabase/functions/_backend/public/app/post.ts'
+
+async function getRejectedCause(action: () => Promise<unknown>) {
+  try {
+    await action()
+  }
+  catch (error) {
+    return (error as Error & { cause?: any }).cause
+  }
+  throw new Error('Expected action to throw')
+}
+
+describe('create app error redaction', () => {
+  it('summarizes create-app bodies without exposing raw identifiers or URLs', () => {
+    const metadata = getCreateAppBodyMetadata({
+      app_id: 'com.secret.app',
+      name: 'Secret App',
+      owner_org: 'secret-org-id',
+      icon: 'orgs/secret/icon.png',
+      ios_store_url: 'https://apps.apple.com/app/secret',
+      android_store_url: 'https://play.google.com/store/apps/details?id=com.secret.app',
+      unexpected_secret: 'raw-secret-value',
+    })
+
+    expect(metadata).toEqual({
+      fieldCount: 7,
+      hasBody: true,
+      presentFields: [
+        'android_store_url',
+        'app_id',
+        'icon',
+        'ios_store_url',
+        'name',
+        'owner_org',
+      ],
+      unknownFieldCount: 1,
+    })
+    expect(JSON.stringify(metadata)).not.toContain('com.secret.app')
+    expect(JSON.stringify(metadata)).not.toContain('Secret App')
+    expect(JSON.stringify(metadata)).not.toContain('secret-org-id')
+    expect(JSON.stringify(metadata)).not.toContain('raw-secret-value')
+    expect(JSON.stringify(metadata)).not.toContain('apps.apple.com')
+    expect(JSON.stringify(metadata)).not.toContain('play.google.com')
+  })
+
+  it('handles missing bodies without throwing', () => {
+    expect(getCreateAppBodyMetadata(null)).toEqual({ hasBody: false })
+  })
+
+  it('uses body metadata in create-app validation errors', async () => {
+    const cause = await getRejectedCause(() => post({} as any, {
+      app_id: 'com.secret.app',
+      owner_org: 'secret-org-id',
+      ios_store_url: 'https://apps.apple.com/app/secret',
+    } as any))
+
+    expect(cause.error).toBe('missing_name')
+    expect(cause.moreInfo).toEqual({
+      body: {
+        fieldCount: 3,
+        hasBody: true,
+        presentFields: ['app_id', 'ios_store_url', 'owner_org'],
+        unknownFieldCount: 0,
+      },
+    })
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('com.secret.app')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('secret-org-id')
+    expect(JSON.stringify(cause.moreInfo)).not.toContain('apps.apple.com')
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw create-app request bodies in missing-field errors with field-presence metadata
- keep existing validation error codes and statuses unchanged
- add focused unit coverage for helper and thrown error metadata redaction

/claim #1667

## Tests
- `bunx vitest run tests/create-app-redaction.unit.test.ts`
- `bunx eslint supabase/functions/_backend/public/app/post.ts tests/create-app-redaction.unit.test.ts`
- `bun run typecheck`
- `git diff --check`