### PR TITLE
fix(updater): bypass cache for encoded file fallbacks

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -21,7 +21,7 @@ import { app as files_config } from './files_config.ts'
 import { parseUploadMetadata } from './parse.ts'
 import { DEFAULT_RETRY_PARAMS, RetryBucket } from './retry.ts'
 import { supabaseTusCreateHandler, supabaseTusHeadHandler, supabaseTusPatchHandler } from './supabaseTusProxy.ts'
-import { ALLOWED_HEADERS, ALLOWED_METHODS, buildFileHttpMetadata, EXPOSED_HEADERS, getSafeAttachmentReadCandidateKeys, headFirstExistingAttachmentCandidate, isRetryableDurableObjectResetError, MAX_UPLOAD_LENGTH_BYTES, parseAppScopedAttachmentPath, toBase64, TUS_EXTENSIONS, TUS_VERSION, withNoTransformCacheControl, X_CHECKSUM_SHA256, X_UPLOAD_HANDLER_RETRYABLE } from './util.ts'
+import { ALLOWED_HEADERS, ALLOWED_METHODS, buildFileHttpMetadata, EXPOSED_HEADERS, getSafeAttachmentReadCandidateKeys, headFirstExistingAttachmentCandidate, isRetryableDurableObjectResetError, MAX_UPLOAD_LENGTH_BYTES, parseAppScopedAttachmentPath, shouldBypassAttachmentCache, toBase64, TUS_EXTENSIONS, TUS_VERSION, withNoTransformCacheControl, X_CHECKSUM_SHA256, X_UPLOAD_HANDLER_RETRYABLE } from './util.ts'
 
 const DO_CALL_TIMEOUT = 1000 * 60 * 30 // 30 minutes
 const DO_FETCH_RETRY_ATTEMPTS = 3
