### PR TITLE
fix(api): cap Grafana CPU check responses

### DIFF
--- a/supabase/functions/_backend/public/check_cpu_usage.ts
+++ b/supabase/functions/_backend/public/check_cpu_usage.ts
@@ -3,10 +3,50 @@ import { cloudlogErr } from '../utils/logging.ts'
 import { getEnv } from '../utils/utils.ts'
 
 const CPU_THRESHOLD_PERCENT = 50
+const GRAFANA_ERROR_BODY_LOG_BYTES = 4 * 1024
+const GRAFANA_QUERY_RESPONSE_BYTES = 128 * 1024
 
 export const app = honoFactory.createApp()
 
 app.use('*', useCors)
+
+async function readResponseTextWithLimit(response: Response, limit: number) {
+  const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    await response.body?.cancel().catch(() => undefined)
+    return null
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    return new TextEncoder().encode(text).byteLength > limit ? null : text
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let total = 0
+  let text = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      text += decoder.decode()
+      break
+    }
+
+    if (!value)
+      continue
+
+    total += value.byteLength
+    if (total > limit) {
+      await reader.cancel()
+      return null
+    }
+    text += decoder.decode(value, { stream: true })
+  }
+
+  return text
+}
 
 app.get('/', middlewareAPISecret, async (c) => {
   const grafanaUrl = getEnv(c, 'GRAFANA_URL')
@@ -30,11 +70,18 @@ app.get('/', middlewareAPISecret, async (c) => {
     })
 
     if (!response.ok) {
-      cloudlogErr({ requestId: c.get('requestId'), message: 'check_cpu_usage_grafana_error', status: response.status, detail: await response.text() })
+      const detail = await readResponseTextWithLimit(response, GRAFANA_ERROR_BODY_LOG_BYTES)
+      cloudlogErr({ requestId: c.get('requestId'), message: 'check_cpu_usage_grafana_error', status: response.status, detail: detail ?? 'response_body_too_large' })
       return c.json({ status: 'error', error: 'grafana_request_failed', message: `Grafana returned ${response.status}` }, 502)
     }
 
-    const data = await response.json() as { status: string, data?: { result?: Array<{ value?: [number, string] }> } }
+    const text = await readResponseTextWithLimit(response, GRAFANA_QUERY_RESPONSE_BYTES)
+    if (text === null) {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'check_cpu_usage_grafana_response_too_large' })
+      return c.json({ status: 'error', error: 'grafana_response_too_large', message: 'Grafana response is too large' }, 502)
+    }
+
+    const data = JSON.parse(text) as { status: string, data?: { result?: Array<{ value?: [number, string] }> } }
 
     if (data.status !== 'success' || !data.data?.result?.length) {
       cloudlogErr({ requestId: c.get('requestId'), message: 'check_cpu_usage_no_data', data })
@@ -64,3 +111,7 @@ app.get('/', middlewareAPISecret, async (c) => {
     return c.json({ status: 'error', error: 'cpu_check_failed', message: 'Failed to check CPU usage' }, 502)
   }
 })
+
+export const checkCpuUsageTestUtils = {
+  readResponseTextWithLimit,
+}

--- a/tests/check-cpu-usage-response-limit.unit.test.ts
+++ b/tests/check-cpu-usage-response-limit.unit.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { app, checkCpuUsageTestUtils } from '../supabase/functions/_backend/public/check_cpu_usage.ts'
+
+const API_SECRET = 'test-secret'
+const SMALL_GRAFANA_BODY = JSON.stringify({
+  status: 'success',
+  data: {
+    result: [
+      { value: [Date.now(), '12.34'] },
+    ],
+  },
+})
+
+function requestCheckCpuUsage() {
+  return app.request('http://localhost/', {
+    headers: {
+      apisecret: API_SECRET,
+    },
+  })
+}
+
+function stubEnv() {
+  vi.stubEnv('API_SECRET', API_SECRET)
+  vi.stubEnv('GRAFANA_URL', 'https://grafana.example.com')
+  vi.stubEnv('GRAFANA_TOKEN', 'token')
+}
+
+function responseStream(chunks: string[]) {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function expectCpuCheckError(responseBody: BodyInit, error: string, status = 200, headers?: HeadersInit) {
+  stubEnv()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(responseBody, { status, headers })))
+
+  const response = await requestCheckCpuUsage()
+
+  expect(response.status).toBe(502)
+  await expect(response.json()).resolves.toMatchObject({ error })
+}
+
+describe('check_cpu_usage Grafana response limits', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('rejects Grafana query responses with oversized content-length before parsing JSON', async () => {
+    await expectCpuCheckError('{}', 'grafana_response_too_large', 200, {
+      'content-length': String(129 * 1024),
+    })
+  })
+
+  it('keeps the normal Grafana success path unchanged', async () => {
+    stubEnv()
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(SMALL_GRAFANA_BODY)))
+
+    const response = await requestCheckCpuUsage()
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'ok',
+      cpu_usage_percent: 12.34,
+      threshold_percent: 50,
+    })
+  })
+
+  it('rejects chunked Grafana query responses after the size cap is exceeded', async () => {
+    await expectCpuCheckError(responseStream([
+      '{"status":"success","padding":"',
+      'x'.repeat(129 * 1024),
+      '"}',
+    ]), 'grafana_response_too_large')
+  })
+
+  it('caps non-ok Grafana error bodies before logging them', async () => {
+    const body = 'x'.repeat(4097)
+    const response = new Response(responseStream([body]))
+
+    await expect(checkCpuUsageTestUtils.readResponseTextWithLimit(response, 4096)).resolves.toBeNull()
+  })
+
+  it('caps non-ok Grafana error bodies on the endpoint path', async () => {
+    stubEnv()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const oversizedBody = 'x'.repeat(4097)
+    const fetchMock = vi.fn(async () => new Response(responseStream([oversizedBody]), { status: 503 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await requestCheckCpuUsage()
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'grafana_request_failed',
+    })
+    expect(JSON.stringify(errorSpy.mock.calls)).toContain('response_body_too_large')
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(oversizedBody)
+  })
+})


### PR DESCRIPTION
## Summary
- Add bounded reads for Grafana CPU-check responses before parsing/logging.
- Cap non-OK Grafana error bodies logged by the endpoint.
- Keep the normal success path unchanged with regression coverage.

## Security note
This is public-safe DoS/log hardening for the Grafana CPU check endpoint. Normal small Grafana responses are preserved, while oversized upstream responses no longer force unbounded buffering or log retention.

## Tests
- `npx --yes bun@latest x vitest run tests/check-cpu-usage-response-limit.unit.test.ts --reporter=verbose`
- `npx --yes bun@latest x eslint supabase/functions/_backend/public/check_cpu_usage.ts tests/check-cpu-usage-response-limit.unit.test.ts`
- `npx --yes bun@latest typecheck`
- `git diff --check`

## Screenshots
Not applicable; backend API hardening only.

## Checklist
- [x] Focused regression tests added
- [x] Code style/lint checks pass locally
- [x] Public-safe security details only

/claim #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CPU usage checks now limit how much data is read from external monitoring responses, returning proper error codes for oversized or failed responses and truncating large error bodies in logs.

* **Tests**
  * Added unit tests covering oversized, streamed, and normal monitoring responses, plus logging/truncation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2219)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->