### PR TITLE
fix(stats): reuse deleted unknown placeholder

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -97,7 +97,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   }
   let appVersion = await getAppVersionPostgres(c, app_id, versionOnly, allowedDeleted, drizzleClient as ReturnType<typeof getDrizzleClient>)
   if (!appVersion) {
-    const appVersion2 = await getAppVersionPostgres(c, app_id, 'unknown', allowedDeleted, drizzleClient as ReturnType<typeof getDrizzleClient>)
+    const appVersion2 = await getAppVersionPostgres(c, app_id, 'unknown', true, drizzleClient as ReturnType<typeof getDrizzleClient>)
     if (appVersion2) {
       appVersion = appVersion2
       cloudlog({ requestId: c.get('requestId'), message: `Version name ${version_name} not found, using unknown instead`, app_id, version_name })

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -183,6 +183,32 @@ describe('[POST] /stats', () => {
     await getSupabaseClient().from('devices').delete().eq('device_id', uuid).eq('app_id', APP_NAME_STATS)
   })
 
+  it('uses deleted unknown placeholder instead of scheduling repeated placeholder inserts', async () => {
+    const uuid = randomUUID().toLowerCase()
+    const appId = `${APP_NAME}.deleted.unknown.${randomUUID().split('-')[0]}`
+    await resetAndSeedAppData(appId)
+    await resetAndSeedAppDataStats(appId)
+
+    try {
+      await createAppVersions('unknown', appId, { deleted: true })
+
+      const baseData = getBaseData(appId) as StatsPayload
+      baseData.device_id = uuid
+      baseData.action = 'set'
+      baseData.version_build = '1.0.0-missing.1'
+      baseData.version_name = '1.0.0-missing.1'
+
+      const response = await postStats(baseData)
+      expect(response.status).toBe(200)
+      expect(await response.json<StatsRes>()).toEqual({ status: 'ok' })
+    }
+    finally {
+      await getSupabaseClient().from('devices').delete().eq('device_id', uuid).eq('app_id', appId)
+      await resetAppData(appId)
+      await resetAppDataStats(appId)
+    }
+  })
+
   it('should ignore custom_id when app disables allow_device_custom_id and emit customIdBlocked stat', async () => {
     const shortId = randomUUID().split('-')[0]
     const appId = `${APP_NAME}.cidb.${shortId}`


### PR DESCRIPTION
## Summary (AI generated)

- Reuse an existing deleted `unknown` placeholder version when `/stats` falls back after a missing version.
- Add a regression test covering the deleted placeholder fallback path.

## Motivation (AI generated)

The stats endpoint could fail to find a deleted `unknown` placeholder when the reported version was missing, causing repeated placeholder insert scheduling instead of accepting the existing placeholder.

## Business Impact (AI generated)

This keeps plugin stats ingestion stable for apps that already have a deleted `unknown` placeholder, reducing noisy retries and avoiding unnecessary backend work on a hot plugin path.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun run supabase:with-env -- bunx vitest run tests/stats.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the fallback logic for retrieving app version information when standard lookups don't return results, improving the system's handling of edge cases.

* **Tests**
  * Added test coverage verifying proper stats API behavior when processing requests with deleted version records and incomplete version identification data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2267)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->