### PR TITLE
fix(api): redact stats version errors

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -16,6 +16,10 @@ import { backgroundTask, INVALID_STRING_APP_ID, isLimited, MISSING_STRING_APP_ID
 
 const PLAN_ERROR = 'Cannot send stats, upgrade plan to continue to update'
 
+export function getVersionNotFoundResult(): PostResult {
+  return { success: false, error: 'version_not_found', message: 'Version not found' }
+}
+
 export interface BatchStatsResult {
   status: 'ok' | 'error'
   error?: string
@@ -100,11 +104,14 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     const appVersion2 = await getAppVersionPostgres(c, app_id, 'unknown', allowedDeleted, drizzleClient as ReturnType<typeof getDrizzleClient>)
     if (appVersion2) {
       appVersion = appVersion2
-      cloudlog({ requestId: c.get('requestId'), message: `Version name ${version_name} not found, using unknown instead`, app_id, version_name })
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Version name not found, using unknown instead',
+      })
     }
     else {
       backgroundTask(c, ensurePlaceholderVersions(c, app_id))
-      return { success: false, error: 'version_not_found', message: 'Version not found', moreInfo: { app_id, version_name } }
+      return getVersionNotFoundResult()
     }
   }
   // device.version = appVersion.id

--- a/tests/plugin-stats-redaction.unit.test.ts
+++ b/tests/plugin-stats-redaction.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { getVersionNotFoundResult } from '../supabase/functions/_backend/plugins/stats.ts'
+
+describe('plugin stats redaction', () => {
+  it('returns missing version errors without app or version identifiers', () => {
+    const result = getVersionNotFoundResult()
+
+    expect(result).toEqual({
+      success: false,
+      error: 'version_not_found',
+      message: 'Version not found',
+    })
+    expect(result.moreInfo).toBeUndefined()
+    expect(JSON.stringify(result)).not.toContain('com.secret.app')
+    expect(JSON.stringify(result)).not.toContain('1.2.3')
+    expect(JSON.stringify(result)).not.toContain('secret-file.js')
+  })
+})


### PR DESCRIPTION
## Summary
- stop logging raw stats `version_name` and `app_id` when falling back to `unknown`
- stop returning raw `app_id` and `version_name` in `version_not_found` stats errors
- add focused unit coverage for the redacted missing-version result

/claim #1667

## Tests
- `bunx vitest run tests/plugin-stats-redaction.unit.test.ts`
- `bunx eslint supabase/functions/_backend/plugins/stats.ts tests/plugin-stats-redaction.unit.test.ts`
- `bun run typecheck`
- `git diff --check`