### PR TITLE
fix(api): cap builder error response bodies

### DIFF
--- a/supabase/functions/_backend/public/build/builder_response.ts
+++ b/supabase/functions/_backend/public/build/builder_response.ts
@@ -1,0 +1,43 @@
+export const MAX_BUILDER_ERROR_BODY_BYTES = 4 * 1024
+
+export async function readBuilderErrorBody(response: Response, limit = MAX_BUILDER_ERROR_BODY_BYTES) {
+  const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    await response.body?.cancel().catch(() => undefined)
+    return null
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    return new TextEncoder().encode(text).byteLength > limit ? null : text
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let total = 0
+  let text = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      text += decoder.decode()
+      break
+    }
+
+    if (!value)
+      continue
+
+    total += value.byteLength
+    if (total > limit) {
+      await reader.cancel()
+      return null
+    }
+    text += decoder.decode(value, { stream: true })
+  }
+
+  return text
+}
+
+export function formatBuilderErrorBody(errorBody: string | null) {
+  return errorBody ?? 'builder_error_body_too_large'
+}

--- a/supabase/functions/_backend/public/build/cancel.ts
+++ b/supabase/functions/_backend/public/build/cancel.ts
@@ -5,6 +5,7 @@ import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
+import { formatBuilderErrorBody, readBuilderErrorBody } from './builder_response.ts'
 
 export async function cancelBuild(
   c: Context,
@@ -72,7 +73,7 @@ export async function cancelBuild(
   })
 
   if (!builderResponse.ok) {
-    const errorText = await builderResponse.text()
+    const errorText = formatBuilderErrorBody(await readBuilderErrorBody(builderResponse))
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Builder cancel failed',

--- a/supabase/functions/_backend/public/build/logs.ts
+++ b/supabase/functions/_backend/public/build/logs.ts
@@ -5,6 +5,7 @@ import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
+import { formatBuilderErrorBody, readBuilderErrorBody } from './builder_response.ts'
 
 async function cancelBuildOnDisconnect(
   builderUrl: string,
@@ -38,7 +39,7 @@ async function cancelBuildOnDisconnect(
       })
     }
     else {
-      const errorText = await response.text()
+      const errorText = formatBuilderErrorBody(await readBuilderErrorBody(response))
       cloudlogErr({
         requestId,
         message: 'Failed to cancel build after client disconnect',
@@ -142,7 +143,7 @@ export async function streamBuildLogs(
   })
 
   if (!builderResponse.ok) {
-    const errorText = await builderResponse.text()
+    const errorText = formatBuilderErrorBody(await readBuilderErrorBody(builderResponse))
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Builder logs fetch failed',

--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -5,6 +5,7 @@ import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
+import { formatBuilderErrorBody, readBuilderErrorBody } from './builder_response.ts'
 
 export interface RequestBuildBody {
   app_id: string
@@ -217,7 +218,7 @@ export async function requestBuild(
       })
     }
     else {
-      const errorText = await builderResponse.text()
+      const errorText = formatBuilderErrorBody(await readBuilderErrorBody(builderResponse))
       const responseHeaders: Record<string, string> = {}
       builderResponse.headers.forEach((value, key) => {
         responseHeaders[key] = value

--- a/supabase/functions/_backend/public/build/start.ts
+++ b/supabase/functions/_backend/public/build/start.ts
@@ -6,6 +6,7 @@ import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
+import { formatBuilderErrorBody, readBuilderErrorBody } from './builder_response.ts'
 import { reserveNativeBuildSlot } from './concurrency.ts'
 
 interface BuilderStartResponse {
@@ -210,7 +211,7 @@ export async function startBuild(
     })
 
     if (!builderResponse.ok) {
-      const errorText = await builderResponse.text()
+      const errorText = formatBuilderErrorBody(await readBuilderErrorBody(builderResponse))
       const errorMsg = `Failed to start build: ${errorText}`
       cloudlogErr({
         requestId: c.get('requestId'),

--- a/supabase/functions/_backend/public/build/status.ts
+++ b/supabase/functions/_backend/public/build/status.ts
@@ -15,6 +15,7 @@ import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { recordBuildTime, supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
+import { formatBuilderErrorBody, readBuilderErrorBody } from './builder_response.ts'
 
 export interface BuildStatusParams {
   job_id: string
@@ -47,7 +48,7 @@ async function cancelTimedOutBuilderJob(c: Context, jobId: string, appId: string
     })
 
     if (!builderResponse.ok) {
-      const errorText = await builderResponse.text()
+      const errorText = formatBuilderErrorBody(await readBuilderErrorBody(builderResponse))
       cloudlogErr({
         requestId: c.get('requestId'),
         message: 'Builder timeout cancel failed',
@@ -151,7 +152,7 @@ export async function getBuildStatus(
   })
 
   if (!builderResponse.ok) {
-    const errorText = await builderResponse.text()
+    const errorText = formatBuilderErrorBody(await readBuilderErrorBody(builderResponse))
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Builder status fetch failed',

--- a/tests/build-builder-error-body-limit.unit.test.ts
+++ b/tests/build-builder-error-body-limit.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatBuilderErrorBody,
+  MAX_BUILDER_ERROR_BODY_BYTES,
+  readBuilderErrorBody,
+} from '../supabase/functions/_backend/public/build/builder_response.ts'
+
+function streamChunks(chunks: string[]) {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function expectOversizedBodyRejected(response: Response) {
+  await expect(readBuilderErrorBody(response)).resolves.toBeNull()
+}
+
+describe('builder error body limits', () => {
+  it('keeps small builder error bodies available for logs and client errors', async () => {
+    const response = new Response('builder unavailable')
+
+    await expect(readBuilderErrorBody(response)).resolves.toBe('builder unavailable')
+  })
+
+  it('rejects oversized builder error bodies from content-length before reading', async () => {
+    await expectOversizedBodyRejected(new Response('too large', {
+      headers: {
+        'content-length': String(MAX_BUILDER_ERROR_BODY_BYTES + 1),
+      },
+    }))
+  })
+
+  it('rejects chunked builder error bodies after the cap is exceeded', async () => {
+    await expectOversizedBodyRejected(new Response(streamChunks([
+      'builder error:',
+      'x'.repeat(MAX_BUILDER_ERROR_BODY_BYTES + 1),
+    ])))
+  })
+
+  it('uses a stable placeholder when a builder error body is too large', () => {
+    expect(formatBuilderErrorBody(null)).toBe('builder_error_body_too_large')
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- Add a shared bounded reader for native builder error responses.
- Use the bounded reader across build request/start/status/cancel/logs error paths before logging or returning builder failure text.
- Replace oversized builder error bodies with a stable placeholder instead of buffering the full response.
- Add regression coverage for small bodies, `Content-Length` fast-fail, chunked overflow, and placeholder formatting.

## Security note
This is public-safe DoS/log hardening for native build endpoints. Normal small builder error messages are preserved, while oversized upstream error bodies no longer force unbounded buffering or log retention.

## Test plan
- `./node_modules/.bin/vitest.exe run tests/build-builder-error-body-limit.unit.test.ts tests/build-start-log-token.test.ts --reporter=verbose`
- `git diff --check`

## Screenshots
Not applicable; backend API hardening only.

## Checklist
- [x] Focused regression tests added
- [x] Public-safe security details only