### PR TITLE
fix(api): cap webhook response body reads

### DIFF
--- a/supabase/functions/_backend/utils/webhook.ts
+++ b/supabase/functions/_backend/utils/webhook.ts
@@ -58,6 +58,9 @@ const WEBHOOK_URL_VALIDATION_MESSAGES = {
   dnsResolution: 'Webhook URL host could not be resolved',
 }
 
+const WEBHOOK_RESPONSE_BODY_LIMIT_BYTES = 10000
+const WEBHOOK_RESPONSE_BODY_TOO_LARGE = '[webhook_response_body_too_large]'
+
 export function getWebhookUrlValidationError(c: Context, urlString: string): string | null {
   return getPublicUrlSyntaxValidationError(urlString, {
     allowLocalUrls: allowLocalWebhookUrls(c),
@@ -185,6 +188,53 @@ export async function generateWebhookSignature(
   return `v1=${timestamp}.${hexSignature}`
 }
 
+function isOversizedContentLength(response: Response, maxBytes: number) {
+  const contentLength = response.headers.get('content-length')
+  if (!contentLength)
+    return false
+
+  const parsed = Number.parseInt(contentLength, 10)
+  return Number.isFinite(parsed) && parsed > maxBytes
+}
+
+async function readLimitedWebhookResponseBody(response: Response, maxBytes: number) {
+  if (isOversizedContentLength(response, maxBytes)) {
+    await response.body?.cancel().catch(() => undefined)
+    return WEBHOOK_RESPONSE_BODY_TOO_LARGE
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    return new TextEncoder().encode(text).byteLength > maxBytes ? WEBHOOK_RESPONSE_BODY_TOO_LARGE : text
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let receivedBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      break
+
+    receivedBytes += value.byteLength
+    if (receivedBytes > maxBytes) {
+      await reader.cancel().catch(() => undefined)
+      return WEBHOOK_RESPONSE_BODY_TOO_LARGE
+    }
+    chunks.push(value)
+  }
+
+  const body = new Uint8Array(receivedBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new TextDecoder().decode(body)
+}
+
 /**
  * Deliver a webhook to the user's endpoint
  */
@@ -235,33 +285,37 @@ export async function deliverWebhook(
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000) // 10s timeout
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: payloadString,
-      redirect: 'manual',
-      signal: controller.signal,
-    })
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: payloadString,
+        redirect: 'manual',
+        signal: controller.signal,
+      })
 
-    clearTimeout(timeoutId)
-    const duration = Date.now() - startTime
-    const responseBody = await response.text()
+      const responseBody = await readLimitedWebhookResponseBody(response, WEBHOOK_RESPONSE_BODY_LIMIT_BYTES)
+      const duration = Date.now() - startTime
 
-    cloudlog({
-      requestId: c.get('requestId'),
-      message: 'Webhook delivery attempt',
-      deliveryId,
-      url,
-      status: response.status,
-      success: response.ok,
-      duration,
-    })
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Webhook delivery attempt',
+        deliveryId,
+        url,
+        status: response.status,
+        success: response.ok,
+        duration,
+      })
 
-    return {
-      success: response.ok,
-      status: response.status,
-      body: responseBody.slice(0, 10000), // Limit stored body size
-      duration,
+      return {
+        success: response.ok,
+        status: response.status,
+        body: responseBody,
+        duration,
+      }
+    }
+    finally {
+      clearTimeout(timeoutId)
     }
   }
   catch (error) {
@@ -283,6 +337,11 @@ export async function deliverWebhook(
       duration,
     }
   }
+}
+
+export const webhookTestUtils = {
+  WEBHOOK_RESPONSE_BODY_LIMIT_BYTES,
+  WEBHOOK_RESPONSE_BODY_TOO_LARGE,
 }
 
 /**

--- a/tests/webhook-delivery-redirect.unit.test.ts
+++ b/tests/webhook-delivery-redirect.unit.test.ts
@@ -16,7 +16,12 @@ vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
   getEnv: mockGetEnv,
 }))
 
-const { deliverWebhook } = await import('../supabase/functions/_backend/utils/webhook.ts')
+vi.mock('../supabase/functions/_backend/utils/publicUrl.ts', () => ({
+  getPublicHostnameValidationError: vi.fn().mockResolvedValue(null),
+  getPublicUrlSyntaxValidationError: vi.fn().mockReturnValue(null),
+}))
+
+const { deliverWebhook, webhookTestUtils } = await import('../supabase/functions/_backend/utils/webhook.ts')
 
 describe('webhook delivery redirect handling', () => {
   const payload = {
@@ -47,9 +52,10 @@ describe('webhook delivery redirect handling', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
-  it.concurrent('uses manual redirect mode for outbound webhook delivery', async () => {
+  it('uses manual redirect mode for outbound webhook delivery', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('redirect blocked', {
       status: 302,
       headers: {
@@ -76,5 +82,69 @@ describe('webhook delivery redirect handling', () => {
       status: 302,
       body: 'redirect blocked',
     })
+  })
+
+  it('does not read or store oversized webhook response bodies', async () => {
+    const oversizedBody = 'x'.repeat(webhookTestUtils.WEBHOOK_RESPONSE_BODY_LIMIT_BYTES + 1)
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(oversizedBody, {
+      status: 200,
+      headers: { 'content-length': String(webhookTestUtils.WEBHOOK_RESPONSE_BODY_LIMIT_BYTES + 1) },
+    }))
+
+    const result = await deliverWebhook(
+      context as any,
+      'delivery-oversized',
+      'https://example.com/webhook',
+      payload,
+      'whsec_test_secret',
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      status: 200,
+      body: webhookTestUtils.WEBHOOK_RESPONSE_BODY_TOO_LARGE,
+    })
+    expect(JSON.stringify(result)).not.toContain(oversizedBody)
+  })
+
+  it('keeps the delivery timeout active while reading the response body', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const signal = init?.signal as AbortSignal
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('partial body'))
+          signal.addEventListener('abort', () => {
+            controller.error(new DOMException('aborted', 'AbortError'))
+          })
+        },
+      })
+      return new Response(body, { status: 200 })
+    })
+
+    const resultPromise = deliverWebhook(
+      context as any,
+      'delivery-slow-body',
+      'https://example.com/webhook',
+      payload,
+      'whsec_test_secret',
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(10000)
+    const result = await resultPromise
+
+    expect(result).toMatchObject({
+      success: false,
+      body: 'Error: Webhook delivery failed',
+      duration: 10000,
+    })
+    expect(mockCloudlogErr).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Webhook delivery failed',
+      deliveryId: 'delivery-slow-body',
+      error: 'aborted',
+      duration: 10000,
+    }))
   })
 })


### PR DESCRIPTION
/claim #1667

## Summary
- bound outbound webhook response body reads before storing delivery results
- replace oversized webhook responses with a fixed marker instead of reading/logging large bodies
- add unit coverage for oversized webhook response handling and keep fetch-mocking tests sequential

## Tests
- `vitest run tests/webhook-delivery-redirect.unit.test.ts --reporter=verbose`
- `bun typecheck`