### PR TITLE
[codex] fix CLI warnings for app-scoped API keys

### DIFF
--- a/supabase/migrations/20260516151507_fix_cli_warnings_app_scoped_apikeys.sql
+++ b/supabase/migrations/20260516151507_fix_cli_warnings_app_scoped_apikeys.sql
@@ -1,0 +1,90 @@
+-- App-scoped API keys are allowed to upload only when every permission check is
+-- evaluated with an app context. Existing CLIs call this warning RPC with only
+-- the org id, so bridge that org-level warning check through one allowed app in
+-- the same org when the request key has limited_to_apps.
+
+CREATE OR REPLACE FUNCTION public.get_organization_cli_warnings(
+    orgid uuid,
+    cli_version text
+) RETURNS jsonb []
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    messages jsonb[] := ARRAY[]::jsonb[];
+    request_apikey text;
+    api_key public.apikeys%ROWTYPE;
+    fallback_app_id text;
+    has_org_read boolean;
+BEGIN
+    PERFORM cli_version;
+
+    has_org_read := public.cli_check_permission(
+        permission_key := public.rbac_perm_org_read(),
+        org_id := orgid
+    );
+
+    IF NOT has_org_read THEN
+        SELECT public.get_apikey_header() INTO request_apikey;
+
+        IF request_apikey IS NOT NULL AND request_apikey <> '' THEN
+            SELECT * INTO api_key
+            FROM public.find_apikey_by_value(request_apikey)
+            LIMIT 1;
+
+            IF api_key.id IS NOT NULL
+                AND COALESCE(array_length(api_key.limited_to_apps, 1), 0) > 0
+            THEN
+                SELECT public.apps.app_id INTO fallback_app_id
+                FROM public.apps
+                WHERE public.apps.owner_org = orgid
+                    AND public.apps.app_id = ANY(api_key.limited_to_apps)
+                ORDER BY public.apps.app_id
+                LIMIT 1;
+
+                IF fallback_app_id IS NOT NULL THEN
+                    has_org_read := public.cli_check_permission(
+                        permission_key := public.rbac_perm_org_read(),
+                        org_id := orgid,
+                        app_id := fallback_app_id
+                    );
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+
+    IF NOT has_org_read THEN
+        messages := array_append(messages, jsonb_build_object(
+            'message', 'API key does not have read access to this organization',
+            'fatal', true
+        ));
+        RETURN messages;
+    END IF;
+
+    IF (
+        public.is_paying_and_good_plan_org_action(orgid, ARRAY['mau']::public.action_type[]) = true
+        AND public.is_paying_and_good_plan_org_action(orgid, ARRAY['bandwidth']::public.action_type[]) = true
+        AND public.is_paying_and_good_plan_org_action(orgid, ARRAY['storage']::public.action_type[]) = false
+    ) THEN
+        messages := array_append(messages, jsonb_build_object(
+            'message', 'You have exceeded your storage limit.\nUpload will fail, but you can still download your data.\nMAU and bandwidth limits are not exceeded.\nIn order to upload your plan, please upgrade your plan here: https://console.capgo.app/settings/plans.',
+            'fatal', true
+        ));
+    END IF;
+
+    RETURN messages;
+END;
+$$;
+
+ALTER FUNCTION public.get_organization_cli_warnings(uuid, text)
+OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.get_organization_cli_warnings(uuid, text)
+FROM public;
+GRANT EXECUTE ON FUNCTION public.get_organization_cli_warnings(uuid, text)
+TO anon;
+GRANT EXECUTE ON FUNCTION public.get_organization_cli_warnings(uuid, text)
+TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_organization_cli_warnings(uuid, text)
+TO service_role;

--- a/supabase/tests/20_test_org_management_functions.sql
+++ b/supabase/tests/20_test_org_management_functions.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 
-SELECT plan(49);
+SELECT plan(51);
 
 -- Test accept_invitation_to_org (user is already a member, so should return INVALID_ROLE)
 SELECT tests.authenticate_as('test_user');
@@ -528,6 +528,8 @@ DECLARE
     v_user_id uuid;
     v_apikey_rbac_id uuid;
     v_org_member_role_id uuid;
+    v_app_uploader_role_id uuid;
+    v_demoadmin_app_uuid uuid;
 BEGIN
     SELECT user_id INTO v_user_id FROM public.apikeys
     WHERE key = '67eeaff4-ae4c-49a6-8eb1-0875f5369de1';
@@ -545,6 +547,84 @@ BEGIN
     SELECT id INTO v_org_member_role_id
     FROM public.roles
     WHERE name = public.rbac_role_org_member();
