### PR TITLE
fix: reduce sensitive backend request logging

### DIFF
--- a/supabase/functions/_backend/private/delete_failed_version.ts
+++ b/supabase/functions/_backend/private/delete_failed_version.ts
@@ -24,8 +24,8 @@ app.delete('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
     cloudlog({
       requestId: c.get('requestId'),
       message: 'apikey context',
-      apikeyId: (apikey as { id?: number }).id,
-      userId: (apikey as { user_id?: string }).user_id,
+      hasApikey: !!(apikey as { id?: number }).id,
+      hasUser: !!(apikey as { user_id?: string }).user_id,
       mode: (apikey as { mode?: string }).mode,
     })
   }

--- a/supabase/functions/_backend/private/delete_failed_version.ts
+++ b/supabase/functions/_backend/private/delete_failed_version.ts
@@ -17,7 +17,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.delete('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
   const body = await parseBody<DataUpload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'delete failed version body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'delete failed version request', app_id: body.app_id, hasName: !!body.name })
   const apikey = c.get('apikey')
   const capgkey = c.get('capgkey') as string
   if (apikey && typeof apikey === 'object') {

--- a/supabase/functions/_backend/private/delete_failed_version.ts
+++ b/supabase/functions/_backend/private/delete_failed_version.ts
@@ -17,7 +17,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.delete('/', middlewareKey(['all', 'write', 'upload']), async (c) => {
   const body = await parseBody<DataUpload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'delete failed version request', app_id: body.app_id, hasName: !!body.name })
+  cloudlog({ requestId: c.get('requestId'), message: 'delete failed version request', hasAppId: !!body.app_id, hasName: !!body.name })
   const apikey = c.get('apikey')
   const capgkey = c.get('capgkey') as string
   if (apikey && typeof apikey === 'object') {

--- a/supabase/functions/_backend/private/download_link.ts
+++ b/supabase/functions/_backend/private/download_link.ts
@@ -20,7 +20,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<DataDownload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post download link request', app_id: body.app_id, bundleId: body.id, storage_provider: body.storage_provider, isManifest: !!body.isManifest })
+  cloudlog({ requestId: c.get('requestId'), message: 'post download link request', hasAppId: !!body.app_id, hasBundleId: !!body.id, storage_provider: body.storage_provider, isManifest: !!body.isManifest })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('cannot_find_authorization', 'Cannot find authorization')

--- a/supabase/functions/_backend/private/download_link.ts
+++ b/supabase/functions/_backend/private/download_link.ts
@@ -20,7 +20,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<DataDownload>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post download link body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post download link request', app_id: body.app_id, bundleId: body.id, storage_provider: body.storage_provider, isManifest: !!body.isManifest })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('cannot_find_authorization', 'Cannot find authorization')

--- a/supabase/functions/_backend/private/stripe_checkout.ts
+++ b/supabase/functions/_backend/private/stripe_checkout.ts
@@ -23,7 +23,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<CheckoutData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout request', orgId: body.orgId, recurrence: body.recurrence, hasClientReferenceId: !!body.clientReferenceId, hasAttributionId: !!body.attributionId, hasSuccessUrl: !!body.successUrl, hasCancelUrl: !!body.cancelUrl })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout request', hasOrgId: !!body.orgId, recurrence: body.recurrence, hasClientReferenceId: !!body.clientReferenceId, hasAttributionId: !!body.attributionId, hasSuccessUrl: !!body.successUrl, hasCancelUrl: !!body.cancelUrl })
 
   if (!body.orgId)
     throw simpleError('no_org_id_provided', 'No org_id provided')

--- a/supabase/functions/_backend/private/stripe_checkout.ts
+++ b/supabase/functions/_backend/private/stripe_checkout.ts
@@ -23,7 +23,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<CheckoutData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe checkout request', orgId: body.orgId, recurrence: body.recurrence, hasClientReferenceId: !!body.clientReferenceId, hasAttributionId: !!body.attributionId, hasSuccessUrl: !!body.successUrl, hasCancelUrl: !!body.cancelUrl })
 
   if (!body.orgId)
     throw simpleError('no_org_id_provided', 'No org_id provided')
@@ -40,7 +40,6 @@ app.post('/', middlewareAuth, async (c) => {
   // Use authenticated client - RLS will enforce access based on JWT
   const supabase = supabaseClient(c, authorization)
 
-  cloudlog({ requestId: c.get('requestId'), message: 'auth', auth: authContext.userId })
   const { data: org, error: dbError } = await supabase
     .from('orgs')
     .select('customer_id')
@@ -54,7 +53,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
     throw simpleError('not_authorize', 'Not authorize')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'user', org })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe checkout org loaded', hasCustomer: !!org.customer_id })
   const checkout = await createCheckout(c, org.customer_id, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId)
   return c.json({ url: checkout.url })
 })

--- a/supabase/functions/_backend/private/stripe_portal.ts
+++ b/supabase/functions/_backend/private/stripe_portal.ts
@@ -17,7 +17,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<PortalData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal request', orgId: body.orgId, hasCallbackUrl: !!body.callbackUrl })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal request', hasOrgId: !!body.orgId, hasCallbackUrl: !!body.callbackUrl })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('not_authorized', 'Not authorized')

--- a/supabase/functions/_backend/private/stripe_portal.ts
+++ b/supabase/functions/_backend/private/stripe_portal.ts
@@ -17,7 +17,7 @@ app.use('/', useCors)
 
 app.post('/', middlewareAuth, async (c) => {
   const body = await parseBody<PortalData>(c)
-  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal body', body })
+  cloudlog({ requestId: c.get('requestId'), message: 'post stripe portal request', orgId: body.orgId, hasCallbackUrl: !!body.callbackUrl })
   const authorization = c.get('authorization')
   if (!authorization)
     throw simpleError('not_authorized', 'Not authorized')
@@ -30,7 +30,6 @@ app.post('/', middlewareAuth, async (c) => {
   if (!authContext?.userId)
     throw simpleError('not_authorized', 'Not authorized')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'auth', auth: authContext.userId })
   const { data: org, error: dbError } = await supabase
     .from('orgs')
     .select('customer_id')
@@ -44,7 +43,7 @@ app.post('/', middlewareAuth, async (c) => {
   if (!await checkPermission(c, 'org.update_billing', { orgId: body.orgId }))
     throw simpleError('not_authorize', 'Not authorize')
 
-  cloudlog({ requestId: c.get('requestId'), message: 'org', org })
+  cloudlog({ requestId: c.get('requestId'), message: 'stripe portal org loaded', hasCustomer: !!org.customer_id })
   const link = await createPortal(c, org.customer_id, body.callbackUrl)
   return c.json({ url: link.url })
 })


### PR DESCRIPTION
## Summary

- replace full request-body logging in billing/download/delete-failed-version endpoints with metadata-only summaries
- avoid logging raw Stripe customer IDs from loaded org rows
- preserve request flow and permission checks; this only reduces routine log retention

## Security note

This is a public-safe log hardening change for the security retribution thread. It avoids retaining callback/success/cancel URLs, client reference IDs, attribution IDs, bundle names, and raw customer IDs in routine cloud logs where presence flags or stable IDs are enough for debugging.

Related: #1667
/claim #1667

## Testing

- `git diff --check`
- `bun run lint:backend` could not be run locally because `bun` is not installed in this environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced raw request-body logging with structured, presence-flag style logs across several private backend endpoints to reduce exposed data in logs and improve observability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2186)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->