### PR TITLE
fix(api): redact invitation accept token logs

### DIFF
--- a/supabase/functions/_backend/private/accept_invitation.ts
+++ b/supabase/functions/_backend/private/accept_invitation.ts
@@ -272,8 +272,8 @@ app.post('/', async (c) => {
   }
 
   const baseBody = baseValidationResult.data
-  const { password: _password, captchaToken: _captchaToken, ...baseBodyWithoutSecrets } = baseBody
-  cloudlog({ requestId: c.get('requestId'), context: 'accept_invitation raw body', rawBody: baseBodyWithoutSecrets })
+  const { password: _password, captchaToken: _captchaToken, magic_invite_string: _magicInviteString, ...baseBodyWithoutSecrets } = baseBody
+  cloudlog({ requestId: c.get('requestId'), context: 'accept_invitation raw body', rawBody: { ...baseBodyWithoutSecrets, has_magic_invite_string: true } })
 
   const supabaseAdmin = useSupabaseAdmin(c)
 
@@ -373,8 +373,8 @@ app.post('/', async (c) => {
     ...baseBody,
     password: baseBody.password,
   }
-  const { password: _pwd, captchaToken: _cap, ...bodyWithoutSecrets } = body
-  cloudlog({ requestId: c.get('requestId'), context: 'accept_invitation validated body', body: bodyWithoutSecrets })
+  const { password: _pwd, captchaToken: _cap, magic_invite_string: _magic, ...bodyWithoutSecrets } = body
+  cloudlog({ requestId: c.get('requestId'), context: 'accept_invitation validated body', body: { ...bodyWithoutSecrets, has_magic_invite_string: true } })
 
   // here the real magic happens
   const { data: user, error: userError } = await supabaseAdmin.auth.admin.createUser({

--- a/tests/accept-invitation-redaction.unit.test.ts
+++ b/tests/accept-invitation-redaction.unit.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { app as acceptInvitationApp } from '../supabase/functions/_backend/private/accept_invitation.ts'
+
+const {
+  cloudlogMock,
+  createUserMock,
+  invitationState,
+} = vi.hoisted(() => ({
+  cloudlogMock: vi.fn(),
+  createUserMock: vi.fn(),
+  invitationState: {
+    invitation: null as any,
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: vi.fn(),
+  serializeError: (error: unknown) => ({
+    message: error instanceof Error ? error.message : String(error),
+    name: error instanceof Error ? error.name : 'Error',
+    stack: error instanceof Error ? error.stack ?? 'N/A' : 'N/A',
+  }),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  emptySupabase: vi.fn(),
+  supabaseAdmin: () => ({
+    auth: {
+      admin: {
+        createUser: createUserMock,
+      },
+    },
+    from: (table: string) => {
+      if (table === 'tmp_users') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: invitationState.invitation,
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'orgs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: {
+                  password_policy_config: null,
+                  use_new_rbac: false,
+                },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    },
+  }),
+}))
+
+function acceptInvitationRequest() {
+  return acceptInvitationApp.request('http://local/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      captchaToken: 'captcha-secret-token',
+      magic_invite_string: 'invite-bearer-token-secret',
+      opt_for_newsletters: false,
+      password: 'ValidPassword123!',
+    }),
+  })
+}
+
+function expectLoggedInviteBodyIsRedacted() {
+  const serializedLogs = JSON.stringify(cloudlogMock.mock.calls)
+  expect(serializedLogs).not.toContain('invite-bearer-token-secret')
+  expect(serializedLogs).not.toContain('ValidPassword123!')
+  expect(serializedLogs).not.toContain('captcha-secret-token')
+  expect(serializedLogs).toContain('has_magic_invite_string')
+}
+
+beforeEach(() => {
+  cloudlogMock.mockReset()
+  createUserMock.mockReset()
+  createUserMock.mockResolvedValue({
+    data: null,
+    error: new Error('create user stopped by test'),
+  })
+  invitationState.invitation = {
+    cancelled_at: null,
+    email: 'invitee@example.com',
+    future_uuid: '00f6d303-9514-4c56-83d5-7fbcfb0f4dd0',
+    org_id: 'org-id',
+    right: 'read',
+  }
+})
+
+describe('accept invitation log redaction', () => {
+  it('does not log the invite token before invitation lookup failures', async () => {
+    invitationState.invitation = null
+
+    await acceptInvitationRequest()
+
+    expectLoggedInviteBodyIsRedacted()
+  })
+
+  it('does not log the invite token after validation succeeds', async () => {
+    await acceptInvitationRequest()
+
+    expectLoggedInviteBodyIsRedacted()
+  })
+})


### PR DESCRIPTION
## Summary

- Stop logging `magic_invite_string` in the accept-invitation raw and validated body logs.
- Keep a boolean `has_magic_invite_string` marker so the logs retain request-shape context without storing the bearer token.
- Add a focused unit test for the lookup-failure and validated-body paths.

## Root cause

The accept-invitation handler removed `password` and `captchaToken` before logging request bodies, but left `magic_invite_string`. That invite string is the bearer credential from the invite link and may still be valid when validation or account creation fails.

## Validation

- `bunx vitest run tests/accept-invitation-redaction.unit.test.ts`
- `bun x eslint supabase/functions/_backend/private/accept_invitation.ts tests/accept-invitation-redaction.unit.test.ts`
- `git diff --check`