### PR TITLE
[codex] fix(db): drop redundant channel_devices constraint

### DIFF
--- a/supabase/migrations/20260515170516_drop_redundant_channel_devices_unique_constraint.sql
+++ b/supabase/migrations/20260515170516_drop_redundant_channel_devices_unique_constraint.sql
@@ -1,0 +1,4 @@
+-- channel_devices_app_id_device_id_key already enforces one device per app.
+-- Keep channel_devices_device_id_idx for device_id-only lookup paths.
+ALTER TABLE "public"."channel_devices"
+  DROP CONSTRAINT IF EXISTS "unique_device_app";


### PR DESCRIPTION
## Summary (AI generated)

- Drop the redundant `unique_device_app` unique constraint on `public.channel_devices`.
- Keep `channel_devices_app_id_device_id_key` for `(app_id, device_id)` uniqueness and `channel_devices_device_id_idx` for device lookup paths.

## Motivation (AI generated)

`unique_device_app` enforces the same device/app uniqueness as `channel_devices_app_id_device_id_key` with reversed column order. Since `channel_devices_device_id_idx` already supports `device_id` lookup plans, the reversed unique constraint adds index size and write overhead without adding useful enforcement or planning coverage.

## Business Impact (AI generated)

This reduces database index bloat and write amplification on `channel_devices`, reclaiming storage and lowering maintenance overhead on insert/update paths without changing product behavior.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] Pre-commit hook ran `bun run cli:build` and `vue-tsc --noEmit`
- [x] Started isolated local Supabase stack and applied all migrations, including this new migration
- [x] Confirmed local catalog keeps `channel_devices_app_id_device_id_key` and `channel_devices_device_id_idx`, and removes `unique_device_app`

## Screenshots (AI generated)

Not applicable; database migration only.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint` where applicable. This migration does not touch backend TypeScript; `bun lint` was run.
- [x] My change does not require a documentation update.
- [x] E2E test coverage is not applicable for this index-only database cleanup.
- [x] I have tested the migration manually with the local Supabase stack.

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant database constraints to improve schema consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2273)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->