### PR TITLE
fix(api): redact query details in Hono logs

### DIFF
--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -13,6 +13,7 @@ import { requestId } from 'hono/request-id'
 import { Hono } from 'hono/tiny'
 import { timingSafeEqual } from 'hono/utils/buffer'
 import { cloudlog } from './logging.ts'
+import { redactQueryParams, redactUrl } from './log_redaction.ts'
 import { onError } from './on_error.ts'
 import { getEnv } from './utils.ts'
 
@@ -157,7 +158,7 @@ export async function getBodyOrQuery<T>(c: Context<MiddlewareKeyVariables, any, 
     }
   }
   if (!body || Object.keys(body).length === 0) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find body', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find body', query: redactQueryParams(c.req.query()) })
     throw simpleError('invalid_json_parse_body', 'Invalid JSON body')
   }
   if ((body as any).device_id) {
@@ -169,7 +170,7 @@ export async function getBodyOrQuery<T>(c: Context<MiddlewareKeyVariables, any, 
 export const middlewareAuth = honoFactory.createMiddleware(async (c, next) => {
   const authorization = c.req.header('authorization')
   if (!authorization) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorization', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorization', query: redactQueryParams(c.req.query()) })
     return quickError(401, 'no_jwt_apikey_or_subkey', 'No JWT, apikey or subkey provided')
   }
   c.set('authorization', authorization)
@@ -198,11 +199,11 @@ export const middlewareAPISecret = honoFactory.createMiddleware(async (c, next) 
 
   // timingSafeEqual is here to prevent a timing attack
   if (!authorizationSecret || !API_SECRET) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorizationSecret or API_SECRET', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find authorizationSecret or API_SECRET', query: redactQueryParams(c.req.query()) })
     throw simpleError('cannot_find_authorization_secret', 'Cannot find authorization')
   }
   if (!await timingSafeEqual(authorizationSecret, API_SECRET)) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Invalid API secret', query: c.req.query() })
+    cloudlog({ requestId: c.get('requestId'), message: 'Invalid API secret', query: redactQueryParams(c.req.query()) })
     throw simpleError('invalid_api_secret', 'Invalid API secret')
   }
   c.set('APISecret', authorizationSecret)
@@ -267,7 +268,7 @@ export function createHono(functionName: string, _version: string) {
 
 export function createAllCatch(appGlobal: Hono<MiddlewareKeyVariables>, functionName: string) {
   appGlobal.all('*', (c) => {
-    cloudlog({ requestId: c.get('requestId'), functionName, message: 'Not found', url: c.req.url })
+    cloudlog({ requestId: c.get('requestId'), functionName, message: 'Not found', url: redactUrl(c.req.url) })
     return c.json({ error: 'not_found', message: 'Not found' }, 404)
   })
   appGlobal.onError(onError(functionName))

--- a/supabase/functions/_backend/utils/log_redaction.ts
+++ b/supabase/functions/_backend/utils/log_redaction.ts
@@ -52,7 +52,7 @@ export function redactUrl(rawUrl: string): string {
     parsed = new URL(rawUrl)
   }
   catch {
-    // If URL is unparseable, return without any modification
+    // If URL is unparsable, return without any modification
     return rawUrl
   }
 

--- a/supabase/functions/_backend/utils/log_redaction.ts
+++ b/supabase/functions/_backend/utils/log_redaction.ts
@@ -1,0 +1,68 @@
+/**
+ * Sensitive query parameter name patterns.
+ * Values for these keys are replaced with '[REDACTED]' before logging
+ * so that API keys, tokens, and passwords never appear in log output.
+ */
+const SENSITIVE_QUERY_PARAM_PATTERNS: RegExp[] = [
+  /^api[_-]?key$/i,
+  /^apikey$/i,
+  /^capgkey$/i,
+  /^access[_-]?token$/i,
+  /^auth(?:orization)?$/i,
+  /^token$/i,
+  /^password$/i,
+  /^passwd$/i,
+  /^secret$/i,
+  /^private[_-]?key$/i,
+  /^key$/i,
+  /^credential$/i,
+  /^sig(?:nature)?$/i,
+  /^x-amz-signature$/i,
+  /^x-amz-credential$/i,
+  /^x-amz-security-token$/i,
+  /^client[_-]?secret$/i,
+  /^refresh[_-]?token$/i,
+  /^id[_-]?token$/i,
+]
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_QUERY_PARAM_PATTERNS.some(pattern => pattern.test(key))
+}
+
+/**
+ * Returns a copy of the query params object with sensitive values replaced
+ * by '[REDACTED]'. Non-sensitive values are preserved for operational debugging.
+ */
+export function redactQueryParams(params: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(params)) {
+    result[key] = isSensitiveKey(key) ? '[REDACTED]' : value
+  }
+  return result
+}
+
+/**
+ * Returns a copy of the URL string with sensitive query parameter values
+ * replaced by '[REDACTED]'. The URL structure and non-sensitive params are
+ * preserved so not-found logs remain useful for debugging routing issues.
+ */
+export function redactUrl(rawUrl: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  }
+  catch {
+    // If URL is unparseable, return without any modification
+    return rawUrl
+  }
+
+  let hasRedacted = false
+  for (const [key] of parsed.searchParams.entries()) {
+    if (isSensitiveKey(key)) {
+      parsed.searchParams.set(key, '[REDACTED]')
+      hasRedacted = true
+    }
+  }
+
+  return hasRedacted ? parsed.toString() : rawUrl
+}

