### PR TITLE
fix(api): stop 429 handler from hiding the real error cause

### DIFF
--- a/supabase/functions/_backend/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugins/channel_self.ts
@@ -505,7 +505,10 @@ async function parseChannelSelfPluginRequest(
   cloudlog({ requestId: c.get('requestId'), message: logMessage, body })
 
   if (isLimited(c, body.app_id)) {
-    return { response: simpleRateLimit(body) }
+    // Pass curated metadata only — see simpleRateLimit contract in hono.ts.
+    // Reflecting the raw `body` would echo the client's full DeviceLink
+    // payload back inside the 429 response's `moreInfo`.
+    return { response: simpleRateLimit({ app_id: body.app_id, device_id: body.device_id }) }
   }
 
   const bodyParsed = parsePluginBody<DeviceLink>(c, body, schema, requireDevice)

--- a/supabase/functions/_backend/plugins/updates.ts
+++ b/supabase/functions/_backend/plugins/updates.ts
@@ -21,7 +21,10 @@ app.post('/', async (c) => {
   const body = await parseBody<AppInfos>(c)
   cloudlog({ requestId: c.get('requestId'), message: 'post updates body', body })
   if (isLimited(c, body.app_id)) {
-    return simpleRateLimit(body)
+    // Pass curated metadata only — see simpleRateLimit contract in hono.ts.
+    // Reflecting the raw `body` would echo the client's full update payload
+    // back inside the 429 response's `moreInfo`.
+    return simpleRateLimit({ app_id: body.app_id })
   }
   return update(c, parsePluginBody<AppInfos>(c, body, updateRequestSchema))
 })

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -314,6 +314,17 @@ export function quickError(status: number, errorCode: string, message: string, m
   })
 }
 
