### PR TITLE
fix(cli): clean up Android onboarding checks

### DIFF
--- a/cli/src/build/onboarding/android/gcp-api.ts
+++ b/cli/src/build/onboarding/android/gcp-api.ts
@@ -339,10 +339,10 @@ export async function pollOperation(
  */
 export function sanitizeGcpProjectDisplayName(input: string): string {
   const fallback = 'Capgo Build'
-  const allowed = input.replace(/[^A-Za-z0-9 \-'!.]/g, ' ').replace(/\s+/g, ' ').trim()
+  const allowed = input.replace(/[^a-z0-9 \-'!.]/gi, ' ').replace(/\s+/g, ' ').trim()
   // Must start and end with a letter or digit.
-  const trimmed = allowed.replace(/^[^A-Za-z0-9]+/, '').replace(/[^A-Za-z0-9]+$/, '')
-  let result = trimmed.slice(0, 30).replace(/[^A-Za-z0-9]+$/, '')
+  const trimmed = allowed.replace(/^[^a-z0-9]+/i, '').replace(/[^a-z0-9]+$/i, '')
+  let result = trimmed.slice(0, 30).replace(/[^a-z0-9]+$/i, '')
   if (result.length < 4)
     result = fallback
   return result

--- a/cli/src/build/onboarding/android/oauth-config.ts
+++ b/cli/src/build/onboarding/android/oauth-config.ts
@@ -30,8 +30,10 @@ export const PLAY_DEV_ID_TUTORIAL_URL = 'https://www.youtube.com/watch?v=Y1_Ngj8
 export interface CapgoOAuthClientConfig {
   clientId: string
   clientSecret: string
-  /** Scopes the backend tells the CLI to request. Always at least
-   *  `https://www.googleapis.com/auth/androidpublisher`. */
+  /**
+   * Scopes the backend tells the CLI to request. Always at least
+   * `https://www.googleapis.com/auth/androidpublisher`.
+   */
   scopes: string[]
 }
 

--- a/cli/src/build/onboarding/android/oauth-google.ts
+++ b/cli/src/build/onboarding/android/oauth-google.ts
@@ -31,7 +31,6 @@ export const GOOGLE_OAUTH_SCOPES_ANDROIDPUBLISHER = [
 const GOOGLE_AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
 const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
 const GOOGLE_USERINFO_ENDPOINT = 'https://openidconnect.googleapis.com/v1/userinfo'
-const GOOGLE_REVOKE_ENDPOINT = 'https://oauth2.googleapis.com/revoke'
 
 const DEFAULT_FLOW_TIMEOUT_MS = 5 * 60 * 1000
 const LOOPBACK_HOST = '127.0.0.1'
@@ -249,23 +248,6 @@ export async function fetchUserInfo(accessToken: string): Promise<GoogleUserInfo
     emailVerified: !!data.email_verified,
     name: data.name,
     picture: data.picture,
-  }
-}
-
-/**
- * Revoke a Google OAuth token. Accepts either an access or refresh token —
- * revoking a refresh token also invalidates any access tokens minted from it.
- */
-export async function revokeToken(token: string): Promise<void> {
-  const res = await fetch(GOOGLE_REVOKE_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ token }).toString(),
-  })
-  // Google returns 400 when the token is already invalid/revoked — treat as success.
-  if (!res.ok && res.status !== 400) {
-    const text = await res.text().catch(() => '')
-    throw new Error(`revoke failed (${res.status}): ${text.slice(0, 200)}`)
   }
 }
 

--- a/cli/src/build/onboarding/android/types.ts
+++ b/cli/src/build/onboarding/android/types.ts
@@ -115,12 +115,8 @@ export interface AndroidOnboardingProgress {
     playInviteProvisioned?: PlayInviteProvisioned
   }
 
-  // Ephemeral — wiped when onboarding finishes. Held on disk only so resume
-  // across a crash doesn't force a full re-auth. NEVER written to credentials.
-  _oauthRefreshToken?: string
+  // Ephemeral keystore data, wiped when onboarding finishes.
   _keystoreBase64?: string
-  /** Base64 of the downloaded SA JSON key — saved as PLAY_CONFIG_JSON at end. */
-  _serviceAccountKeyBase64?: string
 }
 
 export const ANDROID_STEP_PROGRESS: Record<AndroidOnboardingStep, number> = {

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -144,7 +144,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
     initialProgress?.completedSteps.googleSignInComplete || null,
   )
   const [accessToken, setAccessToken] = useState<string>('')
-  const [refreshTokenState, setRefreshTokenState] = useState<string>(initialProgress?._oauthRefreshToken || '')
+  const [refreshTokenState, setRefreshTokenState] = useState<string>('')
   const [oauthClientId, setOauthClientId] = useState<string>('')
   const [oauthStatusMessages, setOauthStatusMessages] = useState<string[]>([])
 
@@ -181,9 +181,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
   const [, setPlayInviteProvisioned] = useState<PlayInviteProvisioned | null>(
     initialProgress?.completedSteps.playInviteProvisioned || null,
   )
-  const [serviceAccountKeyBase64, setServiceAccountKeyBase64] = useState<string>(
-    initialProgress?._serviceAccountKeyBase64 || '',
-  )
+  const [serviceAccountKeyBase64, setServiceAccountKeyBase64] = useState<string>('')
 
   // Phase 6 — build output
   const [buildUrl, setBuildUrl] = useState('')
@@ -526,7 +524,6 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
           setGoogleSignIn(complete)
           await persist((p) => ({
             ...p,
-            _oauthRefreshToken: tokens.refreshToken,
             completedSteps: { ...p.completedSteps, googleSignInComplete: complete },
           }))
           addLog(`✔ Signed in as ${info.email}`)
@@ -639,7 +636,6 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
           setServiceAccountKeyBase64(key.privateKeyDataBase64)
           await persist((p) => ({
             ...p,
-            _serviceAccountKeyBase64: key.privateKeyDataBase64,
             completedSteps: { ...p.completedSteps, serviceAccountProvisioned: saProv },
           }))
           addSetupStatus('✔ Key created')

--- a/cli/src/build/onboarding/file-picker.ts
+++ b/cli/src/build/onboarding/file-picker.ts
@@ -58,12 +58,3 @@ export function openKeystorePicker(): Promise<string | null> {
     'POSIX path of (choose file of type {"jks", "keystore", "p12"} with prompt "Select your Android keystore")',
   )
 }
-
-/**
- * Open the macOS native file picker filtered to JSON service-account keys.
- */
-export function openServiceAccountJsonPicker(): Promise<string | null> {
-  return openMacFilePicker(
-    'POSIX path of (choose file of type {"json"} with prompt "Select your service-account JSON key")',
-  )
-}

--- a/knip.json
+++ b/knip.json
@@ -52,10 +52,12 @@
       "entry": [
         "src/index.ts!",
         "src/sdk.ts!",
-        "src/mcp/server.ts!"
+        "src/mcp/server.ts!",
+        "test/**/*.mjs!"
       ],
       "project": [
-        "src/**/*.{ts,tsx}!"
+        "src/**/*.{ts,tsx}!",
+        "test/**/*.mjs!"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- fix Android onboarding regex lint violations from `regexp/use-ignore-case`
- stop persisting OAuth refresh tokens and service-account JSON key material in resumable onboarding progress
- remove unused picker/revoke helpers and include CLI test files in the knip export graph

## Validation
- `bun run cli:lint`
- `bun run lint:deadcode`
- worker also ran `cli:typecheck`, `cli:build`, `test/test-android-keystore.mjs`, and `test/test-android-oauth.mjs`

Follow-up for #2064 failing checks.