### PR TITLE
fix(files): cache TUS upload access checks

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -7,6 +7,7 @@ import { Hono } from 'hono/tiny'
 import { app as download_link } from '../private/download_link.ts'
 import { app as upload_link } from '../private/upload_link.ts'
 import { app as ok } from '../public/ok.ts'
+import { CacheHelper } from '../utils/cache.ts'
 import { sendDiscordAlert } from '../utils/discord.ts'
 import { quickError, simpleError } from '../utils/hono.ts'
 import { middlewareKey } from '../utils/hono_middleware.ts'
@@ -30,8 +31,19 @@ const DO_FETCH_RETRY_DELAY_MS = 250
 const ATTACHMENT_PREFIX = 'attachments'
 const ATTACHMENT_PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth', 'storage']
 const TUS_UPLOAD_CONTENT_TYPE = 'application/offset+octet-stream'
+const ATTACHMENT_WRITE_ACCESS_CACHE_PATH = '/.files-upload-write-access-v1'
+const ATTACHMENT_WRITE_ACCESS_CACHE_TTL_SECONDS = 60
 
 export const app = new Hono<MiddlewareKeyVariables>()
+
+interface AttachmentWriteAccessCachePayload {
+  status: 'allowed' | 'ready_bundle'
+  apikeyId: number
+  appId: string
+  ownerOrg: string
+  fileId: string
+  expiresAt: number
+}
 
 function isRetryableDurableObjectFetchError(error: unknown): boolean {
   return isRetryableDurableObjectResetError(error)
@@ -640,6 +652,105 @@ function buildNormalizedUploadMetadataHeader(c: Context, filename: string): stri
   return metadata.join(',')
 }
 
+function shouldReadAttachmentWriteAccessCache(c: Context) {
+  const method = c.req.raw.method
+  return method === 'HEAD' || method === 'PATCH'
+}
+
+function buildAttachmentWriteAccessCacheEntry(
+  c: Context,
+  apikeyId: number,
+  ownerOrg: string,
+  appId: string,
+  fileId: string,
+) {
+  const helper = new CacheHelper(c)
+  const request = helper.buildRequest(ATTACHMENT_WRITE_ACCESS_CACHE_PATH, {
+    apikey_id: String(apikeyId),
+    owner_org: ownerOrg,
+    app_id: appId,
+    file_id: fileId,
+  })
+  return { helper, request }
+}
+
+function isMatchingAttachmentWriteAccessCache(
+  payload: AttachmentWriteAccessCachePayload | null,
+  apikeyId: number,
+  ownerOrg: string,
+  appId: string,
+  fileId: string,
+  now = Date.now(),
+): payload is AttachmentWriteAccessCachePayload {
+  return !!payload
+    && payload.apikeyId === apikeyId
+    && payload.ownerOrg === ownerOrg
+    && payload.appId === appId
+    && payload.fileId === fileId
+    && payload.expiresAt > now
+}
+
+async function getCachedAttachmentWriteAccess(
+  c: Context,
+  apikeyId: number,
+  ownerOrg: string,
+  appId: string,
+  fileId: string,
+) {
+  if (!shouldReadAttachmentWriteAccessCache(c))
+    return null
+
+  const cacheEntry = buildAttachmentWriteAccessCacheEntry(c, apikeyId, ownerOrg, appId, fileId)
+  const cached = await cacheEntry.helper.matchJson<AttachmentWriteAccessCachePayload>(cacheEntry.request)
+  if (!isMatchingAttachmentWriteAccessCache(cached, apikeyId, ownerOrg, appId, fileId))
+    return null
+
+  // Active TUS uploads may span many HEAD/PATCH calls. Extend only fresh,
+  // exact-match cache entries; POST creation still performs the full primary DB check.
+  await backgroundTask(
+    c,
+    cacheAttachmentWriteAccess(c, apikeyId, ownerOrg, appId, fileId, cached.status),
+  )
+
+  return cached.status
+}
+
+async function cacheAttachmentWriteAccess(
+  c: Context,
+  apikeyId: number,
+  ownerOrg: string,
+  appId: string,
+  fileId: string,
+  status: AttachmentWriteAccessCachePayload['status'],
+) {
+  const cacheEntry = buildAttachmentWriteAccessCacheEntry(c, apikeyId, ownerOrg, appId, fileId)
+  await cacheEntry.helper.putJson(cacheEntry.request, {
+    status,
+    apikeyId,
+    ownerOrg,
+    appId,
+    fileId,
+    expiresAt: Date.now() + ATTACHMENT_WRITE_ACCESS_CACHE_TTL_SECONDS * 1000,
+  } satisfies AttachmentWriteAccessCachePayload, ATTACHMENT_WRITE_ACCESS_CACHE_TTL_SECONDS)
+}
+
+function throwReadyBundlePathConflict(c: Context, appId: string, ownerOrg: string, fileId: string): never {
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'checkWriteAppAccess - ready bundle path mutation blocked',
+    app_id: appId,
+    owner_org: ownerOrg,
+    fileId,
+  })
+  throw new HTTPException(409, {
+    res: c.json({
+      error: 'bundle_already_ready',
+      message: 'Bundle content cannot be changed after upload is complete. Upload a new bundle instead.',
+      moreInfo: { app_id: appId, requestId: c.get('requestId') },
+    }),
+  })
+}
+
 // TUS protocol requests (POST/PATCH/HEAD) that get forwarded to a durable object
 async function uploadHandler(c: Context) {
   const requestId = c.get('fileId') as string
@@ -867,8 +978,24 @@ async function checkWriteAppAccess(c: Context, next: Next) {
     userId: apikey.user_id,
   })
 
