### PR TITLE
fix(api): cap website preview icon reads

### DIFF
--- a/supabase/functions/_backend/private/website_preview.ts
+++ b/supabase/functions/_backend/private/website_preview.ts
@@ -148,13 +148,13 @@ async function getWebsitePublicHostnameValidationError(urlString: string) {
   })
 }
 
-async function readResponseTextWithLimit(response: Response, limit: number) {
+async function readResponseBytesWithLimit(response: Response, limit: number) {
   const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
   if (Number.isFinite(contentLength) && contentLength > limit)
     return null
 
   if (!response.body)
-    return await response.text()
+    return new Uint8Array()
 
   const reader = response.body.getReader()
   const chunks: Uint8Array[] = []
@@ -183,6 +183,14 @@ async function readResponseTextWithLimit(response: Response, limit: number) {
     offset += chunk.byteLength
   }
 
+  return bytes
+}
+
+async function readResponseTextWithLimit(response: Response, limit: number) {
+  const bytes = await readResponseBytesWithLimit(response, limit)
+  if (!bytes)
+    return null
+
   return new TextDecoder().decode(bytes)
 }
 
@@ -209,15 +217,10 @@ async function fetchIconDataUrl(iconUrl: string) {
   if (!contentType.startsWith('image/'))
     return null
 
-  const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
-  if (Number.isFinite(contentLength) && contentLength > MAX_ICON_BYTES)
+  const bytes = await readResponseBytesWithLimit(response, MAX_ICON_BYTES)
+  if (!bytes || bytes.byteLength === 0)
     return null
 
-  const arrayBuffer = await response.arrayBuffer()
-  if (arrayBuffer.byteLength === 0 || arrayBuffer.byteLength > MAX_ICON_BYTES)
-    return null
-
-  const bytes = new Uint8Array(arrayBuffer)
   let binary = ''
   const chunkSize = 0x8000
   for (let index = 0; index < bytes.length; index += chunkSize)
@@ -278,3 +281,8 @@ app.post('/', middlewareAuth, async (c) => {
     icon,
   })
 })
+
+export const websitePreviewTestUtils = {
+  fetchIconDataUrl,
+  readResponseBytesWithLimit,
+}

--- a/tests/website-preview-icon-limit.unit.test.ts
+++ b/tests/website-preview-icon-limit.unit.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { websitePreviewTestUtils } from '../supabase/functions/_backend/private/website_preview.ts'
+
+const { fetchIconDataUrl } = websitePreviewTestUtils
+
+function dnsResponse(ip: string) {
+  return new Response(JSON.stringify({ Answer: [{ data: ip }] }), {
+    headers: { 'content-type': 'application/dns-json' },
+  })
+}
+
+function emptyDnsResponse() {
+  return new Response(JSON.stringify({ Answer: [] }), {
+    headers: { 'content-type': 'application/dns-json' },
+  })
+}
+
+function mockPublicDnsThenIconResponse(iconResponse: Response) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString()
+    if (url.includes('cloudflare-dns.com') && url.includes('type=A'))
+      return dnsResponse('93.184.216.34')
+    if (url.includes('cloudflare-dns.com') && url.includes('type=AAAA'))
+      return emptyDnsResponse()
+    return iconResponse
+  })
+}
+
+describe('website preview icon fetch limit', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns an icon data URL for bounded image responses', async () => {
+    vi.stubGlobal('fetch', mockPublicDnsThenIconResponse(new Response(new Uint8Array([1, 2, 3]), {
+      headers: { 'content-type': 'image/png' },
+    })))
+
+    await expect(fetchIconDataUrl('https://example.com/favicon.png')).resolves.toBe('data:image/png;base64,AQID')
+  })
+
+  it('rejects oversized icon responses from content-length', async () => {
+    vi.stubGlobal('fetch', mockPublicDnsThenIconResponse(new Response(new Uint8Array([1]), {
+      headers: {
+        'content-length': `${512 * 1024 + 1}`,
+        'content-type': 'image/png',
+      },
+    })))
+
+    await expect(fetchIconDataUrl('https://example.com/favicon.png')).resolves.toBeNull()
+  })
+
+  it('rejects chunked icon responses that grow past the icon cap', async () => {
+    const chunk = new Uint8Array(256 * 1024)
+    let cancelled = false
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(chunk)
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+
+    vi.stubGlobal('fetch', mockPublicDnsThenIconResponse(new Response(body, {
+      headers: { 'content-type': 'image/png' },
+    })))
+
+    await expect(fetchIconDataUrl('https://example.com/favicon.png')).resolves.toBeNull()
+    expect(cancelled).toBe(true)
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- Replace website preview icon `arrayBuffer()` reads with the existing bounded streaming read path.
- Reject icon responses above 512 KiB from `Content-Length` before reading the body.
- Add regression coverage for bounded icon responses, `Content-Length` fast-fail, and chunked icon bodies that exceed the cap.

## Security note
This is public-safe DoS hardening for the authenticated website preview endpoint. Website HTML already had a streaming cap; this applies the same bounded-read behavior to discovered icon responses.

## Test plan
- `npx --yes bun@latest x vitest run tests/website-preview-icon-limit.unit.test.ts`
- `npx --yes bun@latest x vitest run tests/website-preview-icon-limit.unit.test.ts tests/organization-website.unit.test.ts`
- `git diff --check`

## Screenshots
Not applicable; backend API hardening only.

## Checklist
- [x] Focused regression tests added
- [x] Public-safe security details only