### PR TITLE
ci: use Node 22 for Wrangler tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,6 +175,10 @@ jobs:
           fetch-depth: 2
       - name: Setup bun
         run: bash scripts/setup-bun.sh
+      - name: Setup Node.js for Wrangler
+        uses: actions/setup-node@v6 # v6
+        with:
+          node-version: 22
       - name: Validate migration timestamps
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: bash scripts/check-supabase-migration-order.sh


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v6` with Node 22 in the `test_all` job before dependency install and Wrangler-backed worker startup.
- Keeps the Cloudflare Workers test stage aligned with the current `wrangler@4.90.0` runtime requirement.

## Why
Current PR runs reach the Cloudflare Workers startup step, then fail because Wrangler requires Node.js 22+ while the runner is using Node 20.20.2. The logs show all three local worker health checks timing out after Wrangler exits with the Node version error.

## Test plan
- `git diff --check`

## Screenshots
Not applicable; CI workflow change only.