@@ -419,36 +419,42 @@ async function getHandler(c: Context): Promise<Response> {
   const cache = getRuntimeKey() === 'workerd' ? caches.default : caches
   const rawFileId = getRawAttachmentRouteId(c)
   const candidateKeys = getSafeAttachmentReadCandidateKeys(fileId, rawFileId)
+  const bypassAttachmentCache = shouldBypassAttachmentCache(fileId, rawFileId)
   const cacheUrl = new URL(c.req.url)
   cacheUrl.searchParams.set('range', c.req.header('range') || '')
   const cacheKey = new Request(cacheUrl, c.req)
-  let response = await cache.match(cacheKey)
-  if (response != null) {
-    response = ensureNoTransformResponse(response)
-    cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache hit' })
-    // Best-effort restore: if file is cached but missing in R2, write it back.
-    await backgroundTask(c, async () => {
-      try {
-        const retryBucket = new RetryBucket(bucket, DEFAULT_RETRY_PARAMS)
-        const existingObject = await headFirstExistingAttachmentCandidate(retryBucket, candidateKeys)
-        if (existingObject != null)
-          return
+  if (bypassAttachmentCache) {
+    cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache bypass for encoded route key', fileId, rawFileId })
+  }
+  else {
+    let cachedResponse = await cache.match(cacheKey)
+    if (cachedResponse != null) {
+      cachedResponse = ensureNoTransformResponse(cachedResponse)
+      cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache hit' })
+      // Best-effort restore: if file is cached but missing in R2, write it back.
+      await backgroundTask(c, async () => {
+        try {
+          const retryBucket = new RetryBucket(bucket, DEFAULT_RETRY_PARAMS)
+          const existingObject = await headFirstExistingAttachmentCandidate(retryBucket, candidateKeys)
+          if (existingObject != null)
+            return
 
-        const cached = response.clone()
-        const data = await cached.arrayBuffer()
-        const contentType = cached.headers.get('content-type') || undefined
-        const httpMetadata = buildFileHttpMetadata(contentType, cached.headers.get('cache-control'))
-        await bucket.put(fileId, data, { httpMetadata })
-        cloudlog({ requestId: c.get('requestId'), message: 'Restored cached file to R2', fileId })
-        await sendDiscordAlert(c, {
-          content: `🛠️ Restored cached file to R2\nFile: ${fileId}\nRequest ID: ${c.get('requestId') ?? 'unknown'}`,
-        })
-      }
-      catch (err) {
-        cloudlog({ requestId: c.get('requestId'), message: 'Failed to restore cached file to R2', fileId, error: String(err) })
-      }
-    })
-    return response
+          const cached = cachedResponse.clone()
+          const data = await cached.arrayBuffer()
+          const contentType = cached.headers.get('content-type') || undefined
+          const httpMetadata = buildFileHttpMetadata(contentType, cached.headers.get('cache-control'))
+          await bucket.put(fileId, data, { httpMetadata })
+          cloudlog({ requestId: c.get('requestId'), message: 'Restored cached file to R2', fileId })
+          await sendDiscordAlert(c, {
+            content: `🛠️ Restored cached file to R2\nFile: ${fileId}\nRequest ID: ${c.get('requestId') ?? 'unknown'}`,
+          })
+        }
+        catch (err) {
+          cloudlog({ requestId: c.get('requestId'), message: 'Failed to restore cached file to R2', fileId, error: String(err) })
+        }
+      })
+      return cachedResponse
+    }
   }
 
   const rangeHeaderFromRequest = c.req.header('range')
@@ -499,15 +505,17 @@ async function getHandler(c: Context): Promise<Response> {
   if (object.range != null && c.req.header('range')) {
     cloudlog({ requestId: c.get('requestId'), message: 'getHandler files range request', range: rangeHeader(object.size, object.range) })
     headers.set('content-range', rangeHeader(object.size, object.range))
-    response = new Response(object.body, { headers, status: 206 })
+    const response = new Response(object.body, { headers, status: 206 })
     return response
   }
   headers.set('Content-Disposition', `attachment; filename="${object.key}"`)
-  response = new Response(object.body, { headers })
-  await backgroundTask(c, () => {
-    cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache saved', fileId })
-    cache.put(cacheKey, response.clone())
-  })
+  const response = new Response(object.body, { headers })
+  if (!bypassAttachmentCache) {
+    await backgroundTask(c, () => {
+      cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache saved', fileId })
+      cache.put(cacheKey, response.clone())
+    })
+  }
   return response
 }
 

--- a/supabase/functions/_backend/files/util.ts
+++ b/supabase/functions/_backend/files/util.ts
@@ -113,6 +113,10 @@ export function getSafeAttachmentReadCandidateKeys(decodedKey: string, rawRouteK
   return [decodedKey]
 }
 
+export function shouldBypassAttachmentCache(decodedKey: string, rawRouteKey: string | null): boolean {
+  return getSafeAttachmentReadCandidateKeys(decodedKey, rawRouteKey).length > 1
+}
+
 export interface AttachmentHeadReader<T> {
   head: (key: string) => Promise<T | null>
 }

--- a/tests/upload-path-encoding.unit.test.ts
+++ b/tests/upload-path-encoding.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { encodeR2KeyForUploadLocation, getSafeAttachmentReadCandidateKeys, headFirstExistingAttachmentCandidate } from '../supabase/functions/_backend/files/util.ts'
+import { encodeR2KeyForUploadLocation, getSafeAttachmentReadCandidateKeys, headFirstExistingAttachmentCandidate, shouldBypassAttachmentCache } from '../supabase/functions/_backend/files/util.ts'
 
 describe('upload path encoding', () => {
   it.concurrent('encodes returned upload locations so literal percent signs are valid URLs', () => {
@@ -46,6 +46,20 @@ describe('upload path encoding', () => {
 
     expect(objectInfo).toBe(legacyObjectInfo)
     expect(checkedKeys).toEqual([decodedRouteKey, encodedStoragePath])
+  })
+
+  it.concurrent('bypasses cache for same-app decoded/raw percent route fallbacks', () => {
+    expect(shouldBypassAttachmentCache(
+      'orgs/org-id/apps/app-id/delta/hash_sad_post_grey@2x.png',
+      'orgs/org-id/apps/app-id/delta/hash_sad_post_grey%402x.png',
+    )).toBe(true)
+  })
+
+  it.concurrent('keeps cache enabled when raw percent route fallback is outside the app scope', () => {
+    expect(shouldBypassAttachmentCache(
+      'orgs/org-id/apps/app-id/delta/hash_sad_post_grey@2x.png',
+      'orgs/org-id/apps/other-app-id/delta/hash_sad_post_grey%402x.png',
+    )).toBe(false)
   })
 
   it.concurrent('does not try raw percent route keys outside the authorized app scope', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Bypass the file endpoint cache when a request has same-app decoded/raw percent-encoded route fallback candidates.
- Keep normal file download URLs on the existing cache path.
- Add unit coverage proving cache bypass only applies to safe same-app encoded fallback paths.

## Motivation (AI generated)

PR #2247 fixes the manifest/path mismatch, but an already cached bad response for an encoded file URL could still be returned before the worker checks R2. This follow-up makes affected encoded fallback requests ignore the file cache and read directly from the safe decoded/raw R2 candidates.

## Business Impact (AI generated)

Customers do not need to re-upload, publish a native release, or wait for new CLI adoption for the already fixed uploads to begin working after deploy. Normal file URLs keep the existing cache behavior, so cache and performance impact is limited to special-character fallback requests that need this protection.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/manifest-path-encoding.unit.test.ts tests/upload-path-encoding.unit.test.ts`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `git diff --check origin/main...HEAD`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attachment cache now conditionally bypasses caching for certain files, enabling more flexible content delivery based on file identifiers.

* **Tests**
  * Added test coverage for cache bypass behavior across different file path scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2248)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->