### PR TITLE
fix(api): cap Bento error response bodies

### DIFF
--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -2,6 +2,9 @@ import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
 import { getEnv } from './utils.ts'
 
+const MAX_BENTO_ERROR_BODY_BYTES = 4 * 1024
+const BENTO_ERROR_BODY_TOO_LARGE = '[bento_error_body_too_large]'
+
 export function isBentoConfigured(c: Context) {
   const publishableKey = (getEnv(c, 'BENTO_PUBLISHABLE_KEY') || '').trim()
   const secretKey = (getEnv(c, 'BENTO_SECRET_KEY') || '').trim()
@@ -37,6 +40,53 @@ function getBentoHeaders(c: Context) {
   }
 }
 
+function isOversizedContentLength(response: Response, maxBytes: number) {
+  const contentLength = response.headers.get('content-length')
+  if (!contentLength)
+    return false
+
+  const parsed = Number.parseInt(contentLength, 10)
+  return Number.isFinite(parsed) && parsed > maxBytes
+}
+
+async function readLimitedBentoErrorBody(response: Response, maxBytes: number) {
+  if (isOversizedContentLength(response, maxBytes)) {
+    await response.body?.cancel().catch(() => undefined)
+    return BENTO_ERROR_BODY_TOO_LARGE
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    return new TextEncoder().encode(text).byteLength > maxBytes ? BENTO_ERROR_BODY_TOO_LARGE : text
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let receivedBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      break
+
+    receivedBytes += value.byteLength
+    if (receivedBytes > maxBytes) {
+      await reader.cancel().catch(() => undefined)
+      return BENTO_ERROR_BODY_TOO_LARGE
+    }
+    chunks.push(value)
+  }
+
+  const body = new Uint8Array(receivedBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new TextDecoder().decode(body)
+}
+
 async function bentoFetch(c: Context, path: string, siteUuid: string, body: any) {
   const headers = getBentoHeaders(c)
   if (!headers)
@@ -52,7 +102,7 @@ async function bentoFetch(c: Context, path: string, siteUuid: string, body: any)
   })
 
   if (!response.ok) {
-    const error = await response.text()
+    const error = await readLimitedBentoErrorBody(response, MAX_BENTO_ERROR_BODY_BYTES)
     throw new Error(`Bento API error: ${response.status} ${error}`)
   }
 
@@ -184,4 +234,9 @@ export async function unsubscribeBento(c: Context, email: string) {
     cloudlog({ requestId: c.get('requestId'), message: 'unsubscribeBento error', error: e })
     return false
   }
+}
+
+export const bentoTestUtils = {
+  BENTO_ERROR_BODY_TOO_LARGE,
+  MAX_BENTO_ERROR_BODY_BYTES,
 }

--- a/tests/bento.unit.test.ts
+++ b/tests/bento.unit.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cloudlogErrMock,
+  cloudlogMock,
+  fetchMock,
+} = vi.hoisted(() => ({
+  cloudlogErrMock: vi.fn(),
+  cloudlogMock: vi.fn(),
+  fetchMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: cloudlogMock,
+  cloudlogErr: cloudlogErrMock,
+  serializeError: (error: unknown) => ({
+    message: error instanceof Error ? error.message : String(error),
+    name: error instanceof Error ? error.name : 'Error',
+    stack: error instanceof Error ? error.stack ?? 'N/A' : 'N/A',
+  }),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  getEnv: (_c: unknown, key: string) => {
+    if (key === 'BENTO_PUBLISHABLE_KEY')
+      return 'publishable-key'
+    if (key === 'BENTO_SECRET_KEY')
+      return 'secret-key'
+    if (key === 'BENTO_SITE_UUID')
+      return 'site-uuid'
+    return ''
+  },
+}))
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+  } as any
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cloudlogErrMock.mockReset()
+  cloudlogMock.mockReset()
+  fetchMock.mockReset()
+})
+
+describe('bento helper', () => {
+  it('logs small Bento error bodies', async () => {
+    const { trackBentoEvent } = await import('../supabase/functions/_backend/utils/bento.ts')
+    fetchMock.mockResolvedValue(new Response('bad request', { status: 400 }))
+
+    const result = await trackBentoEvent(createContext(), 'user@example.com', { app_id: 'app-id' }, 'test:event')
+
+    expect(result).toBe(false)
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'trackBentoEvent error',
+      error: expect.objectContaining({
+        message: expect.stringContaining('Bento API error: 400 bad request'),
+      }),
+    }))
+  })
+
+  it('does not log oversized Bento error bodies', async () => {
+    const { bentoTestUtils, trackBentoEvent } = await import('../supabase/functions/_backend/utils/bento.ts')
+    const oversizedBody = 'x'.repeat(bentoTestUtils.MAX_BENTO_ERROR_BODY_BYTES + 1)
+    fetchMock.mockResolvedValue(new Response(oversizedBody, { status: 502 }))
+
+    const result = await trackBentoEvent(createContext(), 'user@example.com', { app_id: 'app-id' }, 'test:event')
+
+    expect(result).toBe(false)
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        message: `Bento API error: 502 ${bentoTestUtils.BENTO_ERROR_BODY_TOO_LARGE}`,
+      }),
+    }))
+    expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain(oversizedBody)
+  })
+
+  it('rejects oversized Bento error bodies from content-length before logging', async () => {
+    const { bentoTestUtils, trackBentoEvent } = await import('../supabase/functions/_backend/utils/bento.ts')
+    const oversizedBody = 'y'.repeat(bentoTestUtils.MAX_BENTO_ERROR_BODY_BYTES + 1)
+    fetchMock.mockResolvedValue(new Response(oversizedBody, {
+      status: 503,
+      headers: { 'content-length': String(bentoTestUtils.MAX_BENTO_ERROR_BODY_BYTES + 1) },
+    }))
+
+    const result = await trackBentoEvent(createContext(), 'user@example.com', { app_id: 'app-id' }, 'test:event')
+
+    expect(result).toBe(false)
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        message: `Bento API error: 503 ${bentoTestUtils.BENTO_ERROR_BODY_TOO_LARGE}`,
+      }),
+    }))
+    expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain(oversizedBody)
+  })
+
+  it('cancels oversized Bento error bodies rejected by content-length', async () => {
+    const { bentoTestUtils, trackBentoEvent } = await import('../supabase/functions/_backend/utils/bento.ts')
+    const cancelMock = vi.fn()
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('oversized'))
+      },
+      cancel: cancelMock,
+    })
+    fetchMock.mockResolvedValue(new Response(body, {
+      status: 503,
+      headers: { 'content-length': String(bentoTestUtils.MAX_BENTO_ERROR_BODY_BYTES + 1) },
+    }))
+
+    const result = await trackBentoEvent(createContext(), 'user@example.com', { app_id: 'app-id' }, 'test:event')
+
+    expect(result).toBe(false)
+    expect(cancelMock).toHaveBeenCalledTimes(1)
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        message: `Bento API error: 503 ${bentoTestUtils.BENTO_ERROR_BODY_TOO_LARGE}`,
+      }),
+    }))
+  })
+})


### PR DESCRIPTION
/claim #1667

## Summary
- bound Bento API error response reads before including them in thrown errors/logs
- replace oversized Bento error bodies with a fixed marker
- add unit coverage for small, chunked oversized, and content-length oversized Bento error responses

## Tests
- `vitest run tests/bento.unit.test.ts --reporter=verbose`
- `bun typecheck`