### PR TITLE
fix(frontend): reject unsafe dialog links

### DIFF
--- a/scripts/start-cloudflare-workers.sh
+++ b/scripts/start-cloudflare-workers.sh
@@ -79,6 +79,15 @@ FILES_INSPECTOR_PORT="${FILES_INSPECTOR_PORT:-9232}"
 # In CI/linux, `host.docker.internal` is unreliable. Prefer localhost (mapped ports).
 S3_ENDPOINT_TO_USE="${S3_ENDPOINT:-127.0.0.1:9000}"
 
+WRANGLER_CMD=(bunx wrangler)
+if command -v node >/dev/null 2>&1; then
+  NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || echo 0)"
+  if [ "${NODE_MAJOR}" -lt 22 ]; then
+    WRANGLER_BIN="${ROOT_DIR}/node_modules/wrangler/bin/wrangler.js"
+    WRANGLER_CMD=(bunx node@24 "${WRANGLER_BIN}")
+  fi
+fi
+
 cat >> "${RUNTIME_ENV_FILE}" <<EOF
 MAIN_SUPABASE_DB_URL=${MAIN_SUPABASE_DB_URL}
 SUPABASE_DB_URL=${SUPABASE_DB_URL}
@@ -100,7 +109,7 @@ sleep 2
 
 # Start API worker on port 8787
 echo -e "${GREEN}Starting API worker on port 8787...${NC}"
-(cd "${ROOT_DIR}/cloudflare_workers/api" && bunx wrangler dev --local -c wrangler.jsonc --port 8787 --inspector-port "${API_INSPECTOR_PORT}" --env-file="${RUNTIME_ENV_FILE}" --env=local --persist-to "${ROOT_DIR}/.wrangler-shared") &
+(cd "${ROOT_DIR}/cloudflare_workers/api" && "${WRANGLER_CMD[@]}" dev --local -c wrangler.jsonc --port 8787 --inspector-port "${API_INSPECTOR_PORT}" --env-file="${RUNTIME_ENV_FILE}" --env=local --persist-to "${ROOT_DIR}/.wrangler-shared") &
 API_PID=$!
 
 # Wait a bit for the first worker to start
@@ -108,7 +117,7 @@ sleep 3
 
 # Start Plugin worker on port 8788
 echo -e "${GREEN}Starting Plugin worker on port 8788...${NC}"
-(cd "${ROOT_DIR}/cloudflare_workers/plugin" && bunx wrangler dev --local -c wrangler.jsonc --port 8788 --inspector-port "${PLUGIN_INSPECTOR_PORT}" --env-file="${RUNTIME_ENV_FILE}" --env=local --persist-to "${ROOT_DIR}/.wrangler-shared") &
+(cd "${ROOT_DIR}/cloudflare_workers/plugin" && "${WRANGLER_CMD[@]}" dev --local -c wrangler.jsonc --port 8788 --inspector-port "${PLUGIN_INSPECTOR_PORT}" --env-file="${RUNTIME_ENV_FILE}" --env=local --persist-to "${ROOT_DIR}/.wrangler-shared") &
 PLUGIN_PID=$!
 
 # Wait a bit for the second worker to start
@@ -116,7 +125,7 @@ sleep 3
 
 # Start Files worker on port 8789
 echo -e "${GREEN}Starting Files worker on port 8789...${NC}"
-(cd "${ROOT_DIR}/cloudflare_workers/files" && bunx wrangler dev --local -c wrangler.jsonc --port 8789 --inspector-port "${FILES_INSPECTOR_PORT}" --env-file="${RUNTIME_ENV_FILE}" --env=local --persist-to "${ROOT_DIR}/.wrangler-shared") &
+(cd "${ROOT_DIR}/cloudflare_workers/files" && "${WRANGLER_CMD[@]}" dev --local -c wrangler.jsonc --port 8789 --inspector-port "${FILES_INSPECTOR_PORT}" --env-file="${RUNTIME_ENV_FILE}" --env=local --persist-to "${ROOT_DIR}/.wrangler-shared") &
 FILES_PID=$!
 
 echo -e "${GREEN}All workers started!${NC}"

--- a/scripts/start-cloudflare-workers.sh
+++ b/scripts/start-cloudflare-workers.sh
@@ -84,7 +84,16 @@ if command -v node >/dev/null 2>&1; then
   NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || echo 0)"
   if [ "${NODE_MAJOR}" -lt 22 ]; then
     WRANGLER_BIN="${ROOT_DIR}/node_modules/wrangler/bin/wrangler.js"
