### PR TITLE
[codex] Fix sidebar active state for dashboard and app routes

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -27,8 +27,27 @@ const route = useRoute()
 
 onClickOutside(sidebar, () => emit('closeSidebar'))
 
+function normalizeSidebarPath(path: string) {
+  let normalizedPath = path
+
+  while (normalizedPath.length > 1 && normalizedPath.endsWith('/'))
+    normalizedPath = normalizedPath.slice(0, -1)
+
+  return normalizedPath || '/'
+}
+
 function isTabActive(tab: string) {
-  return route.path.includes(tab)
+  if (tab === '#')
+    return false
+
+  const currentPath = normalizeSidebarPath(route.path)
+  const activePaths = tab === '/apps' ? ['/apps', '/app'] : [tab]
+
+  return activePaths.some((activePath) => {
+    const tabPath = normalizeSidebarPath(activePath)
+
+    return currentPath === tabPath || currentPath.startsWith(`${tabPath}/`)
+  })
 }
 function openTab(tab: Tab) {
   if (tab.onClick)


### PR DESCRIPTION
## Summary (AI generated)

- Updated the sidebar active-route check to match exact routes or child routes instead of substring matches.
- Kept the regular Dashboard item inactive on `/admin/dashboard` routes.
- Kept the Apps item active on app-detail routes such as `/app/ee.forgr.capacitor_go`.
- Prevented external placeholder links from being marked active.

## Motivation (AI generated)

The Admin Dashboard route (`/admin/dashboard`) was also selecting the regular Dashboard item because `/admin/dashboard` contains `/dashboard` as a substring. After tightening route matching, app detail routes under `/app/...` also needed to map back to the Apps sidebar entry.

## Business Impact (AI generated)

This reduces navigation confusion by showing only the correct current console section in the sidebar for both admin pages and app detail pages.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun typecheck`
- [x] Opened `http://127.0.0.1:5173/admin/dashboard` locally; unauthenticated session redirected to login with no browser console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced sidebar navigation to more accurately highlight the currently active tab based on your location in the application. The sidebar now properly handles nested routes and various navigation structures, providing consistent and reliable navigation feedback as you navigate through the app.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->