### PR TITLE
fix: redact sensitive proxy log values

### DIFF
--- a/aliproxy/index.js
+++ b/aliproxy/index.js
@@ -17,11 +17,17 @@ const SENSITIVE_QUERY_KEYS = new Set([
   'token',
 ])
 
+function isSensitiveQueryKey(key) {
+  const lowerKey = key.toLowerCase()
+  const normalizedKey = lowerKey.replace(/[^a-z0-9]/g, '')
+  return SENSITIVE_QUERY_KEYS.has(lowerKey) || /(token|secret|password|apikey|auth|signature|session|code|key)/.test(normalizedKey)
+}
+
 function safeLogPath(path) {
   try {
     const url = new URL(path, `https://${TARGET_HOST}`)
     for (const key of [...url.searchParams.keys()]) {
-      if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
+      if (isSensitiveQueryKey(key)) {
         url.searchParams.set(key, 'REDACTED')
       }
     }

--- a/aliproxy/index.js
+++ b/aliproxy/index.js
@@ -4,6 +4,33 @@ const { Buffer } = require('node:buffer')
 const https = require('node:https')
 
 const TARGET_HOST = 'updater.capgo.com.cn'
+const SENSITIVE_QUERY_KEYS = new Set([
+  'apikey',
+  'api_key',
+  'authorization',
+  'code',
+  'key',
+  'password',
+  'secret',
+  'session',
+  'signature',
+  'token',
+])
+
+function safeLogPath(path) {
+  try {
+    const url = new URL(path, `https://${TARGET_HOST}`)
+    for (const key of [...url.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
+        url.searchParams.set(key, 'REDACTED')
+      }
+    }
+    return `${url.pathname}${url.search}`
+  }
+  catch {
+    return '/'
+  }
+}
 
 exports.handler = function (event, _context, callback) {
   try {
@@ -23,7 +50,7 @@ exports.handler = function (event, _context, callback) {
 
     console.log('[DEBUG] Parsed request data:', {
       version: requestData.version,
-      rawPath: requestData.rawPath,
+      rawPath: safeLogPath(requestData.rawPath || requestData.path || '/'),
       hasHeaders: !!requestData.headers,
       hasBody: !!requestData.body,
       method: requestData.requestContext?.http?.method,
@@ -62,7 +89,7 @@ exports.handler = function (event, _context, callback) {
     }
 
     console.log('[DEBUG] Proxying request:', {
-      url: `https://${TARGET_HOST}${path}`,
+      url: `https://${TARGET_HOST}${safeLogPath(path)}`,
       method,
       hasBody: !!bodyBuffer,
       bodySize: bodyBuffer ? bodyBuffer.length : 0,
@@ -103,12 +130,12 @@ exports.handler = function (event, _context, callback) {
       })
     })
 
-    req.on('error', (err) => {
-      console.error('[ERROR] Request failed:', err)
+    req.on('error', () => {
+      console.error('[ERROR] Request failed')
       callback(null, {
         statusCode: 502,
         headers: { 'content-type': 'text/plain' },
-        body: `upstream error: ${err.message}`,
+        body: 'upstream error',
       })
     })
 
@@ -117,12 +144,12 @@ exports.handler = function (event, _context, callback) {
     }
     req.end()
   }
-  catch (err) {
-    console.error('[ERROR] Handler exception:', err)
+  catch {
+    console.error('[ERROR] Handler exception')
     callback(null, {
       statusCode: 500,
       headers: { 'content-type': 'text/plain' },
-      body: `internal error: ${err.message}`,
+      body: 'internal error',
     })
   }
 }


### PR DESCRIPTION
## Summary

This updates the Alibaba proxy to avoid writing sensitive query parameter values to logs. It redacts common secret-bearing keys such as `token`, `api_key`, `secret`, `session`, and related names in logged paths while preserving the original request path used for the upstream proxy call.

It also returns and logs generic upstream/internal error messages so runtime exception details are not exposed through responses or proxy logs.

/claim #1667

## Validation

- `node --check aliproxy/index.js`
- Smoke-tested that proxy forwarding still uses the original path while log output redacts sensitive query values.
- Smoke-tested upstream error handling to confirm detailed error text is not returned or logged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Responses now return generic error messages (e.g., "internal error" / "upstream error") to avoid exposing internal exception details.

* **Chores**
  * Debug logs and proxy logging now redact sensitive query parameter values to protect private data in logs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->