### PR TITLE
fix(api): cap LogSnag error response bodies

### DIFF
--- a/supabase/functions/_backend/utils/logsnag.ts
+++ b/supabase/functions/_backend/utils/logsnag.ts
@@ -4,6 +4,9 @@ import { LogSnag } from '@logsnag/node'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
 import { getEnv } from './utils.ts'
 
+const MAX_LOGSNAG_ERROR_BODY_BYTES = 4 * 1024
+const LOGSNAG_ERROR_BODY_TOO_LARGE = '[logsnag_error_body_too_large]'
+
 function logsnag(c: Context) {
   const ls = getEnv(c, 'LOGSNAG_TOKEN')
     ? new LogSnag({
@@ -19,6 +22,53 @@ function logsnag(c: Context) {
         },
       }
   return ls as LogSnag
+}
+
+function isOversizedContentLength(response: Response, maxBytes: number) {
+  const contentLength = response.headers.get('content-length')
+  if (!contentLength)
+    return false
+
+  const parsed = Number.parseInt(contentLength, 10)
+  return Number.isFinite(parsed) && parsed > maxBytes
+}
+
+async function readLimitedResponseText(response: Response, maxBytes: number) {
+  if (isOversizedContentLength(response, maxBytes)) {
+    await response.body?.cancel().catch(() => undefined)
+    return LOGSNAG_ERROR_BODY_TOO_LARGE
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    return new TextEncoder().encode(text).byteLength > maxBytes ? LOGSNAG_ERROR_BODY_TOO_LARGE : text
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let receivedBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      break
+
+    receivedBytes += value.byteLength
+    if (receivedBytes > maxBytes) {
+      await reader.cancel().catch(() => undefined)
+      return LOGSNAG_ERROR_BODY_TOO_LARGE
+    }
+    chunks.push(value)
+  }
+
+  const body = new Uint8Array(receivedBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new TextDecoder().decode(body)
 }
 
 async function logsnagInsights(c: Context, data: { title: string, value: string | boolean | number, icon: string }[]) {
@@ -48,7 +98,7 @@ async function logsnagInsights(c: Context, data: { title: string, value: string 
       })
 
       if (!response.ok) {
-        const error = await response.text()
+        const error = await readLimitedResponseText(response, MAX_LOGSNAG_ERROR_BODY_BYTES)
         cloudlogErr({ requestId: c.get('requestId'), message: 'logsnagInsights error', status: response.status, error, payload })
         return false
       }
@@ -62,6 +112,11 @@ async function logsnagInsights(c: Context, data: { title: string, value: string 
   })
 
   return Promise.all(promises)
+}
+
+export const logsnagTestUtils = {
+  LOGSNAG_ERROR_BODY_TOO_LARGE,
+  MAX_LOGSNAG_ERROR_BODY_BYTES,
 }
 
 export { logsnag, logsnagInsights }

--- a/tests/logsnag.unit.test.ts
+++ b/tests/logsnag.unit.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cloudlogErrMock,
+  cloudlogMock,
+  fetchMock,
+} = vi.hoisted(() => ({
+  cloudlogErrMock: vi.fn(),
+  cloudlogMock: vi.fn(),
+  fetchMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: cloudlogErrMock,
+  serializeError: (error: unknown) => ({
+    message: error instanceof Error ? error.message : String(error),
+    name: error instanceof Error ? error.name : 'Error',
+    stack: error instanceof Error ? error.stack ?? 'N/A' : 'N/A',
+  }),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  getEnv: (_c: unknown, key: string) => {
+    if (key === 'LOGSNAG_TOKEN')
+      return 'logsnag-token'
+    if (key === 'LOGSNAG_PROJECT')
+      return 'logsnag-project'
+    return ''
+  },
+}))
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+  } as any
+}
+
+const insightPayload = [{ title: 'Deploys', value: 1, icon: 'rocket' }]
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cloudlogErrMock.mockReset()
+  cloudlogMock.mockReset()
+  fetchMock.mockReset()
+})
+
+describe('logsnag helper', () => {
+  it.concurrent('logs small LogSnag error bodies', async () => {
+    const { logsnagInsights } = await import('../supabase/functions/_backend/utils/logsnag.ts')
+    fetchMock.mockResolvedValue(new Response('bad request', { status: 400 }))
+
+    const result = await logsnagInsights(createContext(), insightPayload)
+
+    expect(result).toEqual([false])
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'logsnagInsights error',
+      status: 400,
+      error: 'bad request',
+    }))
+  })
+
+  it.concurrent('rejects oversized LogSnag error bodies from content-length before logging', async () => {
+    const { logsnagInsights, logsnagTestUtils } = await import('../supabase/functions/_backend/utils/logsnag.ts')
+    const oversizedBody = 'x'.repeat(logsnagTestUtils.MAX_LOGSNAG_ERROR_BODY_BYTES + 1)
+    fetchMock.mockResolvedValue(new Response(oversizedBody, {
+      status: 502,
+      headers: { 'content-length': String(logsnagTestUtils.MAX_LOGSNAG_ERROR_BODY_BYTES + 1) },
+    }))
+
+    const result = await logsnagInsights(createContext(), insightPayload)
+
+    expect(result).toEqual([false])
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: logsnagTestUtils.LOGSNAG_ERROR_BODY_TOO_LARGE,
+      status: 502,
+    }))
+    expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain(oversizedBody)
+  })
+
+  it.concurrent('cancels oversized LogSnag error bodies rejected by content-length', async () => {
+    const { logsnagInsights, logsnagTestUtils } = await import('../supabase/functions/_backend/utils/logsnag.ts')
+    const cancelMock = vi.fn()
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('oversized'))
+      },
+      cancel: cancelMock,
+    })
+    fetchMock.mockResolvedValue(new Response(body, {
+      status: 502,
+      headers: { 'content-length': String(logsnagTestUtils.MAX_LOGSNAG_ERROR_BODY_BYTES + 1) },
+    }))
+
+    const result = await logsnagInsights(createContext(), insightPayload)
+
+    expect(result).toEqual([false])
+    expect(cancelMock).toHaveBeenCalledTimes(1)
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: logsnagTestUtils.LOGSNAG_ERROR_BODY_TOO_LARGE,
+      status: 502,
+    }))
+  })
+
+  it.concurrent('does not log chunked oversized LogSnag error bodies', async () => {
+    const { logsnagInsights, logsnagTestUtils } = await import('../supabase/functions/_backend/utils/logsnag.ts')
+    const oversizedBody = 'y'.repeat(logsnagTestUtils.MAX_LOGSNAG_ERROR_BODY_BYTES + 1)
+    fetchMock.mockResolvedValue(new Response(oversizedBody, { status: 503 }))
+
+    const result = await logsnagInsights(createContext(), insightPayload)
+
+    expect(result).toEqual([false])
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: logsnagTestUtils.LOGSNAG_ERROR_BODY_TOO_LARGE,
+      status: 503,
+    }))
+    expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain(oversizedBody)
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- bound LogSnag insight error response reads to 4 KiB before logging
- avoid logging oversized external response bodies by replacing them with a fixed marker
- add unit coverage for small, content-length oversized, and chunked oversized LogSnag error responses

## Tests
- `vitest run tests/logsnag.unit.test.ts --reporter=verbose`
- `bun typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added size-limiting support for error body handling with automatic overflow detection and safe stream processing.

* **Tests**
  * Added comprehensive test suite for error logging with coverage for size limits, overflow detection, and response stream handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->