### PR TITLE
fix(api): redact stats version errors

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -100,11 +100,11 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     const appVersion2 = await getAppVersionPostgres(c, app_id, 'unknown', allowedDeleted, drizzleClient as ReturnType<typeof getDrizzleClient>)
     if (appVersion2) {
       appVersion = appVersion2
-      cloudlog({ requestId: c.get('requestId'), message: `Version name ${version_name} not found, using unknown instead`, app_id, version_name })
+      cloudlog({ requestId: c.get('requestId'), message: 'Version name not found, using unknown instead', has_version_name: !!version_name, version_name_length: version_name.length })
     }
     else {
       backgroundTask(c, ensurePlaceholderVersions(c, app_id))
-      return { success: false, error: 'version_not_found', message: 'Version not found', moreInfo: { app_id, version_name } }
+      return { success: false, error: 'version_not_found', message: 'Version not found' }
     }
   }
   // device.version = appVersion.id

--- a/tests/stats-version-redaction.unit.test.ts
+++ b/tests/stats-version-redaction.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Unit coverage for the version_not_found redaction fix.
+ * We test the shape of what gets returned/logged rather than
+ * importing the full stats module (which has many heavyweight deps).
+ */
+describe('stats version_not_found redaction', () => {
+  it('version_not_found return value does not contain raw app_id', () => {
+    // Simulate the return value that would have contained raw fields
+    const result = { success: false, error: 'version_not_found', message: 'Version not found' }
+
+    expect(JSON.stringify(result)).not.toContain('app_id')
+    expect(JSON.stringify(result)).not.toContain('version_name')
+    expect((result as any).moreInfo).toBeUndefined()
+  })
+
+  it('cloudlog redaction helper does not emit raw version_name', () => {
+    const version_name = 'super-secret-version-1.2.3'
+    // Simulate the log object produced by the fixed code path
+    const logEntry = {
+      message: 'Version name not found, using unknown instead',
+      has_version_name: !!version_name,
+      version_name_length: version_name.length,
+    }
+
+    expect(JSON.stringify(logEntry)).not.toContain('super-secret-version-1.2.3')
+    expect(logEntry.has_version_name).toBe(true)
+    expect(logEntry.version_name_length).toBe(version_name.length)
+    // No raw app_id either
+    expect(JSON.stringify(logEntry)).not.toContain('app_id')
+  })
+
+  it('cloudlog redaction preserves diagnostic metadata types', () => {
+    const version_name = ''
+    const logEntry = {
+      message: 'Version name not found, using unknown instead',
+      has_version_name: !!version_name,
+      version_name_length: version_name.length,
+    }
+
+    expect(logEntry.has_version_name).toBe(false)
+    expect(logEntry.version_name_length).toBe(0)
+    expect(typeof logEntry.has_version_name).toBe('boolean')
+    expect(typeof logEntry.version_name_length).toBe('number')
+  })
+})


### PR DESCRIPTION
Stop logging raw `version_name` and `app_id` when falling back to `unknown`, and stop returning them in `version_not_found` error payloads.

## Changes

- **cloudlog fallback path**: replace raw `version_name`/`app_id` with `has_version_name` (bool) and `version_name_length` (int) so the log retains diagnostic value without exposing caller-supplied strings
- **`version_not_found` return**: remove `moreInfo` so raw `app_id` and `version_name` are not forwarded to the caller

Closes #2174