### PR TITLE
ci: use node 24 for Cloudflare deploys

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -140,6 +140,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -166,6 +169,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -192,6 +198,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -251,6 +260,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary
- Add Node 24 setup before Wrangler-based Cloudflare deploy steps.

## Motivation
Wrangler now requires Node.js 22 or newer, while the affected deploy jobs were using the runner default Node 20.

## Business Impact
Restores Cloudflare worker deploys for release tags without changing Bun-based dependency install or scripts.

## Test Plan
- Not run, per request for a quick PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline configuration to ensure Node.js 24 runtime is available across all cloud deployment jobs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->