### PR TITLE
fix(api): harden webhook and store metadata fetches

### DIFF
--- a/supabase/functions/_backend/private/website_preview.ts
+++ b/supabase/functions/_backend/private/website_preview.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
 import { createHono, middlewareAuth, parseBody, quickError, useCors } from '../utils/hono.ts'
+import { readResponseBytesWithLimit } from '../utils/response.ts'
 import { version } from '../utils/version.ts'
 import { getWebhookUrlValidationError } from '../utils/webhook.ts'
 
@@ -220,40 +221,9 @@ async function getPublicHostnameValidationError(c: Context, urlString: string) {
 }
 
 async function readResponseTextWithLimit(response: Response, limit: number) {
-  const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
-  if (Number.isFinite(contentLength) && contentLength > limit)
+  const bytes = await readResponseBytesWithLimit(response, limit)
+  if (!bytes)
     return null
-
-  if (!response.body)
-    return await response.text()
-
-  const reader = response.body.getReader()
-  const chunks: Uint8Array[] = []
-  let total = 0
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done)
-      break
-
-    if (!value)
-      continue
-
-    total += value.byteLength
-    if (total > limit) {
-      await reader.cancel()
-      return null
-    }
-    chunks.push(value)
-  }
-
-  const bytes = new Uint8Array(total)
-  let offset = 0
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset)
-    offset += chunk.byteLength
-  }
-
   return new TextDecoder().decode(bytes)
 }
 

--- a/supabase/functions/_backend/public/app/store_metadata.ts
+++ b/supabase/functions/_backend/public/app/store_metadata.ts
@@ -1,10 +1,13 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import { quickError } from '../../utils/hono.ts'
+import { readResponseBytesWithLimit } from '../../utils/response.ts'
 
 export interface FetchStoreMetadataBody {
   url?: string
 }
