### PR TITLE
fix: route API key writes through backend

### DIFF
--- a/src/components/organization/ApiKeyRbacManager.vue
+++ b/src/components/organization/ApiKeyRbacManager.vue
@@ -12,10 +12,12 @@ import DataTable from '~/components/DataTable.vue'
 import {
   confirmApiKeyDeletion,
   confirmApiKeyRegeneration,
+  deleteApiKey,
   formatApiKeyScope,
   isApiKeyExpired,
   showApiKeySecretModal,
   sortApiKeyRows,
+  updateApiKey,
 } from '~/services/apikeys'
 import { formatDate, formatLocalDate } from '~/services/date'
 import { useSupabase } from '~/services/supabase'
@@ -362,7 +364,7 @@ async function deleteKey(apiKey: OrgApiKey) {
 
   isSubmitting.value = true
   try {
-    const { error } = await supabase.from('apikeys').delete().eq('id', apiKey.id)
+    const { error } = await deleteApiKey(supabase, apiKey.id)
     if (error)
       throw error
     toast.success(t('removed-apikey'))
@@ -381,10 +383,7 @@ async function regenerateKey(apiKey: OrgApiKey) {
   if (!await confirmApiKeyRegeneration(dialogStore, t))
     return
 
-  const { data, error } = await supabase.functions.invoke('apikey', {
-    method: 'PUT',
-    body: { id: apiKey.id, regenerate: true },
-  })
+  const { data, error } = await updateApiKey(supabase, apiKey.id, { regenerate: true })
   if (error || !data) {
     toast.error(t('failed-to-regenerate-api-key'))
     return

--- a/src/pages/ApiKeys.vue
+++ b/src/pages/ApiKeys.vue
@@ -16,10 +16,12 @@ import IconTrash from '~icons/heroicons/trash'
 import {
   confirmApiKeyDeletion,
   confirmApiKeyRegeneration,
+  deleteApiKey,
   formatApiKeyScope,
   isApiKeyExpired,
   showApiKeySecretModal,
   sortApiKeyRows,
+  updateApiKey,
 } from '~/services/apikeys'
 import { formatLocalDate } from '~/services/date'
 import { useSupabase } from '~/services/supabase'
@@ -496,13 +498,7 @@ async function regenrateKey(apikey: Database['public']['Tables']['apikeys']['Row
 
   const wasHashed = isHashedKey(apikey)
 
-  const { data, error } = await supabase.functions.invoke('apikey', {
-    method: 'PUT',
-    body: {
-      id: apikey.id,
-      regenerate: true,
-    },
-  })
+  const { data, error } = await updateApiKey(supabase, apikey.id, { regenerate: true })
 
   if (error || !data) {
     console.error('Error regenerating API key:', error)
@@ -535,10 +531,7 @@ async function deleteKey(key: Database['public']['Tables']['apikeys']['Row']) {
   if (!await confirmApiKeyDeletion(dialogStore, t))
     return
 
-  const { error } = await supabase
-    .from('apikeys')
-    .delete()
-    .eq('id', key.id)
+  const { error } = await deleteApiKey(supabase, key.id)
 
   if (error)
     throw error
@@ -580,9 +573,7 @@ async function changeName(key: Database['public']['Tables']['apikeys']['Row']) {
             return false
           }
 
-          const { error } = await supabase.from('apikeys')
-            .update({ name: newName })
-            .eq('id', key.id)
+          const { error } = await updateApiKey(supabase, key.id, { name: newName })
 
           if (error) {
             toast.error(t('cannot-change-name'))

--- a/src/pages/settings/organization/ApiKeys.[id].vue
+++ b/src/pages/settings/organization/ApiKeys.[id].vue
@@ -10,6 +10,7 @@ import { toast } from 'vue-sonner'
 import IconCalendar from '~icons/heroicons/calendar'
 import IconClipboard from '~icons/heroicons/clipboard-document'
 import IconTrash from '~icons/heroicons/trash'
+import { updateApiKey } from '~/services/apikeys'
 import { checkPermissions } from '~/services/permissions'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -641,14 +642,11 @@ async function saveKey() {
 
   isSubmitting.value = true
   try {
-    const { error } = await supabase
-      .from('apikeys')
-      .update({
-        name: editName.value.trim(),
-        limited_to_orgs: [currentOrganization.value!.gid],
-        limited_to_apps: configuredLimitedAppIds.value,
-      })
-      .eq('id', apiKey.value.id)
+    const { error } = await updateApiKey(supabase, apiKey.value.id, {
+      name: editName.value.trim(),
+      limited_to_orgs: [currentOrganization.value!.gid],
+      limited_to_apps: configuredLimitedAppIds.value,
+    })
     if (error)
       throw error
 

--- a/src/services/apikeys.ts
+++ b/src/services/apikeys.ts
@@ -3,7 +3,7 @@ import type { TableColumn } from '~/components/comp_def'
 import type { DialogV2Button, DialogV2Options } from '~/stores/dialogv2'
 import type { Database } from '~/types/supabase.types'
 
-type ApiKeyId = number | string
+type ApiKeyId = number
 
 type ApiKeyUpdatePayload = Pick<
   Database['public']['Tables']['apikeys']['Update'],

--- a/src/services/apikeys.ts
+++ b/src/services/apikeys.ts
@@ -3,6 +3,19 @@ import type { TableColumn } from '~/components/comp_def'
 import type { DialogV2Button, DialogV2Options } from '~/stores/dialogv2'
 import type { Database } from '~/types/supabase.types'
 
+type ApiKeyId = number | string
+
+type ApiKeyUpdatePayload = Pick<
+  Database['public']['Tables']['apikeys']['Update'],
+  'name' | 'mode' | 'limited_to_apps' | 'limited_to_orgs' | 'expires_at'
+> & {
+  regenerate?: boolean
+}
+
+function getApiKeyRoute(id: ApiKeyId) {
+  return `apikey/${encodeURIComponent(String(id))}`
+}
+
 export async function createDefaultApiKey(
   supabase: SupabaseClient<Database>,
   name: string,
@@ -13,6 +26,26 @@ export async function createDefaultApiKey(
       name,
       mode: 'all',
     },
+  })
+}
+
+export async function updateApiKey(
+  supabase: SupabaseClient<Database>,
+  id: ApiKeyId,
+  updates: ApiKeyUpdatePayload,
+) {
+  return supabase.functions.invoke(getApiKeyRoute(id), {
+    method: 'PUT',
+    body: updates,
+  })
+}
+
+export async function deleteApiKey(
+  supabase: SupabaseClient<Database>,
+  id: ApiKeyId,
+) {
+  return supabase.functions.invoke(getApiKeyRoute(id), {
+    method: 'DELETE',
   })
 }
 

--- a/supabase/functions/_backend/public/apikey/delete.ts
+++ b/supabase/functions/_backend/public/apikey/delete.ts
@@ -3,6 +3,7 @@ import type { Database } from '../../utils/supabase.types.ts'
 import { BRES, honoFactory, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
 import { supabaseWithAuth } from '../../utils/supabase.ts'
+import { getApiKeyLookupFilter } from './lookup.ts'
 
 const app = honoFactory.createApp()
 
@@ -37,7 +38,13 @@ app.delete('/:id', middlewareV2(['all']), async (c) => {
   // Use supabaseWithAuth which handles both JWT and API key authentication
   const supabase = supabaseWithAuth(c, auth)
 
-  const { data: apikey, error: apikeyError } = await supabase.from('apikeys').select('*').or(`key.eq.${id},id.eq.${id}`).eq('user_id', auth.userId).single()
+  const lookup = getApiKeyLookupFilter(id)
+  const { data: apikey, error: apikeyError } = await supabase
+    .from('apikeys')
+    .select('id')
+    .eq('user_id', auth.userId)
+    .eq(lookup.column, lookup.value)
+    .single()
   if (!apikey || apikeyError) {
     throw quickError(404, 'api_key_not_found', 'API key not found', { supabaseError: apikeyError })
   }
@@ -45,7 +52,7 @@ app.delete('/:id', middlewareV2(['all']), async (c) => {
   const { error } = await supabase
     .from('apikeys')
     .delete()
-    .or(`key.eq.${id},id.eq.${id}`)
+    .eq('id', apikey.id)
     .eq('user_id', auth.userId)
 
   if (error) {

--- a/supabase/functions/_backend/public/apikey/get.ts
+++ b/supabase/functions/_backend/public/apikey/get.ts
@@ -3,6 +3,7 @@ import type { Database } from '../../utils/supabase.types.ts'
 import { honoFactory, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareV2 } from '../../utils/hono_middleware.ts'
 import { supabaseWithAuth } from '../../utils/supabase.ts'
+import { getApiKeyLookupFilter } from './lookup.ts'
 
 const app = honoFactory.createApp()
 
@@ -61,11 +62,12 @@ app.get('/:id', middlewareV2(['all']), async (c) => {
 
   // Use supabaseWithAuth which handles both JWT and API key authentication
   const supabase = supabaseWithAuth(c, auth)
+  const lookup = getApiKeyLookupFilter(id)
   const { data: fetchedApikey, error } = await supabase
     .from('apikeys')
     .select('*')
-    .or(`key.eq.${id},id.eq.${id}`)
     .eq('user_id', auth.userId)
+    .eq(lookup.column, lookup.value)
     .single()
   if (error) {
     throw quickError(404, 'failed_to_get_apikey', 'Failed to get API key', { supabaseError: error })

--- a/supabase/functions/_backend/public/apikey/lookup.ts
+++ b/supabase/functions/_backend/public/apikey/lookup.ts
@@ -11,6 +11,8 @@ export function getApiKeyLookupFilter(id: string): ApiKeyLookupFilter {
     }
   }
 
+  // Legacy compatibility only. New clients should use numeric API key IDs so
+  // plaintext key values are not placed in request URLs.
   return {
     column: 'key',
     value: id,

--- a/supabase/functions/_backend/public/apikey/lookup.ts
+++ b/supabase/functions/_backend/public/apikey/lookup.ts
@@ -1,0 +1,18 @@
+interface ApiKeyLookupFilter {
+  column: 'id' | 'key'
+  value: number | string
+}
+
+export function getApiKeyLookupFilter(id: string): ApiKeyLookupFilter {
+  if (/^\d+$/.test(id)) {
+    return {
+      column: 'id',
+      value: Number(id),
+    }
+  }
+
+  return {
+    column: 'key',
+    value: id,
+  }
+}

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -6,6 +6,21 @@ import { BASE_URL, getSupabaseClient, headers, resetAndSeedAppData, resetAppData
 const id = randomUUID()
 const APPNAME = `com.app.key.${id}`
 
+async function createPlainApiKey(name: string) {
+  const response = await fetch(`${BASE_URL}/apikey`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      name,
+      mode: 'all',
+      hashed: false,
+    }),
+  })
+  const data = await response.json<{ id: number, key: string }>()
+  expect(response.status).toBe(200)
+  return data
+}
+
 beforeAll(async () => {
   await resetAndSeedAppData(APPNAME)
 })
@@ -36,6 +51,25 @@ describe('[GET] /apikey operations', () => {
     const data = await response.json()
     expect(response.status).toBe(200)
     expect(data).toHaveProperty('id', 10)
+  })
+
+  it('get specific api key by key UUID', async () => {
+    const createData = await createPlainApiKey('key-to-get-by-uuid')
+
+    const response = await fetch(`${BASE_URL}/apikey/${createData.key}`, {
+      method: 'GET',
+      headers,
+    })
+
+    const data = await response.json() as { id: number, key: string }
+    expect(response.status).toBe(200)
+    expect(data).toHaveProperty('id', createData.id)
+    expect(data).toHaveProperty('key', createData.key)
+
+    await fetch(`${BASE_URL}/apikey/${createData.id}`, {
+      method: 'DELETE',
+      headers,
+    })
   })
 
   it('get api key with invalid id', async () => {
@@ -500,6 +534,22 @@ describe('[DELETE] /apikey/:id operations', () => {
     expect(data).toHaveProperty('status', 'ok')
 
     // Verify deletion
+    const verifyResponse = await fetch(`${BASE_URL}/apikey/${createData.id}`, { headers })
+    expect(verifyResponse.status).toBe(404)
+  })
+
+  it('delete api key by key UUID', async () => {
+    const createData = await createPlainApiKey('key-to-delete-by-uuid')
+
+    const response = await fetch(`${BASE_URL}/apikey/${createData.key}`, {
+      method: 'DELETE',
+      headers,
+    })
+
+    const data = await response.json() as { status: string }
+    expect(response.status).toBe(200)
+    expect(data).toHaveProperty('status', 'ok')
+
     const verifyResponse = await fetch(`${BASE_URL}/apikey/${createData.id}`, { headers })
     expect(verifyResponse.status).toBe(404)
   })

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, getSupabaseClient, headers, resetAndSeedAppData, resetAppData } from './test-utils.ts'
+import { BASE_URL, getEndpointUrl, getSupabaseClient, headers, resetAndSeedAppData, resetAppData } from './test-utils.ts'
 
 const id = randomUUID()
 const APPNAME = `com.app.key.${id}`
 
 async function createPlainApiKey(name: string) {
-  const response = await fetch(`${BASE_URL}/apikey`, {
+  const response = await fetch(getEndpointUrl('/apikey'), {
     method: 'POST',
     headers,
     body: JSON.stringify({
@@ -53,10 +53,12 @@ describe('[GET] /apikey operations', () => {
     expect(data).toHaveProperty('id', 10)
   })
 
-  it('get specific api key by key UUID', async () => {
+  it('gets specific api key by legacy key UUID path', async () => {
     const createData = await createPlainApiKey('key-to-get-by-uuid')
 
-    const response = await fetch(`${BASE_URL}/apikey/${createData.key}`, {
+    // Legacy compatibility only: new clients should use numeric ids so API
+    // key material is not placed in URLs.
+    const response = await fetch(getEndpointUrl(`/apikey/${createData.key}`), {
       method: 'GET',
       headers,
     })
@@ -66,7 +68,7 @@ describe('[GET] /apikey operations', () => {
     expect(data).toHaveProperty('id', createData.id)
     expect(data).toHaveProperty('key', createData.key)
 
-    await fetch(`${BASE_URL}/apikey/${createData.id}`, {
+    await fetch(getEndpointUrl(`/apikey/${createData.id}`), {
       method: 'DELETE',
       headers,
     })
@@ -538,10 +540,12 @@ describe('[DELETE] /apikey/:id operations', () => {
     expect(verifyResponse.status).toBe(404)
   })
 
-  it('delete api key by key UUID', async () => {
+  it('deletes api key by legacy key UUID path', async () => {
     const createData = await createPlainApiKey('key-to-delete-by-uuid')
 
-    const response = await fetch(`${BASE_URL}/apikey/${createData.key}`, {
+    // Legacy compatibility only: new clients should use numeric ids so API
+    // key material is not placed in URLs.
+    const response = await fetch(getEndpointUrl(`/apikey/${createData.key}`), {
       method: 'DELETE',
       headers,
     })
@@ -550,7 +554,7 @@ describe('[DELETE] /apikey/:id operations', () => {
     expect(response.status).toBe(200)
     expect(data).toHaveProperty('status', 'ok')
 
-    const verifyResponse = await fetch(`${BASE_URL}/apikey/${createData.id}`, { headers })
+    const verifyResponse = await fetch(getEndpointUrl(`/apikey/${createData.id}`), { headers })
     expect(verifyResponse.status).toBe(404)
   })
 


### PR DESCRIPTION
/claim #1667

## Summary
- add shared frontend helpers for the existing `PUT /apikey/:id` and `DELETE /apikey/:id` backend routes
- route API-key rename, scope save, regenerate, and delete UI writes through those backend routes instead of direct browser-side `apikeys` table mutations
- align `GET /apikey/:id` and `DELETE /apikey/:id` lookup behavior with `PUT /apikey/:id` so numeric ids and UUID key values are queried separately
- add regression coverage for fetching and deleting a plain API key by UUID key value

## Why
The backend API-key routes already centralize ownership checks, limited-key guards, validation, and policy enforcement. The UI should use that path for API-key mutations instead of writing the table directly.

The GET/DELETE lookup change also avoids mixing UUID key values into the numeric `id` filter, matching the safer lookup pattern already used by the PUT handler.

Related: #1667

## Testing
- `git diff --check`
- `npx.cmd --yes vitest run tests/apikeys.test.ts` *(blocked locally: this checkout has no installed dependencies; Vitest cannot resolve `vite` from `vitest.config.ts`)*
- `npx.cmd --yes eslint src/services/apikeys.ts src/pages/ApiKeys.vue src/components/organization/ApiKeyRbacManager.vue src/pages/settings/organization/ApiKeys.[id].vue supabase/functions/_backend/public/apikey/get.ts supabase/functions/_backend/public/apikey/delete.ts tests/apikeys.test.ts` *(blocked locally: ESLint cannot resolve `@antfu/eslint-config` without installed dependencies)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now uses centralized API-key service for create/rename/regenerate/delete flows.

* **Bug Fixes**
  * Tighter validation and scoping for API key deletion to prevent unintended access.
  * More reliable lookup logic for identifying keys across legacy and numeric formats.

* **Tests**
  * Added end-to-end tests covering legacy plain (UUID) API key creation, retrieval, and deletion.

* **Chores**
  * Introduced a helper to standardize API-key lookup and service routes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2197)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->