### PR TITLE
[codex] Fix Stripe revenue backfill expand depth

### DIFF
--- a/scripts/fix_stripe_admin_revenue_dashboard_metrics.ts
+++ b/scripts/fix_stripe_admin_revenue_dashboard_metrics.ts
@@ -646,7 +646,7 @@ async function getInvoiceLines(stripe: Stripe, invoice: Stripe.Invoice) {
   if (!invoice.lines.has_more)
     return lines
 
-  const params = { limit: STRIPE_PAGE_SIZE, expand: ['data.price.product'] } as Stripe.InvoiceListLineItemsParams
+  const params = { limit: STRIPE_PAGE_SIZE } as Stripe.InvoiceListLineItemsParams
   const startingAfter = lines.at(-1)?.id
   if (startingAfter)
     params.starting_after = startingAfter
@@ -679,7 +679,6 @@ async function fetchStripeRevenueIntervals(
   let checkedInvoices = 0
   let matchedLines = 0
   const invoiceParams = {
-    expand: ['data.lines.data.price.product'],
     limit: STRIPE_PAGE_SIZE,
     status: 'paid',
   } as Stripe.InvoiceListParams
@@ -702,7 +701,6 @@ async function fetchStripeRevenueIntervals(
 
   let checkedSubscriptions = 0
   const subscriptionParams = {
-    expand: ['data.items.data.price.product'],
     limit: STRIPE_PAGE_SIZE,
     status: 'all',
   } as Stripe.SubscriptionListParams


### PR DESCRIPTION
## Summary (AI generated)

- Removed invalid nested Stripe expand paths from the admin revenue backfill script.
- Kept the shallow Stripe price product expansion used to classify historical prices.

## Motivation (AI generated)

Stripe rejects `data.lines.data.price.product` because expand paths cannot exceed four property levels. The backfill already fetches prices and products separately, so invoice and subscription list calls do not need nested product expansions.

## Business Impact (AI generated)

This unblocks the Stripe revenue dashboard repair command so historical MRR, ARR, subscription flow, plan distribution, and churn data can be rebuilt instead of failing before data collection starts.

## Test Plan (AI generated)

- [ ] Not run per request.

Generated with AI
