### PR TITLE
fix: rate limit translation queue requests

### DIFF
--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -13,6 +13,9 @@ const TRANSLATION_STORE_CLEANUP_INTERVAL_SECONDS = 60
 const TRANSLATION_REQUEUE_AFTER_SECONDS = 60
 const TRANSLATION_BATCH_LEASE_SECONDS = 15 * 60
 const TRANSLATION_STORE_TABLE = 'translation_messages_cache'
+const TRANSLATION_RATE_LIMIT_PATH = '/translation/messages-rate-limit'
+const TRANSLATION_RATE_LIMIT_TTL_SECONDS = 60
+const DEFAULT_TRANSLATION_REQUEST_LIMIT = 30
 const CLAIMED_TRANSLATION_BATCH_INDEX_OFFSET = 1_000_000_000
 const PLACEHOLDER_PATTERN = /\{[\w.]+\}|%\w+%?|\$\d+/g
 
@@ -64,6 +67,7 @@ interface TranslationWorkerBindings {
   AI?: AiBinding
   DB_TRANSLATIONS?: D1Database
   ENV_NAME?: string
+  TRANSLATION_MESSAGES_RATE_LIMIT?: string
   TRANSLATION_MESSAGES_QUEUE?: Queue<Required<TranslationQueuePayload>>
   TRANSLATION_MODEL?: string
 }
@@ -96,6 +100,11 @@ interface TranslationQueuePayload {
   checksum?: string
   model?: string
   targetLanguage?: string
+}
+
+interface RateLimitEntry {
+  count: number
+  resetAt: number
 }
 
 type MessageEntry = [string, string]
@@ -140,7 +149,8 @@ function jsonResponse(data: unknown, status = 200, headers: HeadersInit = {}) {
 }
 
 function errorResponse(status: number, code: string, message: string) {
-  return jsonResponse({ error: code, message }, status)
+  const headers = status === 429 ? { 'Retry-After': String(TRANSLATION_RATE_LIMIT_TTL_SECONDS) } : {}
+  return jsonResponse({ error: code, message }, status, headers)
 }
 
 function serializeError(error: unknown) {
@@ -191,6 +201,53 @@ async function sha256Hex(value: string) {
   for (const byte of new Uint8Array(hash))
     encoded += byte.toString(16).padStart(2, '0')
   return encoded
+}
+
+function clientIP(request: Request) {
+  return request.headers.get('cf-connecting-ip')
+    ?? request.headers.get('x-real-ip')
+    ?? request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? ''
+}
+
+function translationRequestLimit(env: TranslationWorkerBindings) {
+  const configured = Number.parseInt(env.TRANSLATION_MESSAGES_RATE_LIMIT ?? '', 10)
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_TRANSLATION_REQUEST_LIMIT
+}
+
+function rateLimitResetAt(now = Date.now()) {
+  return now + TRANSLATION_RATE_LIMIT_TTL_SECONDS * 1000
+}
+
+async function translationRateLimitCacheRequest(ip: string) {
+  const ipHash = await sha256Hex(ip)
+  const url = new URL(TRANSLATION_RATE_LIMIT_PATH, 'https://translation-cache.capgo.local')
+  url.searchParams.set('ip', ipHash)
+  return new Request(url)
+}
+
+async function checkTranslationRequestRateLimit(request: Request, env: TranslationWorkerBindings) {
+  const ip = clientIP(request)
+  if (!ip)
+    return
+
+  const cache = globalThis.caches?.default
+  if (!cache)
+    return
+
+  const cacheRequest = await translationRateLimitCacheRequest(ip)
+  const cached = await cache.match(cacheRequest)
+  const existing = cached ? await cached.json().catch(() => null) as RateLimitEntry | null : null
+  const count = (existing?.count ?? 0) + 1
+  const resetAt = existing?.resetAt && existing.resetAt > Date.now() ? existing.resetAt : rateLimitResetAt()
+  const entry: RateLimitEntry = { count, resetAt }
+
+  await cache.put(cacheRequest, jsonResponse(entry, 200, {
+    'Cache-Control': `max-age=${TRANSLATION_RATE_LIMIT_TTL_SECONDS}`,
+  }))
+
+  if (count > translationRequestLimit(env))
+    fail(429, 'rate_limited', 'Too many translation requests')
 }
 
 function recordOf(value: unknown): Record<string, unknown> | null {
@@ -968,6 +1025,8 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
     if (readyResponse)
       return readyResponse
   }
+
+  await checkTranslationRequestRateLimit(request, env)
 
   try {
     const queuedResponse = await queueCurrentTranslationResponse(env, requestId, readyRequest, checksum, targetLanguage, model)

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -14,6 +14,24 @@ function stubWorkerCache() {
   return cache
 }
 
+function stubStatefulWorkerCache() {
+  const store = new Map<string, Response>()
+  const cache = {
+    match: vi.fn(async (request: Request) => {
+      const response = store.get(request.url)
+      return response?.clone() ?? null
+    }),
+    put: vi.fn(async (request: Request, response: Response) => {
+      store.set(request.url, response.clone())
+    }),
+  }
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: { default: cache },
+  })
+  return cache
+}
+
 function createTranslationStoreMock(latestReadyEntry: Record<string, unknown> | null) {
   return {
     prepare: vi.fn((sql: string) => ({
@@ -193,6 +211,41 @@ describe('translation queue helpers', () => {
 
     expect(response.status).toBe(202)
     expect(payload.status).toBe('pending')
+    expect(queue.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('rate limits repeated public translation queue requests by client IP', async () => {
+    stubStatefulWorkerCache()
+    const db = createTranslationStoreMock(null)
+    const queue = {
+      send: vi.fn(),
+    }
+    const env = {
+      DB_TRANSLATIONS: db,
+      TRANSLATION_MESSAGES_QUEUE: queue,
+      TRANSLATION_MESSAGES_RATE_LIMIT: '1',
+    } as any
+
+    const firstResponse = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'fr' }),
+      headers: {
+        'Content-Type': 'application/json',
+        'cf-connecting-ip': '203.0.113.10',
+      },
+      method: 'POST',
+    }), env)
+    const secondResponse = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'es' }),
+      headers: {
+        'Content-Type': 'application/json',
+        'cf-connecting-ip': '203.0.113.10',
+      },
+      method: 'POST',
+    }), env)
+
+    expect(firstResponse.status).toBe(202)
+    expect(secondResponse.status).toBe(429)
+    expect(secondResponse.headers.get('retry-after')).toBe('60')
     expect(queue.send).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- add an IP-based per-minute limit before public translation requests can enqueue Workers AI translation work
- hash client IPs before using them in Cache API keys
- return a 429 with Retry-After when the translation request limit is exceeded

## Why
The public translation endpoint can enqueue paid Workers AI translation jobs. Cached ready translations are still served normally, but cache misses now have a small per-IP guardrail so repeated public requests cannot keep queueing translation work unchecked.

## Tests
- npx vitest run tests/translation-queue.unit.test.ts --config vitest.config.cloudflare.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation requests are now rate-limited per client IP with a configurable limit (default: 30 requests).
  * Requests exceeding the limit return HTTP 429 with retry timing headers for proper client handling.

* **Tests**
  * Added tests verifying rate-limiting behavior across multiple requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2216)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->