### PR TITLE
fix(api): redact create device validation body

### DIFF
--- a/supabase/functions/_backend/private/create_device.ts
+++ b/supabase/functions/_backend/private/create_device.ts
@@ -22,7 +22,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
 
-interface CreateDeviceBody {
+export interface CreateDeviceBody {
   device_id: string
   app_id: string
   org_id: string
@@ -30,16 +30,20 @@ interface CreateDeviceBody {
   version_name: string
 }
 
+export function parseCreateDeviceBody(body: unknown): CreateDeviceBody {
+  const parsedBodyResult = safeParseSchema(bodySchema, body)
+  if (!parsedBodyResult.success) {
+    throw simpleError('invalid_json_body', 'Invalid JSON body')
+  }
+
+  return parsedBodyResult.data
+}
+
 app.post('/', middlewareV2(['all', 'write']), async (c) => {
   const auth = c.get('auth')!
 
   const body = await parseBody<CreateDeviceBody>(c)
-  const parsedBodyResult = safeParseSchema(bodySchema, body)
-  if (!parsedBodyResult.success) {
-    throw simpleError('invalid_json_body', 'Invalid JSON body', { body, parsedBodyResult })
-  }
-
-  const safeBody = parsedBodyResult.data
+  const safeBody = parseCreateDeviceBody(body)
   const normalizedOrgId = safeBody.org_id.toLowerCase()
 
   // Use authenticated client for data queries - RLS will enforce access

--- a/supabase/functions/_backend/private/create_device.ts
+++ b/supabase/functions/_backend/private/create_device.ts
@@ -26,7 +26,7 @@ export interface CreateDeviceBody {
   device_id: string
   app_id: string
   org_id: string
-  platform: string
+  platform: 'ios' | 'android'
   version_name: string
 }
 

--- a/tests/create-device-redaction.unit.test.ts
+++ b/tests/create-device-redaction.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { parseCreateDeviceBody } from '../supabase/functions/_backend/private/create_device.ts'
+
+function getThrownCause(action: () => void) {
+  try {
+    action()
+  }
+  catch (error) {
+    const thrown = error as Error & { cause?: any, status?: number }
+    return {
+      status: thrown.status,
+      cause: thrown.cause,
+    }
+  }
+
+  throw new Error('Expected action to throw')
+}
+
+describe('create_device error redaction', () => {
+  it('does not expose request bodies in schema validation errors', () => {
+    const rawBody = {
+      app_id: 'com.secret.app',
+      org_id: 'not-a-uuid',
+      device_id: 'also-not-a-uuid',
+      platform: 'windows',
+      version_name: '1.2.3-secret',
+      token: 'super-secret-token',
+    }
+
+    const { status, cause } = getThrownCause(() => parseCreateDeviceBody(rawBody))
+    const serialized = JSON.stringify(cause)
+
+    expect(status).toBe(400)
+    expect(cause).toMatchObject({
+      error: 'invalid_json_body',
+      message: 'Invalid JSON body',
+      moreInfo: {},
+    })
+    expect(serialized).not.toMatch(/com\.secret\.app|not-a-uuid|also-not-a-uuid|windows|1\.2\.3-secret|super-secret-token/)
+  })
+})


### PR DESCRIPTION
## Summary
- remove raw request body and full schema parse result from create_device validation errors
- route create_device validation through a small shared parser
- add a unit test proving invalid payload values are not serialized in the thrown error cause

## Validation
- bunx vitest run tests/create-device-redaction.unit.test.ts
- bun run lint:backend -- supabase/functions/_backend/private/create_device.ts
- git diff --check