### PR TITLE
fix(dashboard): use build init for both iOS and Android setup steps

### DIFF
--- a/src/components/dashboard/StepsBuild.vue
+++ b/src/components/dashboard/StepsBuild.vue
@@ -93,7 +93,7 @@ const setupStep = computed<Step>(() => {
     return {
       key: 'setup-ios',
       title: t('build-step-ios-setup-title'),
-      command: `npx @capgo/cli@latest build init -a ${apiKey.value}`,
+      command: `npx @capgo/cli@latest build init -a ${apiKey.value} --platform ios`,
       subtitle: t('build-step-ios-setup-subtitle'),
       icon: IconSettings,
     }
@@ -102,7 +102,7 @@ const setupStep = computed<Step>(() => {
   return {
     key: 'setup-android',
     title: t('build-step-android-setup-title'),
-    command: `npx @capgo/cli@latest build credentials save --appId ${props.appId} --platform android`,
+    command: `npx @capgo/cli@latest build init -a ${apiKey.value} --platform android`,
     subtitle: t('build-step-android-setup-subtitle'),
     icon: IconSettings,
   }


### PR DESCRIPTION
## Summary

The Build Steps dashboard (`StepsBuild.vue`) hands users a CLI command to set up signing credentials. The Android command was still pointing at the legacy non-interactive `build credentials save --appId ... --platform android`, which doesn't drive the new Android onboarding (keystore + Google Cloud + Play Console wizard). Switch both platforms to the unified interactive command:

- **iOS**: `npx @capgo/cli@latest build init -a <apikey> --platform ios`
- **Android**: `npx @capgo/cli@latest build init -a <apikey> --platform android`

iOS was already on `build init` but missing the explicit `--platform ios` flag — added for symmetry and clarity (the user-pasted command will look the same shape on both platforms).

## Why

- The legacy `build credentials save` flow does not exercise the new Android onboarding (OAuth, Play Console, keystore wizard) that `feat/cli-android-oauth-onboarding` ships.
- `build init` is the single entry point the CLI now exposes for both iOS and Android. Pointing the dashboard at it keeps the onboarding consistent.
- Uses `apiKey.value` (already used by the iOS line and `requestStep`) instead of `props.appId`, matching the API-key-based auth pattern.

## Depends on

This change is paired with the CLI Android onboarding work (`feat/cli-android-oauth-onboarding` / CLI repo `feat/android-onboarding-oauth`). The new `--platform android` flag for `build init` must be released in `@capgo/cli` before this dashboard change lands on production, otherwise users will copy a command their installed CLI doesn't yet support.

## Test plan

- [ ] Open the dashboard, navigate to Build → setup step
- [ ] iOS tab shows `npx @capgo/cli@latest build init -a <API_KEY> --platform ios`
- [ ] Android tab shows `npx @capgo/cli@latest build init -a <API_KEY> --platform android`
- [ ] Both commands copy correctly and advance to the next step
- [ ] Confirm `@capgo/cli` published version supports `build init --platform android` before merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI commands generated during setup steps for iOS and Android platforms to ensure explicit platform targeting and consistency across the build initialization process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2260)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->