### PR TITLE
fix(api): redact admin stats unauthorized logs

### DIFF
--- a/supabase/functions/_backend/private/admin_stats.ts
+++ b/supabase/functions/_backend/private/admin_stats.ts
@@ -91,6 +91,25 @@ interface AdminStatsBody {
   offset?: number
 }
 
+export function buildAdminStatsLogContext(body: Partial<AdminStatsBody>) {
+  const context: Partial<AdminStatsBody> = {
+    metric_category: body.metric_category,
+    start_date: body.start_date,
+    end_date: body.end_date,
+  }
+
+  if (body.app_id)
+    context.app_id = body.app_id
+  if (body.org_id)
+    context.org_id = body.org_id
+  if (typeof body.limit === 'number')
+    context.limit = body.limit
+  if (typeof body.offset === 'number')
+    context.offset = body.offset
+
+  return context
+}
+
 type CancellationDetails = Stripe.Subscription.CancellationDetails
 
 const cancellationFeedbackLabels: Record<string, string> = {
@@ -154,7 +173,7 @@ app.post('/', middlewareAuth, async (c) => {
   }
 
   if (!isAdmin) {
-    cloudlog({ requestId: c.get('requestId'), message: 'not_admin', body })
+    cloudlog({ requestId: c.get('requestId'), message: 'not_admin', body: buildAdminStatsLogContext(parsedBodyResult.data) })
     throw simpleError('not_admin', 'Not admin - only admin users can access platform statistics')
   }
 

--- a/tests/admin-stats.unit.test.ts
+++ b/tests/admin-stats.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { adminStatsBodySchema, MAX_ADMIN_STATS_LIMIT, MAX_ADMIN_STATS_OFFSET } from '../supabase/functions/_backend/private/admin_stats.ts'
+import { adminStatsBodySchema, buildAdminStatsLogContext, MAX_ADMIN_STATS_LIMIT, MAX_ADMIN_STATS_OFFSET } from '../supabase/functions/_backend/private/admin_stats.ts'
 import { safeParseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
 import { buildPluginBreakdownResult, normalizeAnalyticsLimit } from '../supabase/functions/_backend/utils/cloudflare.ts'
 
@@ -47,6 +47,32 @@ describe('admin stats validation', () => {
     })
 
     expect(parsed.success).toBe(true)
+  })
+
+  it('keeps caller-supplied extra fields out of admin stats log context', () => {
+    const parsed = safeParseSchema(adminStatsBodySchema, {
+      ...baseBody,
+      app_id: 'com.capgo.app',
+      limit: 25,
+      token: 'secret-token',
+      authorization: 'Bearer secret',
+    })
+
+    expect(parsed.success).toBe(true)
+    if (!parsed.success)
+      return
+
+    const context = buildAdminStatsLogContext(parsed.data)
+
+    expect(context).toEqual({
+      metric_category: 'org_metrics',
+      start_date: '2025-01-01T00:00:00.000Z',
+      end_date: '2025-01-31T00:00:00.000Z',
+      app_id: 'com.capgo.app',
+      limit: 25,
+    })
+    expect(context).not.toHaveProperty('token')
+    expect(context).not.toHaveProperty('authorization')
   })
 
   it.each([


### PR DESCRIPTION
## Summary
- Replace the unauthorized admin_stats body log with a whitelisted request context
- Keep caller-supplied extra JSON fields out of logs while preserving metric/date/filter context
- Add a unit test covering extra-field redaction after schema validation

## Verification
- bun x vitest run tests/admin-stats.unit.test.ts
- bun x eslint supabase/functions/_backend/private/admin_stats.ts tests/admin-stats.unit.test.ts

Related to #1667