### PR TITLE
[codex] fix admin global stats primary read

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1164,7 +1164,10 @@ export async function getAdminGlobalStatsTrend(
   end_date: string,
 ): Promise<AdminGlobalStatsTrend[]> {
   try {
-    const pgClient = getPgClient(c, true) // Read-only query
+    // Admin global stats are low traffic and depend on recently migrated
+    // global_stats columns. Use primary DB so replica schema/data drift does not
+    // silently blank the dashboard.
+    const pgClient = getPgClient(c)
     const drizzleClient = getDrizzleClient(pgClient)
 
     // Extract just the date portion (YYYY-MM-DD) from ISO timestamps
@@ -1390,7 +1393,7 @@ export async function getAdminGlobalStatsTrend(
   }
   catch (e: unknown) {
     logPgError(c, 'getAdminGlobalStatsTrend', e)
-    return []
+    throw e
   }
 }
 


### PR DESCRIPTION
## Summary (AI generated)
- Force `global_stats_trend` admin metrics to use the primary DB connection instead of the read-only replica path.
- Re-throw DB errors after logging so the admin stats API stops returning `success: true` with fake empty chart data on query failure.

## Motivation (AI generated)
Production primary has `global_stats` rows for the requested window, but the deployed worker still returned an empty dataset. The remaining failure path was the replica read plus error masking in `getAdminGlobalStatsTrend`.

## Business Impact (AI generated)
Restores admin dashboard trend charts and makes future DB/schema drift visible as an API error instead of silently hiding reporting failures.

## Test Plan (AI generated)
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/admin-stats.unit.test.ts tests/admin-stats.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/admin-stats.test.ts --config vitest.config.cloudflare.ts`
- [x] `bun test:backend`
- [x] `bun run supabase:with-env -- bun test:cloudflare:backend`
- [x] Verified production primary `global_stats` has 28 rows from `2026-04-12` through `2026-05-11` for the current 30-day window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to properly surface database errors instead of silently returning empty results
  * Enhanced global statistics data accuracy by updating the data source used for queries

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2245)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->