### PR TITLE
fix: redact sensitive Discord alert fields

### DIFF
--- a/supabase/functions/_backend/utils/discord.ts
+++ b/supabase/functions/_backend/utils/discord.ts
@@ -46,7 +46,7 @@ export function sendDiscordAlert500(c: Context, functionName: string, body: stri
   const userAgent = c.req.header('user-agent') ?? 'unknown'
   const ip = c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for') ?? 'unknown'
   const method = c.req.method
-  const url = c.req.url
+  const url = sanitizeSensitiveFromString(c.req.url)
   const rawHeaders = Object.fromEntries((c.req.raw.headers as any).entries())
   const headers = sanitizeSensitiveHeaders(rawHeaders)
   const errorMessage = sanitizeSensitiveFromString(e?.message ?? 'Unknown error')

--- a/supabase/functions/_backend/utils/discord.ts
+++ b/supabase/functions/_backend/utils/discord.ts
@@ -2,66 +2,9 @@ import type {
   RESTPostAPIWebhookWithTokenJSONBody,
 } from 'discord-api-types/v10'
 import type { Context } from 'hono'
+import { sanitizeSensitiveFromString, sanitizeSensitiveHeaders } from './discord_sanitization.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { getEnv } from './utils.ts'
-
-// Fields that should be completely removed from logs (never logged)
-const REMOVED_FIELDS = ['password']
-// Fields that should show first 4 and last 4 characters
-const PARTIALLY_REDACTED_FIELDS = ['secret', 'token', 'apikey', 'api_key', 'authorization', 'credential', 'private_key']
-
-// Partially redact a value - show first 4 and last 4 characters
-function partialRedact(value: string): string {
-  if (value.length <= 8) {
-    return '***REDACTED***'
-  }
-  return `${value.slice(0, 4)}...${value.slice(-4)}`
-}
-
-// Remove or redact sensitive fields from a string that might contain JSON
-function sanitizeSensitiveFromString(str: string): string {
-  let result = str
-
-  // Completely remove password fields (including the key)
-  for (const field of REMOVED_FIELDS) {
-    // Remove "password":"value", or "password": "value" (with optional trailing comma)
-    const jsonRegexWithComma = new RegExp(`"${field}"\\s*:\\s*"[^"]*"\\s*,?\\s*`, 'gi')
-    result = result.replace(jsonRegexWithComma, '')
-    // Clean up any resulting double commas or leading/trailing commas in objects
-    result = result.replace(/,\s*,/g, ',')
-    result = result.replace(/\{\s*,/g, '{')
-    result = result.replace(/,\s*\}/g, '}')
-  }
-
-  // Partially redact other sensitive fields (show first 4 and last 4 chars)
-  for (const field of PARTIALLY_REDACTED_FIELDS) {
-    const jsonRegex = new RegExp(`("${field}"\\s*:\\s*)"([^"]*)"`, 'gi')
-    result = result.replace(jsonRegex, (_match, prefix, value) => {
-      return `${prefix}"${partialRedact(value)}"`
-    })
-  }
-
-  return result
-}
-
-// Sanitize sensitive headers - remove or redact
-function sanitizeSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
-  const sanitized: Record<string, string> = {}
-  for (const [key, value] of Object.entries(headers)) {
-    const lowerKey = key.toLowerCase()
-    // Skip password-related headers entirely
-    if (REMOVED_FIELDS.some(field => lowerKey.includes(field))) {
-      continue
-    }
-    else if (PARTIALLY_REDACTED_FIELDS.some(field => lowerKey.includes(field))) {
-      sanitized[key] = partialRedact(value)
-    }
-    else {
-      sanitized[key] = value
-    }
-  }
-  return sanitized
-}
 
 export async function sendDiscordAlert(c: Context, payload: RESTPostAPIWebhookWithTokenJSONBody): Promise<boolean> {
   const webhookUrl = getEnv(c, 'DISCORD_ALERT')
@@ -106,11 +49,12 @@ export function sendDiscordAlert500(c: Context, functionName: string, body: stri
   const url = c.req.url
   const rawHeaders = Object.fromEntries((c.req.raw.headers as any).entries())
   const headers = sanitizeSensitiveHeaders(rawHeaders)
-  const errorMessage = e?.message ?? 'Unknown error'
-  const errorStack = e?.stack ?? 'No stack trace'
+  const errorMessage = sanitizeSensitiveFromString(e?.message ?? 'Unknown error')
+  const errorStack = sanitizeSensitiveFromString(e?.stack ?? 'No stack trace')
   const errorName = e?.name ?? 'Error'
   // Defense-in-depth: remove/sanitize sensitive fields from body string
   const safeBody = sanitizeSensitiveFromString(body)
+  const safeErrorObject = sanitizeSensitiveFromString(JSON.stringify(e, Object.getOwnPropertyNames(e), 2))
   return sendDiscordAlert(c, {
     content: `🚨 **${functionName}** Error Alert`,
     embeds: [
@@ -147,7 +91,7 @@ export function sendDiscordAlert500(c: Context, functionName: string, body: stri
           },
           {
             name: '🔍 Full Error Object',
-            value: `\`\`\`json\n${JSON.stringify(e, Object.getOwnPropertyNames(e), 2).substring(0, 1000)}\n\`\`\``,
+            value: `\`\`\`json\n${safeErrorObject.substring(0, 1000)}\n\`\`\``,
             inline: false,
           },
         ],

--- a/supabase/functions/_backend/utils/discord_sanitization.ts
+++ b/supabase/functions/_backend/utils/discord_sanitization.ts
@@ -1,0 +1,135 @@
+// Fields that should be completely removed from logs (never logged)
+const REMOVED_FIELD_MARKERS = ['password']
+// Fields that should show first 4 and last 4 characters
+const PARTIALLY_REDACTED_FIELD_MARKERS = [
+  'secret',
+  'token',
+  'apikey',
+  'authorization',
+  'credential',
+  'privatekey',
+  'sessionkey',
+]
+
+// Partially redact a value - show first 4 and last 4 characters
+function partialRedact(value: string): string {
+  if (value.length <= 8) {
+    return '***REDACTED***'
+  }
+  return `${value.slice(0, 4)}...${value.slice(-4)}`
+}
+
+function normalizedFieldName(field: string): string {
+  return field.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function shouldRemoveField(field: string): boolean {
+  const normalized = normalizedFieldName(field)
+  return REMOVED_FIELD_MARKERS.some(marker => normalized.includes(marker))
+}
+
+function shouldPartiallyRedactField(field: string): boolean {
+  const normalized = normalizedFieldName(field)
+  return PARTIALLY_REDACTED_FIELD_MARKERS.some(marker =>
+    normalized.includes(marker),
+  )
+}
+
+function sanitizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value))
+    return value.map(sanitizeJsonValue)
+
+  if (typeof value === 'string')
+    return sanitizeKeyValueSegments(value)
+
+  if (value && typeof value === 'object') {
+    const sanitized: Record<string, unknown> = {}
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (shouldRemoveField(key))
+        continue
+
+      if (shouldPartiallyRedactField(key)) {
+        sanitized[key] = partialRedact(String(nestedValue ?? ''))
+        continue
+      }
+
+      sanitized[key] = sanitizeJsonValue(nestedValue)
+    }
+    return sanitized
+  }
+
+  return value
+}
+
+function decodeComponent(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, ' '))
+  }
+  catch {
+    return value
+  }
+}
+
+function sanitizeKeyValueSegments(value: string): string {
+  const hashIndex = value.indexOf('#')
+  const suffix = hashIndex === -1 ? '' : value.slice(hashIndex)
+  const valueWithoutHash = hashIndex === -1 ? value : value.slice(0, hashIndex)
+  const queryIndex = valueWithoutHash.indexOf('?')
+  const prefix = queryIndex === -1 ? '' : valueWithoutHash.slice(0, queryIndex + 1)
+  const query = queryIndex === -1 ? valueWithoutHash : valueWithoutHash.slice(queryIndex + 1)
+
+  if (!query.includes('='))
+    return value
+
+  const sanitizedSegments = query.split('&').flatMap((segment) => {
+    const separatorIndex = segment.indexOf('=')
+    if (separatorIndex === -1)
+      return [segment]
+
+    const key = segment.slice(0, separatorIndex)
+    const decodedKey = decodeComponent(key)
+    if (shouldRemoveField(decodedKey))
+      return []
+
+    if (!shouldPartiallyRedactField(decodedKey))
+      return [segment]
+
+    const rawValue = segment.slice(separatorIndex + 1)
+    return [`${key}=${encodeURIComponent(partialRedact(decodeComponent(rawValue)))}`]
+  })
+
+  return `${prefix}${sanitizedSegments.join('&')}${suffix}`
+}
+
+// Remove or redact sensitive fields from a string that might contain JSON
+export function sanitizeSensitiveFromString(str: string): string {
+  try {
+    return JSON.stringify(sanitizeJsonValue(JSON.parse(str)))
+  }
+  catch {
+    // Fall back to string replacement for non-JSON payloads.
+  }
+
+  return sanitizeKeyValueSegments(str)
+}
+
+// Sanitize sensitive headers - remove or redact
+export function sanitizeSensitiveHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const sanitized: Record<string, string> = {}
+  for (const [key, value] of Object.entries(headers)) {
+    const lowerKey = key.toLowerCase()
+    // Skip password-related headers entirely
+    if (shouldRemoveField(lowerKey)) {
+      continue
+    }
+    else if (shouldPartiallyRedactField(lowerKey)) {
+      sanitized[key] = partialRedact(value)
+    }
+    else {
+      sanitized[key] = value
+    }
+  }
+  return sanitized
+}

