### PR TITLE
fix: route app settings updates through API

### DIFF
--- a/src/components/dashboard/AppSetting.vue
+++ b/src/components/dashboard/AppSetting.vue
@@ -15,7 +15,7 @@ import iconName from '~icons/ph/user?raw'
 import Toggle from '~/components/Toggle.vue'
 import { checkPermissions } from '~/services/permissions'
 import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
-import { useSupabase } from '~/services/supabase'
+import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
 
 const props = defineProps<{ appId: string }>()
@@ -84,6 +84,25 @@ const isImportingStoreIcon = ref(false)
 const isAppIconLoading = ref(false)
 
 const isCustomRetention = computed(() => selectedRetentionPreset.value === -1)
+
+async function updateAppSettings(payload: Partial<Database['public']['Tables']['apps']['Update']>) {
+  const { data: currentSession } = await supabase.auth.getSession()
+  const currentJwt = currentSession.session?.access_token
+  if (!currentJwt)
+    throw new Error('Not authorized')
+
+  const response = await fetch(`${defaultApiHost}/app/${props.appId}`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${currentJwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok)
+    throw new Error(`Unable to update app settings: HTTP ${response.status}`)
+}
 
 const retentionOptions = computed(() => {
   return RETENTION_PRESETS.map(preset => ({
@@ -435,8 +454,10 @@ async function updateAppName(newName: string) {
     return Promise.reject(t('new-name-to-long'))
   }
 
-  const { error } = await supabase.from('apps').update({ name: newName }).eq('app_id', props.appId)
-  if (error) {
+  try {
+    await updateAppSettings({ name: newName })
+  }
+  catch (error) {
     toast.error(t('cannot-change-name'))
     console.error(error)
     return
@@ -461,8 +482,10 @@ async function updateAppRetention(newRetention: number) {
     return Promise.reject(t('retention-to-big'))
   }
 
-  const { error } = await supabase.from('apps').update({ retention: newRetention }).eq('app_id', props.appId)
-  if (error) {
+  try {
+    await updateAppSettings({ retention: newRetention })
+  }
+  catch {
     return Promise.reject(t('cannot-change-retention'))
   }
   toast.success(t('changed-app-retention'))
@@ -483,9 +506,12 @@ async function updateBuildTimeout(rawTimeoutMinutes: number | string | undefined
   if (timeoutSeconds === appRef.value?.build_timeout_seconds)
     return
 
-  const { error } = await supabase.from('apps').update({ build_timeout_seconds: timeoutSeconds }).eq('app_id', props.appId)
-  if (error)
+  try {
+    await updateAppSettings({ build_timeout_seconds: timeoutSeconds })
+  }
+  catch {
     throw t('cannot-change-build-timeout')
+  }
 
   toast.success(t('changed-build-timeout'))
   if (appRef.value)
@@ -497,8 +523,10 @@ async function updateExposeMetadata(newExposeMetadata: boolean) {
     return Promise.resolve()
   }
 
-  const { error } = await supabase.from('apps').update({ expose_metadata: newExposeMetadata }).eq('app_id', props.appId)
-  if (error) {
+  try {
+    await updateAppSettings({ expose_metadata: newExposeMetadata })
+  }
+  catch {
     return Promise.reject(t('cannot-change-expose-metadata'))
   }
   toast.success(t('changed-expose-metadata'))
@@ -511,8 +539,10 @@ async function updateAllowPreview(newAllowPreview: boolean) {
     return Promise.resolve()
   }
 
-  const { error } = await supabase.from('apps').update({ allow_preview: newAllowPreview }).eq('app_id', props.appId)
-  if (error) {
+  try {
+    await updateAppSettings({ allow_preview: newAllowPreview })
+  }
+  catch {
     return Promise.reject(t('cannot-change-allow-preview'))
   }
   toast.success(t('changed-allow-preview'))
@@ -528,8 +558,10 @@ async function updateAllowDeviceCustomId(newAllowDeviceCustomId: boolean) {
     return Promise.resolve()
   }
 
-  const { error } = await supabase.from('apps').update({ allow_device_custom_id: newAllowDeviceCustomId }).eq('app_id', props.appId)
-  if (error) {
+  try {
+    await updateAppSettings({ allow_device_custom_id: newAllowDeviceCustomId })
+  }
+  catch {
     return Promise.reject(t('cannot-change-allow-device-custom-id'))
   }
   toast.success(t('changed-allow-device-custom-id'))

--- a/supabase/functions/_backend/public/app/index.ts
+++ b/supabase/functions/_backend/public/app/index.ts
@@ -44,20 +44,22 @@ app.post('/', middlewareV2(['all', 'write']), async (c) => {
   return post(c, body)
 })
 
-app.put('/:id', middlewareKey(['all', 'write']), async (c) => {
+app.put('/:id', middlewareV2(['all', 'write']), async (c) => {
   const id = c.req.param('id')
   const body = await getBodyOrQuery<{
     name?: string
     icon?: string
     retention?: number
+    build_timeout_seconds?: number
     expose_metadata?: boolean
+    allow_preview?: boolean
     allow_device_custom_id?: boolean
     need_onboarding?: boolean
     existing_app?: boolean
     ios_store_url?: string | null
     android_store_url?: string | null
   }>(c)
-  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
+  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row'] | undefined
   const subkey = c.get('subkey') as Database['public']['Tables']['apikeys']['Row'] | undefined
   const keyToUse = subkey || apikey
   return put(c, id, body, keyToUse)

--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -8,14 +8,16 @@ import { quickError, simpleError } from '../../utils/hono.ts'
 import { cloudlog } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { createSignedImageUrl, normalizeImagePath } from '../../utils/storage.ts'
-import { supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
+import { supabaseAdmin, supabaseWithAuth } from '../../utils/supabase.ts'
 import { isValidAppId } from '../../utils/utils.ts'
 
 interface UpdateApp {
   name?: string
   icon?: string
   retention?: number
+  build_timeout_seconds?: number
   expose_metadata?: boolean
+  allow_preview?: boolean
   allow_device_custom_id?: boolean
   need_onboarding?: boolean
   existing_app?: boolean
@@ -23,7 +25,7 @@ interface UpdateApp {
   android_store_url?: string | null
 }
 
-export async function put(c: Context<MiddlewareKeyVariables>, appId: string, body: UpdateApp, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
+export async function put(c: Context<MiddlewareKeyVariables>, appId: string, body: UpdateApp, _apikey?: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
   if (!appId) {
     throw quickError(400, 'missing_app_id', 'Missing app_id')
   }
@@ -41,8 +43,18 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
   else if (body.retention && body.retention < 0) {
     throw quickError(400, 'retention_to_small', 'Retention cannot be smaller than 0', { retention: body.retention })
   }
+  if (body.build_timeout_seconds !== undefined) {
+    if (!Number.isSafeInteger(body.build_timeout_seconds) || body.build_timeout_seconds < 300 || body.build_timeout_seconds > 21600) {
+      throw quickError(400, 'invalid_build_timeout', 'Build timeout must be between 5 minutes and 6 hours', { build_timeout_seconds: body.build_timeout_seconds })
+    }
+  }
 
-  const { data: previousApp, error: previousAppError } = await supabaseApikey(c, apikey.key)
+  const auth = c.get('auth')
+  if (!auth)
+    throw quickError(401, 'not_authorized', 'Not authorized')
+
+  const supabase = supabaseWithAuth(c, auth)
+  const { data: previousApp, error: previousAppError } = await supabase
     .from('apps')
     .select('need_onboarding, owner_org, name, app_id')
     .eq('app_id', appId)
@@ -60,13 +72,15 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
 
   const { data, error: dbError } = await (async () => {
     try {
-      return await supabaseApikey(c, apikey.key)
+      return await supabase
         .from('apps')
         .update({
           name: body.name,
           icon_url: normalizedIcon ?? body.icon,
           retention: body.retention,
+          build_timeout_seconds: body.build_timeout_seconds,
           expose_metadata: body.expose_metadata,
+          allow_preview: body.allow_preview,
           allow_device_custom_id: body.allow_device_custom_id,
           need_onboarding: body.need_onboarding,
           existing_app: body.existing_app,


### PR DESCRIPTION
## Summary

- route app settings edits through `PUT /app/:id` instead of direct browser-side PostgREST updates
- allow JWT auth on the app update endpoint via `middlewareV2`, while preserving API-key/subkey support
- add backend handling for `build_timeout_seconds` and `allow_preview`, including server-side build-timeout validation

## Security note

This keeps app-setting validation and side effects on the backend path. Previously the settings page updated `public.apps` directly from the browser for fields such as retention, build timeout, preview, metadata exposure, and custom device IDs. That made the browser path depend entirely on table RLS and bypassed the existing API validation/side-effect path.

Related: #1667
/claim #1667

## Testing

- `git diff --check`
- Could not run `bun run lint` locally because `bun` is not installed in this environment