--- a/tests/hono-log-redaction.unit.test.ts
+++ b/tests/hono-log-redaction.unit.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import { redactQueryParams, redactUrl } from '../supabase/functions/_backend/utils/log_redaction.ts'
+
+describe('redactQueryParams', () => {
+  it('redacts api_key', () => {
+    const result = redactQueryParams({ api_key: 'super-secret-key', page: '1' })
+    expect(result.api_key).toBe('[REDACTED]')
+    expect(result.page).toBe('1')
+  })
+
+  it('redacts apikey (no underscore)', () => {
+    const result = redactQueryParams({ apikey: 'my-api-key', limit: '10' })
+    expect(result.apikey).toBe('[REDACTED]')
+    expect(result.limit).toBe('10')
+  })
+
+  it('redacts capgkey', () => {
+    const result = redactQueryParams({ capgkey: 'capgo-secret', version: '1.0.0' })
+    expect(result.capgkey).toBe('[REDACTED]')
+    expect(result.version).toBe('1.0.0')
+  })
+
+  it('redacts access_token', () => {
+    const result = redactQueryParams({ access_token: 'tok-abc123', app_id: 'com.example' })
+    expect(result.access_token).toBe('[REDACTED]')
+    expect(result.app_id).toBe('com.example')
+  })
+
+  it('redacts token', () => {
+    const result = redactQueryParams({ token: 'secret-tok' })
+    expect(result.token).toBe('[REDACTED]')
+  })
+
+  it('redacts password', () => {
+    const result = redactQueryParams({ password: 'hunter2', username: 'alice' })
+    expect(result.password).toBe('[REDACTED]')
+    expect(result.username).toBe('alice')
+  })
+
+  it('redacts secret', () => {
+    const result = redactQueryParams({ secret: 'my-secret' })
+    expect(result.secret).toBe('[REDACTED]')
+  })
+
+  it('redacts key', () => {
+    const result = redactQueryParams({ key: 'private-key-value' })
+    expect(result.key).toBe('[REDACTED]')
+  })
+
+  it('redacts refresh_token', () => {
+    const result = redactQueryParams({ refresh_token: 'rt-abc', org_id: 'org-123' })
+    expect(result.refresh_token).toBe('[REDACTED]')
+    expect(result.org_id).toBe('org-123')
+  })
+
+  it('is case-insensitive for key names', () => {
+    const result = redactQueryParams({ API_KEY: 'sensitive', Token: 'tok', PAGE: '2' })
+    expect(result.API_KEY).toBe('[REDACTED]')
+    expect(result.Token).toBe('[REDACTED]')
+    expect(result.PAGE).toBe('2')
+  })
+
+  it('preserves non-sensitive params', () => {
+    const params = { app_id: 'com.example.app', platform: 'ios', version: '1.2.3', page: '5', limit: '20' }
+    const result = redactQueryParams(params)
+    expect(result).toEqual(params)
+  })
+
+  it('returns empty object for empty input', () => {
+    expect(redactQueryParams({})).toEqual({})
+  })
+
+  it('does not mutate the original object', () => {
+    const original = { api_key: 'secret', page: '1' }
+    const copy = { ...original }
+    redactQueryParams(original)
+    expect(original).toEqual(copy)
+  })
+})
+
+describe('redactUrl', () => {
+  it('redacts api_key in URL query string', () => {
+    const url = 'https://api.capgo.app/channel?api_key=super-secret&app_id=com.example'
+    const result = redactUrl(url)
+    expect(result).not.toContain('super-secret')
+    expect(result).toContain('[REDACTED]')
+    expect(result).toContain('app_id=com.example')
+  })
+
+  it('redacts token in URL query string', () => {
+    const url = 'https://api.capgo.app/device?token=tok-abc&platform=ios'
+    const result = redactUrl(url)
+    expect(result).not.toContain('tok-abc')
+    expect(result).toContain('[REDACTED]')
+    expect(result).toContain('platform=ios')
+  })
+
+  it('preserves URL with no sensitive params unchanged', () => {
+    const url = 'https://api.capgo.app/stats?app_id=com.test&platform=android&version=1.0.0'
+    const result = redactUrl(url)
+    expect(result).toBe(url)
+  })
+
+  it('preserves the path and non-sensitive query params', () => {
+    const url = 'https://api.capgo.app/not-found/path?api_key=secret&page=3&limit=10'
+    const result = redactUrl(url)
+    expect(result).toContain('/not-found/path')
+    expect(result).toContain('page=3')
+    expect(result).toContain('limit=10')
+    expect(result).not.toContain('secret')
+  })
+
+  it('handles URL with no query string', () => {
+    const url = 'https://api.capgo.app/channel'
+    expect(redactUrl(url)).toBe(url)
+  })
+
+  it('handles unparseable URL gracefully', () => {
+    const bad = 'not-a-url'
+    expect(redactUrl(bad)).toBe(bad)
+  })
+
+  it('redacts presigned S3-style params', () => {
+    const url = 'https://bucket.s3.amazonaws.com/file.zip?X-Amz-Signature=abc123&X-Amz-Algorithm=AWS4&response-expires=3600'
+    const result = redactUrl(url)
+    expect(result).not.toContain('abc123')
+    expect(result).toContain('[REDACTED]')
+    expect(result).toContain('X-Amz-Algorithm=AWS4')
+  })
+
+  it('redacts multiple sensitive params in one URL', () => {
+    const url = 'https://example.com/api?api_key=k1&token=t1&secret=s1&app_id=myapp'
+    const result = redactUrl(url)
+    expect(result).not.toContain('k1')
+    expect(result).not.toContain('t1')
+    expect(result).not.toContain('s1')
+    expect(result).toContain('app_id=myapp')
+    expect(result.match(/\[REDACTED\]/g)?.length).toBe(3)
+  })
+})