--- a/tests/discord-alert-sanitization.unit.test.ts
+++ b/tests/discord-alert-sanitization.unit.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { sendDiscordAlert500 } from '../supabase/functions/_backend/utils/discord.ts'
 import {
   sanitizeSensitiveFromString,
   sanitizeSensitiveHeaders,
@@ -9,6 +10,10 @@ function sampleValue(prefix: string) {
 }
 
 describe('Discord alert sanitization', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('removes password-like JSON fields and redacts token-like JSON fields', () => {
     const accessToken = sampleValue('access-token')
     const passwordConfirmation = sampleValue('confirmation')
@@ -93,5 +98,42 @@ describe('Discord alert sanitization', () => {
     expect(sanitized['x-session-key']).toBe('sess...xxxx')
     expect(sanitized['user-agent']).toBe('vitest')
     expect(sanitized).not.toHaveProperty('x-password-confirm')
+  })
+
+  it('redacts sensitive query parameters from Discord request details URL', async () => {
+    const accessToken = sampleValue('access-token')
+    const requestUrl = `https://api.example.test/callback?access_token=${accessToken}&next=/dashboard`
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const headers = new Headers({
+      'user-agent': 'vitest',
+    })
+    const context = {
+      env: {
+        DISCORD_ALERT: 'https://discord.example.test/webhook',
+        ENVIRONMENT: 'test',
+      },
+      get: (key: string) => key === 'requestId' ? 'request-1' : undefined,
+      req: {
+        method: 'GET',
+        url: requestUrl,
+        header: (key: string) => headers.get(key) ?? undefined,
+        raw: { headers },
+      },
+    }
+
+    await sendDiscordAlert500(context as any, 'callback', '{}', new Error('boom'))
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, init] = fetchMock.mock.calls[0]
+    const payload = JSON.parse(String((init as RequestInit).body))
+    const requestDetails = payload.embeds[0].fields.find(
+      (field: { name: string }) => field.name.includes('Request Details'),
+    )?.value
+
+    expect(requestDetails).toContain('access_token=acce...xxxx')
+    expect(requestDetails).toContain('next=/dashboard')
+    expect(JSON.stringify(payload)).not.toContain(accessToken)
   })
 })

--- a/tests/discord-alert-sanitization.unit.test.ts
+++ b/tests/discord-alert-sanitization.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  sanitizeSensitiveFromString,
+  sanitizeSensitiveHeaders,
+} from '../supabase/functions/_backend/utils/discord_sanitization.ts'
+
+function sampleValue(prefix: string) {
+  return `${prefix}-${'x'.repeat(16)}`
+}
+
+describe('Discord alert sanitization', () => {
+  it('removes password-like JSON fields and redacts token-like JSON fields', () => {
+    const accessToken = sampleValue('access-token')
+    const passwordConfirmation = sampleValue('confirmation')
+    const refreshToken = sampleValue('refresh-token')
+    const sessionKey = sampleValue('session-key')
+    const sanitized = sanitizeSensitiveFromString(
+      JSON.stringify({
+        access_token: accessToken,
+        nested: {
+          password_confirm: passwordConfirmation,
+          refreshToken,
+          session_key: sessionKey,
+        },
+        safe: 'visible',
+      }),
+    )
+
+    expect(sanitized).toContain('"safe":"visible"')
+    expect(sanitized).toContain('"access_token":"acce...xxxx"')
+    expect(sanitized).toContain('"refreshToken":"refr...xxxx"')
+    expect(sanitized).toContain('"session_key":"sess...xxxx"')
+    expect(sanitized).not.toContain(accessToken)
+    expect(sanitized).not.toContain(refreshToken)
+    expect(sanitized).not.toContain(sessionKey)
+    expect(sanitized).not.toContain('password_confirm')
+    expect(sanitized).not.toContain(passwordConfirmation)
+  })
+
+  it('redacts sensitive query parameters in non-JSON bodies', () => {
+    const accessToken = sampleValue('access-token')
+    const refreshToken = sampleValue('refresh-token')
+    const sanitized = sanitizeSensitiveFromString(
+      `redirect=/login?access_token=${accessToken}&refresh_token=${refreshToken}&next=/dashboard`,
+    )
+
+    expect(sanitized).toContain('redirect=/login?access_token=acce...xxxx')
+    expect(sanitized).toContain('&refresh_token=refr...xxxx')
+    expect(sanitized).toContain('&next=/dashboard')
+    expect(sanitized).not.toContain(accessToken)
+    expect(sanitized).not.toContain(refreshToken)
+  })
+
+  it('does not throw on malformed encoded sensitive query parameters', () => {
+    const sanitized = sanitizeSensitiveFromString(
+      'redirect=/login?access_token=%E0%A4%A&next=/dashboard',
+    )
+
+    expect(sanitized).toContain('redirect=/login?access_token=')
+    expect(sanitized).toContain('&next=/dashboard')
+  })
+
+  it('redacts token-like query parameters inside JSON string values', () => {
+    const accessToken = sampleValue('access-token')
+    const refreshToken = sampleValue('refresh-token')
+    const sanitized = sanitizeSensitiveFromString(
+      JSON.stringify({
+        error: {
+          message: `failed callback /login?access_token=${accessToken}`,
+          stack: `Error: /login?refresh_token=${refreshToken}`,
+        },
+      }),
+    )
+
+    expect(sanitized).toContain('/login?access_token=acce...xxxx')
+    expect(sanitized).toContain('/login?refresh_token=refr...xxxx')
+    expect(sanitized).not.toContain(accessToken)
+    expect(sanitized).not.toContain(refreshToken)
+  })
+
+  it('removes password-like headers and redacts token-like headers', () => {
+    const authorization = sampleValue('Bearer')
+    const sessionKey = sampleValue('session-key')
+    const passwordConfirmation = sampleValue('confirmation')
+    const sanitized = sanitizeSensitiveHeaders({
+      Authorization: authorization,
+      'x-session-key': sessionKey,
+      'x-password-confirm': passwordConfirmation,
+      'user-agent': 'vitest',
+    })
+
+    expect(sanitized.Authorization).toBe('Bear...xxxx')
+    expect(sanitized['x-session-key']).toBe('sess...xxxx')
+    expect(sanitized['user-agent']).toBe('vitest')
+    expect(sanitized).not.toHaveProperty('x-password-confirm')
+  })
+})

