### PR TITLE
[codex] Harden public outbound URL validation

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -134,7 +134,7 @@ const tabs = computed<Tab[]>(() => {
           <ul class="space-y-1 lg:space-y-2">
             <li v-for="tab, i in tabs" :key="i">
               <button
-                class="flex items-center p-3 w-full rounded-md transition duration-150 cursor-pointer lg:p-3 lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-[44px] lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
+                class="flex items-center p-3 w-full rounded-md transition duration-150 cursor-pointer lg:p-3 lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-11 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
                 :class="{
                   'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
                   'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),

--- a/src/pages/admin/dashboard/replication.vue
+++ b/src/pages/admin/dashboard/replication.vue
@@ -99,26 +99,19 @@ const checkedAt = computed(() => {
   return formatLocalDateTime(data.value.checked_at)
 })
 
-const internalReplicationSecret = import.meta.env.VITE_REPLICATION_API_SECRET as string | undefined
-
 async function loadReplicationStatus() {
   isLoading.value = true
   errorMessage.value = null
 
   try {
     const headers: Record<string, string> = {}
-    if (internalReplicationSecret) {
-      headers.apisecret = internalReplicationSecret
-    }
-    else {
-      const supabase = useSupabase()
-      const { data: { session } } = await supabase.auth.getSession()
+    const supabase = useSupabase()
+    const { data: { session } } = await supabase.auth.getSession()
 
-      if (!session?.access_token)
-        throw new Error('No session available and replication secret is not configured')
+    if (!session?.access_token)
+      throw new Error('No session available and replication secret is not configured')
 
-      headers.Authorization = `Bearer ${session.access_token}`
-    }
+    headers.Authorization = `Bearer ${session.access_token}`
 
     const response = await fetch(`${defaultApiHost}/replication`, {
       method: 'GET',
@@ -209,7 +202,7 @@ displayStore.defaultBack = '/dashboard'
           {{ errorMessage }}
         </div>
 
-        <div v-else-if="isLoading && !data" class="flex items-center justify-center min-h-[300px]">
+        <div v-else-if="isLoading && !data" class="flex items-center justify-center min-h-75">
           <Spinner size="w-24 h-24" />
         </div>
 

--- a/src/pages/admin/dashboard/replication.vue
+++ b/src/pages/admin/dashboard/replication.vue
@@ -109,7 +109,7 @@ async function loadReplicationStatus() {
     const { data: { session } } = await supabase.auth.getSession()
 
     if (!session?.access_token)
-      throw new Error('No session available and replication secret is not configured')
+      throw new Error('No active session available')
 
     headers.Authorization = `Bearer ${session.access_token}`
 
@@ -202,7 +202,7 @@ displayStore.defaultBack = '/dashboard'
           {{ errorMessage }}
         </div>
 
-        <div v-else-if="isLoading && !data" class="flex items-center justify-center min-h-75">
+        <div v-else-if="isLoading && !data" class="flex items-center justify-center min-h-80">
           <Spinner size="w-24 h-24" />
         </div>
 

--- a/supabase/functions/_backend/private/website_preview.ts
+++ b/supabase/functions/_backend/private/website_preview.ts
@@ -1,12 +1,19 @@
-import type { Context } from 'hono'
 import { createHono, middlewareAuth, parseBody, quickError, useCors } from '../utils/hono.ts'
+import { fetchPublicUrl, getPublicHostnameValidationError as getPublicHostnameValidationErrorBase } from '../utils/publicUrl.ts'
 import { version } from '../utils/version.ts'
-import { getWebhookUrlValidationError } from '../utils/webhook.ts'
 
 const MAX_ICON_BYTES = 512 * 1024
 const MAX_HTML_BYTES = 1024 * 1024
 const MAX_REDIRECTS = 5
-const DNS_LOOKUP_URL = 'https://cloudflare-dns.com/dns-query'
+const WEBSITE_URL_VALIDATION_MESSAGES = {
+  invalidUrl: 'Website must be a valid URL',
+  publicHost: 'Website must point to a public host',
+  ipLiteral: 'Website must point to a public host',
+  https: 'Website must use HTTPS',
+  dnsResolution: 'Could not resolve website host',
+  fetchFailed: 'Could not fetch website',
+  tooManyRedirects: 'Too many redirects',
+}
 
 export const app = createHono('', version)
 
@@ -134,89 +141,11 @@ function findIconHref(html: string) {
   return candidates.sort((a, b) => b.priority - a.priority)[0]?.href ?? ''
 }
 
-function isPrivateIpv4(ip: string) {
-  const octets = ip.split('.').map(part => Number.parseInt(part, 10))
-  if (octets.length !== 4 || octets.some(part => Number.isNaN(part) || part < 0 || part > 255))
-    return true
-
-  const [a, b] = octets
-  return a === 0
-    || a === 10
-    || a === 127
-    || (a === 169 && b === 254)
-    || (a === 172 && b >= 16 && b <= 31)
-    || (a === 192 && b === 168)
-    || (a === 100 && b >= 64 && b <= 127)
-    || (a === 198 && (b === 18 || b === 19))
-  // Reserved TEST-NET ranges are also non-public for this fetch path.
-    || (a === 192 && b === 0)
-    || (a === 192 && b === 0 && octets[2] === 2)
-    || (a === 198 && b === 51 && octets[2] === 100)
-    || (a === 203 && b === 0 && octets[2] === 113)
-}
-
-function isPrivateIpv6(ip: string) {
-  const normalized = ip.toLowerCase()
-  if (normalized === '::1' || normalized === '::')
-    return true
-  if (normalized.startsWith('fe80:') || normalized.startsWith('fc') || normalized.startsWith('fd'))
-    return true
-  if (normalized.startsWith('::ffff:')) {
-    const mappedIpv4 = normalized.slice(7)
-    return isPrivateIpv4(mappedIpv4)
-  }
-  return false
-}
-
-function isPrivateIp(ip: string) {
-  return ip.includes(':') ? isPrivateIpv6(ip) : isPrivateIpv4(ip)
-}
-
-function isIpLiteral(value: string) {
-  return /^[0-9.]+$/.test(value) || value.includes(':')
-}
-
-async function resolveHostnameIps(hostname: string, type: 'A' | 'AAAA') {
-  const dnsUrl = new URL(DNS_LOOKUP_URL)
-  dnsUrl.searchParams.set('name', hostname)
-  dnsUrl.searchParams.set('type', type)
-
-  const response = await fetch(dnsUrl.toString(), {
-    headers: { Accept: 'application/dns-json' },
+async function getWebsitePublicHostnameValidationError(urlString: string) {
+  return await getPublicHostnameValidationErrorBase(urlString, {
+    messages: WEBSITE_URL_VALIDATION_MESSAGES,
+    requireDnsResolution: true,
   })
-  if (!response.ok)
-    return []
-
-  const data = await response.json() as { Answer?: Array<{ data?: string }> }
-  return (data.Answer ?? [])
-    .map(answer => answer.data?.trim() ?? '')
-    .filter(answer => !!answer && isIpLiteral(answer))
-}
-
-async function getPublicHostnameValidationError(c: Context, urlString: string) {
-  const validationError = getWebhookUrlValidationError(c, urlString)
-  if (validationError)
-    return validationError
-
-  let url: URL
-  try {
-    url = new URL(urlString)
-  }
-  catch {
-    return 'Website must be a valid URL'
-  }
-
-  const ips = [
-    ...await resolveHostnameIps(url.hostname, 'A'),
-    ...await resolveHostnameIps(url.hostname, 'AAAA'),
-  ]
-
-  if (ips.length === 0)
-    return 'Could not resolve website host'
-  if (ips.some(isPrivateIp))
-    return 'Website must point to a public host'
-
-  return null
 }
 
 async function readResponseTextWithLimit(response: Response, limit: number) {
@@ -258,45 +187,18 @@ async function readResponseTextWithLimit(response: Response, limit: number) {
 }
 
 async function fetchValidatedUrl(
-  c: Context,
   urlString: string,
   init?: RequestInit,
 ) {
-  let currentUrl = urlString
-
-  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
-    const validationError = await getPublicHostnameValidationError(c, currentUrl)
-    if (validationError)
-      return { error: validationError, response: null as Response | null }
-
-    let response: Response
-    try {
-      response = await fetch(currentUrl, {
-        ...init,
-        redirect: 'manual',
-      })
-    }
-    catch {
-      return { error: 'Could not fetch website', response: null as Response | null }
-    }
-
-    if (response.status >= 300 && response.status < 400) {
-      const location = response.headers.get('location')
-      if (!location)
-        return { error: 'Could not fetch website', response: null as Response | null }
-
-      currentUrl = new URL(location, currentUrl).toString()
-      continue
-    }
-
-    return { error: null, response }
-  }
-
-  return { error: 'Too many redirects', response: null as Response | null }
+  return await fetchPublicUrl(urlString, init, {
+    messages: WEBSITE_URL_VALIDATION_MESSAGES,
+    requireDnsResolution: true,
+    maxRedirects: MAX_REDIRECTS,
+  })
 }
 
-async function fetchIconDataUrl(c: Context, iconUrl: string) {
-  const { error, response } = await fetchValidatedUrl(c, iconUrl)
+async function fetchIconDataUrl(iconUrl: string) {
+  const { error, response } = await fetchValidatedUrl(iconUrl)
   if (error || !response)
     return null
 
@@ -334,11 +236,11 @@ app.post('/', middlewareAuth, async (c) => {
   if (!website)
     return quickError(400, 'invalid_website', 'Website must be a valid URL')
 
-  const websiteValidationError = await getPublicHostnameValidationError(c, website)
+  const websiteValidationError = await getWebsitePublicHostnameValidationError(website)
   if (websiteValidationError)
     return quickError(400, 'invalid_website', websiteValidationError)
 
-  const { error: fetchError, response } = await fetchValidatedUrl(c, website, {
+  const { error: fetchError, response, finalUrl } = await fetchValidatedUrl(website, {
     headers: {
       'User-Agent': 'CapgoWebsitePreview/1.0',
       'Accept': 'text/html,application/xhtml+xml',
@@ -357,8 +259,8 @@ app.post('/', middlewareAuth, async (c) => {
   const html = await readResponseTextWithLimit(response, MAX_HTML_BYTES)
   if (!html)
     return quickError(400, 'website_too_large', 'Website response is too large')
-  const finalUrl = new URL(response.url)
-  const hostname = finalUrl.hostname.replace(/^www\./, '')
+  const finalUrlParsed = new URL(finalUrl ?? response.url)
+  const hostname = finalUrlParsed.hostname.replace(/^www\./, '')
 
   const name = normalizeCandidateName(findMetaContent(html, 'og:site_name'), hostname)
     || normalizeCandidateName(findMetaContent(html, 'application-name'), hostname)
@@ -366,11 +268,11 @@ app.post('/', middlewareAuth, async (c) => {
     || deriveNameFromHostname(hostname)
 
   const iconHref = findIconHref(html)
-  const iconUrl = iconHref ? new URL(iconHref, finalUrl).toString() : ''
-  const icon = iconUrl ? await fetchIconDataUrl(c, iconUrl) : null
+  const iconUrl = iconHref ? new URL(iconHref, finalUrlParsed).toString() : ''
+  const icon = iconUrl ? await fetchIconDataUrl(iconUrl) : null
 
   return c.json({
-    website: finalUrl.toString(),
+    website: finalUrlParsed.toString(),
     hostname,
     name,
     icon,

--- a/supabase/functions/_backend/public/webhooks/deliveries.ts
+++ b/supabase/functions/_backend/public/webhooks/deliveries.ts
@@ -11,7 +11,7 @@ import { supabaseApikey, supabaseWithAuth } from '../../utils/supabase.ts'
 import {
   getDeliveryById,
   getWebhookById,
-  getWebhookUrlValidationError,
+  getWebhookPublicUrlValidationError,
   queueWebhookDelivery,
 } from '../../utils/webhook.ts'
 import { checkWebhookPermission, checkWebhookPermissionV2 } from './index.ts'
@@ -144,7 +144,7 @@ export async function retryDelivery(c: Context<MiddlewareKeyVariables, any, any>
     throw simpleError('webhook_disabled', 'Webhook is disabled')
   }
 
-  const urlError = getWebhookUrlValidationError(c, webhook.url)
+  const urlError = await getWebhookPublicUrlValidationError(c, webhook.url)
   if (urlError)
     throw simpleError('invalid_url', urlError, { url: webhook.url })
 

--- a/supabase/functions/_backend/public/webhooks/post.ts
+++ b/supabase/functions/_backend/public/webhooks/post.ts
@@ -4,7 +4,7 @@ import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
-import { getWebhookUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
+import { getWebhookPublicUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
 import { checkWebhookPermission } from './index.ts'
 
 const bodySchema = type({
@@ -33,7 +33,7 @@ export async function post(c: Context, bodyRaw: any, apikey: Database['public'][
     })
   }
 
-  const urlError = getWebhookUrlValidationError(c, body.url)
+  const urlError = await getWebhookPublicUrlValidationError(c, body.url)
   if (urlError)
     throw simpleError('invalid_url', urlError, { url: body.url })
 

--- a/supabase/functions/_backend/public/webhooks/put.ts
+++ b/supabase/functions/_backend/public/webhooks/put.ts
@@ -4,7 +4,7 @@ import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
-import { getWebhookUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
+import { getWebhookPublicUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
 import { checkWebhookPermission } from './index.ts'
 
 const bodySchema = type({
@@ -57,7 +57,7 @@ export async function put(c: Context, bodyRaw: any, apikey: Database['public']['
 
   // Validate URL if provided
   if (body.url) {
-    const urlError = getWebhookUrlValidationError(c, body.url)
+    const urlError = await getWebhookPublicUrlValidationError(c, body.url)
     if (urlError)
       throw simpleError('invalid_url', urlError, { url: body.url })
   }

--- a/supabase/functions/_backend/public/webhooks/test.ts
+++ b/supabase/functions/_backend/public/webhooks/test.ts
@@ -8,7 +8,7 @@ import {
   createDeliveryRecord,
   createTestPayload,
   deliverWebhook,
-  getWebhookUrlValidationError,
+  getWebhookPublicUrlValidationError,
   updateDeliveryResult,
 } from '../../utils/webhook.ts'
 import { checkWebhookPermissionV2 } from './index.ts'
@@ -46,7 +46,7 @@ export async function test(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw
     throw simpleError('no_permission', 'Webhook does not belong to this organization', { webhookId: body.webhookId })
   }
 
-  const urlError = getWebhookUrlValidationError(c, webhook.url)
+  const urlError = await getWebhookPublicUrlValidationError(c, webhook.url)
   if (urlError)
     throw simpleError('invalid_url', urlError, { url: webhook.url })
 

--- a/supabase/functions/_backend/triggers/webhook_dispatcher.ts
+++ b/supabase/functions/_backend/triggers/webhook_dispatcher.ts
@@ -9,7 +9,7 @@ import {
   buildWebhookPayload,
   createDeliveryRecord,
   findWebhooksForEvent,
-  getWebhookUrlValidationError,
+  getWebhookPublicUrlValidationError,
   queueWebhookDelivery,
   updateDeliveryResult,
 } from '../utils/webhook.ts'
@@ -99,7 +99,7 @@ app.post('/', middlewareAPISecret, async (c) => {
           return
         }
 
-        const urlError = getWebhookUrlValidationError(c, webhook.url)
+        const urlError = await getWebhookPublicUrlValidationError(c, webhook.url)
         if (urlError) {
           await updateDeliveryResult(
             c,

--- a/supabase/functions/_backend/utils/publicUrl.ts
+++ b/supabase/functions/_backend/utils/publicUrl.ts
@@ -42,7 +42,7 @@ function isPrivateIpv4(ip: string) {
   if (octets.length !== 4 || octets.some(part => Number.isNaN(part) || part < 0 || part > 255))
     return true
 
-  const [a, b, c, d] = octets
+  const [a, b, c] = octets
   return a === 0
     || a === 10
     || a === 127
@@ -57,7 +57,6 @@ function isPrivateIpv4(ip: string) {
     || (a === 198 && b === 51 && c === 100)
     || (a === 203 && b === 0 && c === 113)
     || a >= 224
-    || (a === 255 && b === 255 && c === 255 && d === 255)
 }
 
 function isPrivateIpv6(ip: string) {
@@ -151,10 +150,11 @@ export async function getPublicHostnameValidationError(urlString: string, option
     return options.messages.invalidUrl
   }
 
-  const ips = [
-    ...await resolveHostnameIps(url.hostname, 'A'),
-    ...await resolveHostnameIps(url.hostname, 'AAAA'),
-  ]
+  const [ipv4Answers, ipv6Answers] = await Promise.all([
+    resolveHostnameIps(url.hostname, 'A'),
+    resolveHostnameIps(url.hostname, 'AAAA'),
+  ])
+  const ips = [...ipv4Answers, ...ipv6Answers]
 
   if (ips.some(isPrivateIp))
     return options.messages.publicHost

--- a/supabase/functions/_backend/utils/publicUrl.ts
+++ b/supabase/functions/_backend/utils/publicUrl.ts
@@ -1,0 +1,210 @@
+const DNS_LOOKUP_URL = 'https://cloudflare-dns.com/dns-query'
+const DNS_LOOKUP_TIMEOUT_MS = 1500
+const DEFAULT_MAX_REDIRECTS = 5
+const IPV4_REGEX = /^\d{1,3}(?:\.\d{1,3}){3}$/
+const LOCALHOST_SUFFIX = '.localhost'
+
+export interface PublicUrlValidationMessages {
+  invalidUrl: string
+  publicHost: string
+  ipLiteral: string
+  https: string
+  dnsResolution: string
+  fetchFailed?: string
+  tooManyRedirects?: string
+}
+
+export interface PublicUrlValidationOptions {
+  allowLocalUrls?: boolean
+  requireDnsResolution?: boolean
+  requireHttps?: boolean
+  messages: PublicUrlValidationMessages
+}
+
+export interface FetchPublicUrlOptions extends PublicUrlValidationOptions {
+  maxRedirects?: number
+}
+
+export function normalizePublicHostname(hostname: string): string {
+  return hostname.replace(/\.$/, '').toLowerCase()
+}
+
+function isLocalhostHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname.endsWith(LOCALHOST_SUFFIX)
+}
+
+function isIpLiteral(hostname: string): boolean {
+  return IPV4_REGEX.test(hostname) || hostname.includes(':')
+}
+
+function isPrivateIpv4(ip: string) {
+  const octets = ip.split('.').map(part => Number.parseInt(part, 10))
+  if (octets.length !== 4 || octets.some(part => Number.isNaN(part) || part < 0 || part > 255))
+    return true
+
+  const [a, b, c, d] = octets
+  return a === 0
+    || a === 10
+    || a === 127
+    || (a === 100 && b >= 64 && b <= 127)
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 0 && c === 0)
+    || (a === 192 && b === 0 && c === 2)
+    || (a === 192 && b === 88 && c === 99)
+    || (a === 192 && b === 168)
+    || (a === 198 && (b === 18 || b === 19))
+    || (a === 198 && b === 51 && c === 100)
+    || (a === 203 && b === 0 && c === 113)
+    || a >= 224
+    || (a === 255 && b === 255 && c === 255 && d === 255)
+}
+
+function isPrivateIpv6(ip: string) {
+  const normalized = ip.toLowerCase()
+
+  if (normalized === '::' || normalized === '::1')
+    return true
+  if (normalized.startsWith('::ffff:'))
+    return isPrivateIpv4(normalized.slice(7))
+  if (normalized.startsWith('100:') || normalized.startsWith('2001:db8:') || normalized.startsWith('2002:'))
+    return true
+  if (normalized.startsWith('fc') || normalized.startsWith('fd') || normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb'))
+    return true
+  if (normalized.startsWith('ff'))
+    return true
+
+  return false
+}
+
+function isPrivateIp(ip: string) {
+  return ip.includes(':') ? isPrivateIpv6(ip) : isPrivateIpv4(ip)
+}
+
+async function resolveHostnameIps(hostname: string, type: 'A' | 'AAAA') {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), DNS_LOOKUP_TIMEOUT_MS)
+
+  try {
+    const dnsUrl = new URL(DNS_LOOKUP_URL)
+    dnsUrl.searchParams.set('name', hostname)
+    dnsUrl.searchParams.set('type', type)
+
+    const response = await fetch(dnsUrl.toString(), {
+      headers: { Accept: 'application/dns-json' },
+      signal: controller.signal,
+    })
+    if (!response.ok)
+      return []
+
+    const data = await response.json() as { Answer?: Array<{ data?: string }> }
+    return (data.Answer ?? [])
+      .map(answer => answer.data?.trim() ?? '')
+      .filter(answer => !!answer && isIpLiteral(answer))
+  }
+  catch {
+    return []
+  }
+  finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+export function getPublicUrlSyntaxValidationError(urlString: string, options: PublicUrlValidationOptions): string | null {
+  let url: URL
+  try {
+    url = new URL(urlString)
+  }
+  catch {
+    return options.messages.invalidUrl
+  }
+
+  if (options.allowLocalUrls)
+    return null
+
+  const hostname = normalizePublicHostname(url.hostname)
+  if (isLocalhostHostname(hostname))
+    return options.messages.publicHost
+
+  if (isIpLiteral(hostname))
+    return options.messages.ipLiteral
+
+  if ((options.requireHttps ?? true) && url.protocol !== 'https:')
+    return options.messages.https
+
+  if (!(options.requireHttps ?? true) && url.protocol !== 'https:' && url.protocol !== 'http:')
+    return options.messages.https
+
+  return null
+}
+
+export async function getPublicHostnameValidationError(urlString: string, options: PublicUrlValidationOptions): Promise<string | null> {
+  const syntaxError = getPublicUrlSyntaxValidationError(urlString, options)
+  if (syntaxError || options.allowLocalUrls)
+    return syntaxError
+
+  let url: URL
+  try {
+    url = new URL(urlString)
+  }
+  catch {
+    return options.messages.invalidUrl
+  }
+
+  const ips = [
+    ...await resolveHostnameIps(url.hostname, 'A'),
+    ...await resolveHostnameIps(url.hostname, 'AAAA'),
+  ]
+
+  if (ips.some(isPrivateIp))
+    return options.messages.publicHost
+
+  if (options.requireDnsResolution && ips.length === 0)
+    return options.messages.dnsResolution
+
+  return null
+}
+
+export async function fetchPublicUrl(
+  urlString: string,
+  init: RequestInit | undefined,
+  options: FetchPublicUrlOptions,
+): Promise<{ error: string | null, response: Response | null, finalUrl: string | null }> {
+  let currentUrl = urlString
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS
+
+  for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
+    const validationError = await getPublicHostnameValidationError(currentUrl, options)
+    if (validationError)
+      return { error: validationError, response: null, finalUrl: null }
+
+    let response: Response
+    try {
+      response = await fetch(currentUrl, {
+        ...init,
+        redirect: 'manual',
+      })
+    }
+    catch {
+      return { error: options.messages.fetchFailed ?? options.messages.invalidUrl, response: null, finalUrl: null }
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location')
+      if (!location)
+        return { error: options.messages.fetchFailed ?? options.messages.invalidUrl, response: null, finalUrl: null }
+
+      try {
+        currentUrl = new URL(location, currentUrl).toString()
+      }
+      catch {
+        return { error: options.messages.fetchFailed ?? options.messages.invalidUrl, response: null, finalUrl: null }
+      }
+      continue
+    }
+
+    return { error: null, response, finalUrl: currentUrl }
+  }
+
+  return { error: options.messages.tooManyRedirects ?? options.messages.invalidUrl, response: null, finalUrl: null }
+}

--- a/supabase/functions/_backend/utils/webhook.ts
+++ b/supabase/functions/_backend/utils/webhook.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
 import { closeClient, getPgClient } from './pg.ts'
+import { getPublicHostnameValidationError, getPublicUrlSyntaxValidationError } from './publicUrl.ts'
 import { supabaseAdmin } from './supabase.ts'
 import { getEnv } from './utils.ts'
 
@@ -45,51 +46,32 @@ export const WEBHOOK_EVENT_TYPES = [
 
 export type WebhookEventType = typeof WEBHOOK_EVENT_TYPES[number]
 
-const LOCALHOST_SUFFIX = '.localhost'
-const IPV4_REGEX = /^\d{1,3}(?:\.\d{1,3}){3}$/
-
 function allowLocalWebhookUrls(c: Context): boolean {
   return getEnv(c, 'CAPGO_ALLOW_LOCAL_WEBHOOK_URLS') === 'true'
 }
 
-function normalizeHostname(hostname: string): string {
-  return hostname.replace(/\.$/, '').toLowerCase()
-}
-
-function isLocalhostHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname.endsWith(LOCALHOST_SUFFIX)
-}
-
-function isIpLiteral(hostname: string): boolean {
-  return IPV4_REGEX.test(hostname) || hostname.includes(':')
+const WEBHOOK_URL_VALIDATION_MESSAGES = {
+  invalidUrl: 'Webhook URL is invalid',
+  publicHost: 'Webhook URL must point to a public host',
+  ipLiteral: 'Webhook URL must use a hostname, not an IP address',
+  https: 'Webhook URL must use HTTPS',
+  dnsResolution: 'Webhook URL host could not be resolved',
 }
 
 export function getWebhookUrlValidationError(c: Context, urlString: string): string | null {
-  let url: URL
-  try {
-    url = new URL(urlString)
-  }
-  catch {
-    return 'Webhook URL is invalid'
-  }
+  return getPublicUrlSyntaxValidationError(urlString, {
+    allowLocalUrls: allowLocalWebhookUrls(c),
+    messages: WEBHOOK_URL_VALIDATION_MESSAGES,
+  })
+}
 
-  if (allowLocalWebhookUrls(c))
-    return null
-
-  // We intentionally stop at syntactic/public-host checks: webhook delivery runs
-  // entirely from serverless infrastructure, so private/internal addresses are not
-  // reachable by design.
-  const hostname = normalizeHostname(url.hostname)
-  if (isLocalhostHostname(hostname))
-    return 'Webhook URL must point to a public host'
-
-  if (isIpLiteral(hostname))
-    return 'Webhook URL must use a hostname, not an IP address'
-
-  if (url.protocol !== 'https:')
-    return 'Webhook URL must use HTTPS'
-
-  return null
+export async function getWebhookPublicUrlValidationError(c: Context, urlString: string): Promise<string | null> {
+  return await getPublicHostnameValidationError(urlString, {
+    allowLocalUrls: allowLocalWebhookUrls(c),
+    // Do not fail customer webhooks when DNS preflight is unavailable; block only explicit private answers.
+    requireDnsResolution: false,
+    messages: WEBHOOK_URL_VALIDATION_MESSAGES,
+  })
 }
 
 /**
@@ -215,7 +197,7 @@ export async function deliverWebhook(
 ): Promise<{ success: boolean, status?: number, body?: string, duration?: number }> {
   const startTime = Date.now()
 
-  const urlValidationError = getWebhookUrlValidationError(c, url)
+  const urlValidationError = await getWebhookPublicUrlValidationError(c, url)
   if (urlValidationError) {
     const duration = Date.now() - startTime
     cloudlogErr({

--- a/tests/public-url-validation.unit.test.ts
+++ b/tests/public-url-validation.unit.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchPublicUrl,
+  getPublicHostnameValidationError,
+  getPublicUrlSyntaxValidationError,
+} from '../supabase/functions/_backend/utils/publicUrl.ts'
+
+const messages = {
+  invalidUrl: 'invalid',
+  publicHost: 'public host',
+  ipLiteral: 'ip literal',
+  https: 'https',
+  dnsResolution: 'dns',
+  fetchFailed: 'fetch failed',
+  tooManyRedirects: 'too many redirects',
+}
+
+function dnsResponse(records: string[]) {
+  return new Response(JSON.stringify({
+    Answer: records.map(data => ({ data })),
+  }))
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('public outbound URL validation', () => {
+  it.concurrent('rejects non-public URL syntax before DNS lookup', () => {
+    expect(getPublicUrlSyntaxValidationError('https://localhost/webhook', { messages })).toBe('public host')
+    expect(getPublicUrlSyntaxValidationError('https://127.0.0.1/webhook', { messages })).toBe('ip literal')
+    expect(getPublicUrlSyntaxValidationError('http://example.com/webhook', { messages })).toBe('https')
+  })
+
+  it('blocks hosts that resolve to private IPv4 or IPv6 addresses', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      const name = url.searchParams.get('name')
+      const type = url.searchParams.get('type')
+
+      if (name === 'private.example' && type === 'A')
+        return dnsResponse(['169.254.169.254'])
+      if (name === 'private6.example' && type === 'AAAA')
+        return dnsResponse(['fd00::1'])
+
+      return dnsResponse([])
+    }))
+
+    await expect(getPublicHostnameValidationError('https://private.example/webhook', { messages })).resolves.toBe('public host')
+    await expect(getPublicHostnameValidationError('https://private6.example/webhook', { messages })).resolves.toBe('public host')
+  })
+
+  it('can treat missing DNS answers as either allowed or invalid', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => dnsResponse([])))
+
+    await expect(getPublicHostnameValidationError('https://unresolved.example/webhook', {
+      messages,
+      requireDnsResolution: false,
+    })).resolves.toBeNull()
+    await expect(getPublicHostnameValidationError('https://unresolved.example/webhook', {
+      messages,
+      requireDnsResolution: true,
+    })).resolves.toBe('dns')
+  })
+
+  it('revalidates redirect targets before following them', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = String(input)
+      const url = new URL(urlString)
+
+      if (url.hostname === 'cloudflare-dns.com') {
+        const name = url.searchParams.get('name')
+        if (name === 'safe.example')
+          return dnsResponse(['93.184.216.34'])
+        if (name === 'private.example')
+          return dnsResponse(['127.0.0.1'])
+        return dnsResponse([])
+      }
+
+      if (urlString === 'https://safe.example/')
+        return new Response('', { status: 302, headers: { location: 'https://private.example/' } })
+
+      return new Response('should not fetch', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchPublicUrl('https://safe.example/', undefined, {
+      messages,
+      requireDnsResolution: true,
+    })
+
+    expect(result).toMatchObject({
+      error: 'public host',
+      response: null,
+      finalUrl: null,
+    })
+    expect(fetchMock.mock.calls.some(([url]) => url === 'https://private.example/')).toBe(false)
+  })
+})

--- a/tests/webhook-delivery-redirect.unit.test.ts
+++ b/tests/webhook-delivery-redirect.unit.test.ts
@@ -65,13 +65,12 @@ describe('webhook delivery redirect handling', () => {
       'whsec_test_secret',
     )
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://example.com/webhook',
-      expect.objectContaining({
-        method: 'POST',
-        redirect: 'manual',
-      }),
-    )
+    const webhookCalls = fetchMock.mock.calls.filter(([url]) => url === 'https://example.com/webhook')
+    expect(webhookCalls).toHaveLength(1)
+    expect(webhookCalls[0]?.[1]).toMatchObject({
+      method: 'POST',
+      redirect: 'manual',
+    })
     expect(result).toMatchObject({
       success: false,
       status: 302,

--- a/tests/webhook-delivery-security.unit.test.ts
+++ b/tests/webhook-delivery-security.unit.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 describe('webhook delivery redirect handling', () => {
   it('sends webhook requests with manual redirect handling', async () => {
     mockGetEnv.mockReturnValue('')
-    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    const fetchMock = vi.fn().mockImplementation(async () => new Response('ok', { status: 200 }))
     vi.stubGlobal('fetch', fetchMock)
 
     const { deliverWebhook } = await import('../supabase/functions/_backend/utils/webhook.ts')
@@ -60,8 +60,9 @@ describe('webhook delivery redirect handling', () => {
     )
 
     expect(result.success).toBe(true)
-    expect(fetchMock).toHaveBeenCalledOnce()
-    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+    const webhookCalls = fetchMock.mock.calls.filter(([url]) => url === 'https://example.com/webhook')
+    expect(webhookCalls).toHaveLength(1)
+    expect(webhookCalls[0]?.[1]).toMatchObject({
       method: 'POST',
       redirect: 'manual',
     })
@@ -101,6 +102,53 @@ describe('webhook delivery redirect handling', () => {
 
     expect(result.success).toBe(false)
     expect(result.status).toBe(302)
-    expect(fetchMock).toHaveBeenCalledOnce()
+    const webhookCalls = fetchMock.mock.calls.filter(([url]) => url === 'https://example.com/webhook')
+    expect(webhookCalls).toHaveLength(1)
+  })
+
+  it('blocks webhook hosts that resolve to private addresses before delivery', async () => {
+    mockGetEnv.mockReturnValue('')
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = String(input)
+      const url = new URL(urlString)
+
+      if (url.hostname === 'cloudflare-dns.com') {
+        const type = url.searchParams.get('type')
+        return new Response(JSON.stringify({
+          Answer: type === 'A' ? [{ data: '127.0.0.1' }] : [],
+        }))
+      }
+
+      return new Response('should not post', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { deliverWebhook } = await import('../supabase/functions/_backend/utils/webhook.ts')
+    const result = await deliverWebhook(
+      createContext(),
+      'delivery-3',
+      'https://private.example/webhook',
+      {
+        event: 'app_versions.INSERT',
+        event_id: 'event-3',
+        timestamp: new Date().toISOString(),
+        org_id: 'org-1',
+        data: {
+          table: 'app_versions',
+          operation: 'INSERT',
+          record_id: 'record-3',
+          old_record: null,
+          new_record: null,
+          changed_fields: null,
+        },
+      },
+      'secret',
+    )
+
+    expect(result).toMatchObject({
+      success: false,
+      body: 'Error: Webhook URL must point to a public host',
+    })
+    expect(fetchMock.mock.calls.some(([url]) => url === 'https://private.example/webhook')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Added a shared public outbound URL validator for syntax checks, DNS-over-HTTPS preflight, private IP blocking, and manual redirect revalidation.
- Reused that validator for website preview fetches and webhook URL create/update/test/retry/dispatch/delivery paths.
- Added unit coverage for private DNS answers, redirect-to-private blocking, and webhook delivery preflight behavior.

## Motivation (AI generated)

DNS-based SSRF advisories kept recurring because webhook targets only had syntactic URL checks. Centralizing public outbound validation gives the advisory scanners a concrete preflight path while keeping the existing Cloudflare serverless assumptions documented in code.

## Business Impact (AI generated)

This should reduce repeated advisory noise around website preview and webhooks without blocking normal customer webhooks when DNS preflight is unavailable. Explicit private DNS answers are blocked before outbound delivery.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx vitest run tests/public-url-validation.unit.test.ts tests/webhook-delivery-security.unit.test.ts tests/webhook-delivery-redirect.unit.test.ts`
- [x] `bun typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Admin dashboard now requires proper user authentication for replication status checks.
  * Enhanced webhook security validation to prevent delivery to private network addresses.
  * Improved website preview URL validation with centralized error messaging.

* **Style**
  * Updated sidebar navigation button styling and admin dashboard loading UI appearance.

* **Tests**
  * Added comprehensive public URL validation test coverage.
  * Enhanced webhook delivery test assertions for better accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2199)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->