### PR TITLE
[codex] allow Stripe subscription coupons

### DIFF
--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -500,6 +500,7 @@ export async function createCheckout(c: Context, customerId: string, recurrence:
   const allowedSuccessUrl = getAllowedRedirectUrl(c, successUrl, 'success_url')
   const allowedCancelUrl = getAllowedRedirectUrl(c, cancelUrl, 'cancel_url')
   const session = await getStripe(c).checkout.sessions.create({
+    allow_promotion_codes: true,
     billing_address_collection: 'auto',
     mode: 'subscription',
     customer: customerId,

--- a/tests/stripe-redirects.unit.test.ts
+++ b/tests/stripe-redirects.unit.test.ts
@@ -136,6 +136,7 @@ describe('stripe redirect URL allowlist', () => {
 
     expect(result.url).toBe('https://pay.capgo.test/p/pay')
     expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+      allow_promotion_codes: true,
       success_url: 'https://capgo.test/app/success?success=true',
       cancel_url: 'https://capgo.test/app/cancel',
     }))


### PR DESCRIPTION
## Summary (AI generated)

- Enable promotion-code entry on Stripe subscription Checkout sessions.
- Add unit coverage so subscription Checkout sessions keep sending `allow_promotion_codes: true`.

## Motivation (AI generated)

Customers with valid Stripe promotion codes need a way to apply them when subscribing through Stripe Checkout.

## Business Impact (AI generated)

This reduces billing support friction and lets Capgo honor promotional offers directly in the Stripe-hosted subscription checkout flow.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bunx vitest run tests/stripe-redirects.unit.test.ts tests/stripe-emulator.test.ts`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`

## Stripe Portal Note (AI generated)

Stripe Billing Portal does not expose a per-session `allow_promotion_codes` option on portal links. Portal promotion-code entry is controlled by the Stripe Billing Portal configuration (`features.subscription_update.default_allowed_updates` includes `promotion_code`), so the generated portal link will use whatever is enabled on the default Stripe portal configuration.
