### PR TITLE
fix(api): redact store metadata URL errors

### DIFF
--- a/supabase/functions/_backend/public/app/store_metadata.ts
+++ b/supabase/functions/_backend/public/app/store_metadata.ts
@@ -63,7 +63,7 @@ function assertAllowedStoreUrl(rawUrl: string) {
   const parsedUrl = new URL(rawUrl)
 
   if (parsedUrl.protocol !== 'https:' || !ALLOWED_STORE_HOSTS.has(parsedUrl.hostname.toLowerCase()))
-    throw quickError(400, 'invalid_url', 'Only official App Store and Google Play URLs are allowed', { url: rawUrl })
+    throw quickError(400, 'invalid_url', 'Only official App Store and Google Play URLs are allowed')
 
   return parsedUrl
 }
@@ -162,7 +162,7 @@ export async function fetchStoreMetadata(c: Context<MiddlewareKeyVariables>, bod
     parsedUrl = assertAllowedStoreUrl(body.url)
   }
   catch {
-    throw quickError(400, 'invalid_url', 'Invalid store URL', { url: body.url })
+    throw quickError(400, 'invalid_url', 'Invalid store URL')
   }
 
   const response = await fetch(parsedUrl.toString(), {
@@ -174,8 +174,8 @@ export async function fetchStoreMetadata(c: Context<MiddlewareKeyVariables>, bod
 
   if (!response.ok) {
     throw quickError(400, 'cannot_fetch_store_metadata', 'Unable to fetch store metadata', {
+      host: parsedUrl.hostname,
       status: response.status,
-      url: parsedUrl.toString(),
     })
   }
 

--- a/tests/store-metadata-redaction.unit.test.ts
+++ b/tests/store-metadata-redaction.unit.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchStoreMetadata } from '../supabase/functions/_backend/public/app/store_metadata.ts'
+
+async function getRejectedCause(action: () => Promise<unknown>) {
+  try {
+    await action()
+  }
+  catch (error) {
+    return (error as Error & { cause?: any }).cause
+  }
+  throw new Error('Expected action to throw')
+}
+
+describe('store metadata error redaction', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not echo invalid raw store URLs in error details', async () => {
+    const cause = await getRejectedCause(() => fetchStoreMetadata({} as any, {
+      url: 'https://example.com/reset?token=secret',
+    }))
+
+    expect(cause.error).toBe('invalid_url')
+    expect(cause.moreInfo).toEqual({})
+    expect(JSON.stringify(cause)).not.toContain('https://example.com/reset')
+    expect(JSON.stringify(cause)).not.toContain('token=')
+    expect(JSON.stringify(cause)).not.toContain('secret')
+  })
+
+  it('keeps only safe fetch failure metadata for allowed store URLs', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })))
+
+    const cause = await getRejectedCause(() => fetchStoreMetadata({} as any, {
+      url: 'https://play.google.com/store/apps/details?id=com.app&token=secret',
+    }))
+
+    expect(cause.error).toBe('cannot_fetch_store_metadata')
+    expect(cause.moreInfo).toEqual({
+      host: 'play.google.com',
+      status: 404,
+    })
+    expect(JSON.stringify(cause)).not.toContain('com.app')
+    expect(JSON.stringify(cause)).not.toContain('token=')
+    expect(JSON.stringify(cause)).not.toContain('secret')
+  })
+})


### PR DESCRIPTION
## Summary
- stop returning raw submitted store URLs in invalid_url error metadata
- keep fetch failure diagnostics to status plus allowed host only
- add unit coverage for invalid and fetch-failure URL redaction

## Validation
- bunx vitest run tests/store-metadata-redaction.unit.test.ts
- bun x eslint supabase/functions/_backend/public/app/store_metadata.ts tests/store-metadata-redaction.unit.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error response handling for store metadata operations to improve consistency and security by removing sensitive information from error messages.

* **Tests**
  * Added unit tests to verify proper sanitization of error responses and handling of metadata validation failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->