### PR TITLE
fix(api): redact plugin parser error details

### DIFF
--- a/supabase/functions/_backend/utils/plugin_parser.ts
+++ b/supabase/functions/_backend/utils/plugin_parser.ts
@@ -45,19 +45,19 @@ export function makeDevice(devBody: AppInfos | DeviceLink | AppStats, allowCusto
 
 export function parsePluginBody<T extends AppInfos | DeviceLink | AppStats>(c: Context, body: T, schema: StandardSchema<T>, requireDevice = true) {
   if (Object.keys(body ?? {}).length === 0) {
-    throw simpleError(getInvalidCode(c), 'Cannot parse body', { body })
+    throw simpleError(getInvalidCode(c), 'Cannot parse body', { has_fields: false })
   }
   if (requireDevice && !body.device_id) {
-    throw simpleError('missing_device_id', 'Cannot find device_id', { body })
+    throw simpleError('missing_device_id', 'Cannot find device_id', { has_device_id: false, has_app_id: !!body.app_id })
   }
   if (!body.app_id) {
-    throw simpleError('missing_app_id', 'Cannot find app_id', { body })
+    throw simpleError('missing_app_id', 'Cannot find app_id', { has_device_id: !!body.device_id, has_app_id: false })
   }
   // Only validate version_build if it's provided (not required for GET /channel_self)
   if (body.version_build) {
     const coerce = tryParse(fixSemver(body.version_build))
     if (!coerce) {
-      throw simpleError('semver_error', `Native version: ${body.version_build} doesn't follow semver convention, please check https://capgo.app/semver_tester/ to learn more about semver usage in Capgo`, { version_build: body.version_build })
+      throw simpleError('semver_error', 'Native version does not follow semver convention, please check https://capgo.app/semver_tester/ to learn more about semver usage in Capgo', { version_build_length: typeof body.version_build === 'string' ? body.version_build.length : 0 })
     }
     body.version_build = format(coerce)
   }
@@ -69,7 +69,11 @@ export function parsePluginBody<T extends AppInfos | DeviceLink | AppStats>(c: C
   }
   const parseResult = safeParseSchema(schema, body)
   if (!parseResult.success) {
-    throw simpleError(getInvalidCode(c), 'Cannot parse body', { parseResult })
+    const safeIssues = (parseResult.error?.issues ?? []).map((issue: any) => ({
+      code: issue.code ?? 'unknown',
+      path: Array.isArray(issue.path) ? issue.path.map(String) : [],
+    }))
+    throw simpleError(getInvalidCode(c), 'Cannot parse body', { issue_count: safeIssues.length, issues: safeIssues })
   }
   return parseResult.data
 }

--- a/tests/plugin-parser-redaction.unit.test.ts
+++ b/tests/plugin-parser-redaction.unit.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
+  simpleError: (code: string, message: string, data?: Record<string, unknown>) => {
+    const err: any = new Error(message)
+    err.code = code
+    err.data = data ?? null
+    return err
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/ark_validation.ts', async () => {
+  const actual = await import('../supabase/functions/_backend/utils/ark_validation.ts')
+  return actual
+})
+
+const { parsePluginBody } = await import('../supabase/functions/_backend/utils/plugin_parser.ts')
+const { type } = await import('arktype')
+
+const testSchema = type({
+  device_id: 'string',
+  app_id: 'string',
+  plugin_version: 'string',
+  version_build: 'string',
+  platform: 'string',
+})
+
+function makeCtx(method = 'POST') {
+  return { req: { method } } as any
+}
+
+describe('parsePluginBody redaction', () => {
+  it('empty body error does not echo raw body', () => {
+    let thrown: any
+    try {
+      parsePluginBody(makeCtx(), {} as any, testSchema)
+    }
+    catch (e) { thrown = e }
+
+    expect(thrown).toBeDefined()
+    expect(thrown.data).not.toHaveProperty('body')
+    expect(thrown.data?.has_fields).toBe(false)
+  })
+
+  it('missing_device_id error does not echo raw body', () => {
+    let thrown: any
+    try {
+      parsePluginBody(makeCtx(), { app_id: 'com.secret.app', version_build: '1.0.0', plugin_version: '5.0.0', platform: 'ios' } as any, testSchema)
+    }
+    catch (e) { thrown = e }
+
+    expect(thrown?.code).toBe('missing_device_id')
+    expect(JSON.stringify(thrown?.data ?? {})).not.toContain('com.secret.app')
+    expect(thrown?.data?.has_device_id).toBe(false)
+    expect(thrown?.data?.has_app_id).toBe(true)
+  })
+
+  it('missing_app_id error does not echo raw body', () => {
+    let thrown: any
+    try {
+      parsePluginBody(makeCtx(), { device_id: 'secret-device-id', version_build: '1.0.0', plugin_version: '5.0.0', platform: 'ios' } as any, testSchema)
+    }
+    catch (e) { thrown = e }
+
+    expect(thrown?.code).toBe('missing_app_id')
+    expect(JSON.stringify(thrown?.data ?? {})).not.toContain('secret-device-id')
+    expect(thrown?.data?.has_app_id).toBe(false)
+    expect(thrown?.data?.has_device_id).toBe(true)
+  })
+
+  it('semver_error does not embed raw version_build in message or data', () => {
+    let thrown: any
+    try {
+      parsePluginBody(makeCtx(), {
+        device_id: 'dev-123',
+        app_id: 'com.example',
+        version_build: 'not-semver-secret-value-abc123',
+        plugin_version: '5.0.0',
+        platform: 'ios',
+      } as any, testSchema)
+    }
+    catch (e) { thrown = e }
+
+    expect(thrown?.code).toBe('semver_error')
+    expect(thrown?.message).not.toContain('not-semver-secret-value-abc123')
+    expect(JSON.stringify(thrown?.data ?? {})).not.toContain('not-semver-secret-value-abc123')
+    expect(typeof thrown?.data?.version_build_length).toBe('number')
+    expect(thrown?.data?.version_build_length).toBe('not-semver-secret-value-abc123'.length)
+  })
+
+  it('schema parse failure does not include raw parseResult with embedded values', () => {
+    let thrown: any
+    try {
+      parsePluginBody(makeCtx(), {
+        device_id: 12345 as any, // wrong type, should be string
+        app_id: 'com.example',
+        version_build: '1.0.0',
+        plugin_version: '5.0.0',
+        platform: 'ios',
+      } as any, testSchema, false)
+    }
+    catch (e) { thrown = e }
+
+    if (thrown) {
+      expect(thrown?.data).not.toHaveProperty('parseResult')
+      expect(thrown?.data).not.toHaveProperty('body')
+      if (thrown?.data?.issues) {
+        thrown.data.issues.forEach((issue: any) => {
+          expect(Object.keys(issue).sort()).toEqual(['code', 'path'])
+          expect((issue as any).data).toBeUndefined()
+        })
+      }
+    }
+  })
+})


### PR DESCRIPTION
Replace raw request bodies, full schema parse results, and raw `version_build` values in plugin parser validation errors.

## Changes

- Empty body error: replace `{ body }` with `{ has_fields: false }`
- `missing_device_id`: replace `{ body }` with `{ has_device_id: false, has_app_id }`
- `missing_app_id`: replace `{ body }` with `{ has_device_id, has_app_id: false }`
- `semver_error`: strip raw `version_build` from error message template and data; emit `{ version_build_length }` instead
- Schema parse failure: replace `{ parseResult }` with safe issues list (`{ code, path }` only) + `issue_count`

Closes #2171