### PR TITLE
fix(webhooks): route dashboard writes through API

### DIFF
--- a/src/stores/webhooks.ts
+++ b/src/stores/webhooks.ts
@@ -34,8 +34,71 @@ const DELIVERIES_PER_PAGE = 50
 
 const supabase = useSupabase()
 
+type WebhookRow = Database['public']['Tables']['webhooks']['Row']
+type WebhookWriteData = Partial<{
+  name: string
+  url: string
+  events: string[]
+  enabled: boolean
+}>
+
+function getCurrentOrgId(): string | undefined {
+  return useOrganizationStore().currentOrganization?.gid
+}
+
+function validateWebhookUrl(url: string): string | undefined {
+  try {
+    const parsedUrl = new URL(url)
+    const isLocalhost = parsedUrl.hostname === 'localhost' || parsedUrl.hostname.endsWith('.localhost')
+    const isLoopback = parsedUrl.hostname === '127.0.0.1' || parsedUrl.hostname === '::1'
+    if (parsedUrl.protocol !== 'https:' && !isLocalhost && !isLoopback) {
+      return 'Webhook URL must use HTTPS'
+    }
+  }
+  catch {
+    return 'Invalid URL'
+  }
+}
+
+function validateWebhookEvents(events: string[]): string | undefined {
+  const validEvents = WEBHOOK_EVENT_TYPES.map(e => e.value)
+  const invalidEvents = events.filter(e => !validEvents.includes(e as any))
+  if (invalidEvents.length > 0) {
+    return `Invalid event types: ${invalidEvents.join(', ')}`
+  }
+}
+
+function validateWebhookData(webhookData: WebhookWriteData): string | undefined {
+  if (webhookData.url) {
+    const urlError = validateWebhookUrl(webhookData.url)
+    if (urlError)
+      return urlError
+  }
+
+  if (webhookData.events) {
+    const eventsError = validateWebhookEvents(webhookData.events)
+    if (eventsError)
+      return eventsError
+  }
+}
+
+async function invokeWebhookApi(
+  method: 'POST' | 'PUT' | 'DELETE',
+  body: Record<string, unknown>,
+  failureMessage: string,
+  exceptionMessage: string,
+): Promise<{ data?: any, error?: string }> {
+  try {
+    const { data, error } = await supabase.functions.invoke('webhooks', { method, body })
+    return error ? { error: error.message || failureMessage } : { data }
+  }
+  catch (err: any) {
+    return { error: err?.message || exceptionMessage }
+  }
+}
+
 export const useWebhooksStore = defineStore('webhooks', () => {
-  const webhooks: Ref<Database['public']['Tables']['webhooks']['Row'][]> = ref([])
+  const webhooks: Ref<WebhookRow[]> = ref([])
   const deliveries: Ref<Database['public']['Tables']['webhook_deliveries']['Row'][]> = ref([])
   const deliveryPagination: Ref<DeliveryPagination | null> = ref(null)
   const isLoading = ref(false)
@@ -81,7 +144,7 @@ export const useWebhooksStore = defineStore('webhooks', () => {
    * Get a single webhook
    * Uses direct Supabase SDK - RLS handles permissions
    */
-  async function getWebhook(webhookId: string): Promise<Database['public']['Tables']['webhooks']['Row'] | null> {
+  async function getWebhook(webhookId: string): Promise<WebhookRow | null> {
     const organizationStore = useOrganizationStore()
     const orgId = organizationStore.currentOrganization?.gid
 
@@ -113,172 +176,82 @@ export const useWebhooksStore = defineStore('webhooks', () => {
 
   /**
    * Create a new webhook
-   * Uses direct Supabase SDK - RLS handles permissions
+   * Uses the webhook API so backend permission checks stay centralized
    */
   async function createWebhook(webhookData: {
     name: string
     url: string
     events: string[]
-  }): Promise<{ success: boolean, webhook?: Database['public']['Tables']['webhooks']['Row'], error?: string }> {
-    const organizationStore = useOrganizationStore()
-    const orgId = organizationStore.currentOrganization?.gid
-
+  }): Promise<{ success: boolean, webhook?: WebhookRow, error?: string }> {
+    const orgId = getCurrentOrgId()
     if (!orgId) {
       return { success: false, error: 'No organization selected' }
     }
 
-    // Validate URL is HTTPS (except localhost for testing)
-    try {
-      const parsedUrl = new URL(webhookData.url)
-      const isLocalhost = parsedUrl.hostname === 'localhost' || parsedUrl.hostname.endsWith('.localhost')
-      const isLoopback = parsedUrl.hostname === '127.0.0.1' || parsedUrl.hostname === '::1'
-      if (parsedUrl.protocol !== 'https:' && !isLocalhost && !isLoopback) {
-        return { success: false, error: 'Webhook URL must use HTTPS' }
-      }
-    }
-    catch {
-      return { success: false, error: 'Invalid URL' }
-    }
+    const validationError = validateWebhookData(webhookData)
+    if (validationError)
+      return { success: false, error: validationError }
 
-    // Validate events
-    const validEvents = WEBHOOK_EVENT_TYPES.map(e => e.value)
-    const invalidEvents = webhookData.events.filter(e => !validEvents.includes(e as any))
-    if (invalidEvents.length > 0) {
-      return { success: false, error: `Invalid event types: ${invalidEvents.join(', ')}` }
+    const result = await invokeWebhookApi('POST', { orgId, ...webhookData, enabled: true }, 'Failed to create webhook', 'Error creating webhook')
+    if (result.error)
+      return { success: false, error: result.error }
+
+    const webhook = result.data?.webhook as WebhookRow | undefined
+    if (webhook) {
+      webhooks.value.unshift(webhook)
     }
 
-    try {
-      const { data, error } = await supabase
-        .from('webhooks')
-        .insert({
-          org_id: orgId,
-          name: webhookData.name,
-          url: webhookData.url,
-          events: webhookData.events,
-          enabled: true, // Always enabled on creation
-        })
-        .select()
-        .single()
-
-      if (error) {
-        return { success: false, error: error.message || 'Failed to create webhook' }
-      }
-
-      // Add to local list
-      if (data) {
-        webhooks.value.unshift(data)
-      }
-
-      return { success: true, webhook: data }
-    }
-    catch (err: any) {
-      return { success: false, error: err?.message || 'Error creating webhook' }
-    }
+    return { success: true, webhook }
   }
 
   /**
    * Update an existing webhook
-   * Uses direct Supabase SDK - RLS handles permissions
+   * Uses the webhook API so backend permission checks stay centralized
    */
   async function updateWebhook(
     webhookId: string,
-    webhookData: Partial<{
-      name: string
-      url: string
-      events: string[]
-      enabled: boolean
-    }>,
-  ): Promise<{ success: boolean, webhook?: Database['public']['Tables']['webhooks']['Row'], error?: string }> {
-    const organizationStore = useOrganizationStore()
-    const orgId = organizationStore.currentOrganization?.gid
-
+    webhookData: WebhookWriteData,
+  ): Promise<{ success: boolean, webhook?: WebhookRow, error?: string }> {
+    const orgId = getCurrentOrgId()
     if (!orgId) {
       return { success: false, error: 'No organization selected' }
     }
 
-    // Validate URL if provided
-    if (webhookData.url) {
-      try {
-        const parsedUrl = new URL(webhookData.url)
-        const isLocalhost = parsedUrl.hostname === 'localhost' || parsedUrl.hostname.endsWith('.localhost')
-        const isLoopback = parsedUrl.hostname === '127.0.0.1' || parsedUrl.hostname === '::1'
-        if (parsedUrl.protocol !== 'https:' && !isLocalhost && !isLoopback) {
-          return { success: false, error: 'Webhook URL must use HTTPS' }
-        }
-      }
-      catch {
-        return { success: false, error: 'Invalid URL' }
-      }
-    }
+    const validationError = validateWebhookData(webhookData)
+    if (validationError)
+      return { success: false, error: validationError }
 
-    // Validate events if provided
-    if (webhookData.events) {
-      const validEvents = WEBHOOK_EVENT_TYPES.map(e => e.value)
-      const invalidEvents = webhookData.events.filter(e => !validEvents.includes(e as any))
-      if (invalidEvents.length > 0) {
-        return { success: false, error: `Invalid event types: ${invalidEvents.join(', ')}` }
+    const result = await invokeWebhookApi('PUT', { orgId, webhookId, ...webhookData }, 'Failed to update webhook', 'Error updating webhook')
+    if (result.error)
+      return { success: false, error: result.error }
+
+    const webhook = result.data?.webhook as WebhookRow | undefined
+    if (webhook) {
+      const index = webhooks.value.findIndex(w => w.id === webhookId)
+      if (index !== -1) {
+        webhooks.value[index] = webhook
       }
     }
 
-    try {
-      const { data, error } = await supabase
-        .from('webhooks')
-        .update(webhookData)
-        .eq('id', webhookId)
-        .eq('org_id', orgId)
-        .select()
-        .single()
-
-      if (error) {
-        return { success: false, error: error.message || 'Failed to update webhook' }
-      }
-
-      // Update local list
-      if (data) {
-        const index = webhooks.value.findIndex(w => w.id === webhookId)
-        if (index !== -1) {
-          webhooks.value[index] = data
-        }
-      }
-
-      return { success: true, webhook: data }
-    }
-    catch (err: any) {
-      return { success: false, error: err?.message || 'Error updating webhook' }
-    }
+    return { success: true, webhook }
   }
 
   /**
    * Delete a webhook
-   * Uses direct Supabase SDK - RLS handles permissions
+   * Uses the webhook API so backend permission checks stay centralized
    */
   async function deleteWebhook(webhookId: string): Promise<{ success: boolean, error?: string }> {
-    const organizationStore = useOrganizationStore()
-    const orgId = organizationStore.currentOrganization?.gid
-
+    const orgId = getCurrentOrgId()
     if (!orgId) {
       return { success: false, error: 'No organization selected' }
     }
 
-    try {
-      const { error } = await supabase
-        .from('webhooks')
-        .delete()
-        .eq('id', webhookId)
-        .eq('org_id', orgId)
+    const result = await invokeWebhookApi('DELETE', { orgId, webhookId }, 'Failed to delete webhook', 'Error deleting webhook')
+    if (result.error)
+      return { success: false, error: result.error }
 
-      if (error) {
-        return { success: false, error: error.message || 'Failed to delete webhook' }
-      }
-
-      // Remove from local list
-      webhooks.value = webhooks.value.filter(w => w.id !== webhookId)
-
-      return { success: true }
-    }
-    catch (err: any) {
-      return { success: false, error: err?.message || 'Error deleting webhook' }
-    }
+    webhooks.value = webhooks.value.filter(w => w.id !== webhookId)
+    return { success: true }
   }
 
   /**

--- a/supabase/functions/_backend/public/webhooks/delete.ts
+++ b/supabase/functions/_backend/public/webhooks/delete.ts
@@ -1,27 +1,23 @@
 import type { Context } from 'hono'
-import type { Database } from '../../utils/supabase.types.ts'
+import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
-import { supabaseApikey } from '../../utils/supabase.ts'
-import { checkWebhookPermission } from './index.ts'
+import { getWebhookSupabaseWithAuth } from './index.ts'
 
 const bodySchema = type({
   orgId: 'string',
   webhookId: 'string',
 })
 
-export async function deleteWebhook(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
+export async function deleteWebhook(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw: any, auth: AuthInfo): Promise<Response> {
   const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
   if (!bodyParsed.success) {
     throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
   }
   const body = bodyParsed.data
 
-  await checkWebhookPermission(c, body.orgId, apikey)
-
-  // Use authenticated client - RLS will enforce access
-  const supabase = supabaseApikey(c, c.get('capgkey') as string)
+  const supabase = await getWebhookSupabaseWithAuth(c, body.orgId, auth)
 
   // Verify webhook belongs to org
   // Note: Using type assertion as webhooks table types are not yet generated

--- a/supabase/functions/_backend/public/webhooks/index.ts
+++ b/supabase/functions/_backend/public/webhooks/index.ts
@@ -3,7 +3,7 @@ import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { getBodyOrQuery, honoFactory, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareKey, middlewareV2 } from '../../utils/hono_middleware.ts'
-import { apikeyHasOrgRight, apikeyHasOrgRightWithPolicy, hasOrgRight, hasOrgRightApikey, supabaseApikey } from '../../utils/supabase.ts'
+import { apikeyHasOrgRight, apikeyHasOrgRightWithPolicy, hasOrgRight, hasOrgRightApikey, supabaseApikey, supabaseWithAuth } from '../../utils/supabase.ts'
 import { deleteWebhook } from './delete.ts'
 import { getDeliveries, retryDelivery } from './deliveries.ts'
 import { get } from './get.ts'
@@ -113,6 +113,24 @@ export async function checkWebhookPermissionV2(
   }
 }
 
+export async function getWebhookSupabaseWithAuth(
+  c: Context<MiddlewareKeyVariables, any, any>,
+  orgId: string,
+  auth: AuthInfo,
+) {
+  await checkWebhookPermissionV2(c, orgId, auth)
+  return supabaseWithAuth(c, auth)
+}
+
+async function handleWebhookWrite(
+  c: Context<MiddlewareKeyVariables, any, any>,
+  handler: (c: Context<MiddlewareKeyVariables, any, any>, body: any, auth: AuthInfo) => Promise<Response>,
+): Promise<Response> {
+  const body = await getBodyOrQuery<any>(c)
+  const auth = c.get('auth') as AuthInfo
+  return handler(c, body, auth)
+}
+
 // List all webhooks for org
 app.get('/', middlewareKey(['all', 'write']), async (c) => {
   const body = await getBodyOrQuery<any>(c)
@@ -121,24 +139,18 @@ app.get('/', middlewareKey(['all', 'write']), async (c) => {
 })
 
 // Create webhook
-app.post('/', middlewareKey(['all', 'write']), async (c) => {
-  const body = await getBodyOrQuery<any>(c)
-  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
-  return post(c, body, apikey)
+app.post('/', middlewareV2(['all', 'write']), async (c) => {
+  return handleWebhookWrite(c, post)
 })
 
 // Update webhook
-app.put('/', middlewareKey(['all', 'write']), async (c) => {
-  const body = await getBodyOrQuery<any>(c)
-  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
-  return put(c, body, apikey)
+app.put('/', middlewareV2(['all', 'write']), async (c) => {
+  return handleWebhookWrite(c, put)
 })
 
 // Delete webhook
-app.delete('/', middlewareKey(['all', 'write']), async (c) => {
-  const body = await getBodyOrQuery<any>(c)
-  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
-  return deleteWebhook(c, body, apikey)
+app.delete('/', middlewareV2(['all', 'write']), async (c) => {
+  return handleWebhookWrite(c, deleteWebhook)
 })
 
 // Test webhook (supports both JWT and API key auth)

--- a/supabase/functions/_backend/public/webhooks/post.ts
+++ b/supabase/functions/_backend/public/webhooks/post.ts
@@ -1,11 +1,10 @@
 import type { Context } from 'hono'
-import type { Database } from '../../utils/supabase.types.ts'
+import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
-import { supabaseApikey } from '../../utils/supabase.ts'
 import { getWebhookPublicUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
-import { checkWebhookPermission } from './index.ts'
+import { getWebhookSupabaseWithAuth } from './index.ts'
 
 const bodySchema = type({
   'orgId': 'string',
@@ -15,14 +14,12 @@ const bodySchema = type({
   'enabled?': 'boolean',
 })
 
-export async function post(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
+export async function post(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw: any, auth: AuthInfo): Promise<Response> {
   const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
   if (!bodyParsed.success) {
     throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
   }
   const body = bodyParsed.data
-
-  await checkWebhookPermission(c, body.orgId, apikey)
 
   // Validate events are allowed
   const invalidEvents = body.events.filter(e => !WEBHOOK_EVENT_TYPES.includes(e as any))
@@ -37,9 +34,8 @@ export async function post(c: Context, bodyRaw: any, apikey: Database['public'][
   if (urlError)
     throw simpleError('invalid_url', urlError, { url: body.url })
 
-  // Create webhook using authenticated client - RLS will enforce access
   // Note: Using type assertion as webhooks table types are not yet generated
-  const supabase = supabaseApikey(c, c.get('capgkey') as string)
+  const supabase = await getWebhookSupabaseWithAuth(c, body.orgId, auth)
   const { data, error } = await (supabase as any)
     .from('webhooks')
     .insert({
@@ -48,7 +44,7 @@ export async function post(c: Context, bodyRaw: any, apikey: Database['public'][
       url: body.url,
       events: body.events,
       enabled: body.enabled ?? true,
-      created_by: apikey.user_id,
+      created_by: auth.userId,
     })
     .select()
     .single()

--- a/supabase/functions/_backend/public/webhooks/put.ts
+++ b/supabase/functions/_backend/public/webhooks/put.ts
@@ -1,11 +1,10 @@
 import type { Context } from 'hono'
-import type { Database } from '../../utils/supabase.types.ts'
+import type { AuthInfo, MiddlewareKeyVariables } from '../../utils/hono.ts'
 import { type } from 'arktype'
 import { safeParseSchema } from '../../utils/ark_validation.ts'
 import { simpleError } from '../../utils/hono.ts'
-import { supabaseApikey } from '../../utils/supabase.ts'
 import { getWebhookPublicUrlValidationError, WEBHOOK_EVENT_TYPES } from '../../utils/webhook.ts'
-import { checkWebhookPermission } from './index.ts'
+import { getWebhookSupabaseWithAuth } from './index.ts'
 
 const bodySchema = type({
   'orgId': 'string',
@@ -16,17 +15,14 @@ const bodySchema = type({
   'enabled?': 'boolean',
 })
 
-export async function put(c: Context, bodyRaw: any, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
+export async function put(c: Context<MiddlewareKeyVariables, any, any>, bodyRaw: any, auth: AuthInfo): Promise<Response> {
   const bodyParsed = safeParseSchema(bodySchema, bodyRaw)
   if (!bodyParsed.success) {
     throw simpleError('invalid_body', 'Invalid body', { error: bodyParsed.error })
   }
   const body = bodyParsed.data
 
-  await checkWebhookPermission(c, body.orgId, apikey)
-
-  // Use authenticated client - RLS will enforce access
-  const supabase = supabaseApikey(c, c.get('capgkey') as string)
+  const supabase = await getWebhookSupabaseWithAuth(c, body.orgId, auth)
 
   // Verify webhook belongs to org
   // Note: Using type assertion as webhooks table types are not yet generated

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { BASE_URL, fetchWithRetry, getSupabaseClient, headers, TEST_EMAIL, USER_ID } from './test-utils.ts'
+import { BASE_URL, fetchWithRetry, getAuthHeaders, getSupabaseClient, headers, TEST_EMAIL, USER_ID } from './test-utils.ts'
 
 // Test org and webhook IDs
 const WEBHOOK_TEST_ORG_ID = randomUUID()
@@ -12,10 +12,19 @@ const webhookUrl = 'https://example.com/webhook'
 const customerId = `cus_test_${WEBHOOK_TEST_ORG_ID}`
 
 let createdWebhookId: string | null = null
+let jwtCreatedWebhookId: string | null = null
 let lastDeliveryId: string | null = null
 let appScopedKeyId: number | null = null
 let appScopedKey: string | null = null
 let orgScopedSubkeyId: number | null = null
+
+async function sendJwtWebhookRequest(method: 'POST' | 'PUT' | 'DELETE', body: Record<string, unknown>): Promise<Response> {
+  return fetch(`${BASE_URL}/webhooks`, {
+    method,
+    headers: await getAuthHeaders(),
+    body: JSON.stringify({ orgId: WEBHOOK_TEST_ORG_ID, ...body }),
+  })
+}
 
 beforeAll(async () => {
   // Create stripe_info for this test org
@@ -87,6 +96,9 @@ afterAll(async () => {
   // Note: Using type assertion as webhooks table types are not yet generated
   if (createdWebhookId) {
     await (getSupabaseClient() as any).from('webhooks').delete().eq('id', createdWebhookId)
+  }
+  if (jwtCreatedWebhookId) {
+    await (getSupabaseClient() as any).from('webhooks').delete().eq('id', jwtCreatedWebhookId)
   }
   if (appScopedKeyId) {
     await getSupabaseClient().from('apikeys').delete().eq('id', appScopedKeyId)
@@ -167,6 +179,37 @@ describe('[POST] /webhooks', () => {
     expect(data.webhook.url).toBe(webhookUrl)
 
     createdWebhookId = data.webhook.id
+  })
+
+  it('create, update, and delete webhook with JWT auth', async () => {
+    const createResponse = await sendJwtWebhookRequest('POST', {
+      name: `JWT Webhook ${globalId}`,
+      url: 'https://example.com/webhook-jwt',
+      events: ['apps'],
+    })
+
+    expect(createResponse.status).toBe(201)
+    const createData = await createResponse.json() as { webhook: { id: string, name: string } }
+    expect(createData.webhook.name).toBe(`JWT Webhook ${globalId}`)
+    jwtCreatedWebhookId = createData.webhook.id
+
+    const updateResponse = await sendJwtWebhookRequest('PUT', {
+      webhookId: jwtCreatedWebhookId,
+      enabled: false,
+    })
+
+    expect(updateResponse.status).toBe(200)
+    const updateData = await updateResponse.json() as { webhook: { enabled: boolean } }
+    expect(updateData.webhook.enabled).toBe(false)
+
+    const deleteResponse = await sendJwtWebhookRequest('DELETE', {
+      webhookId: jwtCreatedWebhookId,
+    })
+
+    expect(deleteResponse.status).toBe(200)
+    const deleteData = await deleteResponse.json() as { webhookId: string }
+    expect(deleteData.webhookId).toBe(jwtCreatedWebhookId)
+    jwtCreatedWebhookId = null
   })
 
   it('create webhook with missing required fields', async () => {


### PR DESCRIPTION
## Summary

- route dashboard webhook create/update/delete actions through the existing `webhooks` edge-function API
- allow webhook write endpoints to use the same unified JWT/API-key auth path already used by test/retry routes
- add regression coverage for JWT create/update/delete webhook API access

## Why

The dashboard was still writing webhook rows directly through the browser-side Supabase client while the backend already has centralized webhook permission checks for org admin access, API-key scope policy, and URL/event validation. This keeps the UI behavior the same while putting write operations through the backend authorization path.

This complements the existing webhook API-key/RLS hardening work by removing the remaining direct browser-side write path for webhook management.

Related: #1667
/claim #1667

## Testing

- `git diff --check`
- Not run locally: this checkout does not have `bun`, `vitest`, or installed `node_modules`; CI should run `tests/webhooks.test.ts`.

## Security note

Public-safe hardening only. No production systems, credentials, or private data were accessed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook operations (create, update, delete) now support JWT-based authentication.

* **Tests**
  * Expanded webhook test suite with JWT authentication workflows and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2242)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->