### PR TITLE
fix: remove shared UI debug logs

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -172,7 +172,6 @@ function loadFromUrlParams() {
       newFilters[key] = filterParams.includes(key)
     })
     if (JSON.stringify(newFilters) !== JSON.stringify(props.filters)) {
-      console.log('update filters', newFilters, props.filters)
       emit('update:filters', newFilters)
     }
   }

--- a/src/components/TabSidebar.vue
+++ b/src/components/TabSidebar.vue
@@ -26,7 +26,6 @@ function findTab(key: string) {
 }
 
 watch(props, (p) => {
-  // console.log('activeTab', p.activeTab)
   const tab = findTab(p.activeTab)
   if (!tab || props.noRoute)
     return
@@ -42,7 +41,6 @@ watch(router.currentRoute, (p) => {
 })
 onMounted(() => {
   if (props.activeTab && props.activeTab !== router.currentRoute.value.path) {
-    console.log('activeTab', props.activeTab)
     openLink(props.activeTab)
   }
 })

--- a/src/components/tables/BundleTable.vue
+++ b/src/components/tables/BundleTable.vue
@@ -489,7 +489,6 @@ async function reload() {
 }
 
 async function massDelete() {
-  console.log('massDelete')
   if (!canDeleteBundle.value) {
     toast.error(t('no-permission'))
     return
@@ -576,7 +575,6 @@ async function massDelete() {
 }
 
 function selectedElementsFilter(val: boolean[]) {
-  console.log('selectedElementsFilter', val)
   selectedElements.value = (elements.value as any).filter((_: any, i: number) => val[i])
 }
 


### PR DESCRIPTION
## Summary
- remove DataTable filter hydration debug logging
- remove TabSidebar active route debug logging
- remove BundleTable mass-delete and selection debug logging

This keeps behavior unchanged while avoiding routine browser-console exposure of route, filter, and table-selection context.

/claim #1667

## Tests
- bun x eslint src/components/DataTable.vue src/components/TabSidebar.vue src/components/tables/BundleTable.vue
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements from table and sidebar components to maintain code cleanliness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2177)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->