### PR TITLE
fix(stats): read completed public stats snapshot

### DIFF
--- a/supabase/functions/_backend/private/public_stats.ts
+++ b/supabase/functions/_backend/private/public_stats.ts
@@ -8,13 +8,25 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
 
+export function getLatestCompletedGlobalStatsDateId(referenceDate = new Date()) {
+  const completedDay = new Date(Date.UTC(
+    referenceDate.getUTCFullYear(),
+    referenceDate.getUTCMonth(),
+    referenceDate.getUTCDate() - 1,
+  ))
+
+  return completedDay.toISOString().slice(0, 10)
+}
+
 app.get('/', async (c) => {
-  const date_id = new Date().toISOString().slice(0, 10)
+  const latestCompletedDateId = getLatestCompletedGlobalStatsDateId()
   const { data, error } = await supabaseAdmin(c)
     .from('global_stats')
     .select()
-    .eq('date_id', date_id)
-    .single()
+    .lte('date_id', latestCompletedDateId)
+    .order('date_id', { ascending: false })
+    .limit(1)
+    .maybeSingle()
   if (data && !error) {
     return c.json({
       apps: data.apps,
@@ -22,7 +34,7 @@ app.get('/', async (c) => {
       stars: data.stars,
     })
   }
-  cloudlog({ requestId: c.get('requestId'), message: 'Supabase error:', error })
+  cloudlog({ requestId: c.get('requestId'), message: 'Missing completed global_stats row', latestCompletedDateId, error })
   return c.json({
     apps: 1688,
     updates: 1862788600,

--- a/tests/public-stats.unit.test.ts
+++ b/tests/public-stats.unit.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const maybeSingle = vi.fn()
+  const limit = vi.fn(() => ({ maybeSingle }))
+  const order = vi.fn(() => ({ limit }))
+  const lte = vi.fn(() => ({ order }))
+  const select = vi.fn(() => ({ lte }))
+  const from = vi.fn(() => ({ select }))
+
+  return {
+    cloudlog: vi.fn(),
+    from,
+    limit,
+    lte,
+    maybeSingle,
+    order,
+    select,
+    supabaseAdmin: vi.fn(() => ({ from })),
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: mocks.cloudlog,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin: mocks.supabaseAdmin,
+}))
+
+const { app, getLatestCompletedGlobalStatsDateId } = await import('../supabase/functions/_backend/private/public_stats.ts')
+
+describe('public stats endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the latest completed UTC day for stats lookup', () => {
+    expect(getLatestCompletedGlobalStatsDateId(new Date('2026-05-11T00:06:17.122Z'))).toBe('2026-05-10')
+  })
+
+  it('reads the latest completed global stats snapshot', async () => {
+    mocks.maybeSingle.mockResolvedValueOnce({
+      data: {
+        apps: 42,
+        stars: 9,
+        updates: 100,
+        updates_external: 5,
+      },
+      error: null,
+    })
+
+    const res = await app.request('http://localhost/')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      apps: 42,
+      stars: 9,
+      updates: 105,
+    })
+    expect(mocks.from).toHaveBeenCalledWith('global_stats')
+    expect(mocks.lte).toHaveBeenCalledWith('date_id', '2026-05-10')
+    expect(mocks.order).toHaveBeenCalledWith('date_id', { ascending: false })
+    expect(mocks.limit).toHaveBeenCalledWith(1)
+  })
+
+  it('keeps the fallback counters when no completed stats row exists', async () => {
+    const error = { code: 'PGRST116', message: 'The result contains 0 rows' }
+    mocks.maybeSingle.mockResolvedValueOnce({
+      data: null,
+      error,
+    })
+
+    const res = await app.request('http://localhost/')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      apps: 1688,
+      stars: 595,
+      updates: 1862788600,
+    })
+    expect(mocks.cloudlog).toHaveBeenCalledWith({
+      error,
+      latestCompletedDateId: '2026-05-10',
+      message: 'Missing completed global_stats row',
+      requestId: undefined,
+    })
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Read public website stats from the latest completed global_stats snapshot instead of the current UTC day.
- Added unit coverage for completed-day lookup and fallback behavior.

## Motivation (AI generated)

- global_stats is populated for completed days, so querying today returns no row before the next nightly job and triggers hardcoded fallback values.

## Business Impact (AI generated)

- Restores accurate public/admin-visible summary stats after nightly processing and avoids showing stale fallback counters in production.

## Test Plan (AI generated)

- [x] bunx vitest run tests/public-stats.unit.test.ts
- [x] bun lint
- [x] bun lint:backend
- [x] bunx eslint tests/public-stats.unit.test.ts
- [x] pre-commit hook: bun run cli:build && vue-tsc --noEmit
- [x] GitHub Actions CI
- [x] CodeRabbit review: no actionable comments
