### PR TITLE
fix(stripe): classify never paid trial orgs

### DIFF
--- a/scripts/export_stripe_six_month_org_emails.ts
+++ b/scripts/export_stripe_six_month_org_emails.ts
@@ -8,11 +8,12 @@
  *   bun run stripe:export-six-month-org-emails --output=./tmp/export.csv
  *   bun run stripe:export-six-month-org-emails --min-months=6
  *   bun run stripe:export-six-month-org-emails --status=active
+ *   bun run stripe:export-six-month-org-emails --status=never_paid
  *   bun run stripe:export-six-month-org-emails --customer-id=cus_...
  *   bun run stripe:export-six-month-org-emails --env-file=./internal/cloudflare/.env.preprod
  */
 import type { Database } from '../supabase/functions/_backend/utils/supabase.types.ts'
-import type { CustomerPaidCoverage, CustomerPaidSummary } from './stripe_paid_invoice_export_utils.ts'
+import type { CustomerPaidSummary } from './stripe_paid_invoice_export_utils.ts'
 import process from 'node:process'
 import {
   createStripeClient,
@@ -62,7 +63,7 @@ Usage:
 Options:
   --output=PATH        CSV output path. Default: ${DEFAULT_OUTPUT}.
   --min-months=N      Minimum paid duration for paid, active, and canceled statuses. Default: ${DEFAULT_MIN_MONTHS}.
-  --status=VALUE      One of: paid, active, canceled, never_paid, all. Default: ${DEFAULT_STATUS_FILTER}.
+  --status=VALUE      One of: paid, active, canceled, never_paid, all. never_paid means trial orgs with no positive paid invoice. Default: ${DEFAULT_STATUS_FILTER}.
   --customer-id=ID    Limit export to one Stripe customer.
   --limit=N           Stop after N paid Stripe invoices. Only allowed for paid, active, canceled.
   --env-file=PATH     Env file to load. Default: ${DEFAULT_ENV_FILE}.
@@ -249,14 +250,14 @@ function filterCustomerSummaries(customerSummaries: CustomerPaidSummary[], statu
 
 function buildNeverPaidCustomerSummaries(
   customerIds: Set<string>,
-  coverageByCustomerId: Map<string, CustomerPaidCoverage>,
+  customerIdsWithPositivePaidInvoices: Set<string>,
   statusFilter: StatusFilter,
 ) {
   if (statusFilter !== 'never_paid' && statusFilter !== 'all')
     return []
 
   return [...customerIds]
-    .filter(customerId => !coverageByCustomerId.has(customerId))
+    .filter(customerId => !customerIdsWithPositivePaidInvoices.has(customerId))
     .map((customerId): CustomerPaidSummary => ({
       activePaying: false,
       customerId,
@@ -359,7 +360,10 @@ async function main(args = process.argv.slice(2), runtimeEnv: Record<string, str
     return
   }
 
-  const coverageByCustomerId = await collectPaidCoverageByCustomerId(stripe, {
+  const {
+    coverageByCustomerId,
+    customerIdsWithPositivePaidInvoices,
+  } = await collectPaidCoverageByCustomerId(stripe, {
     customerId,
     includeCustomerIds: customerIds,
     invoiceLimit,
@@ -371,7 +375,7 @@ async function main(args = process.argv.slice(2), runtimeEnv: Record<string, str
   )
   const customerSummaries = [
     ...filterCustomerSummaries(paidCustomerSummaries, statusFilter),
-    ...buildNeverPaidCustomerSummaries(customerIds, coverageByCustomerId, statusFilter),
+    ...buildNeverPaidCustomerSummaries(customerIds, customerIdsWithPositivePaidInvoices, statusFilter),
   ]
   const qualifyingOrgIds = customerSummaries
     .flatMap(summary => orgsByCustomerId.get(summary.customerId) ?? [])

--- a/scripts/stripe_paid_invoice_export_utils.ts
+++ b/scripts/stripe_paid_invoice_export_utils.ts
@@ -23,6 +23,11 @@ export interface CustomerPaidSummary {
   paidDurationMs: number
 }
 
+export interface CustomerPaidCoverageResult {
+  coverageByCustomerId: Map<string, CustomerPaidCoverage>
+  customerIdsWithPositivePaidInvoices: Set<string>
+}
+
 interface CollectPaidCoverageOptions {
   customerId?: string | null
   excludeCustomerIds?: Set<string>
@@ -174,8 +179,9 @@ function shouldIncludeCustomer(customerId: string, options: CollectPaidCoverageO
 export async function collectPaidCoverageByCustomerId(
   stripe: Stripe,
   options: CollectPaidCoverageOptions,
-) {
+): Promise<CustomerPaidCoverageResult> {
   const coverageByCustomerId = new Map<string, CustomerPaidCoverage>()
+  const customerIdsWithPositivePaidInvoices = new Set<string>()
   const invoiceListParams: Stripe.InvoiceListParams = {
     limit: 100,
     status: 'paid',
@@ -191,6 +197,9 @@ export async function collectPaidCoverageByCustomerId(
 
     const customerId = toStripeId(invoice.customer)
     if (customerId && shouldIncludeCustomer(customerId, options)) {
+      if (getInvoiceAmountPaid(invoice) > 0)
+        customerIdsWithPositivePaidInvoices.add(customerId)
+
       const intervals = await getInvoicePaidIntervals(stripe, invoice)
       if (intervals.length > 0) {
         addPaidCoverage(coverageByCustomerId, customerId, intervals, options.nowMs)
@@ -206,7 +215,10 @@ export async function collectPaidCoverageByCustomerId(
   }
 
   console.log(`Checked ${checkedInvoices} paid Stripe invoices (${matchedInvoices} matched subscription invoices)`)
-  return coverageByCustomerId
+  return {
+    coverageByCustomerId,
+    customerIdsWithPositivePaidInvoices,
+  }
 }
 
 function mergeElapsedIntervals(intervals: PaidInterval[], nowMs: number) {


### PR DESCRIPTION
## Summary (AI generated)
- Updates the Stripe org email export so `--status=never_paid` means org-linked Stripe customers with no positive paid invoice at all.
- Keeps paid duration logic based on paid subscription invoice coverage for `paid`, `active`, and `canceled` exports.
- Clarifies the help text for the `never_paid` status.

## Motivation (AI generated)
The trial churn export should identify org users whose org never paid anything, not customers that merely lack subscription coverage while still having another positive paid invoice.

## Business Impact (AI generated)
This makes the CSV reliable for trial-churn outreach and avoids mixing paid customers into the never-paid segment.

## Test Plan (AI generated)
- [x] `bunx eslint --no-ignore scripts/export_stripe_six_month_org_emails.ts scripts/stripe_paid_invoice_export_utils.ts`
- [x] `bun --bun tsc --noEmit --ignoreConfig --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module ESNext --target ESNext scripts/export_stripe_six_month_org_emails.ts scripts/stripe_paid_invoice_export_utils.ts`
- [x] `git diff --check`
- [x] `bun scripts/export_stripe_six_month_org_emails.ts --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in identifying and exporting trial organization data by refining how customer payment history is tracked and categorized.

* **Chores**
  * Enhanced internal data structures for better distinction between trial and paid customer statuses during export operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2252)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->