--- a/tests/discord-alert-sanitization.unit.test.ts
+++ b/tests/discord-alert-sanitization.unit.test.ts
@@ -103,7 +103,7 @@ describe('Discord alert sanitization', () => {
   it('redacts sensitive query parameters from Discord request details URL', async () => {
     const accessToken = sampleValue('access-token')
     const requestUrl = `https://api.example.test/callback?access_token=${accessToken}&next=/dashboard`
-    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 204 }))
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 200 }))
     vi.stubGlobal('fetch', fetchMock)
 
     const headers = new Headers({


### PR DESCRIPTION
## Summary
- move Discord alert request-body/header sanitization into a focused helper
- recursively sanitize JSON request bodies so password-like fields are removed and token-like fields are partially redacted
- cover access/refresh tokens, session keys, password confirmation fields, and sensitive query parameters with unit tests

## Validation
- `npx --yes tsx -` smoke test for JSON body, query-string body, and header sanitization
- `git diff --check`

Could not run the repo Vitest command locally because this checkout has no `node_modules` and `bunx` is not installed; `npx vitest` cannot load the project config without the repo's local Vite dependency.

/claim #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord error alerts now automatically redact sensitive data (passwords, tokens, API keys) before posting to prevent credential exposure.

* **Tests**
  * Added comprehensive test coverage for Discord alert data sanitization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->