### PR TITLE
[codex] remove channel preview eye button

### DIFF
--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -10,7 +10,6 @@ import { toast } from 'vue-sonner'
 import IconCopy from '~icons/heroicons/clipboard-document-check'
 import IconCode from '~icons/heroicons/code-bracket'
 import Settings from '~icons/heroicons/cog-8-tooth'
-import IconEye from '~icons/heroicons/eye'
 import IconInformation from '~icons/heroicons/information-circle'
 import IconSearch from '~icons/ic/round-search?raw'
 import IconAlertCircle from '~icons/lucide/alert-circle'
@@ -83,12 +82,6 @@ function openBundle() {
   if (channel.value.version.name === 'unknown')
     return
   router.push(`/app/${route.params.app}/bundle/${channel.value.version.id}`)
-}
-
-function openPreview() {
-  if (!channel.value)
-    return
-  router.push(`/app/${route.params.app}/channel/${id.value}/preview`)
 }
 
 async function getChannel(force = false) {
@@ -672,15 +665,6 @@ async function copyCurlCommand() {
             <InfoRow :label="t('bundle-number')" :is-link="channel && !isInternalVersionName((channel.version.name))">
               <div class="flex items-center gap-2">
                 <span class="cursor-pointer" @click="openBundle()">{{ channel.version.name }}</span>
-                <button
-                  v-if="channel"
-                  class="border border-gray-200 dark:border-gray-700 d-btn d-btn-ghost d-btn-square d-btn-sm"
-                  :title="t('preview')"
-                  :aria-label="t('preview')"
-                  @click="openPreview()"
-                >
-                  <IconEye class="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                </button>
                 <button
                   v-if="channel"
                   class="p-1 transition-colors border border-gray-200 rounded-md dark:border-gray-700 hover:bg-gray-50 hover:border-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:border-gray-200 dark:disabled:hover:border-gray-700"


### PR DESCRIPTION
## Summary (AI generated)

- Removed the preview eye button shown next to the channel bundle number.
- Removed the now-unused preview handler and icon import from the channel detail page.

## Motivation (AI generated)

The channel detail page should not expose a preview eye action beside the bundle/build number.

## Business Impact (AI generated)

This keeps the console UI aligned with the expected channel management workflow and removes a confusing control from a high-traffic app settings page.

## Test Plan (AI generated)

- [x] Ran `bun lint`.
- [x] Commit hook ran `bun run cli:build` and `vue-tsc --noEmit`.

## Screenshots (AI generated)

Not included. This is a small removal of one icon button from the channel detail row.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes the relevant frontend lint check.
- [x] My change does not require a change to the documentation.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings button to select and manage bundle versions, with access controlled by user permissions.

* **Changes**
  * Removed preview navigation action from bundle number display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->