+/**
+ * Throw a 429 "too_many_requests" HTTPException.
+ *
+ * IMPORTANT: `moreInfo` is reflected to the client as the `moreInfo` field of
+ * the 429 response body (see `onError` in `on_error.ts`). Pass curated
+ * diagnostic metadata only — fields like `app_id`, `device_id`, `reason`,
+ * `apikey_id`, `rateLimitResetAt`, `retryAfterSeconds`. Do NOT pass the raw
+ * parsed request body: that turns the rate-limit response into a reflective
+ * echo of whatever the client submitted and means any future field added to
+ * the request schema (sensitive or not) silently lands in the error payload.
+ */
 export function simpleRateLimit(moreInfo: any = {}, cause?: any): never {
   const status = 429
   const message = 'Too many requests'

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -119,6 +119,16 @@ export function onError(functionName: string) {
         && typeof e.cause === 'object'
         && (e.cause as { suppressDiscordAlert?: unknown }).suppressDiscordAlert === true
       if (e.status === 429) {
+        // Set rate-limit headers from moreInfo when available, but DO NOT
+        // overwrite the response body. Several distinct conditions reach this
+        // branch — `too_many_requests` from simpleRateLimit (IP failed-auth,
+        // API-key flood), `native_build_concurrency_limit_exceeded` from
+        // reserveNativeBuildSlot, and others — and collapsing them to a
+        // generic "You are being rate limited" string strips the actual
+        // errorCode/message/moreInfo (activeBuilds, limit, planName, reason,
+        // …) that callers need to react correctly. Fall through to
+        // `return c.json(res, e.status)` below so the thrower's real error
+        // payload is preserved.
         const rateLimitResetAt = typeof res.moreInfo?.rateLimitResetAt === 'number' ? res.moreInfo.rateLimitResetAt : undefined
         let retryAfterSeconds = typeof res.moreInfo?.retryAfterSeconds === 'number' ? res.moreInfo.retryAfterSeconds : undefined
         if (typeof rateLimitResetAt === 'number' && Number.isFinite(rateLimitResetAt) && !(typeof retryAfterSeconds === 'number' && Number.isFinite(retryAfterSeconds))) {
@@ -130,7 +140,6 @@ export function onError(functionName: string) {
         if (typeof retryAfterSeconds === 'number' && Number.isFinite(retryAfterSeconds)) {
           c.header('Retry-After', String(Math.max(0, Math.floor(retryAfterSeconds))))
         }
-        return c.json({ error: 'too_many_requests', message: 'You are being rate limited' }, e.status)
       }
       if (e.status >= 500 && !suppressDiscordAlert) {
         await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))


### PR DESCRIPTION
## Summary

The 429 branch in `onError` ([supabase/functions/_backend/utils/on_error.ts](supabase/functions/_backend/utils/on_error.ts)) unconditionally rewrote every response body to:

```json
{ "error": "too_many_requests", "message": "You are being rate limited" }
```

This discarded the actual `error` code, `message`, and `moreInfo` from the thrower. Several genuinely different 429-producing conditions all collapsed into the same opaque message:

| Thrower | Real `error` code | Real `moreInfo` |
|---|---|---|
| `simpleRateLimit` (IP failed-auth lockout) | `too_many_requests` | `reason: too_many_failed_auth_attempts`, `rateLimitResetAt`, `retryAfterSeconds` |
| `simpleRateLimit` (API-key flood) | `too_many_requests` | `reason: api_key_rate_limit_exceeded`, `apikey_id`, `rateLimitResetAt`, `retryAfterSeconds` |
| `reserveNativeBuildSlot` | `native_build_concurrency_limit_exceeded` | `activeBuilds`, `limit`, `planName` |
| `cron_clear_versions` guards | `rate_limit_exceeded` | — |

The real-world impact: an org that exhausted its plan's native build concurrency saw `"You are being rate limited"` from `/build/start`, with no signal that the resolution was to free a build slot or upgrade the plan, not to wait for a rate-limit window to roll over. Tracking that down required reading the source. (Discovered while debugging a `Failed to start build: 429 …` report — the rate-limit error reported by the CLI was a `native_build_concurrency_limit_exceeded` in disguise, compounded by orphaned `build_requests` rows that `cron_reconcile_build_status` had not reaped.)

## Change

Keep the header derivation (`Retry-After`, `X-RateLimit-Reset`) — that path is still useful whenever `moreInfo` carries `rateLimitResetAt` / `retryAfterSeconds` — and drop the body override so control falls through to the existing \`return c.json(res, e.status)\` below.

\`\`\`diff
       if (e.status === 429) {
+        // Set rate-limit headers from moreInfo when available, but DO NOT
+        // overwrite the response body. […] Fall through to
+        // \`return c.json(res, e.status)\` below so the thrower's real error
+        // payload is preserved.
         const rateLimitResetAt = …
         …
-        return c.json({ error: 'too_many_requests', message: 'You are being rate limited' }, e.status)
       }
\`\`\`

## Backward-compat / test plan

- [x] `simpleRateLimit` callers still emit \`error: "too_many_requests"\` (only the message changes from \"You are being rate limited\" to \"Too many requests\", which is what the thrower originally set).
- [x] The only existing test that asserts on the body, [tests/account-rate-limit.unit.test.ts:145](tests/account-rate-limit.unit.test.ts), stubs its own \`app.onError\` and asserts on \`error\` and \`reason\` from the thrown cause — unchanged by this diff.
- [x] CLI [error-recovery hint matcher](https://github.com/Cap-go/CLI/blob/main/src/build/onboarding/recovery.ts) checks the lowercased message for \`'429'\` (still present in CLI-side wrapping like \`Failed to start build: 429 - …\`) or \`'rate limit'\`. The substring \`'rate limit'\` no longer appears in `simpleRateLimit` bodies — but that matcher is on the Apple onboarding error path, not the Capgo backend response body, so this is not a regression.

## Follow-ups (not in this PR)

1. Add a regression unit test that throws a 429 with a non-\`too_many_requests\` errorCode (e.g. \`native_build_concurrency_limit_exceeded\`) and asserts the response body still carries that code + moreInfo through \`onError\`.
2. Investigate why \`cron_reconcile_build_status\` is not reaping orphaned native build rows that never reach a terminal status — separate bug surfaced by the same incident.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limit (429) responses now preserve structured error details and set appropriate rate-limit headers for better client handling.
  * Rate-limit metadata is curated to avoid echoing full request payloads, ensuring only intended fields are returned in the error `moreInfo`.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->