--- a/tests/hono-log-redaction.unit.test.ts
+++ b/tests/hono-log-redaction.unit.test.ts
@@ -115,7 +115,7 @@ describe('redactUrl', () => {
     expect(redactUrl(url)).toBe(url)
   })
 
-  it('handles unparseable URL gracefully', () => {
+  it('handles unparsable URL gracefully', () => {
     const bad = 'not-a-url'
     expect(redactUrl(bad)).toBe(bad)
   })


### PR DESCRIPTION
Add a shared log redaction helper and use it to scrub sensitive query parameter values before they reach the log stream.

Without this fix, API keys, tokens, passwords, and other credentials passed as query parameters are emitted verbatim to logs by four middleware log points and the not-found catch-all.

## Changes

**New `utils/log_redaction.ts`**
- `redactQueryParams()` — replaces values of sensitive keys (`api_key`, `apikey`, `capgkey`, `token`, `secret`, `password`, `access_token`, `key`, `refresh_token`, `signature`, `credential`, X-Amz-\* params, etc.) with `[REDACTED]` while preserving non-sensitive values
- `redactUrl()` — redacts sensitive query params within a full URL string so request URLs can still be logged safely

**`utils/hono.ts`**
- Wrap `c.req.query()` with `redactQueryParams()` in `getBodyOrQuery`, `middlewareAuth`, and `middlewareAPISecret` log calls
- Wrap `c.req.url` with `redactUrl()` in the `createAllCatch` not-found handler

Refs #1667
Closes #2168