### PR TITLE
fix: redact queue request body logs

### DIFF
--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -191,6 +191,24 @@ function sanitizeQueueLogValue(value: unknown): unknown {
   ]))
 }
 
+function getQueueLogUrlMetadata(value: string): Record<string, unknown> {
+  try {
+    const parsed = new URL(value)
+    return {
+      host: parsed.host,
+      pathSegments: parsed.pathname.split('/').filter(Boolean).length,
+      hasQuery: parsed.search.length > 0,
+    }
+  }
+  catch {
+    return {
+      host: null,
+      pathSegments: 0,
+      hasQuery: value.includes('?'),
+    }
+  }
+}
+
 // Helper function to generate UUID v4
 function generateUUID(): string {
   return crypto.randomUUID()
@@ -515,7 +533,8 @@ export async function http_post_helper(
   try {
     cloudlog({
       requestId: c.get('requestId'),
-      message: `[${function_name}] Making HTTP POST request to "${url}" with body:`,
+      message: `[${function_name}] Making HTTP POST request with body:`,
+      url: getQueueLogUrlMetadata(url),
       body: sanitizeQueueLogValue(body),
     })
     const response = await fetch(url, {
@@ -665,5 +684,6 @@ export const __queueConsumerTestUtils__ = {
   extractMessageBody,
   getActionableQueueFailures,
   sanitizeDiscordResponseBody,
+  getQueueLogUrlMetadata,
   sanitizeQueueLogValue,
 }

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -150,12 +150,45 @@ function redactEmailLikeSubstrings(value: string): string {
   return `${result}${value.slice(cursor)}`
 }
 
-function sanitizeDiscordResponseBody(value: string): string {
+function sanitizeSensitiveString(value: string): string {
   return redactEmailLikeSubstrings(value)
     .replace(/\b(Bearer\s+)[\w.~+/-]+=*/gi, '$1[REDACTED_TOKEN]')
     .replace(/((?:api[-_]?key|token|authorization|password|secret|access[-_]?token|refresh[-_]?token)["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]')
     .replace(/\b[\dA-F]{32,}\b/gi, '[REDACTED_TOKEN]')
     .replace(/\b[\w+/=-]{40,}\b/g, '[REDACTED_TOKEN]')
+}
+
+function sanitizeDiscordResponseBody(value: string): string {
+  return sanitizeSensitiveString(value)
+}
+
+function isSensitiveLogKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return normalized.includes('apikey')
+    || normalized.includes('authorization')
+    || normalized.includes('password')
+    || normalized.includes('secret')
+    || normalized.includes('token')
+    || normalized.includes('jwt')
+    || normalized.includes('sessionkey')
+    || normalized.includes('capgkey')
+    || normalized.includes('captcha')
+}
+
+function sanitizeQueueLogValue(value: unknown): unknown {
+  if (typeof value === 'string')
+    return sanitizeSensitiveString(value)
+
+  if (value === null || typeof value !== 'object')
+    return value
+
+  if (Array.isArray(value))
+    return value.map(item => sanitizeQueueLogValue(item))
+
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+    key,
+    isSensitiveLogKey(key) ? '[REDACTED]' : sanitizeQueueLogValue(item),
+  ]))
 }
 
 // Helper function to generate UUID v4
@@ -480,7 +513,11 @@ export async function http_post_helper(
   // 15 second timeout, as the queue consumer is running every 10 seconds and the visibility timeout is 60 seconds
 
   try {
-    cloudlog({ requestId: c.get('requestId'), message: `[${function_name}] Making HTTP POST request to "${url}" with body:`, body })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: `[${function_name}] Making HTTP POST request to "${url}" with body:`,
+      body: sanitizeQueueLogValue(body),
+    })
     const response = await fetch(url, {
       method: 'POST',
       headers,
@@ -628,4 +665,5 @@ export const __queueConsumerTestUtils__ = {
   extractMessageBody,
   getActionableQueueFailures,
   sanitizeDiscordResponseBody,
+  sanitizeQueueLogValue,
 }

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import { __queueConsumerTestUtils__, MAX_QUEUE_READS, messagesArraySchema } from '../supabase/functions/_backend/triggers/queue_consumer.ts'
+import { describe, expect, it, vi } from 'vitest'
+import { __queueConsumerTestUtils__, http_post_helper, MAX_QUEUE_READS, messagesArraySchema } from '../supabase/functions/_backend/triggers/queue_consumer.ts'
 import { parseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
+
+const { cloudlogMock } = vi.hoisted(() => ({
+  cloudlogMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: vi.fn(),
+}))
 
 describe('queue_consumer legacy message compatibility', () => {
   it.concurrent('uses the payload envelope when it is present', () => {
@@ -159,6 +168,40 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(body.authorization).toContain('Bearer')
     expect(JSON.stringify(sanitized)).not.toContain('alice@capgo.app')
     expect(JSON.stringify(sanitized)).not.toContain('super-secret-token-value')
+  })
+
+  it('does not write sensitive queue request URL query values to logs', async () => {
+    cloudlogMock.mockClear()
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    const previousApiSecret = process.env.API_SECRET
+    const previousCloudflareFunctionUrl = process.env.CLOUDFLARE_FUNCTION_URL
+    process.env.API_SECRET = 'api-secret'
+    process.env.CLOUDFLARE_FUNCTION_URL = 'https://example.test/hook?token=secret-url-token'
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      await http_post_helper({
+        get: vi.fn(() => 'request-id'),
+      } as any, 'sync_job', 'cloudflare', { metadata: 'token=secret-body-token' }, 'cf-id')
+
+      const loggedPayload = JSON.stringify(cloudlogMock.mock.calls)
+      expect(loggedPayload).toContain('"hasQuery":true')
+      expect(loggedPayload).not.toContain('secret-url-token')
+      expect(loggedPayload).not.toContain('secret-body-token')
+      expect(fetchMock).toHaveBeenCalled()
+    }
+    finally {
+      vi.unstubAllGlobals()
+      if (previousApiSecret === undefined)
+        delete process.env.API_SECRET
+      else
+        process.env.API_SECRET = previousApiSecret
+
+      if (previousCloudflareFunctionUrl === undefined)
+        delete process.env.CLOUDFLARE_FUNCTION_URL
+      else
+        process.env.CLOUDFLARE_FUNCTION_URL = previousCloudflareFunctionUrl
+    }
   })
 
   it.concurrent('keeps message-only JSON error details actionable', async () => {

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -122,6 +122,45 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(sanitized).toContain('builder unavailable')
   })
 
+  it.concurrent('redacts sensitive queue request bodies before logging', () => {
+    const body = {
+      appId: 'com.capgo.demo',
+      authorization: 'Bearer abcdefghijklmnopqrstuvwxyz1234567890',
+      userEmail: 'alice@capgo.app',
+      nested: {
+        session_key: '1234567890abcdefghijklmnopqrstuvwxyz1234567890',
+        metadata: 'token=super-secret-token-value',
+      },
+      rows: [
+        {
+          refreshToken: 'refresh-token-value',
+          status: 'pending',
+        },
+      ],
+    }
+
+    const sanitized = __queueConsumerTestUtils__.sanitizeQueueLogValue(body)
+
+    expect(sanitized).toEqual({
+      appId: 'com.capgo.demo',
+      authorization: '[REDACTED]',
+      userEmail: '[REDACTED_EMAIL]',
+      nested: {
+        session_key: '[REDACTED]',
+        metadata: 'token=[REDACTED]',
+      },
+      rows: [
+        {
+          refreshToken: '[REDACTED]',
+          status: 'pending',
+        },
+      ],
+    })
+    expect(body.authorization).toContain('Bearer')
+    expect(JSON.stringify(sanitized)).not.toContain('alice@capgo.app')
+    expect(JSON.stringify(sanitized)).not.toContain('super-secret-token-value')
+  })
+
   it.concurrent('keeps message-only JSON error details actionable', async () => {
     const response = new Response(JSON.stringify({
       message: 'builder unavailable',


### PR DESCRIPTION
## Summary
- Redact sensitive fields before queue request bodies are written to worker logs.
- Reuse the existing response-body sanitization rules for string values and add recursive request-body sanitization for nested objects/arrays.
- Avoid logging raw queue request URLs; log URL shape metadata instead so query-string secrets are not persisted.
- Add regression coverage for bearer tokens, emails, session keys, refresh tokens, inline token-like metadata, and URL query secrets.

## Why
`queue_consumer` currently logs request details before dispatching internal trigger calls. Queue payloads and destination URLs can contain operational identifiers or secrets such as authorization headers, tokens, session keys, captcha tokens, user emails, callback tokens, or signed query parameters. Those values should not be persisted in logs when the only goal is operational tracing.

This keeps the log useful for routing/debugging while avoiding raw credential or PII exposure.

## Verification
- `git diff --check`
- `bunx vitest run tests/queue-consumer-message-shape.unit.test.ts`
- `bun run lint:backend`
- GitHub Actions: Run tests passed
- GitHub Actions: CodSpeed passed
- SonarQube Cloud: Quality Gate passed

/claim #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data protection: request bodies and alert text are now centrally sanitized before logging, and sensitive query values are omitted from logs.

* **Tests**
  * Added tests to verify sensitive fields (tokens, emails, credentials) are redacted and original inputs are not mutated during queue processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2188)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->