### PR TITLE
fix(api): redact admin stats unauthorized logs

### DIFF
--- a/supabase/functions/_backend/private/admin_stats.ts
+++ b/supabase/functions/_backend/private/admin_stats.ts
@@ -154,7 +154,19 @@ app.post('/', middlewareAuth, async (c) => {
   }
 
   if (!isAdmin) {
-    cloudlog({ requestId: c.get('requestId'), message: 'not_admin', body })
+    // Log only whitelisted schema fields — never caller-supplied extra fields
+    const { metric_category, start_date, end_date, app_id, org_id, limit, offset } = parsedBodyResult.data
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'not_admin',
+      metric_category,
+      start_date,
+      end_date,
+      app_id: app_id ?? null,
+      org_id: org_id ?? null,
+      limit: limit ?? null,
+      offset: offset ?? null,
+    })
     throw simpleError('not_admin', 'Not admin - only admin users can access platform statistics')
   }
 

--- a/tests/admin-stats-redaction.unit.test.ts
+++ b/tests/admin-stats-redaction.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Unit tests verifying that the not_admin log path in admin_stats
+ * only emits whitelisted schema fields and never caller-supplied
+ * extra JSON fields.
+ */
+
+function buildWhitelistedLog(body: Record<string, unknown>) {
+  // Mirrors the fixed logging logic in admin_stats.ts
+  const { metric_category, start_date, end_date, app_id, org_id, limit, offset } = body as any
+  return {
+    message: 'not_admin',
+    metric_category,
+    start_date,
+    end_date,
+    app_id: app_id ?? null,
+    org_id: org_id ?? null,
+    limit: limit ?? null,
+    offset: offset ?? null,
+  }
+}
+
+describe('admin_stats — not_admin log redaction', () => {
+  it('does not include extra caller-supplied fields in log', () => {
+    const maliciousBody = {
+      metric_category: 'org_metrics',
+      start_date: '2025-01-01T00:00:00.000Z',
+      end_date: '2025-01-31T00:00:00.000Z',
+      injected_field: 'sensitive_value',
+      __proto__: 'polluted',
+    }
+
+    const logged = buildWhitelistedLog(maliciousBody)
+    expect(JSON.stringify(logged)).not.toContain('sensitive_value')
+    expect(JSON.stringify(logged)).not.toContain('injected_field')
+    expect(logged).not.toHaveProperty('injected_field')
+  })
+
+  it('preserves all whitelisted schema fields', () => {
+    const body = {
+      metric_category: 'org_metrics',
+      start_date: '2025-01-01T00:00:00.000Z',
+      end_date: '2025-01-31T00:00:00.000Z',
+      app_id: 'com.example.app',
+      org_id: 'org_abc',
+      limit: 100,
+      offset: 0,
+    }
+
+    const logged = buildWhitelistedLog(body)
+    expect(logged.metric_category).toBe('org_metrics')
+    expect(logged.start_date).toBe('2025-01-01T00:00:00.000Z')
+    expect(logged.end_date).toBe('2025-01-31T00:00:00.000Z')
+    expect(logged.app_id).toBe('com.example.app')
+    expect(logged.org_id).toBe('org_abc')
+    expect(logged.limit).toBe(100)
+    expect(logged.offset).toBe(0)
+  })
+
+  it('nulls out optional fields when absent', () => {
+    const body = {
+      metric_category: 'org_metrics',
+      start_date: '2025-01-01T00:00:00.000Z',
+      end_date: '2025-01-31T00:00:00.000Z',
+    }
+
+    const logged = buildWhitelistedLog(body)
+    expect(logged.app_id).toBeNull()
+    expect(logged.org_id).toBeNull()
+    expect(logged.limit).toBeNull()
+    expect(logged.offset).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #2180

## Problem
The `not_admin` log path emitted the full raw request `body` object. Since schema validation passes before the admin check, any extra JSON fields a caller sends beyond the validated schema are stored verbatim in logs.

## Fix
Replace the raw `body` reference with an explicit whitelist of validated schema fields — `metric_category`, `start_date`, `end_date`, `app_id`, `org_id`, `limit`, `offset` — which matches the same fields already logged on the authorized path.

## Tests
Adds `tests/admin-stats-redaction.unit.test.ts` covering:
- Extra caller-supplied fields are excluded from log output
- All whitelisted schema fields are preserved
- Optional fields default to null when absent

```
bun x vitest run tests/admin-stats-redaction.unit.test.ts
```