### PR TITLE
[codex] Show trial plan in expiring admin table

### DIFF
--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -112,6 +112,7 @@ interface TrialOrganization {
   org_id: string
   org_name: string
   management_email: string
+  plan_name: string | null
   trial_end_date: string
   days_remaining: number
   trial_extension_count: number
@@ -179,6 +180,13 @@ const trialOrganizationsColumns = ref<TableColumn[]>([
     ]),
   },
   { label: t('email'), key: 'management_email', mobile: false, sortable: false },
+  {
+    label: t('plan'),
+    key: 'plan_name',
+    mobile: true,
+    sortable: false,
+    displayFunction: (item: TrialOrganization) => item.plan_name || t('unknown'),
+  },
   {
     label: t('days-remaining'),
     key: 'days_remaining',

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1836,6 +1836,7 @@ export interface AdminTrialOrganization {
   org_id: string
   org_name: string
   management_email: string
+  plan_name: string | null
   trial_end_date: string
   days_remaining: number
   trial_extension_count: number
@@ -1863,7 +1864,9 @@ export async function getAdminTrialOrganizations(
   offset: number = 0,
 ): Promise<AdminTrialOrganizationsResult> {
   try {
-    const pgClient = getPgClient(c, true) // Read-only query
+    // The admin dashboard needs plans.name, and plans is not replicated to
+    // PlanetScale read replicas.
+    const pgClient = getPgClient(c)
     const drizzleClient = getDrizzleClient(pgClient)
 
     // Query to get trial organizations ordered by days remaining (ascending - expiring soon first)
@@ -1885,6 +1888,7 @@ export async function getAdminTrialOrganizations(
         o.id AS org_id,
         o.name AS org_name,
         o.management_email,
+        p.name AS plan_name,
         si.trial_at AS trial_end_date,
         GREATEST(0, (si.trial_at::date - CURRENT_DATE)) AS days_remaining,
         CASE
@@ -1896,6 +1900,7 @@ export async function getAdminTrialOrganizations(
         lbu.last_bundle_upload_at
       FROM orgs o
       INNER JOIN stripe_info si ON si.customer_id = o.customer_id
+      LEFT JOIN plans p ON p.stripe_id = si.product_id
       LEFT JOIN latest_bundle_uploads lbu ON lbu.owner_org = o.id
       WHERE si.trial_at::date >= CURRENT_DATE
         AND (si.status IS NULL OR si.status != 'succeeded')
@@ -1922,6 +1927,7 @@ export async function getAdminTrialOrganizations(
       org_id: row.org_id,
       org_name: row.org_name,
       management_email: row.management_email,
+      plan_name: row.plan_name ?? null,
       trial_end_date: normalizeTimestamp(row.trial_end_date) ?? '',
       days_remaining: Number(row.days_remaining),
       trial_extension_count: Number(row.trial_extension_count) || 0,

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -334,6 +334,7 @@ describe('/private/admin_stats', () => {
       data: {
         organizations: Array<{
           org_id: string
+          plan_name: string | null
           last_bundle_upload_at: string | null
           trial_extension_count: number
         }>
@@ -343,6 +344,7 @@ describe('/private/admin_stats', () => {
     expect(payload.success).toBe(true)
     const organization = payload.data.organizations.find(org => org.org_id === TRIAL_ORG_ID)
     expect(organization).toBeTruthy()
+    expect(organization?.plan_name).toBe(soloPlan?.name)
     expect(organization?.last_bundle_upload_at).toBe(TRIAL_LAST_UPLOAD_AT)
     expect(organization?.trial_extension_count).toBe(2)
   })


### PR DESCRIPTION
## Summary (AI generated)

- Add `plan_name` to the admin trial organizations response.
- Show a Plan column in the admin table for organizations whose trials are expiring soon.
- Extend the existing admin stats test to assert the trial organization plan is returned.

## Motivation (AI generated)

Admins need to see which plan an expiring trial organization is on without opening the organization details or cross-referencing billing data.

## Business Impact (AI generated)

This gives the admin team faster context for trial follow-up and conversion work, especially when prioritizing expiring organizations by plan.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/admin-stats.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "plan" column to the Trial Organizations table in the admin dashboard, displaying associated plan names.

* **Tests**
  * Updated admin stats tests to validate plan name data in trial organization records.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2192)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->