+  const cachedWriteAccess = await getCachedAttachmentWriteAccess(c, apikey.id, owner_org, app_id, requestId)
+  if (cachedWriteAccess === 'allowed') {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'checkWriteAppAccess - cache hit',
+      app_id,
+      owner_org,
+      fileId: requestId,
+    })
+    await next()
+    return
+  }
+  if (cachedWriteAccess === 'ready_bundle') {
+    throwReadyBundlePathConflict(c, app_id, owner_org, requestId)
+  }
+
   // Use Postgres instead of Supabase SDK
-  const pgClient = getPgClient(c, false) // authz + plan gating must read primary
+  const pgClient = getPgClient(c, false) // authz, plan gating, and ready-bundle guards must read primary
   const drizzleClient = getDrizzleClient(pgClient)
 
   try {
@@ -1002,20 +1129,8 @@ async function checkWriteAppAccess(c: Context, next: Next) {
     )
 
     if (readyBundlePath.rows.length > 0) {
-      cloudlog({
-        requestId: c.get('requestId'),
-        message: 'checkWriteAppAccess - ready bundle path mutation blocked',
-        app_id,
-        owner_org,
-        fileId: requestId,
-      })
-      throw new HTTPException(409, {
-        res: c.json({
-          error: 'bundle_already_ready',
-          message: 'Bundle content cannot be changed after upload is complete. Upload a new bundle instead.',
-          moreInfo: { app_id, requestId: c.get('requestId') },
-        }),
-      })
+      await cacheAttachmentWriteAccess(c, apikey.id, owner_org, app_id, requestId, 'ready_bundle')
+      throwReadyBundlePathConflict(c, app_id, owner_org, requestId)
     }
 
     cloudlog({
@@ -1024,6 +1139,7 @@ async function checkWriteAppAccess(c: Context, next: Next) {
       app_id,
       owner_org,
     })
+    await cacheAttachmentWriteAccess(c, apikey.id, owner_org, app_id, requestId, 'allowed')
   }
   finally {
     // Always close the connection

--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -97,7 +97,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   }
   let appVersion = await getAppVersionPostgres(c, app_id, versionOnly, allowedDeleted, drizzleClient as ReturnType<typeof getDrizzleClient>)
   if (!appVersion) {
-    const appVersion2 = await getAppVersionPostgres(c, app_id, 'unknown', allowedDeleted, drizzleClient as ReturnType<typeof getDrizzleClient>)
+    const appVersion2 = await getAppVersionPostgres(c, app_id, 'unknown', true, drizzleClient as ReturnType<typeof getDrizzleClient>)
     if (appVersion2) {
       appVersion = appVersion2
       cloudlog({ requestId: c.get('requestId'), message: `Version name ${version_name} not found, using unknown instead`, app_id, version_name })

--- a/supabase/migrations/20260513093535_app_versions_r2_path_index.sql
+++ b/supabase/migrations/20260513093535_app_versions_r2_path_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS app_versions_r2_path_idx
+ON public.app_versions USING btree (r2_path);

--- a/tests/files-upload-access-cache.unit.test.ts
+++ b/tests/files-upload-access-cache.unit.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fileId = 'orgs/test-org/apps/test-app/cache-test.zip'
+const originalCaches = globalThis.caches
+const getPgClientMock = vi.fn()
+const getUserIdFromApikeyMock = vi.fn()
+const getAppByAppIdPgMock = vi.fn()
+const getAppByIdPgMock = vi.fn()
+const checkPermissionPgMock = vi.fn()
+
+function encodeMetadataValue(value: string) {
+  return Buffer.from(value).toString('base64')
+}
+
+function createCache() {
+  const store = new Map<string, Response>()
+  return {
+    match: vi.fn(async (request: Request) => store.get(request.url)?.clone() ?? null),
+    put: vi.fn(async (request: Request, response: Response) => {
+      store.set(request.url, response.clone())
+    }),
+  }
+}
+
+function createExecutionContext() {
+  return {
+    waitUntil: vi.fn(),
+  }
+}
+
+vi.mock('hono/adapter', () => {
+  return {
+    env: () => ({}),
+    getRuntimeKey: () => 'workerd',
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/discord.ts', () => ({
+  sendDiscordAlert500: () => Promise.resolve(),
+  sendDiscordAlert: () => Promise.resolve(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono_middleware.ts', () => ({
+  middlewareKey: () => async (c: any, next: () => Promise<void>) => {
+    const apikey = {
+      id: 123,
+      user_id: '00000000-0000-0000-0000-000000000001',
+      limited_to_apps: [],
+      limited_to_orgs: [],
+    }
+    c.set('apikey', apikey)
+    c.set('parentApikey', apikey)
+    c.set('capgkey', 'test-api-key')
+    c.set('auth', {
+      userId: apikey.user_id,
+      authType: 'apikey',
+      apikey,
+      jwt: null,
+    })
+    await next()
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: vi.fn(() => Promise.resolve()),
+  getAppByIdPg: getAppByIdPgMock,
+  getDrizzleClient: vi.fn(() => ({})),
+  getPgClient: getPgClientMock,
+  logPgError: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg_files.ts', () => ({
+  getAppByAppIdPg: getAppByAppIdPgMock,
+  getUserIdFromApikey: getUserIdFromApikeyMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: vi.fn(() => Promise.resolve(true)),
+  checkPermissionPg: checkPermissionPgMock,
+}))
+
+describe('files upload access cache', () => {
+  afterEach(() => {
+    globalThis.caches = originalCaches
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPgClientMock.mockReturnValue({
+      end: vi.fn(() => Promise.resolve()),
+      query: vi.fn(async () => ({ rows: [] })),
+    })
+    getUserIdFromApikeyMock.mockResolvedValue('00000000-0000-0000-0000-000000000001')
+    getAppByAppIdPgMock.mockResolvedValue({ app_id: 'test-app', owner_org: 'test-org' })
+    getAppByIdPgMock.mockResolvedValue({ plan_valid: true })
+    checkPermissionPgMock.mockResolvedValue(true)
+  })
+
+  it('reuses cached TUS write access for repeated HEAD checks', async () => {
+    const cache = createCache()
+    globalThis.caches = { default: cache } as any
+
+    const handlerFetch = vi.fn(async (request: Request) => {
+      return new Response(null, {
+        status: request.method === 'POST' ? 201 : 204,
+        headers: {
+          'Tus-Resumable': '1.0.0',
+        },
+      })
+    })
+    const env = {
+      ATTACHMENT_UPLOAD_HANDLER: {
+        idFromName: (name: string) => name,
+        get: () => ({ fetch: handlerFetch }),
+      },
+    }
+    const executionCtx = createExecutionContext()
+
+    const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+    const { createAllCatch, createHono } = await import('../supabase/functions/_backend/utils/hono.ts')
+    const { version } = await import('../supabase/functions/_backend/utils/version.ts')
+
+    const appGlobal = createHono('files', version)
+    appGlobal.route('/', files)
+    createAllCatch(appGlobal, 'files')
+
+    const createResponse = await appGlobal.fetch(
+      new Request('http://localhost/upload/attachments', {
+        method: 'POST',
+        headers: {
+          Authorization: 'test-api-key',
+          'Tus-Resumable': '1.0.0',
+          'Upload-Metadata': `filename ${encodeMetadataValue(fileId)},filetype ${encodeMetadataValue('application/zip')}`,
+          'Content-Length': '0',
+        },
+      }),
+      env,
+      executionCtx as any,
+    )
+
+    expect(createResponse.status).toBe(201)
+    expect(getPgClientMock).toHaveBeenCalledTimes(1)
+    expect(cache.put).toHaveBeenCalled()
+
+    const headResponse = await appGlobal.fetch(
+      new Request(`http://localhost/upload/attachments/${fileId}`, {
+        method: 'HEAD',
+        headers: {
+          Authorization: 'test-api-key',
+          'Tus-Resumable': '1.0.0',
+        },
+      }),
+      env,
+      executionCtx as any,
+    )
+
+    expect(headResponse.status).toBe(204)
+    expect(getPgClientMock).toHaveBeenCalledTimes(1)
+    expect(getUserIdFromApikeyMock).toHaveBeenCalledTimes(1)
+    expect(checkPermissionPgMock).toHaveBeenCalledTimes(1)
+    expect(cache.match).toHaveBeenCalled()
+  })
+})

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -183,6 +183,32 @@ describe('[POST] /stats', () => {
     await getSupabaseClient().from('devices').delete().eq('device_id', uuid).eq('app_id', APP_NAME_STATS)
   })
 
+  it('uses deleted unknown placeholder instead of scheduling repeated placeholder inserts', async () => {
+    const uuid = randomUUID().toLowerCase()
+    const appId = `${APP_NAME}.deleted.unknown.${randomUUID().split('-')[0]}`
+    await resetAndSeedAppData(appId)
+    await resetAndSeedAppDataStats(appId)
+
+    try {
+      await createAppVersions('unknown', appId, { deleted: true })
+
+      const baseData = getBaseData(appId) as StatsPayload
+      baseData.device_id = uuid
+      baseData.action = 'set'
+      baseData.version_build = '1.0.0-missing.1'
+      baseData.version_name = '1.0.0-missing.1'
+
+      const response = await postStats(baseData)
+      expect(response.status).toBe(200)
+      expect(await response.json<StatsRes>()).toEqual({ status: 'ok' })
+    }
+    finally {
+      await getSupabaseClient().from('devices').delete().eq('device_id', uuid).eq('app_id', appId)
+      await resetAppData(appId)
+      await resetAppDataStats(appId)
+    }
+  })
+
   it('should ignore custom_id when app disables allow_device_custom_id and emit customIdBlocked stat', async () => {
     const shortId = randomUUID().split('-')[0]
     const appId = `${APP_NAME}.cidb.${shortId}`


### PR DESCRIPTION
## Summary (AI generated)

- Added a tracked migration for the production `app_versions.r2_path` index that Supabase recommended for the TUS/files ready-bundle guard.
- Cached successful and ready-bundle TUS attachment write-access checks for exact API key, org, app, and file path matches so repeated `HEAD`/`PATCH` calls do not repeat the same DB work during an active upload.
- Fixed `/stats` fallback version lookup so a deleted `unknown` placeholder can be reused instead of repeatedly scheduling no-op placeholder inserts.
- Added focused regressions for the TUS write-access cache and the deleted `unknown` stats fallback.

## Motivation (AI generated)

Supabase reported heavy production volume from the ready-bundle `app_versions.r2_path` lookup. That lookup comes from `checkWriteAppAccess` in the files/TUS upload route. The repeated placeholder insert comes from `/stats` falling back to `unknown` with the wrong deleted filter, which can miss the placeholder and schedule `ensurePlaceholderVersions` again on every request.

## Business Impact (AI generated)

This reduces unnecessary database pressure on hot upload and stats paths, keeps the production index tracked in migrations, and lowers the risk of DB saturation from resumable-upload loops or stats traffic. Upload integrity stays intact because TUS create requests still perform the full primary DB validation and only repeated chunk/progress checks reuse a short-lived exact-match cache.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun test tests/files-upload-access-cache.unit.test.ts`
- [x] `bun test tests/stats.test.ts --test-timeout 20000`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`
- [ ] `bunx supabase migration list --local` blocked because local Supabase Postgres is not running on `127.0.0.1:54322` in this worktree.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented caching mechanism for upload authorization decisions to minimize database queries during file transfer operations.
  * Added database index to optimize app version lookups.

* **Bug Fixes**
  * Corrected fallback behavior for deleted app versions in the statistics endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2258)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->