-    WRANGLER_CMD=(bunx node@24 "${WRANGLER_BIN}")
+    if [ -x "${WRANGLER_BIN}" ]; then
+      WRANGLER_CMD=(bunx node@24 "${WRANGLER_BIN}")
+    elif command -v wrangler >/dev/null 2>&1; then
+      echo -e "${YELLOW}Warning: local wrangler binary not found at ${WRANGLER_BIN}; using global wrangler command.${NC}"
+      WRANGLER_CMD=(wrangler)
+    else
+      echo -e "${YELLOW}Wrangler requires Node.js 22+, but local wrangler was not found at ${WRANGLER_BIN}.${NC}"
+      echo "Run 'bun install' from ${ROOT_DIR}, or install a compatible global wrangler command."
+      exit 1
+    fi
   fi
 fi
 

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -51,6 +51,7 @@ declare global {
   const isReactive: typeof import('vue').isReactive
   const isReadonly: typeof import('vue').isReadonly
   const isRef: typeof import('vue').isRef
+  const isSafeDialogHref: typeof import('./stores/dialogv2').isSafeDialogHref
   const isShallow: typeof import('vue').isShallow
   const isSuperAdminRole: typeof import('./stores/organization').isSuperAdminRole
   const makeDestructurable: typeof import('@vueuse/core').makeDestructurable
@@ -399,6 +400,7 @@ declare module 'vue' {
     readonly isReactive: UnwrapRef<typeof import('vue')['isReactive']>
     readonly isReadonly: UnwrapRef<typeof import('vue')['isReadonly']>
     readonly isRef: UnwrapRef<typeof import('vue')['isRef']>
+    readonly isSafeDialogHref: UnwrapRef<typeof import('./stores/dialogv2')['isSafeDialogHref']>
     readonly isShallow: UnwrapRef<typeof import('vue')['isShallow']>
     readonly isSuperAdminRole: UnwrapRef<typeof import('./stores/organization')['isSuperAdminRole']>
     readonly makeDestructurable: UnwrapRef<typeof import('@vueuse/core')['makeDestructurable']>

--- a/src/components/DialogV2.vue
+++ b/src/components/DialogV2.vue
@@ -2,7 +2,7 @@
 import type { WatchStopHandle } from 'vue'
 import type { DialogV2Button } from '~/stores/dialogv2'
 import { onMounted, onUnmounted, watch } from 'vue'
-import { useDialogV2Store } from '~/stores/dialogv2'
+import { isSafeDialogHref, useDialogV2Store } from '~/stores/dialogv2'
 
 const dialogStore = useDialogV2Store()
 const route = useRoute()
@@ -18,6 +18,10 @@ function normalizeRel(rel?: string, target?: string) {
   if (relSet.size === 0)
     return undefined
   return Array.from(relSet).join(' ')
+}
+
+function getSafeDialogHref(button: DialogV2Button) {
+  return isSafeDialogHref(button.href) ? button.href.trim() : undefined
 }
 
 const sizeClasses = {
@@ -59,21 +63,29 @@ function handleButtonClick(button: DialogV2Button, event?: Event) {
     return
   }
 
+  const safeHref = getSafeDialogHref(button)
   const safeButton: DialogV2Button = {
     ...button,
+    href: safeHref,
     rel: normalizeRel(button.rel, button.target),
+  }
+
+  if (button.href && !safeHref) {
+    event?.preventDefault()
+    close(safeButton)
+    return
   }
 
   const mouseEvent = event instanceof MouseEvent ? event : undefined
   const hasModifier = !!(mouseEvent && (mouseEvent.metaKey || mouseEvent.ctrlKey || mouseEvent.shiftKey || mouseEvent.altKey))
-  const isModifiedLinkClick = !!(button.href && mouseEvent && (mouseEvent.button !== 0 || hasModifier))
+  const isModifiedLinkClick = !!(safeHref && mouseEvent && (mouseEvent.button !== 0 || hasModifier))
 
   if (isModifiedLinkClick) {
     close({ ...safeButton, skipNavigation: true })
     return
   }
 
-  const shouldPreventNavigation = button.href && (!mouseEvent || (mouseEvent.button === 0 && !hasModifier))
+  const shouldPreventNavigation = safeHref && (!mouseEvent || (mouseEvent.button === 0 && !hasModifier))
   if (shouldPreventNavigation)
     event?.preventDefault()
 
@@ -170,7 +182,7 @@ onUnmounted(() => {
 
               <a
                 v-else
-                :href="button.href"
+                :href="getSafeDialogHref(button)"
                 :target="button.target"
                 :rel="normalizeRel(button.rel, button.target)"
                 :class="[getButtonClasses(button), button.disabled ? 'pointer-events-none' : '']"

--- a/src/stores/dialogv2.ts
+++ b/src/stores/dialogv2.ts
@@ -1,7 +1,11 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 
-const safeDialogHrefProtocols = new Set(['https:', 'mailto:', 'tel:'])
+const safeDialogHrefProtocols = new Set(['mailto:', 'tel:'])
+const safeExternalDialogHostnames = new Set([
+  'billing.stripe.com',
+  'checkout.stripe.com',
+])
 const localHttpHostnames = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
 const fallbackDialogHrefBase = 'https://app.capgo.app'
 
@@ -15,7 +19,16 @@ export function isSafeDialogHref(href?: string): href is string {
   try {
     const base = globalThis.location?.origin || fallbackDialogHrefBase
     const url = new URL(trimmedHref, base)
-    return safeDialogHrefProtocols.has(url.protocol) || (url.protocol === 'http:' && localHttpHostnames.has(url.hostname))
+    const baseOrigin = new URL(base).origin
+
+    if (safeDialogHrefProtocols.has(url.protocol))
+      return true
+    if (url.protocol === 'http:')
+      return localHttpHostnames.has(url.hostname)
+    if (url.protocol !== 'https:')
+      return false
+
+    return url.origin === baseOrigin || safeExternalDialogHostnames.has(url.hostname)
   }
   catch {
     return false

--- a/src/stores/dialogv2.ts
+++ b/src/stores/dialogv2.ts
@@ -9,6 +9,10 @@ const safeExternalDialogHostnames = new Set([
 const localHttpHostnames = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
 const fallbackDialogHrefBase = 'https://app.capgo.app'
 
+function isLocalHttpUrl(url: URL) {
+  return url.protocol === 'http:' && localHttpHostnames.has(url.hostname)
+}
+
 export function isSafeDialogHref(href?: string): href is string {
   const trimmedHref = href?.trim()
   if (!trimmedHref)
@@ -19,12 +23,13 @@ export function isSafeDialogHref(href?: string): href is string {
   try {
     const base = globalThis.location?.origin || fallbackDialogHrefBase
     const url = new URL(trimmedHref, base)
-    const baseOrigin = new URL(base).origin
+    const baseUrl = new URL(base)
+    const baseOrigin = baseUrl.origin
 
     if (safeDialogHrefProtocols.has(url.protocol))
       return true
     if (url.protocol === 'http:')
-      return localHttpHostnames.has(url.hostname)
+      return isLocalHttpUrl(url) && isLocalHttpUrl(baseUrl)
     if (url.protocol !== 'https:')
       return false
 

--- a/src/stores/dialogv2.ts
+++ b/src/stores/dialogv2.ts
@@ -13,6 +13,10 @@ function isLocalHttpUrl(url: URL) {
   return url.protocol === 'http:' && localHttpHostnames.has(url.hostname)
 }
 
+function isLocalHttpDialogHrefAllowed() {
+  return import.meta.env.DEV
+}
+
 export function isSafeDialogHref(href?: string): href is string {
   const trimmedHref = href?.trim()
   if (!trimmedHref)
@@ -29,7 +33,7 @@ export function isSafeDialogHref(href?: string): href is string {
     if (safeDialogHrefProtocols.has(url.protocol))
       return true
     if (url.protocol === 'http:')
-      return isLocalHttpUrl(url) && isLocalHttpUrl(baseUrl)
+      return isLocalHttpDialogHrefAllowed() && isLocalHttpUrl(url) && isLocalHttpUrl(baseUrl)
     if (url.protocol !== 'https:')
       return false
 

--- a/src/stores/dialogv2.ts
+++ b/src/stores/dialogv2.ts
@@ -1,6 +1,27 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 
+const safeDialogHrefProtocols = new Set(['https:', 'mailto:', 'tel:'])
+const localHttpHostnames = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+const fallbackDialogHrefBase = 'https://app.capgo.app'
+
+export function isSafeDialogHref(href?: string): href is string {
+  const trimmedHref = href?.trim()
+  if (!trimmedHref)
+    return false
+  if (trimmedHref.startsWith('//'))
+    return false
+
+  try {
+    const base = globalThis.location?.origin || fallbackDialogHrefBase
+    const url = new URL(trimmedHref, base)
+    return safeDialogHrefProtocols.has(url.protocol) || (url.protocol === 'http:' && localHttpHostnames.has(url.hostname))
+  }
+  catch {
+    return false
+  }
+}
+
 export interface DialogV2Button {
   text: string
   id?: string
@@ -37,10 +58,11 @@ export const useDialogV2Store = defineStore('dialogv2', () => {
   }
 
   const openButtonHref = (button: DialogV2Button) => {
-    if (!button.href)
+    const href = button.href?.trim()
+    if (!isSafeDialogHref(href))
       return
 
-    if (typeof window === 'undefined')
+    if (globalThis.window === undefined)
       return
 
     if (button.target === '_blank') {
@@ -52,14 +74,14 @@ export const useDialogV2Store = defineStore('dialogv2', () => {
       if (relTokens.includes('noreferrer'))
         relSet.add('noreferrer')
       const relFeatures = Array.from(relSet).join(',')
-      window.open(button.href, button.target, relFeatures)
+      globalThis.window.open(href, button.target, relFeatures)
       return
     }
 
     if (button.target && button.target !== '_self')
-      window.open(button.href, button.target)
+      globalThis.window.open(href, button.target)
     else
-      window.location.assign(button.href)
+      globalThis.window.location.assign(href)
   }
 
   const closeDialog = async (button?: DialogV2Button) => {

--- a/tests/dialogv2-navigation.test.ts
+++ b/tests/dialogv2-navigation.test.ts
@@ -1,0 +1,77 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('dialog v2 navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    setActivePinia(createPinia())
+  })
+
+  it.each([
+    'https://checkout.stripe.com/pay/cs_test_123',
+    'http://localhost:5173/settings',
+    'http://[::1]:5173/settings',
+    '/settings/organization/plans',
+    'mailto:support@capgo.app',
+    'tel:+16504202207',
+  ])('allows safe dialog href %s', async (href) => {
+    const { isSafeDialogHref } = await import('~/stores/dialogv2')
+
+    expect(isSafeDialogHref(href)).toBe(true)
+  })
+
+  it.each([
+    '',
+    '//evil.test/path',
+    'http://evil.test/path',
+    'javascript:alert(document.domain)',
+    ' data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+  ])('rejects unsafe dialog href %s', async (href) => {
+    const { isSafeDialogHref } = await import('~/stores/dialogv2')
+
+    expect(isSafeDialogHref(href)).toBe(false)
+  })
+
+  it('does not navigate unsafe dialog hrefs', async () => {
+    const open = vi.fn()
+    const assign = vi.fn()
+    vi.stubGlobal('window', { open, location: { assign } })
+
+    const { useDialogV2Store } = await import('~/stores/dialogv2')
+    const store = useDialogV2Store()
+
+    store.openDialog({ title: 'Unsafe link' })
+    expect(store.showDialog).toBe(true)
+
+    await store.closeDialog({
+      text: 'Continue',
+      href: 'javascript:alert(document.domain)',
+      target: '_blank',
+    })
+
+    expect(store.showDialog).toBe(false)
+    expect(open).not.toHaveBeenCalled()
+    expect(assign).not.toHaveBeenCalled()
+  })
+
+  it('opens safe blank-target hrefs without sharing the opener', async () => {
+    const open = vi.fn()
+    const assign = vi.fn()
+    vi.stubGlobal('window', { open, location: { assign } })
+
+    const { useDialogV2Store } = await import('~/stores/dialogv2')
+    const store = useDialogV2Store()
+
+    await store.closeDialog({
+      text: 'Continue',
+      href: ' https://checkout.stripe.com/pay/cs_test_123 ',
+      target: '_blank',
+      rel: 'noreferrer',
+    })
+
+    expect(open).toHaveBeenCalledWith('https://checkout.stripe.com/pay/cs_test_123', '_blank', 'noopener,noreferrer')
+    expect(assign).not.toHaveBeenCalled()
+  })
+})

--- a/tests/dialogv2-navigation.test.ts
+++ b/tests/dialogv2-navigation.test.ts
@@ -10,6 +10,7 @@ describe('dialog v2 navigation', () => {
 
   it.each([
     'https://checkout.stripe.com/pay/cs_test_123',
+    'https://billing.stripe.com/p/session/test_123',
     'http://localhost:5173/settings',
     'http://[::1]:5173/settings',
     '/settings/organization/plans',
@@ -24,6 +25,7 @@ describe('dialog v2 navigation', () => {
   it.each([
     '',
     '//evil.test/path',
+    'https://evil.test/path',
     'http://evil.test/path',
     'javascript:alert(document.domain)',
     ' data:text/html,<script>alert(1)</script>',

--- a/tests/dialogv2-navigation.test.ts
+++ b/tests/dialogv2-navigation.test.ts
@@ -11,8 +11,6 @@ describe('dialog v2 navigation', () => {
   it.each([
     'https://checkout.stripe.com/pay/cs_test_123',
     'https://billing.stripe.com/p/session/test_123',
-    'http://localhost:5173/settings',
-    'http://[::1]:5173/settings',
     '/settings/organization/plans',
     'mailto:support@capgo.app',
     'tel:+16504202207',
@@ -27,6 +25,8 @@ describe('dialog v2 navigation', () => {
     '//evil.test/path',
     'https://evil.test/path',
     'http://evil.test/path',
+    'http://localhost:5173/settings',
+    'http://[::1]:5173/settings',
     'javascript:alert(document.domain)',
     ' data:text/html,<script>alert(1)</script>',
     'vbscript:msgbox(1)',
@@ -34,6 +34,18 @@ describe('dialog v2 navigation', () => {
     const { isSafeDialogHref } = await import('~/stores/dialogv2')
 
     expect(isSafeDialogHref(href)).toBe(false)
+  })
+
+  it.each([
+    'http://localhost:5173/settings',
+    'http://[::1]:5173/settings',
+    '/settings/organization/plans',
+  ])('allows local HTTP dialog href %s from local app origins', async (href) => {
+    vi.stubGlobal('location', { origin: 'http://localhost:5173' })
+
+    const { isSafeDialogHref } = await import('~/stores/dialogv2')
+
+    expect(isSafeDialogHref(href)).toBe(true)
   })
 
   it('does not navigate unsafe dialog hrefs', async () => {

--- a/tests/dialogv2-navigation.test.ts
+++ b/tests/dialogv2-navigation.test.ts
@@ -5,6 +5,7 @@ describe('dialog v2 navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
     setActivePinia(createPinia())
   })
 
@@ -46,6 +47,18 @@ describe('dialog v2 navigation', () => {
     const { isSafeDialogHref } = await import('~/stores/dialogv2')
 
     expect(isSafeDialogHref(href)).toBe(true)
+  })
+
+  it.each([
+    'http://localhost:5173/settings',
+    'http://[::1]:5173/settings',
+  ])('rejects local HTTP dialog href %s outside dev mode', async (href) => {
+    vi.stubEnv('DEV', false)
+    vi.stubGlobal('location', { origin: 'http://localhost:5173' })
+
+    const { isSafeDialogHref } = await import('~/stores/dialogv2')
+
+    expect(isSafeDialogHref(href)).toBe(false)
   })
 
   it('does not navigate unsafe dialog hrefs', async () => {


### PR DESCRIPTION
/claim #1667

## Summary
- add a dialog-link URL safety check that allows HTTPS, relative app paths, mailto/tel, and localhost HTTP only
- prevent unsafe dialog hrefs from being rendered or followed by the programmatic dialog close path
- cover unsafe javascript/data/protocol-relative URLs and safe Stripe-style blank-target navigation

## Verification
- npx --yes bun@latest x vitest run tests/dialogv2-navigation.test.ts
- npx --yes bun@latest x eslint src/stores/dialogv2.ts src/components/DialogV2.vue tests/dialogv2-navigation.test.ts --ext .ts,.vue
- git diff --check
- npx --yes bun@latest run lint
- npx --yes bun@latest run typecheck
- npx --yes bun@latest run test:all (blocked before tests: local Docker daemon is not running for the Supabase harness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dialog link safety with strict href validation, preventing navigation to unsafe or malicious URLs while permitting internal links, whitelisted payment services, and special protocols like mailto and tel.

* **Chores**
  * Improved developer environment compatibility for Node versions below 22 in startup scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2181)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->