### PR TITLE
feat(cli): add build needed check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ Capgo relies on two layered caches for plugin endpoints (`/updates`, `/stats`, `
    - When explicitly discussing the Capgo CLI command itself, always use `@latest`.
    - Use the public shape like `npx @capgo/cli@latest ...` for customer-facing command examples.
    - Use internal execution equivalents (for example, `bunx @capgo/cli@latest ...`) only in internal tooling context.
+   - CLI command names must be lowercase and should use kebab-case for multiple words. Do not add camelCase, PascalCase, or other cased command names.
 
 ### Email Templates
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -7,6 +7,7 @@
 - Keep `src/index.ts` limited to CLI command registration, options, and wiring.
 - Put command implementation logic in dedicated modules/handlers instead of inline `.action(...)` bodies in `src/index.ts`.
 - When adding or changing a CLI command, prefer an exported command handler function in a dedicated module and wire it from `src/index.ts`.
+- CLI command names must be lowercase and should use kebab-case for multiple words. Do not add camelCase, PascalCase, or other cased command names.
 - When adding or changing a CLI command, command option, or CLI-facing workflow, update the TanStack Intent skill docs in `skills/` as part of the same change so the published skills stay aligned with `webdocs/` and `src/index.ts`.
 - For end-customer-facing docs and skills in `skills/` and `webdocs/`, use generic command runners in examples (`npx @capgo/cli@latest ...`) instead of Bun-specific runners. Reserve `bun` and `bunx` for repo-local development and agent execution.
 - Reuse shared option descriptions from `src/index.ts` when an option already exists instead of introducing slightly different wording.

--- a/cli/README.md
+++ b/cli/README.md
@@ -71,6 +71,7 @@ Follow the documentation here: https://capacitorjs.com/docs/getting-started/
   - [Set](#organisation-set)
   - [Delete](#organisation-delete)
 - 🔹 [Build](#build)
+  - [Needed](#build-needed)
   - [Init](#build-init)
   - [Request](#build-request)
   - [Credentials](#build-credentials)
@@ -1146,7 +1147,7 @@ npx @capgo/cli@latest organisation delete
 ## <a id="build"></a> 🔹 **Build**
 
 🏗️  Manage native iOS/Android builds through Capgo Cloud.
-⚠️ This feature is currently in PUBLIC BETA and cannot be used by anyone at this time.
+⚠️ Native cloud build requests are currently in LIMITED BETA. Access is restricted.
  🔒 SECURITY GUARANTEE:
     Build credentials are NEVER stored on Capgo servers.
     They are used only during the build and auto-deleted after.
@@ -1155,6 +1156,32 @@ npx @capgo/cli@latest organisation delete
    Save your credentials first:
    npx @capgo/cli build credentials save --appId <your-app-id> --platform ios
    npx @capgo/cli build credentials save --appId <your-app-id> --platform android
+
+### <a id="build-needed"></a> 🔹 **Needed**
+
+```bash
+npx @capgo/cli@latest build needed
+```
+
+🧭 Print "yes" and exit with code 1 if a native build is required; otherwise print "no" and exit with code 0. Command failures exit with code 2.
+
+**Example:**
+
+```bash
+npx @capgo/cli@latest build needed com.example.app --channel production --verbose
+```
+
+**Options:**
+
+| Param          | Type          | Description          |
+| -------------- | ------------- | -------------------- |
+| **-a** | <code>string</code> | API key to link to your account |
+| **-c** | <code>string</code> | Channel to compare against. Defaults to CapacitorUpdater.defaultChannel or the public default channel |
+| **--package-json** | <code>string</code> | Paths to package.json files for monorepos (comma-separated) |
+| **--node-modules** | <code>string</code> | Paths to node_modules directories for monorepos (comma-separated) |
+| **--verbose** | <code>boolean</code> | Enable verbose output with detailed logging |
+| **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
+| **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
 
 ### <a id="build-init"></a> 🚀 **Init**
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -73,6 +73,7 @@
     "test:credentials-validation": "bun test/test-credentials-validation.mjs",
     "test:build-zip-filter": "bun test/test-build-zip-filter.mjs",
     "test:checksum": "bun test/test-checksum-algorithm.mjs",
+    "test:build-needed": "bun test/test-build-needed.mjs",
     "test:ci-prompts": "bun test/test-ci-prompts.mjs",
     "test:posthog-exception": "bun test/test-posthog-exception.mjs",
     "test:onboarding-recovery": "bun test/test-onboarding-recovery.mjs",
@@ -87,7 +88,7 @@
     "test:version-detection:setup": "./test/fixtures/setup-test-projects.sh",
     "test:platform-paths": "bun test/test-platform-paths.mjs",
     "test:payload-split": "bun test/test-payload-split.mjs",
-    "test": "bun run build && bun run test:version-detection:setup && bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:build-zip-filter && bun run test:checksum && bun run test:ci-prompts && bun run test:posthog-exception && bun run test:build-platform-selection && bun run test:onboarding-recovery && bun run test:onboarding-run-targets && bun run test:run-device-command && bun run test:init-app-conflict && bun run test:init-guardrails && bun run test:prompt-preferences && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths && bun run test:payload-split",
+    "test": "bun run build && bun run test:version-detection:setup && bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:build-zip-filter && bun run test:checksum && bun run test:build-needed && bun run test:ci-prompts && bun run test:posthog-exception && bun run test:build-platform-selection && bun run test:onboarding-recovery && bun run test:onboarding-run-targets && bun run test:run-device-command && bun run test:init-app-conflict && bun run test:init-guardrails && bun run test:prompt-preferences && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths && bun run test:payload-split",
     "test:build-platform-selection": "bun test/test-build-platform-selection.mjs"
   },
   "dependencies": {

--- a/cli/skills/native-builds/SKILL.md
+++ b/cli/skills/native-builds/SKILL.md
@@ -74,6 +74,17 @@ interface BuildLogger {
 
 ## Core build request
 
+### `build needed [appId]`
+
+- Example: `npx @capgo/cli@latest build needed com.example.app --channel production --verbose`
+- Prints `yes` or `no` and exits with code `1` only when local native dependency metadata requires a new native build.
+- If `--channel` is omitted, it uses `plugins.CapacitorUpdater.defaultChannel` from local config, then the public default channel in Capgo Cloud.
+- Key options:
+  - `-c, --channel <channel>`
+  - `--verbose`
+  - `--package-json <packageJson>`
+  - `--node-modules <nodeModules>`
+
 ### `build request [appId]`
 
 - Example: `npx @capgo/cli@latest build request com.example.app --platform ios --path .`

--- a/cli/skills/usage/SKILL.md
+++ b/cli/skills/usage/SKILL.md
@@ -64,6 +64,7 @@ Load `skills/release-management/SKILL.md` when working with:
 Load `skills/native-builds/SKILL.md` when working with:
 
 - `build request`
+- `build needed`
 - `build credentials save`
 - `build credentials list`
 - `build credentials clear`

--- a/cli/src/build/needed.ts
+++ b/cli/src/build/needed.ts
@@ -1,0 +1,324 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { BuildNeededOptions } from '../schemas/build'
+import type { Compatibility } from '../schemas/common'
+import type { Database } from '../types/supabase.types'
+import process, { env, stdout } from 'node:process'
+import { log } from '@clack/prompts'
+import { Table } from '@sauber/table'
+import { difference, parse } from '@std/semver'
+import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import {
+  checkCompatibilityCloud,
+  createSupabaseClient,
+  findSavedKey,
+  formatError,
+  getAppId,
+  getCompatibilityDetails,
+  getConfig,
+  isCompatible,
+  OrganizationPerm,
+} from '../utils'
+
+type VersionChangeType = 'major' | 'minor' | 'patch' | 'prerelease' | 'changed' | 'same' | 'new' | 'removed'
+
+interface PublicChannelRow {
+  name: string | null
+}
+
+export interface BuildNeededResult {
+  required: boolean
+  resolvedAppId: string
+  channel: string
+  finalCompatibility: Compatibility[]
+}
+
+export const BUILD_NEEDED_ERROR_EXIT_CODE = 2
+
+interface FormatOptions {
+  color?: boolean
+}
+
+const colorCodes = {
+  reset: '\x1B[0m',
+  dim: '\x1B[2m',
+  red: '\x1B[31m',
+  yellow: '\x1B[33m',
+  green: '\x1B[32m',
+}
+
+function normalizeString(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  return normalized || undefined
+}
+
+function shouldUseColor(): boolean {
+  if (env.NO_COLOR)
+    return false
+  if (env.FORCE_COLOR && env.FORCE_COLOR !== '0')
+    return true
+  return !!stdout.isTTY
+}
+
+function colorize(value: string, color: keyof typeof colorCodes, enabled: boolean): string {
+  if (!enabled)
+    return value
+  return `${colorCodes[color]}${value}${colorCodes.reset}`
+}
+
+function colorForVersionChange(change: VersionChangeType): keyof typeof colorCodes {
+  switch (change) {
+    case 'major':
+    case 'new':
+      return 'red'
+    case 'minor':
+    case 'changed':
+    case 'prerelease':
+      return 'yellow'
+    case 'patch':
+      return 'green'
+    case 'removed':
+    case 'same':
+      return 'dim'
+  }
+}
+
+export function getConfiguredDefaultChannel(config: unknown): string | undefined {
+  const configured = (config as { plugins?: { CapacitorUpdater?: { defaultChannel?: unknown } } } | undefined)
+    ?.plugins
+    ?.CapacitorUpdater
+    ?.defaultChannel
+
+  return typeof configured === 'string' ? normalizeString(configured) : undefined
+}
+
+export function selectDefaultChannelName(rows: PublicChannelRow[]): string {
+  const names = [...new Set(rows
+    .map(row => normalizeString(row.name ?? undefined))
+    .filter((name): name is string => !!name))]
+
+  if (names.length === 1)
+    return names[0]
+
+  if (names.length === 0)
+    throw new Error('No default channel found. Pass --channel <channel>.')
+
+  throw new Error(`Multiple default channels found (${names.join(', ')}). Pass --channel <channel>.`)
+}
+
+async function getPublicDefaultChannelName(
+  supabase: SupabaseClient<Database>,
+  appId: string,
+): Promise<string> {
+  const { data, error } = await supabase
+    .from('channels')
+    .select('name')
+    .eq('app_id', appId)
+    .eq('public', true)
+    .or('ios.eq.true,android.eq.true')
+
+  if (error)
+    throw new Error(`Cannot load default channel: ${formatError(error)}`)
+
+  return selectDefaultChannelName((data ?? []) as PublicChannelRow[])
+}
+
+async function resolveBuildNeededChannel(
+  supabase: SupabaseClient<Database>,
+  appId: string,
+  options: BuildNeededOptions,
+  config: unknown,
+): Promise<string> {
+  const explicitChannel = normalizeString(options.channel)
+  if (explicitChannel)
+    return explicitChannel
+
+  const configuredDefaultChannel = getConfiguredDefaultChannel(config)
+  if (configuredDefaultChannel)
+    return configuredDefaultChannel
+
+  return getPublicDefaultChannelName(supabase, appId)
+}
+
+export function getVersionChangeType(entry: Compatibility): VersionChangeType {
+  if (!entry.localVersion)
+    return 'removed'
+  if (!entry.remoteVersion)
+    return 'new'
+  if (entry.localVersion === entry.remoteVersion)
+    return 'same'
+
+  try {
+    const change = difference(parse(entry.remoteVersion), parse(entry.localVersion))
+    if (change === 'major' || change === 'premajor')
+      return 'major'
+    if (change === 'minor' || change === 'preminor')
+      return 'minor'
+    if (change === 'patch' || change === 'prepatch')
+      return 'patch'
+    if (change === 'pre' || change === 'prerelease')
+      return 'prerelease'
+  }
+  catch {
+    return 'changed'
+  }
+
+  return 'changed'
+}
+
+export function getNativeDiffLabel(entry: Compatibility): string {
+  const iosChanged = !!(entry.localIosChecksum || entry.remoteIosChecksum)
+    && entry.localIosChecksum !== entry.remoteIosChecksum
+  const androidChanged = !!(entry.localAndroidChecksum || entry.remoteAndroidChecksum)
+    && entry.localAndroidChecksum !== entry.remoteAndroidChecksum
+
+  if (iosChanged && androidChanged)
+    return 'iOS + Android'
+  if (iosChanged)
+    return 'iOS'
+  if (androidChanged)
+    return 'Android'
+  return '-'
+}
+
+export function isBuildNeeded(finalCompatibility: Compatibility[]): boolean {
+  return finalCompatibility.some(entry => !isCompatible(entry))
+}
+
+export function getBuildNeededExitCode(required: boolean): number {
+  return required ? 1 : 0
+}
+
+function sortCompatibility(entries: Compatibility[]): Compatibility[] {
+  return [...entries].sort((a, b) => {
+    const aCompatible = isCompatible(a)
+    const bCompatible = isCompatible(b)
+    if (aCompatible !== bCompatible)
+      return aCompatible ? 1 : -1
+    return a.name.localeCompare(b.name)
+  })
+}
+
+export function formatShortBuildNeeded(required: boolean): string {
+  return required ? 'yes' : 'no'
+}
+
+export function formatBuildNeededTable(finalCompatibility: Compatibility[], options: FormatOptions = {}): string {
+  const color = options.color ?? shouldUseColor()
+  const table = new Table()
+  table.headers = ['Package', 'Current app', 'Local', 'Change', 'Native diff', 'Required']
+  table.theme = Table.roundTheme
+  table.rows = []
+
+  for (const entry of sortCompatibility(finalCompatibility)) {
+    const change = getVersionChangeType(entry)
+    const details = getCompatibilityDetails(entry)
+    const required = !details.compatible
+    const nativeDiff = getNativeDiffLabel(entry)
+    const changeColor = colorForVersionChange(change)
+
+    table.rows.push([
+      entry.name,
+      entry.remoteVersion || '-',
+      entry.localVersion || '-',
+      colorize(change, changeColor, color),
+      nativeDiff === '-' ? nativeDiff : colorize(nativeDiff, 'red', color),
+      required ? colorize('yes', 'red', color) : colorize('no', 'green', color),
+    ])
+  }
+
+  return table.toString()
+}
+
+export function formatVerboseBuildNeeded(
+  result: BuildNeededResult,
+  options: FormatOptions = {},
+): string {
+  return [
+    `Build needed: ${formatShortBuildNeeded(result.required)}`,
+    `Exit code: ${getBuildNeededExitCode(result.required)}`,
+    `App ID: ${result.resolvedAppId}`,
+    `Channel: ${result.channel}`,
+    '',
+    formatBuildNeededTable(result.finalCompatibility, options),
+  ].join('\n')
+}
+
+export async function getBuildNeeded(
+  appId: string | undefined,
+  options: BuildNeededOptions,
+): Promise<BuildNeededResult> {
+  const enrichedOptions: BuildNeededOptions = {
+    ...options,
+    apikey: options.apikey || findSavedKey(true),
+  }
+
+  let extConfig: Awaited<ReturnType<typeof getConfig>> | undefined
+  let configError: unknown
+  try {
+    extConfig = await getConfig(true)
+  }
+  catch (error) {
+    configError = error
+  }
+
+  const resolvedAppId = getAppId(appId, extConfig?.config)
+  if (!resolvedAppId) {
+    if (configError instanceof Error)
+      throw configError
+    throw new Error('Missing appId')
+  }
+
+  if (!enrichedOptions.apikey)
+    throw new Error('Missing API key')
+
+  const supabase = await createSupabaseClient(
+    enrichedOptions.apikey,
+    enrichedOptions.supaHost,
+    enrichedOptions.supaAnon,
+  )
+
+  await check2FAComplianceForApp(supabase, resolvedAppId, true)
+  await checkAppExistsAndHasPermissionOrgErr(
+    supabase,
+    enrichedOptions.apikey,
+    resolvedAppId,
+    OrganizationPerm.read,
+    true,
+    true,
+  )
+
+  const channel = await resolveBuildNeededChannel(supabase, resolvedAppId, enrichedOptions, extConfig?.config)
+  const compatibility = await checkCompatibilityCloud(
+    supabase,
+    resolvedAppId,
+    channel,
+    enrichedOptions.packageJson,
+    enrichedOptions.nodeModules,
+  )
+
+  return {
+    required: isBuildNeeded(compatibility.finalCompatibility),
+    resolvedAppId,
+    channel,
+    finalCompatibility: compatibility.finalCompatibility,
+  }
+}
+
+export async function checkBuildNeeded(
+  appId: string | undefined,
+  options: BuildNeededOptions,
+): Promise<void> {
+  try {
+    const result = await getBuildNeeded(appId, options)
+    const output = options.verbose
+      ? formatVerboseBuildNeeded(result)
+      : formatShortBuildNeeded(result.required)
+
+    stdout.write(`${output}\n`)
+    process.exitCode = getBuildNeededExitCode(result.required)
+  }
+  catch (error) {
+    log.error(`Error checking build requirement ${formatError(error)}`)
+    process.exitCode = BUILD_NEEDED_ERROR_EXIT_CODE
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { listApp } from './app/list'
 import { setApp } from './app/set'
 import { setSetting } from './app/setting'
 import { clearCredentialsCommand, listCredentialsCommand, migrateCredentialsCommand, saveCredentialsCommand, updateCredentialsCommand } from './build/credentials-command'
+import { checkBuildNeeded } from './build/needed'
 import { onboardingBuilderCommand } from './build/onboarding/command'
 import { requestBuildCommand } from './build/request'
 import { cleanupBundle } from './bundle/cleanup'
@@ -744,7 +745,7 @@ const build = program
   .command('build')
   .description(`🏗️  Manage native iOS/Android builds through Capgo Cloud.
 
-⚠️ This feature is currently in PUBLIC BETA and cannot be used by anyone at this time.
+⚠️ Native cloud build requests are currently in LIMITED BETA. Access is restricted.
 
  🔒 SECURITY GUARANTEE:
     Build credentials are NEVER stored on Capgo servers.
@@ -755,6 +756,20 @@ const build = program
    Save your credentials first:
    npx @capgo/cli build credentials save --appId <your-app-id> --platform ios
    npx @capgo/cli build credentials save --appId <your-app-id> --platform android`)
+
+build
+  .command('needed [appId]')
+  .description(`🧭 Print "yes" and exit with code 1 if a native build is required; otherwise print "no" and exit with code 0. Command failures exit with code 2.
+
+Example: npx @capgo/cli@latest build needed com.example.app --channel production --verbose`)
+  .action(checkBuildNeeded)
+  .option('-a, --apikey <apikey>', optionDescriptions.apikey)
+  .option('-c, --channel <channel>', `Channel to compare against. Defaults to CapacitorUpdater.defaultChannel or the public default channel`)
+  .option('--package-json <packageJson>', optionDescriptions.packageJson)
+  .option('--node-modules <nodeModules>', optionDescriptions.nodeModules)
+  .option('--verbose', optionDescriptions.verbose)
+  .option('--supa-host <supaHost>', optionDescriptions.supaHost)
+  .option('--supa-anon <supaAnon>', optionDescriptions.supaAnon)
 
 build
   .command('init')

--- a/cli/src/init/updater.ts
+++ b/cli/src/init/updater.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 
 export const CAPGO_UPDATER_PACKAGE = '@capgo/capacitor-updater'
@@ -57,17 +56,6 @@ function getDeclaredDependency(packageJsonPath: string, packageName: string) {
 
 function readInstalledPackageVersion(packageJsonPath: string, packageName: string): string | null {
   const projectDir = dirname(packageJsonPath)
-
-  try {
-    const requireFromProject = createRequire(join(projectDir, 'package.json'))
-    const resolvedPath = requireFromProject.resolve(`${packageName}/package.json`)
-    const packageJson = JSON.parse(readFileSync(resolvedPath, 'utf-8')) as { version?: unknown }
-    if (typeof packageJson.version === 'string')
-      return packageJson.version
-  }
-  catch {
-    // Fall through to direct node_modules lookup.
-  }
 
   let currentDir = projectDir
   while (true) {

--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -64,6 +64,15 @@ export const buildRequestOptionsSchema = optionsBaseSchema.extend({
 
 export type BuildRequestOptions = z.infer<typeof buildRequestOptionsSchema>
 
+export const buildNeededOptionsSchema = optionsBaseSchema.extend({
+  channel: z.string().optional(),
+  packageJson: z.string().optional(),
+  nodeModules: z.string().optional(),
+  verbose: z.boolean().optional(),
+})
+
+export type BuildNeededOptions = z.infer<typeof buildNeededOptionsSchema>
+
 // ============================================================================
 // Build Response Schemas
 // ============================================================================

--- a/cli/test/test-build-needed.mjs
+++ b/cli/test/test-build-needed.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+
+const {
+  BUILD_NEEDED_ERROR_EXIT_CODE,
+  formatShortBuildNeeded,
+  formatVerboseBuildNeeded,
+  getBuildNeededExitCode,
+  getConfiguredDefaultChannel,
+  getNativeDiffLabel,
+  getVersionChangeType,
+  isBuildNeeded,
+  selectDefaultChannelName,
+} = await import('../src/build/needed.ts')
+
+let failures = 0
+
+async function test(name, fn) {
+  try {
+    await fn()
+    console.log(`✓ ${name}`)
+  }
+  catch (error) {
+    failures += 1
+    console.error(`❌ ${name}`)
+    console.error(error)
+  }
+}
+
+await test('maps build requirement to short output and exit code', () => {
+  assert.equal(formatShortBuildNeeded(true), 'yes')
+  assert.equal(formatShortBuildNeeded(false), 'no')
+  assert.equal(getBuildNeededExitCode(true), 1)
+  assert.equal(getBuildNeededExitCode(false), 0)
+  assert.equal(BUILD_NEEDED_ERROR_EXIT_CODE, 2)
+})
+
+await test('detects build requirement from native compatibility entries', () => {
+  assert.equal(isBuildNeeded([
+    {
+      name: '@capacitor/camera',
+      localVersion: '2.0.0',
+      remoteVersion: '1.0.0',
+    },
+  ]), true)
+
+  assert.equal(isBuildNeeded([
+    {
+      name: '@capacitor/camera',
+      localVersion: undefined,
+      remoteVersion: '1.0.0',
+    },
+  ]), false)
+})
+
+await test('classifies version changes for verbose diff output', () => {
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: '1.2.3', localVersion: '2.0.0' }), 'major')
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: '1.2.3', localVersion: '1.3.0' }), 'minor')
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: '1.2.3', localVersion: '1.2.4' }), 'patch')
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: '1.2.3', localVersion: '1.2.3' }), 'same')
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: undefined, localVersion: '1.2.3' }), 'new')
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: '1.2.3', localVersion: undefined }), 'removed')
+  assert.equal(getVersionChangeType({ name: 'pkg', remoteVersion: 'workspace:*', localVersion: '1.2.3' }), 'changed')
+})
+
+await test('detects native checksum platform changes', () => {
+  assert.equal(getNativeDiffLabel({
+    name: 'pkg',
+    remoteVersion: '1.0.0',
+    localVersion: '1.0.0',
+    remoteIosChecksum: 'ios-old',
+    localIosChecksum: 'ios-new',
+    remoteAndroidChecksum: 'android-old',
+    localAndroidChecksum: 'android-new',
+  }), 'iOS + Android')
+
+  assert.equal(getNativeDiffLabel({
+    name: 'pkg',
+    remoteVersion: '1.0.0',
+    localVersion: '1.0.0',
+    remoteIosChecksum: 'same',
+    localIosChecksum: 'same',
+    remoteAndroidChecksum: 'android-old',
+    localAndroidChecksum: 'android-new',
+  }), 'Android')
+
+  assert.equal(getNativeDiffLabel({
+    name: 'pkg',
+    remoteVersion: '1.0.0',
+    localVersion: '1.0.0',
+    remoteIosChecksum: undefined,
+    localIosChecksum: 'ios-new',
+  }), 'iOS')
+})
+
+await test('resolves configured default channel from Capacitor config', () => {
+  assert.equal(getConfiguredDefaultChannel({
+    plugins: {
+      CapacitorUpdater: {
+        defaultChannel: ' production ',
+      },
+    },
+  }), 'production')
+
+  assert.equal(getConfiguredDefaultChannel({
+    plugins: {
+      CapacitorUpdater: {
+        defaultChannel: ' ',
+      },
+    },
+  }), undefined)
+})
+
+await test('selects a unique public default channel and rejects ambiguous defaults', () => {
+  assert.equal(selectDefaultChannelName([
+    { name: 'production' },
+    { name: ' production ' },
+  ]), 'production')
+
+  assert.throws(() => selectDefaultChannelName([]), /No default channel/)
+  assert.throws(() => selectDefaultChannelName([
+    { name: 'production' },
+    { name: 'beta' },
+  ]), /Multiple default channels/)
+})
+
+await test('formats verbose table with version-change color coding', () => {
+  const output = formatVerboseBuildNeeded({
+    required: true,
+    resolvedAppId: 'com.example.app',
+    channel: 'production',
+    finalCompatibility: [
+      { name: 'major-lib', remoteVersion: '1.0.0', localVersion: '2.0.0' },
+      { name: 'minor-lib', remoteVersion: '1.0.0', localVersion: '1.1.0' },
+      { name: 'patch-lib', remoteVersion: '1.0.0', localVersion: '1.0.1' },
+    ],
+  }, { color: true })
+
+  assert.match(output, /Build needed: yes/)
+  assert.match(output, /Exit code: 1/)
+  assert.match(output, /\x1B\[31mmajor\x1B\[0m/)
+  assert.match(output, /\x1B\[33mminor\x1B\[0m/)
+  assert.match(output, /\x1B\[32mpatch\x1B\[0m/)
+})
+
+if (failures > 0) {
+  console.error(`\n❌ ${failures} build needed test(s) failed`)
+  process.exit(1)
+}
+
+console.log('\n✅ Build needed checks work')

--- a/cli/webdocs/build.mdx
+++ b/cli/webdocs/build.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 🏗️  Manage native iOS/Android builds through Capgo Cloud.
 
-⚠️ This feature is currently in PUBLIC BETA and cannot be used by anyone at this time.
+⚠️ Native cloud build requests are currently in LIMITED BETA. Access is restricted.
  🔒 SECURITY GUARANTEE:
     Build credentials are NEVER stored on Capgo servers.
     They are used only during the build and auto-deleted after.
@@ -17,6 +17,32 @@ sidebar:
    Save your credentials first:
    npx @capgo/cli build credentials save --appId <your-app-id> --platform ios
    npx @capgo/cli build credentials save --appId <your-app-id> --platform android
+
+### <a id="build-needed"></a> 🔹 **Needed**
+
+```bash
+npx @capgo/cli@latest build needed
+```
+
+🧭 Print "yes" and exit with code 1 if a native build is required; otherwise print "no" and exit with code 0. Command failures exit with code 2.
+
+**Example:**
+
+```bash
+npx @capgo/cli@latest build needed com.example.app --channel production --verbose
+```
+
+**Options:**
+
+| Param          | Type          | Description          |
+| -------------- | ------------- | -------------------- |
+| **-a** | <code>string</code> | API key to link to your account |
+| **-c** | <code>string</code> | Channel to compare against. Defaults to CapacitorUpdater.defaultChannel or the public default channel |
+| **--package-json** | <code>string</code> | Paths to package.json files for monorepos (comma-separated) |
+| **--node-modules** | <code>string</code> | Paths to node_modules directories for monorepos (comma-separated) |
+| **--verbose** | <code>boolean</code> | Enable verbose output with detailed logging |
+| **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
+| **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
 
 ### <a id="build-init"></a> 🚀 **Init**
 
@@ -277,4 +303,3 @@ Example:
 | **--appId** | <code>string</code> | App ID (auto-detected from capacitor.config if omitted) |
 | **--platform** | <code>string</code> | Platform (only ios is supported) |
 | **--local** | <code>boolean</code> | Migrate from local .capgo-credentials.json instead of global |
-


### PR DESCRIPTION
## Summary (AI generated)

- Add `build needed` to report whether local native dependency metadata requires a new native build.
- Add verbose package diff output with version-change color coding and native checksum differences.
- Document the command and record the lowercase/kebab-case CLI naming rule in agent instructions.

## Motivation (AI generated)

Teams need a CI-friendly way to decide whether an OTA upload is enough or a native store build is required when native dependencies changed.

## Business Impact (AI generated)

This reduces accidental OTA releases that cannot safely apply native dependency changes, while keeping automated release pipelines simple with yes/no output and exit codes.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:build-needed`
- [x] `bun run test:mcp`
- [x] `bun run test:bundle`
- [x] `node dist/index.js build needed --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `build needed` command to check if native builds are required based on dependency compatibility and native package changes. Returns "yes" or "no" with appropriate exit codes for programmatic use.

* **Documentation**
  * Clarified native cloud build public beta status in CLI documentation.
  * Added comprehensive documentation for the new `build needed` command with all supported options and usage examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2208)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->