### PR TITLE
fix(api): cap translation request bodies

### DIFF
--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -14,6 +14,7 @@ const TRANSLATION_REQUEUE_AFTER_SECONDS = 60
 const TRANSLATION_BATCH_LEASE_SECONDS = 15 * 60
 const TRANSLATION_STORE_TABLE = 'translation_messages_cache'
 const CLAIMED_TRANSLATION_BATCH_INDEX_OFFSET = 1_000_000_000
+const MAX_TRANSLATION_REQUEST_BODY_BYTES = 1024
 const PLACEHOLDER_PATTERN = /\{[\w.]+\}|%\w+%?|\$\d+/g
 
 const SUPPORTED_LANGUAGES = new Set([
@@ -162,11 +163,51 @@ function cloudlogErr(payload: Record<string, unknown>) {
   console.error(JSON.stringify(payload))
 }
 
-async function parseJsonBody<T>(request: Request): Promise<T> {
-  try {
-    return await request.json() as T
+async function readLimitedRequestBody(request: Request, maxBytes: number) {
+  const contentLength = request.headers.get('content-length')
+  if (contentLength && Number(contentLength) > maxBytes)
+    fail(413, 'request_body_too_large', 'Request body is too large')
+
+  if (!request.body)
+    return ''
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      break
+    if (!value)
+      continue
+
+    totalBytes += value.byteLength
+    if (totalBytes > maxBytes) {
+      await reader.cancel().catch(() => {})
+      fail(413, 'request_body_too_large', 'Request body is too large')
+    }
+    chunks.push(value)
   }
-  catch {
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new TextDecoder().decode(body)
+}
+
+async function parseJsonBody<T>(request: Request, maxBytes = MAX_TRANSLATION_REQUEST_BODY_BYTES): Promise<T> {
+  try {
+    const text = await readLimitedRequestBody(request, maxBytes)
+    return text ? JSON.parse(text) as T : {} as T
+  }
+  catch (error) {
+    if (error instanceof PublicHttpError)
+      throw error
     return {} as T
   }
 }

--- a/supabase/functions/_backend/public/translation.ts
+++ b/supabase/functions/_backend/public/translation.ts
@@ -1,7 +1,8 @@
 import type { Context } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 import sourceMessages from '../../../../messages/en.json'
 import { CacheHelper } from '../utils/cache.ts'
-import { honoFactory, parseBody, quickError, useCors } from '../utils/hono.ts'
+import { honoFactory, quickError, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { backgroundTask, getEnv } from '../utils/utils.ts'
 
@@ -9,6 +10,7 @@ const CACHE_TTL_SECONDS = 5 * 60
 const DEFAULT_TRANSLATION_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast'
 const MAX_BATCH_CHARACTERS = 6_000
 const MAX_BATCH_ITEMS = 60
+const MAX_TRANSLATION_REQUEST_BODY_BYTES = 1024
 const TRANSLATION_ATTEMPTS = 3
 const TRANSLATION_CACHE_PATH = '/translation/messages-cache'
 const PLACEHOLDER_PATTERN = /\{[\w.]+\}|%\w+%?|\$\d+/g
@@ -79,6 +81,55 @@ function getTranslationModel(c: Context) {
 
 function getTargetLanguageName(targetLanguage: string) {
   return LANGUAGE_NAMES[targetLanguage] ?? targetLanguage
+}
+
+async function readLimitedRequestBody(request: Request, maxBytes: number) {
+  const contentLength = request.headers.get('content-length')
+  if (contentLength && Number(contentLength) > maxBytes)
+    quickError(413, 'request_body_too_large', 'Request body is too large')
+
+  if (!request.body)
+    return ''
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      break
+    if (!value)
+      continue
+
+    totalBytes += value.byteLength
+    if (totalBytes > maxBytes) {
+      await reader.cancel().catch(() => {})
+      quickError(413, 'request_body_too_large', 'Request body is too large')
+    }
+    chunks.push(value)
+  }
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new TextDecoder().decode(body)
+}
+
+async function parseTranslationBody(c: Context): Promise<TranslationBody> {
+  try {
+    const text = await readLimitedRequestBody(c.req.raw, MAX_TRANSLATION_REQUEST_BODY_BYTES)
+    return text ? JSON.parse(text) as TranslationBody : {}
+  }
+  catch (error) {
+    if (error instanceof HTTPException)
+      throw error
+    quickError(400, 'invalid_json_parse_body', 'Invalid JSON body', { error })
+  }
 }
 
 async function sha256Hex(value: string) {
@@ -340,7 +391,7 @@ export const app = honoFactory.createApp()
 app.use('*', useCors)
 
 app.post('/messages', async (c) => {
-  const body = await parseBody<TranslationBody>(c)
+  const body = await parseTranslationBody(c)
   const targetLanguage = typeof body.targetLanguage === 'string' ? body.targetLanguage.trim().toLowerCase() : ''
   if (!SUPPORTED_LANGUAGES.has(targetLanguage))
     quickError(400, 'unsupported_translation_language', 'Target language is not supported')

--- a/tests/translation-public-body-limit.unit.test.ts
+++ b/tests/translation-public-body-limit.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { app } from '../supabase/functions/_backend/public/translation.ts'
+
+describe('public translation body limit', () => {
+  it('rejects oversized content-length before reading the body', async () => {
+    const response = await app.request(new Request('http://local/messages', {
+      body: JSON.stringify({ targetLanguage: 'fr' }),
+      duplex: 'half',
+      headers: {
+        'Content-Length': '2048',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    } as RequestInit))
+
+    expect(response.status).toBe(413)
+    expect(await response.text()).toContain('Request body is too large')
+  })
+
+  it('rejects streamed bodies that exceed the translation request limit', async () => {
+    const response = await app.request('http://local/messages', {
+      body: JSON.stringify({
+        targetLanguage: 'fr',
+        padding: 'x'.repeat(2048),
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(413)
+    expect(await response.text()).toContain('Request body is too large')
+  })
+})

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -195,4 +195,55 @@ describe('translation queue helpers', () => {
     expect(payload.status).toBe('pending')
     expect(queue.send).toHaveBeenCalledTimes(1)
   })
+
+  it('rejects oversized translation request bodies before touching storage', async () => {
+    stubWorkerCache()
+    const db = createTranslationStoreMock(null)
+    const queue = {
+      send: vi.fn(),
+    }
+    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({
+        targetLanguage: 'fr',
+        padding: 'x'.repeat(2048),
+      }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }), {
+      DB_TRANSLATIONS: db,
+      TRANSLATION_MESSAGES_QUEUE: queue,
+    } as any)
+    const payload = await response.json() as { error: string }
+
+    expect(response.status).toBe(413)
+    expect(payload.error).toBe('request_body_too_large')
+    expect(db.prepare).not.toHaveBeenCalled()
+    expect(queue.send).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized translation content-length before reading the body', async () => {
+    stubWorkerCache()
+    const db = createTranslationStoreMock(null)
+    const queue = {
+      send: vi.fn(),
+    }
+    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'fr' }),
+      duplex: 'half',
+      headers: {
+        'Content-Length': '2048',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    } as RequestInit), {
+      DB_TRANSLATIONS: db,
+      TRANSLATION_MESSAGES_QUEUE: queue,
+    } as any)
+    const payload = await response.json() as { error: string }
+
+    expect(response.status).toBe(413)
+    expect(payload.error).toBe('request_body_too_large')
+    expect(db.prepare).not.toHaveBeenCalled()
+    expect(queue.send).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
/claim #1667

## Summary
- Replace direct unbounded JSON body parsing on both translation message entrypoints with bounded stream reading.
- Reject translation request bodies above 1 KiB with `413 request_body_too_large` before cache, D1 storage, queue, or AI work.
- Add regression coverage for streamed oversized bodies and `Content-Length` fast-fail handling in both translation implementations.

## Security note
This is public-safe DoS hardening for the translation message endpoint. The accepted payload only needs `targetLanguage`, so the cap preserves normal use while avoiding unnecessary memory work on oversized request bodies.

## Test plan
- `git diff --check`
- `npx --yes bun@latest x vitest run tests/translation-public-body-limit.unit.test.ts tests/translation-queue.unit.test.ts` returned exit code 0 in my local shell, but produced no stdout.

## Screenshots
Not applicable; backend worker/API hardening only.

## Checklist
- [x] Focused regression tests added
- [x] Public-safe security details only