+
+const MAX_ICON_BYTES = 512 * 1024
 
 interface AppleLookupResult {
   trackName?: string
@@ -51,7 +54,10 @@ async function fetchIconDataUrl(iconUrl: string | null) {
       return null
 
     const contentType = response.headers.get('content-type')?.split(';')[0]?.trim() || 'image/png'
-    const bytes = new Uint8Array(await response.arrayBuffer())
+    const bytes = await readResponseBytesWithLimit(response, MAX_ICON_BYTES)
+    if (!bytes)
+      return null
+
     return `data:${contentType};base64,${uint8ArrayToBase64(bytes)}`
   }
   catch {

--- a/supabase/functions/_backend/utils/response.ts
+++ b/supabase/functions/_backend/utils/response.ts
@@ -1,0 +1,39 @@
+export async function readResponseBytesWithLimit(response: Response, limit: number) {
+  const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
+  if (Number.isFinite(contentLength) && contentLength > limit)
+    return null
+
+  if (!response.body) {
+    const buffer = await response.arrayBuffer()
+    return buffer.byteLength > limit ? null : new Uint8Array(buffer)
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      break
+
+    if (!value)
+      continue
+
+    total += value.byteLength
+    if (total > limit) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(value)
+  }
+
+  const bytes = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return bytes
+}

--- a/supabase/functions/_backend/utils/webhook.ts
+++ b/supabase/functions/_backend/utils/webhook.ts
@@ -68,6 +68,26 @@ function isIpLiteral(hostname: string): boolean {
   return IPV4_REGEX.test(hostname) || hostname.includes(':')
 }
 
+function getWebhookUrlLogInfo(urlString: string) {
+  try {
+    const url = new URL(urlString)
+    return {
+      protocol: url.protocol,
+      hasHostname: url.hostname !== '',
+      hostnameLength: url.hostname.length,
+      pathSegmentCount: url.pathname.split('/').filter(Boolean).length,
+      hasQuery: url.search !== '',
+      hasCredentials: url.username !== '' || url.password !== '',
+    }
+  }
+  catch {
+    return {
+      invalid: true,
+      length: urlString.length,
+    }
+  }
+}
+
 export function getWebhookUrlValidationError(c: Context, urlString: string): string | null {
   let url: URL
   try {
@@ -229,7 +249,7 @@ export async function deliverWebhook(
       requestId: c.get('requestId'),
       message: 'Webhook delivery blocked by URL validation',
       deliveryId,
-      url,
+      urlInfo: getWebhookUrlLogInfo(url),
       error: urlValidationError,
       duration,
     })

--- a/supabase/functions/_backend/utils/webhook.ts
+++ b/supabase/functions/_backend/utils/webhook.ts
@@ -52,6 +52,10 @@ function allowLocalWebhookUrls(c: Context): boolean {
   return getEnv(c, 'CAPGO_ALLOW_LOCAL_WEBHOOK_URLS') === 'true'
 }
 
+function isLocalWebhookProtocol(protocol: string): boolean {
+  return protocol === 'http:' || protocol === 'https:'
+}
+
 function normalizeHostname(hostname: string): string {
   return hostname.replace(/\.$/, '').toLowerCase()
 }
@@ -73,8 +77,11 @@ export function getWebhookUrlValidationError(c: Context, urlString: string): str
     return 'Webhook URL is invalid'
   }
 
-  if (allowLocalWebhookUrls(c))
-    return null
+  if (allowLocalWebhookUrls(c)) {
+    return isLocalWebhookProtocol(url.protocol)
+      ? null
+      : 'Webhook URL must use HTTP or HTTPS'
+  }
 
   // We intentionally stop at syntactic/public-host checks: webhook delivery runs
   // entirely from serverless infrastructure, so private/internal addresses are not

--- a/tests/store-metadata.unit.test.ts
+++ b/tests/store-metadata.unit.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchStoreMetadata } from '../supabase/functions/_backend/public/app/store_metadata.ts'
+
+function createContext() {
+  return {
+    json: (body: unknown) => Response.json(body),
+  } as any
+}
+
+function storeHtml(iconUrl: string) {
+  return `
+    <html>
+      <head>
+        <meta property="og:title" content="Capgo Test App">
+        <meta property="og:image" content="${iconUrl}">
+      </head>
+      <body></body>
+    </html>
+  `
+}
+
+function mockStoreMetadataFetch(iconResponse: Response) {
+  const iconUrl = 'https://play-lh.googleusercontent.com/icon.png'
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.startsWith('https://play.google.com/')) {
+      return new Response(storeHtml(iconUrl), {
+        headers: { 'content-type': 'text/html' },
+      })
+    }
+
+    return iconResponse
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function fetchPlayStoreMetadata() {
+  const response = await fetchStoreMetadata(createContext(), {
+    url: 'https://play.google.com/store/apps/details?id=app.capgo.test',
+  })
+  return response.json() as Promise<{ icon_data_url: string | null }>
+}
+
+describe('store metadata icon fetching', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not buffer oversized icon responses', async () => {
+    const fetchMock = mockStoreMetadataFetch(
+      new Response('too large', {
+        headers: {
+          'content-length': String(512 * 1024 + 1),
+          'content-type': 'image/png',
+        },
+      }),
+    )
+    const body = await fetchPlayStoreMetadata()
+
+    expect(body.icon_data_url).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps small allowlisted icon responses', async () => {
+    mockStoreMetadataFetch(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { 'content-type': 'image/png' },
+      }),
+    )
+    const body = await fetchPlayStoreMetadata()
+
+    expect(body.icon_data_url).toBe('data:image/png;base64,AQID')
+  })
+})

--- a/tests/webhook-delivery-security.unit.test.ts
+++ b/tests/webhook-delivery-security.unit.test.ts
@@ -114,6 +114,46 @@ describe('webhook delivery redirect handling', () => {
     expect(result.status).toBe(302)
     expect(fetchMock).toHaveBeenCalledOnce()
   })
+
+  it('does not log raw blocked webhook URLs with query secrets', async () => {
+    mockGetEnv.mockReturnValue('')
+
+    const { deliverWebhook } = await import('../supabase/functions/_backend/utils/webhook.ts')
+    const result = await deliverWebhook(
+      createContext(),
+      'delivery-3',
+      'http://localhost/webhook?token=secret-token',
+      {
+        event: 'app_versions.INSERT',
+        event_id: 'event-3',
+        timestamp: new Date().toISOString(),
+        org_id: 'org-1',
+        data: {
+          table: 'app_versions',
+          operation: 'INSERT',
+          record_id: 'record-3',
+          old_record: null,
+          new_record: null,
+          changed_fields: null,
+        },
+      },
+      'secret',
+    )
+
+    expect(result.success).toBe(false)
+    expect(mockCloudlogErr).toHaveBeenCalledOnce()
+    const logged = JSON.stringify(mockCloudlogErr.mock.calls)
+    expect(logged).not.toContain('secret-token')
+    expect(logged).not.toContain('http://localhost/webhook')
+    expect(mockCloudlogErr.mock.calls[0]?.[0]).toMatchObject({
+      message: 'Webhook delivery blocked by URL validation',
+      urlInfo: {
+        protocol: 'http:',
+        hasHostname: true,
+        hasQuery: true,
+      },
+    })
+  })
 })
 
 describe('webhook URL validation', () => {
@@ -135,5 +175,17 @@ describe('webhook URL validation', () => {
     enableLocalWebhookUrls(false)
 
     await expect(validateWebhookUrl('http://example.com/webhook')).resolves.toBe('Webhook URL must use HTTPS')
+  })
+
+  it('allows public HTTPS URLs when local webhook URLs are enabled', async () => {
+    enableLocalWebhookUrls(true)
+
+    await expect(validateWebhookUrl('https://example.com/webhook')).resolves.toBeNull()
+  })
+
+  it('rejects localhost URLs when local webhook URLs are disabled', async () => {
+    enableLocalWebhookUrls(false)
+
+    await expect(validateWebhookUrl('https://localhost/webhook')).resolves.toBe('Webhook URL must point to a public host')
   })
 })

