### PR TITLE
fix(api): cap PostHog error response bodies

### DIFF
--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -5,6 +5,7 @@ import { existInEnv, getEnv } from './utils.ts'
 
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
 const POSTHOG_EXCEPTION_URL = 'https://eu.i.posthog.com/i/v0/e/'
+const MAX_POSTHOG_ERROR_BODY_BYTES = 4 * 1024
 
 export type PostHogGroups = Record<string, string>
 
@@ -15,6 +16,48 @@ interface PostHogCapturePayload extends Pick<TrackOptions, 'event'>, Pick<TrackO
   setPersonProperties?: boolean
   tags?: Record<string, any>
   user_id?: string
+}
+
+async function readPostHogErrorBody(response: Response, limit = MAX_POSTHOG_ERROR_BODY_BYTES) {
+  const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10)
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    await response.body?.cancel().catch(() => undefined)
+    return null
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    return new TextEncoder().encode(text).byteLength > limit ? null : text
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let total = 0
+  let text = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      text += decoder.decode()
+      break
+    }
+
+    if (!value)
+      continue
+
+    total += value.byteLength
+    if (total > limit) {
+      await reader.cancel()
+      return null
+    }
+    text += decoder.decode(value, { stream: true })
+  }
+
+  return text
+}
+
+function formatPostHogErrorBody(errorBody: string | null) {
+  return errorBody ?? 'posthog_error_body_too_large'
 }
 
 export async function trackPosthogEvent(c: Context, payload: PostHogCapturePayload) {
@@ -60,7 +103,7 @@ export async function trackPosthogEvent(c: Context, payload: PostHogCapturePaylo
     })
 
     if (!res.ok) {
-      const error = await res.text()
+      const error = formatPostHogErrorBody(await readPostHogErrorBody(res))
       cloudlogErr({ requestId: c.get('requestId'), message: 'PostHog error', status: res.status, error, event: payload.event, distinctId })
       return false
     }
@@ -221,7 +264,7 @@ export async function capturePosthogException(c: Context, payload: {
     }
 
     if (!res.ok) {
-      const error = await res.text()
+      const error = formatPostHogErrorBody(await readPostHogErrorBody(res))
       cloudlogErr({ requestId: c.get('requestId'), message: 'PostHog exception error', status: res.status, error, event: '$exception', distinctId })
       return false
     }
@@ -273,7 +316,7 @@ export async function groupIdentifyPosthog(c: Context, payload: PostHogGroupIden
     })
 
     if (!res.ok) {
-      const error = await res.text()
+      const error = formatPostHogErrorBody(await readPostHogErrorBody(res))
       cloudlogErr({
         requestId: c.get('requestId'),
         message: 'PostHog $groupidentify error',
@@ -303,4 +346,10 @@ export async function groupIdentifyPosthog(c: Context, payload: PostHogGroupIden
     })
     return false
   }
+}
+
+export const posthogTestUtils = {
+  MAX_POSTHOG_ERROR_BODY_BYTES,
+  formatPostHogErrorBody,
+  readPostHogErrorBody,
 }

--- a/tests/posthog.unit.test.ts
+++ b/tests/posthog.unit.test.ts
@@ -48,12 +48,21 @@ function createContext() {
   } as any
 }
 
+async function expectOversizedPostHogError(sender: (context: ReturnType<typeof createContext>) => Promise<boolean>, message: string) {
+  const oversizedBody = 'x'.repeat(4097)
+  fetchMock.mockResolvedValue(new Response(oversizedBody, { status: 503 }))
+
+  await expect(sender(createContext())).resolves.toBe(false)
+  expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+    message,
+    error: 'posthog_error_body_too_large',
+  }))
+  expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain(oversizedBody)
+}
+
 beforeEach(() => {
   envState.posthogApiHost = 'https://eu.i.posthog.com'
-  fetchMock.mockResolvedValue({
-    ok: true,
-    text: vi.fn().mockResolvedValue(''),
-  })
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }))
   vi.stubGlobal('fetch', fetchMock)
 })
 
@@ -130,5 +139,38 @@ describe('posthog helper', () => {
       message: 'Invalid PostHog host',
       host: '://bad-host',
     }))
+  })
+
+  it('does not log oversized PostHog capture error bodies', async () => {
+    const { trackPosthogEvent } = await import('../supabase/functions/_backend/utils/posthog.ts')
+
+    await expectOversizedPostHogError(context => trackPosthogEvent(context, {
+      event: 'Tracked Event',
+      channel: 'usage',
+      user_id: 'user-id',
+    }), 'PostHog error')
+  })
+
+  it('does not log oversized PostHog exception error bodies', async () => {
+    const { capturePosthogException } = await import('../supabase/functions/_backend/utils/posthog.ts')
+
+    await expectOversizedPostHogError(context => capturePosthogException(context, {
+      error: new Error('boom'),
+      functionName: 'app',
+      kind: 'unhandled_error',
+      status: 500,
+    }), 'PostHog exception error')
+  })
+
+  it('rejects oversized PostHog error bodies from content-length before reading', async () => {
+    const { posthogTestUtils } = await import('../supabase/functions/_backend/utils/posthog.ts')
+    const response = new Response('too large', {
+      status: 503,
+      headers: {
+        'content-length': String(posthogTestUtils.MAX_POSTHOG_ERROR_BODY_BYTES + 1),
+      },
+    })
+
+    await expect(posthogTestUtils.readPostHogErrorBody(response)).resolves.toBeNull()
   })
 })


### PR DESCRIPTION
/claim #1667

## Summary
- Add bounded reads for PostHog error responses before logging them.
- Apply the cap to capture, exception, and group-identify failure paths.
- Replace oversized PostHog error bodies with a stable placeholder instead of retaining the full upstream response.
- Add regression coverage for capture/exception failures and `Content-Length` fast-fail handling.

## Security note
This is public-safe DoS/log hardening for backend telemetry helpers. Normal small PostHog error messages are preserved, while oversized upstream error bodies no longer force unbounded buffering or log retention.

## Test plan
- `./node_modules/.bin/vitest.exe run tests/posthog.unit.test.ts --reporter=verbose`
- `git diff --check`

## Screenshots
Not applicable; backend helper hardening only.

## Checklist
- [x] Focused regression tests added
- [x] Public-safe security details only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to prevent oversized error responses from being excessively logged, ensuring better system performance and preventing potential data capture issues.

* **Tests**
  * Added comprehensive test coverage for error body size limits to verify proper handling of large error responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2237)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->