### PR TITLE
[codex] Fix plan usage alert metric source

### DIFF
--- a/supabase/functions/_backend/utils/plans.ts
+++ b/supabase/functions/_backend/utils/plans.ts
@@ -26,6 +26,20 @@ import { sendEventToTracking } from './tracking.ts'
 import { isStripeConfigured } from './utils.ts'
 
 type CreditMetric = Database['public']['Enums']['credit_metric_type']
+type PlanUsageMetric = Exclude<keyof PlanUsage, 'total_percent'>
+
+const PLAN_USAGE_ALERT_THRESHOLDS = [90, 70, 50] as const
+const PLAN_USAGE_ALERT_EVENT_BY_THRESHOLD: Record<(typeof PLAN_USAGE_ALERT_THRESHOLDS)[number], string> = {
+  50: 'user:usage_50_percent_of_plan',
+  70: 'user:usage_70_percent_of_plan',
+  90: 'user:usage_90_percent_of_plan',
+}
+const PLAN_USAGE_METRICS: Array<{ key: PlanUsageMetric, metric: CreditMetric }> = [
+  { key: 'mau_percent', metric: 'mau' },
+  { key: 'bandwidth_percent', metric: 'bandwidth' },
+  { key: 'storage_percent', metric: 'storage' },
+  { key: 'build_time_percent', metric: 'build_time' },
+]
 
 interface BillingCycleInfo {
   subscription_anchor_start: string | null
@@ -45,6 +59,46 @@ interface CreditApplicationResult {
   overage_covered: number
   overage_unpaid: number
   credit_step_id: number | null
+}
+
+function getHighestPlanUsage(percentUsage: PlanUsage) {
+  return PLAN_USAGE_METRICS.reduce((highest, current) => {
+    const percent = Number(percentUsage[current.key] ?? 0)
+    if (percent > highest.percent) {
+      return {
+        metric: current.metric,
+        percent,
+      }
+    }
+    return highest
+  }, {
+    metric: 'mau' as CreditMetric,
+    percent: 0,
+  })
+}
+
+function normalizePlanUsage(percentUsage: PlanUsage): PlanUsage {
+  const highestUsage = getHighestPlanUsage(percentUsage)
+  return {
+    ...percentUsage,
+    total_percent: highestUsage.percent,
+  }
+}
+
+function getPlanUsageAlert(percentUsage: PlanUsage) {
+  const normalizedUsage = normalizePlanUsage(percentUsage)
+  const highestUsage = getHighestPlanUsage(normalizedUsage)
+  const threshold = PLAN_USAGE_ALERT_THRESHOLDS.find(value => highestUsage.percent >= value)
+  if (!threshold)
+    return null
+
+  return {
+    eventName: PLAN_USAGE_ALERT_EVENT_BY_THRESHOLD[threshold],
+    metric: highestUsage.metric,
+    metricPercent: highestUsage.percent,
+    percentUsage: normalizedUsage,
+    threshold,
+  }
 }
 
 function getDefaultBillingCycleRange(referenceDate = new Date()): BillingCycleRange {
@@ -335,47 +389,30 @@ async function userIsAtPlanUsage(c: Context, orgId: string, customerId: string |
   await set_bandwidth_exceeded(c, customerId, false, orgId)
   await set_build_time_exceeded(c, orgId, false)
 
-  // check if user is at more than 90%, 50% or 70% of plan usage
-  if (percentUsage.total_percent >= 90) {
-    // cron every month
-    const sent = await sendNotifToOrgMembers(c, 'user:usage_90_percent_of_plan', 'usage_limit', { percent: percentUsage }, orgId, orgId, '0 0 1 * *', drizzleClient)
-    if (sent) {
-      await sendEventToTracking(c, {
-        channel: 'usage',
-        event: 'User is at 90% of plan usage',
-        icon: '⚠️',
-        user_id: orgId,
-        groups: { organization: orgId },
-        notify: false,
-      }).catch()
-    }
-  }
-  else if (percentUsage.total_percent >= 70) {
-    // cron every month
-    const sent = await sendNotifToOrgMembers(c, 'user:usage_70_percent_of_plan', 'usage_limit', { percent: percentUsage }, orgId, orgId, '0 0 1 * *', drizzleClient)
-    if (sent) {
-      await sendEventToTracking(c, {
-        channel: 'usage',
-        event: 'User is at 70% of plan usage',
-        icon: '⚠️',
-        user_id: orgId,
-        groups: { organization: orgId },
-        notify: false,
-      }).catch()
-    }
-  }
-  else if (percentUsage.total_percent >= 50) {
-    const sent = await sendNotifToOrgMembers(c, 'user:usage_50_percent_of_plan', 'usage_limit', { percent: percentUsage }, orgId, orgId, '0 0 1 * *', drizzleClient)
-    if (sent) {
-      await sendEventToTracking(c, {
-        channel: 'usage',
-        event: 'User is at 50% of plan usage',
-        icon: '⚠️',
-        user_id: orgId,
-        groups: { organization: orgId },
-        notify: false,
-      }).catch()
-    }
+  const alert = getPlanUsageAlert(percentUsage)
+  if (!alert)
+    return
+
+  const sent = await sendNotifToOrgMembers(c, alert.eventName, 'usage_limit', {
+    metric: alert.metric,
+    metric_percent: alert.metricPercent,
+    percent: alert.percentUsage,
+    threshold: alert.threshold,
+  }, orgId, orgId, '0 0 1 * *', drizzleClient)
+  if (sent) {
+    await sendEventToTracking(c, {
+      channel: 'usage',
+      event: `User is at ${alert.threshold}% of plan usage`,
+      icon: '⚠️',
+      user_id: orgId,
+      groups: { organization: orgId },
+      notify: false,
+      tags: {
+        metric: alert.metric,
+        metric_percent: alert.metricPercent.toString(),
+        threshold: alert.threshold.toString(),
+      },
+    }).catch()
   }
 }
 
@@ -419,7 +456,7 @@ export async function handleTrialOrg(c: Context, orgId: string, org: any): Promi
 export async function calculatePlanStatus(c: Context, orgId: string) {
   const planUsage = await getPlanUsageAndFit(c, orgId)
   const { is_good_plan, total_percent, mau_percent, bandwidth_percent, storage_percent, build_time_percent } = planUsage
-  const percentUsage = { total_percent, mau_percent, bandwidth_percent, storage_percent, build_time_percent }
+  const percentUsage = normalizePlanUsage({ total_percent, mau_percent, bandwidth_percent, storage_percent, build_time_percent })
   return { is_good_plan, percentUsage }
 }
 
@@ -427,12 +464,12 @@ export async function calculatePlanStatusFresh(c: Context, orgId: string) {
   try {
     const planUsage = await getPlanUsageAndFitUncached(c, orgId)
     const { is_good_plan, total_percent, mau_percent, bandwidth_percent, storage_percent, build_time_percent } = planUsage
-    const percentUsage = { total_percent, mau_percent, bandwidth_percent, storage_percent, build_time_percent }
+    const percentUsage = normalizePlanUsage({ total_percent, mau_percent, bandwidth_percent, storage_percent, build_time_percent })
     return { is_good_plan, percentUsage }
   }
   catch (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'calculatePlanStatusFresh fallback', orgId, error })
-    const percentUsage = await getPlanUsagePercent(c, orgId)
+    const percentUsage = normalizePlanUsage(await getPlanUsagePercent(c, orgId))
     const is_good_plan = await isGoodPlanOrg(c, orgId)
     return { is_good_plan, percentUsage }
   }
@@ -476,11 +513,12 @@ export async function handleOrgNotificationsAndEvents(c: Context, org: any, orgI
 
 // Update stripe_info with plan status
 export async function updatePlanStatus(c: Context, org: any, is_good_plan: boolean, percentUsage: PlanUsage): Promise<void> {
+  const normalizedUsage = normalizePlanUsage(percentUsage)
   await supabaseAdmin(c)
     .from('stripe_info')
     .update({
       is_good_plan,
-      plan_usage: Math.round(percentUsage.total_percent),
+      plan_usage: Math.round(normalizedUsage.total_percent),
     })
     .eq('customer_id', org.customer_id!)
     .then()

--- a/tests/plans-onboarding-reminder.unit.test.ts
+++ b/tests/plans-onboarding-reminder.unit.test.ts
@@ -91,7 +91,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     vi.restoreAllMocks()
   })
 
-  it('sends the trial-expired onboarding reminder only through the one-time helper with org context', async () => {
+  it.concurrent('sends the trial-expired onboarding reminder only through the one-time helper with org context', async () => {
     const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
 
     const result = await handleOrgNotificationsAndEvents(
@@ -139,7 +139,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     )
   })
 
-  it('does not send plan usage alerts from stale total percent alone', async () => {
+  it.concurrent('does not send plan usage alerts from stale total percent alone', async () => {
     isOnboardedOrgMock.mockResolvedValue(true)
     isOnboardingNeededMock.mockResolvedValue(false)
     const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
@@ -169,7 +169,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     expect(sendEventToTrackingMock).not.toHaveBeenCalled()
   })
 
-  it('sends plan usage alerts with the metric that crossed the threshold', async () => {
+  it.concurrent('sends plan usage alerts with the metric that crossed the threshold', async () => {
     isOnboardedOrgMock.mockResolvedValue(true)
     isOnboardingNeededMock.mockResolvedValue(false)
     sendNotifToOrgMembersMock.mockResolvedValue(true)

--- a/tests/plans-onboarding-reminder.unit.test.ts
+++ b/tests/plans-onboarding-reminder.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const {
   cloudlogErrMock,
@@ -14,13 +14,13 @@ const {
 } = vi.hoisted(() => ({
   cloudlogErrMock: vi.fn(),
   cloudlogMock: vi.fn(),
-  isGoodPlanOrgMock: vi.fn(),
-  isOnboardedOrgMock: vi.fn(),
-  isOnboardingNeededMock: vi.fn(),
-  isTrialOrgMock: vi.fn(),
-  sendEventToTrackingMock: vi.fn(),
-  sendNotifToOrgMembersMock: vi.fn(),
-  sendNotifToOrgMembersOnceMock: vi.fn(),
+  isGoodPlanOrgMock: vi.fn(async () => false),
+  isOnboardedOrgMock: vi.fn(async (_c: unknown, orgId: string) => !orgId.includes('onboarding')),
+  isOnboardingNeededMock: vi.fn(async (_c: unknown, orgId: string) => orgId.includes('onboarding')),
+  isTrialOrgMock: vi.fn(async () => 0),
+  sendEventToTrackingMock: vi.fn(async () => undefined),
+  sendNotifToOrgMembersMock: vi.fn(async () => true),
+  sendNotifToOrgMembersOnceMock: vi.fn(async () => true),
   supabaseAdminMock: vi.fn(),
 }))
 
@@ -73,26 +73,19 @@ function createContext() {
   } as any
 }
 
+function orgNotificationCalls(mock: typeof sendNotifToOrgMembersMock, orgId: string) {
+  return (mock.mock.calls as unknown[][]).filter(call => call[4] === orgId && call[5] === orgId)
+}
+
+function trackingCalls(orgId: string) {
+  return (sendEventToTrackingMock.mock.calls as unknown[][])
+    .filter(([, event]) => (event as { user_id?: string } | undefined)?.user_id === orgId)
+}
+
 describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
-  beforeEach(() => {
-    isOnboardedOrgMock.mockResolvedValue(false)
-    isOnboardingNeededMock.mockResolvedValue(true)
-    isTrialOrgMock.mockResolvedValue(0)
-    isGoodPlanOrgMock.mockResolvedValue(false)
-    sendNotifToOrgMembersMock.mockReset()
-    sendNotifToOrgMembersOnceMock.mockReset()
-    sendNotifToOrgMembersOnceMock.mockResolvedValue(true)
-    sendEventToTrackingMock.mockReset()
-    sendEventToTrackingMock.mockResolvedValue(undefined)
-    supabaseAdminMock.mockReset()
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
   it.concurrent('sends the trial-expired onboarding reminder only through the one-time helper with org context', async () => {
     const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
+    const orgId = 'org-onboarding-reminder'
 
     const result = await handleOrgNotificationsAndEvents(
       createContext(),
@@ -102,7 +95,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
         stripe_info: null,
         website: 'https://acme.example/',
       },
-      'org-123',
+      orgId,
       false,
       {
         total_percent: 0,
@@ -115,18 +108,18 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     )
 
     expect(result).toBe(false)
-    expect(sendNotifToOrgMembersMock).not.toHaveBeenCalled()
+    expect(orgNotificationCalls(sendNotifToOrgMembersMock, orgId)).toHaveLength(0)
     expect(sendNotifToOrgMembersOnceMock).toHaveBeenCalledWith(
       expect.anything(),
       'user:need_onboarding',
       'onboarding',
       {
-        org_id: 'org-123',
+        org_id: orgId,
         org_name: 'Acme Mobile',
         org_website: 'https://acme.example/',
       },
-      'org-123',
-      'org-123',
+      orgId,
+      orgId,
       expect.anything(),
     )
     expect(sendEventToTrackingMock).toHaveBeenCalledWith(
@@ -134,15 +127,14 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
       expect.objectContaining({
         channel: 'usage',
         event: 'User need onboarding',
-        user_id: 'org-123',
+        user_id: orgId,
       }),
     )
   })
 
   it.concurrent('does not send plan usage alerts from stale total percent alone', async () => {
-    isOnboardedOrgMock.mockResolvedValue(true)
-    isOnboardingNeededMock.mockResolvedValue(false)
     const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
+    const orgId = 'org-usage-stale'
 
     const result = await handleOrgNotificationsAndEvents(
       createContext(),
@@ -152,7 +144,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
         stripe_info: null,
         website: 'https://acme.example/',
       },
-      'org-123',
+      orgId,
       true,
       {
         total_percent: 51,
@@ -165,15 +157,13 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     )
 
     expect(result).toBe(true)
-    expect(sendNotifToOrgMembersMock).not.toHaveBeenCalled()
-    expect(sendEventToTrackingMock).not.toHaveBeenCalled()
+    expect(orgNotificationCalls(sendNotifToOrgMembersMock, orgId)).toHaveLength(0)
+    expect(trackingCalls(orgId)).toHaveLength(0)
   })
 
   it.concurrent('sends plan usage alerts with the metric that crossed the threshold', async () => {
-    isOnboardedOrgMock.mockResolvedValue(true)
-    isOnboardingNeededMock.mockResolvedValue(false)
-    sendNotifToOrgMembersMock.mockResolvedValue(true)
     const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
+    const orgId = 'org-usage-storage'
 
     const result = await handleOrgNotificationsAndEvents(
       createContext(),
@@ -183,7 +173,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
         stripe_info: null,
         website: 'https://acme.example/',
       },
-      'org-123',
+      orgId,
       true,
       {
         total_percent: 20,
@@ -212,8 +202,8 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
         },
         threshold: 50,
       },
-      'org-123',
-      'org-123',
+      orgId,
+      orgId,
       '0 0 1 * *',
       expect.anything(),
     )
@@ -222,6 +212,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
       expect.objectContaining({
         channel: 'usage',
         event: 'User is at 50% of plan usage',
+        user_id: orgId,
         tags: {
           metric: 'storage',
           metric_percent: '51',

--- a/tests/plans-onboarding-reminder.unit.test.ts
+++ b/tests/plans-onboarding-reminder.unit.test.ts
@@ -80,7 +80,9 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     isTrialOrgMock.mockResolvedValue(0)
     isGoodPlanOrgMock.mockResolvedValue(false)
     sendNotifToOrgMembersMock.mockReset()
+    sendNotifToOrgMembersOnceMock.mockReset()
     sendNotifToOrgMembersOnceMock.mockResolvedValue(true)
+    sendEventToTrackingMock.mockReset()
     sendEventToTrackingMock.mockResolvedValue(undefined)
     supabaseAdminMock.mockReset()
   })
@@ -89,7 +91,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
     vi.restoreAllMocks()
   })
 
-  it.concurrent('sends the trial-expired onboarding reminder only through the one-time helper with org context', async () => {
+  it('sends the trial-expired onboarding reminder only through the one-time helper with org context', async () => {
     const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
 
     const result = await handleOrgNotificationsAndEvents(
@@ -133,6 +135,98 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
         channel: 'usage',
         event: 'User need onboarding',
         user_id: 'org-123',
+      }),
+    )
+  })
+
+  it('does not send plan usage alerts from stale total percent alone', async () => {
+    isOnboardedOrgMock.mockResolvedValue(true)
+    isOnboardingNeededMock.mockResolvedValue(false)
+    const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
+
+    const result = await handleOrgNotificationsAndEvents(
+      createContext(),
+      {
+        customer_id: 'cus_123',
+        name: 'Acme Mobile',
+        stripe_info: null,
+        website: 'https://acme.example/',
+      },
+      'org-123',
+      true,
+      {
+        total_percent: 51,
+        mau_percent: 20,
+        bandwidth_percent: 0,
+        storage_percent: 0,
+        build_time_percent: 0,
+      },
+      {} as any,
+    )
+
+    expect(result).toBe(true)
+    expect(sendNotifToOrgMembersMock).not.toHaveBeenCalled()
+    expect(sendEventToTrackingMock).not.toHaveBeenCalled()
+  })
+
+  it('sends plan usage alerts with the metric that crossed the threshold', async () => {
+    isOnboardedOrgMock.mockResolvedValue(true)
+    isOnboardingNeededMock.mockResolvedValue(false)
+    sendNotifToOrgMembersMock.mockResolvedValue(true)
+    const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
+
+    const result = await handleOrgNotificationsAndEvents(
+      createContext(),
+      {
+        customer_id: 'cus_123',
+        name: 'Acme Mobile',
+        stripe_info: null,
+        website: 'https://acme.example/',
+      },
+      'org-123',
+      true,
+      {
+        total_percent: 20,
+        mau_percent: 20,
+        bandwidth_percent: 0,
+        storage_percent: 51,
+        build_time_percent: 0,
+      },
+      {} as any,
+    )
+
+    expect(result).toBe(true)
+    expect(sendNotifToOrgMembersMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'user:usage_50_percent_of_plan',
+      'usage_limit',
+      {
+        metric: 'storage',
+        metric_percent: 51,
+        percent: {
+          total_percent: 51,
+          mau_percent: 20,
+          bandwidth_percent: 0,
+          storage_percent: 51,
+          build_time_percent: 0,
+        },
+        threshold: 50,
+      },
+      'org-123',
+      'org-123',
+      '0 0 1 * *',
+      expect.anything(),
+    )
+    expect(sendEventToTrackingMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: 'usage',
+        event: 'User is at 50% of plan usage',
+        tags: {
+          metric: 'storage',
+          metric_percent: '51',
+          threshold: '50',
+        },
       }),
     )
   })


### PR DESCRIPTION
## Summary (AI generated)

- Normalize plan usage alerts from the per-metric percentages instead of trusting a separate aggregate `total_percent`.
- Include the metric, metric percentage, and threshold in usage-limit notification metadata and tracking tags.
- Add regression coverage for stale aggregate usage and metric-specific alert payloads.

## Motivation (AI generated)

A customer saw a 50% plan-usage warning while comparing it to MAU shown as 405 of 2000. The active Solo MAU limit is already sourced from the `plans` table at 2000, but the alert path could still rely on an aggregate value that is less explicit than the underlying metric percentages. Computing the alert threshold from the metric percentages makes the trigger source deterministic and exposes which resource actually crossed the threshold.

## Business Impact (AI generated)

This reduces confusing billing and usage warnings for customers, especially after plan limit changes. Clearer threshold metadata should lower support load and help customers understand whether MAU, bandwidth, storage, or build time caused an alert.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bunx vitest run tests/plans-onboarding-reminder.unit.test.ts`
- [x] `bunx eslint tests/plans-onboarding-reminder.unit.test.ts`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan usage alerts now trigger based on the highest-usage resource (e.g., storage, bandwidth, MAU) and include metric name, metric percent, percent details, and crossed threshold in notifications.

* **Bug Fixes**
  * Prevented false-positive alerts by normalizing usage percent from the highest metric before deciding alerts and persisting plan status.

* **Tests**
  * Updated onboarding reminder tests, tightened tracking assertions, and added tests verifying metric-specific alerting and one-time notification/tracking behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2272)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->