--- a/tests/webhook-delivery-security.unit.test.ts
+++ b/tests/webhook-delivery-security.unit.test.ts
@@ -22,6 +22,17 @@ function createContext() {
   } as any
 }
 
+function enableLocalWebhookUrls(enabled: boolean) {
+  mockGetEnv.mockImplementation((_c: unknown, key: string) =>
+    key === 'CAPGO_ALLOW_LOCAL_WEBHOOK_URLS' && enabled ? 'true' : '',
+  )
+}
+
+async function validateWebhookUrl(url: string) {
+  const { getWebhookUrlValidationError } = await import('../supabase/functions/_backend/utils/webhook.ts')
+  return getWebhookUrlValidationError(createContext(), url)
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
@@ -102,5 +113,27 @@ describe('webhook delivery redirect handling', () => {
     expect(result.success).toBe(false)
     expect(result.status).toBe(302)
     expect(fetchMock).toHaveBeenCalledOnce()
+  })
+})
+
+describe('webhook URL validation', () => {
+  it('allows HTTP and HTTPS webhooks when local webhook URLs are enabled', async () => {
+    enableLocalWebhookUrls(true)
+
+    await expect(validateWebhookUrl('http://localhost:3000/webhook')).resolves.toBeNull()
+    await expect(validateWebhookUrl('https://localhost/webhook')).resolves.toBeNull()
+  })
+
+  it('rejects unsupported URL schemes even when local webhook URLs are enabled', async () => {
+    enableLocalWebhookUrls(true)
+
+    await expect(validateWebhookUrl('ftp://localhost/webhook')).resolves.toBe('Webhook URL must use HTTP or HTTPS')
+    await expect(validateWebhookUrl('file:///tmp/webhook')).resolves.toBe('Webhook URL must use HTTP or HTTPS')
+  })
+
+  it('continues to reject HTTP URLs when local webhook URLs are disabled', async () => {
+    enableLocalWebhookUrls(false)
+
+    await expect(validateWebhookUrl('http://example.com/webhook')).resolves.toBe('Webhook URL must use HTTPS')
   })
 })


### PR DESCRIPTION
/claim #1667

## Summary
- Keep local webhook test mode constrained to HTTP(S) schemes so enabling `CAPGO_ALLOW_LOCAL_WEBHOOK_URLS` does not also allow unsupported schemes such as `file:` or `ftp:`.
- Add a bounded icon response reader for store metadata imports so allowlisted app-store icon URLs cannot force unbounded buffering before conversion to a data URL.
- Avoid logging raw blocked webhook URLs; blocked deliveries now log URL shape metadata instead of query strings or credentials.
- Add focused regression coverage for local webhook URL scheme validation, redacted blocked-delivery logging, and oversized store metadata icon responses.

## Security note
This is public-safe hardening. The webhook changes preserve the intended local HTTP testing path while blocking non-HTTP schemes and avoiding secret-bearing URL retention in blocked-delivery logs. The store metadata change preserves existing allowlisted app-store behavior while capping fetched icon payload size.

## Test plan
- `./node_modules/.bin/vitest.exe run tests/webhook-delivery-security.unit.test.ts tests/store-metadata.unit.test.ts --reporter=verbose`
- `git diff --check`

## Screenshots
Not applicable; backend/security hardening only.

## Checklist
- [x] Code style checked
- [x] Focused tests added
- [x] Public-safe security details only