+
+    SELECT id INTO v_app_uploader_role_id
+    FROM public.roles
+    WHERE name = public.rbac_role_app_uploader();
+
+    SELECT id INTO v_demoadmin_app_uuid
+    FROM public.apps
+    WHERE app_id = 'com.demoadmin.app';
+
+    INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, granted_by
+    )
+    VALUES (
+        'apikey',
+        v_apikey_rbac_id,
+        v_org_member_role_id,
+        'org',
+        '22dbad8a-b885-4309-9b3b-a09f8460fb6d',
+        v_user_id
+    );
+
+    -- App-scoped RBAC v2 key with org_member + app_uploader bindings. This
+    -- mirrors the org API key UI when an API key is limited to one app.
+    INSERT INTO public.apikeys (
+        id, user_id, key, mode, name, limited_to_orgs, limited_to_apps
+    )
+    VALUES (
+        99020004,
+        v_user_id,
+        'rbac-v2-cli-warnings-test-key-app-scoped',
+        NULL,
+        'rbac-v2-cli-warnings-test-app-scoped',
+        ARRAY['22dbad8a-b885-4309-9b3b-a09f8460fb6d'::uuid],
+        ARRAY['com.demoadmin.app']
+    )
+    RETURNING rbac_id INTO v_apikey_rbac_id;
+
+    INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, granted_by
+    )
+    VALUES (
+        'apikey',
+        v_apikey_rbac_id,
+        v_org_member_role_id,
+        'org',
+        '22dbad8a-b885-4309-9b3b-a09f8460fb6d',
+        v_user_id
+    );
+
+    INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, app_id,
+        granted_by
+    )
+    VALUES (
+        'apikey',
+        v_apikey_rbac_id,
+        v_app_uploader_role_id,
+        'app',
+        '22dbad8a-b885-4309-9b3b-a09f8460fb6d',
+        v_demoadmin_app_uuid,
+        v_user_id
+    );
+
+    -- App-scoped key whose only limited app belongs to another org. The fallback
+    -- must not turn this into org read access for the requested org.
+    INSERT INTO public.apikeys (
+        id, user_id, key, mode, name, limited_to_orgs, limited_to_apps
+    )
+    VALUES (
+        99020005,
+        v_user_id,
+        'rbac-v2-cli-warnings-test-key-app-scoped-away',
+        NULL,
+        'rbac-v2-cli-warnings-test-app-scoped-away',
+        ARRAY['22dbad8a-b885-4309-9b3b-a09f8460fb6d'::uuid],
+        ARRAY['com.demo.app']
+    )
+    RETURNING rbac_id INTO v_apikey_rbac_id;
 
     INSERT INTO public.role_bindings (
         principal_type, principal_id, role_id, scope_type, org_id, granted_by
@@ -615,6 +695,49 @@ SELECT ok(
         WHERE msg->>'message' = 'API key does not have read access to this organization'
     ),
     'get_organization_cli_warnings RBAC v2 - NULL-mode key with org.read binding has no fatal no-read-access warning'
+);
+
+-- Case A2: RBAC v2 key limited to this org and app - expect NO fatal warning.
+-- Existing CLIs call this RPC with only org id, so the function must bridge the
+-- org-read warning check through one allowed app in that org.
+SELECT set_config(
+    'request.headers',
+    '{"capgkey": "rbac-v2-cli-warnings-test-key-app-scoped"}',
+    TRUE
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1
+        FROM unnest(
+            get_organization_cli_warnings(
+                '22dbad8a-b885-4309-9b3b-a09f8460fb6d', '1.0.0'
+            )
+        ) AS msg
+        WHERE msg->>'message' = 'API key does not have read access to this organization'
+    ),
+    'get_organization_cli_warnings RBAC v2 - app-scoped key for this org passes'
+);
+
+-- Case A3: RBAC v2 key limited to an app outside this org - expect fatal.
+SELECT set_config(
+    'request.headers',
+    '{"capgkey": "rbac-v2-cli-warnings-test-key-app-scoped-away"}',
+    TRUE
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM unnest(
+            get_organization_cli_warnings(
+                '22dbad8a-b885-4309-9b3b-a09f8460fb6d', '1.0.0'
+            )
+        ) AS msg
+        WHERE msg->>'message' = 'API key does not have read access to this organization'
+          AND (msg->>'fatal')::boolean = true
+    ),
+    'get_organization_cli_warnings RBAC v2 - app-scoped key outside org fails'
 );
 
 -- Case B: RBAC v2 key WITHOUT a binding for this org — expect the fatal warning


### PR DESCRIPTION
## Summary (AI generated)

- Added a database migration that lets `get_organization_cli_warnings` validate app-scoped API keys through an allowed app in the requested org.
- Added pgTAP regression coverage for app-scoped RBAC v2 keys that should pass and app-scoped keys outside the org that should still fail.

## Motivation (AI generated)

CLI uploads were failing during the warning preflight with `API key does not have read access to this organization` when a customer used a key limited to both an org and a specific app. The warning RPC checked org read without app context, so `limited_to_apps` blocked valid upload keys before the upload permission path ran.

## Business Impact (AI generated)

This restores secure scoped API-key uploads for paid customers with multiple apps, avoiding the need to use unrestricted keys in CI/CD and reducing support load around CLI upload failures.

## Test Plan (AI generated)

- [x] `bunx sqlfluff lint --dialect postgres supabase/migrations/20260516151507_fix_cli_warnings_app_scoped_apikeys.sql`
- [x] `bun scripts/supabase-worktree.ts test db supabase/tests/00-supabase_test_helpers.sql supabase/tests/20_test_org_management_functions.sql`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI permission validation for app-scoped API keys to properly check organization access.
  * Enhanced warning messages for storage limit scenarios, providing clearer guidance on upload restrictions and upgrade recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->