### PR TITLE
fix(api): redact organization audit schema errors

### DIFF
--- a/supabase/functions/_backend/public/organization/audit.ts
+++ b/supabase/functions/_backend/public/organization/audit.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import type { SchemaError } from '../../utils/ark_validation.ts'
 import type { AuthInfo } from '../../utils/hono.ts'
 import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
@@ -28,10 +29,20 @@ const auditLogSchema = type({
 
 const auditLogsSchema = auditLogSchema.array()
 
+export function getAuditSchemaErrorMetadata(error: SchemaError) {
+  return {
+    issueCount: error.issues.length,
+    issues: Array.from(error.issues, issue => ({
+      code: String(issue.code ?? 'schema'),
+      path: Array.from(issue.path ?? [], String),
+    })),
+  }
+}
+
 export async function getAuditLogs(c: Context, bodyRaw: any): Promise<Response> {
   const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
   if (!bodyParsed.success) {
-    throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
+    throw simpleError('invalid_body', 'Invalid body', { error: getAuditSchemaErrorMetadata(bodyParsed.error) })
   }
   const body = bodyParsed.data
 

--- a/tests/organization-audit-redaction.unit.test.ts
+++ b/tests/organization-audit-redaction.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { getAuditLogs } from '../supabase/functions/_backend/public/organization/audit.ts'
+
+async function getRejectedCause(action: () => Promise<unknown>) {
+  try {
+    await action()
+  }
+  catch (error) {
+    return (error as Error & { cause?: any }).cause
+  }
+  throw new Error('Expected action to throw')
+}
+
+describe('organization audit error redaction', () => {
+  it('redacts raw schema values from invalid audit query errors', async () => {
+    const cause = await getRejectedCause(() => getAuditLogs({} as any, {
+      limit: 'abc123secret',
+      orgId: '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    }))
+
+    expect(cause.error).toBe('invalid_body')
+    expect(cause.moreInfo.error.issueCount).toBe(1)
+    expect(cause.moreInfo.error.issues).toHaveLength(1)
+    expect(cause.moreInfo.error.issues[0].code).toEqual(expect.any(String))
+    expect(cause.moreInfo.error.issues[0].path).toEqual(['limit'])
+    expect(JSON.stringify(cause)).not.toContain('abc123secret')
+    expect(JSON.stringify(cause)).not.toContain('was')
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw organization audit schema errors with issue-count/code/path metadata
- coerce ArkType issue data into plain JSON-safe objects
- add unit coverage that invalid audit query values are not reflected in error details

## Validation
- bunx vitest run tests/organization-audit-redaction.unit.test.ts
- bun x eslint supabase/functions/_backend/public/organization/audit.ts tests/organization-audit-redaction.unit.test.ts
- git diff --check
- direct serialization check for invalid audit query errors