### PR TITLE
feat(cli): default credentials manage export to a combined .env file

### DIFF
--- a/cli/src/build/credentials-manage.ts
+++ b/cli/src/build/credentials-manage.ts
@@ -34,6 +34,7 @@ interface ManageCredentialsOptions {
   appId?: string
   platform?: 'ios' | 'android'
   local?: boolean
+  perPlatform?: boolean
 }
 
 interface AppEntry {
@@ -460,7 +461,7 @@ export async function manageCredentialsCommand(options: ManageCredentialsOptions
         }
       }
       else if (action === 'export') {
-        const exported = await exportToEnvFile(currentEntry)
+        const exported = await exportToEnvFile(currentEntry, options.perPlatform === true)
         if (!exported)
           pLog.warn('Export cancelled.')
       }
@@ -632,7 +633,7 @@ async function pickAction(entry: AppEntry, canGoBack: boolean, extraIntro?: stri
       '',
       'View    — flat list of every credential across platforms (show, decode, copy, edit, explain, remove).',
       'Add…    — add a new platform via onboarding, or add a configuration option.',
-      'Export  — write a .env file ready for CI/CD secrets (asks which platform if both are configured).',
+      'Export  — write a .env file ready for CI/CD secrets (combined across platforms by default; pass --per-platform for separate files).',
       'Delete  — wipe all credentials for one platform (asks which if both are configured).',
     ],
     statusLine: canGoBack ? 'Esc = back, Ctrl+C = quit.' : 'Ctrl+C or Esc to quit.',
@@ -1169,11 +1170,17 @@ function summarizeProvisioningMap(raw: string): string {
   }
 }
 
-async function exportToEnvFile(entry: AppEntry): Promise<boolean> {
+async function exportToEnvFile(entry: AppEntry, perPlatform: boolean): Promise<boolean> {
   if (entry.platforms.length === 0) {
     pLog.warn('Nothing to export — no platforms configured for this app.')
     return false
   }
+
+  // Default for multi-platform apps: write a single combined .env file. iOS and
+  // Android env-var names are disjoint, so combining them avoids forcing the user
+  // to run `gh secret set -f` (or equivalent) once per platform.
+  if (!perPlatform && entry.platforms.length > 1)
+    return exportCombinedEnvFile(entry)
 
   const platform = await resolvePlatformChoice(entry, 'Pick which platform to export')
   if (platform === null)
@@ -1207,6 +1214,61 @@ async function exportToEnvFile(entry: AppEntry): Promise<boolean> {
   return true
 }
 
+async function exportCombinedEnvFile(entry: AppEntry): Promise<boolean> {
+  const sections: Array<{ platform: 'ios' | 'android', creds: Partial<BuildCredentials> }> = []
+  for (const platform of entry.platforms) {
+    const creds = entry.saved[platform]
+    if (creds && hasAnyValue(creds))
+      sections.push({ platform, creds })
+  }
+
+  if (sections.length === 0) {
+    pLog.warn('Nothing to export.')
+    return false
+  }
+
+  // If only one of the listed platforms actually has values, fall back to the
+  // per-platform file name so the user isn't surprised by a generic name.
+  if (sections.length === 1) {
+    const { platform, creds } = sections[0]
+    const defaultName = `.env.capgo.${entry.appId}.${platform}`
+    const target = await resolveExportTarget(entry, platform, defaultName)
+    if (target === null) {
+      pLog.info('✗ Export cancelled.')
+      return false
+    }
+    const content = renderEnvFile(entry, platform, creds)
+    await writeFile(target.path, content, { mode: 0o600 })
+    await chmod(target.path, 0o600)
+    const fieldCount = Object.values(creds).filter(v => typeof v === 'string' && v.length > 0).length
+    pLog.success(`✓ Exported ${fieldCount} field${fieldCount === 1 ? '' : 's'} → ${target.path} (mode 0600).`)
+    pLog.info('Add it to .gitignore — never commit this file.')
+    pLog.info('Reference: https://capgo.app/docs/cli/cloud-build/')
+    return true
+  }
+
+  const defaultName = `.env.capgo.${entry.appId}`
+  const target = await resolveExportTarget(entry, 'combined', defaultName)
+  if (target === null) {
+    pLog.info('✗ Export cancelled.')
+    return false
+  }
+
+  const content = renderEnvFileCombined(entry, sections)
+  await writeFile(target.path, content, { mode: 0o600 })
+  await chmod(target.path, 0o600)
+
+  const totalFields = sections.reduce(
+    (sum, { creds }) => sum + Object.values(creds).filter(v => typeof v === 'string' && v.length > 0).length,
+    0,
+  )
+  const platformList = sections.map(s => s.platform).join(' + ')
+  pLog.success(`✓ Exported ${totalFields} fields (${platformList}) → ${target.path} (mode 0600).`)
+  pLog.info('Add it to .gitignore — never commit this file.')
+  pLog.info('Reference: https://capgo.app/docs/cli/cloud-build/')
+  return true
+}
+
 async function resolvePlatformChoice(entry: AppEntry, message: string): Promise<'ios' | 'android' | null> {
   if (entry.platforms.length === 1)
     return entry.platforms[0]
@@ -1227,10 +1289,10 @@ interface ExportTarget {
   path: string
 }
 
-async function resolveExportTarget(entry: AppEntry, platform: 'ios' | 'android', defaultName: string): Promise<ExportTarget | null> {
+async function resolveExportTarget(entry: AppEntry, label: 'ios' | 'android' | 'combined', defaultName: string): Promise<ExportTarget | null> {
   if (canUseFilePicker()) {
     const picked = await openSaveFilePicker({
-      prompt: `Save Capgo .env for ${entry.appId} (${platform})`,
+      prompt: `Save Capgo .env for ${entry.appId} (${label})`,
       defaultName,
       defaultLocation: cwd(),
     })
@@ -1300,6 +1362,48 @@ function renderEnvFile(entry: AppEntry, platform: 'ios' | 'android', creds: Part
     lines.push('# Provisioning map — base64 form is preferred to avoid newline/quoting issues in CI.')
     lines.push(`CAPGO_IOS_PROVISIONING_MAP_BASE64=${base64}`)
     lines.push(`# CAPGO_IOS_PROVISIONING_MAP=${escapeDotenvValue(provisioningMapRaw)}`)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+function renderEnvFileCombined(
+  entry: AppEntry,
+  sections: Array<{ platform: 'ios' | 'android', creds: Partial<BuildCredentials> }>,
+): string {
+  const lines: string[] = []
+  const generated = new Date().toISOString()
+  const platformList = sections.map(s => s.platform).join(', ')
+  lines.push('# Capgo build credentials — CI/CD environment file')
+  lines.push(`# App: ${entry.appId}`)
+  lines.push(`# Platforms: ${platformList}`)
+  lines.push(`# Source: ${entry.local ? 'local' : 'global'} credentials store`)
+  lines.push(`# Generated: ${generated}`)
+  lines.push('#')
+  lines.push('# Paste these into your CI/CD provider as secrets, or source the file locally:')
+  lines.push('#   set -a; . ./this-file; set +a')
+  lines.push('#')
+  lines.push('# DO NOT commit this file. Add to .gitignore: .env.capgo.*')
+
+  for (const { platform, creds } of sections) {
+    lines.push('')
+    lines.push(`# === ${platform.toUpperCase()} ===`)
+    const provisioningMapRaw = creds.CAPGO_IOS_PROVISIONING_MAP
+    for (const [key, value] of Object.entries(creds)) {
+      if (typeof value !== 'string' || value.length === 0)
+        continue
+      if (key === 'CAPGO_IOS_PROVISIONING_MAP')
+        continue
+      lines.push(`${key}=${escapeDotenvValue(value)}`)
+    }
+    if (provisioningMapRaw) {
+      const base64 = Buffer.from(provisioningMapRaw, 'utf-8').toString('base64')
+      lines.push('')
+      lines.push('# Provisioning map — base64 form is preferred to avoid newline/quoting issues in CI.')
+      lines.push(`CAPGO_IOS_PROVISIONING_MAP_BASE64=${base64}`)
+      lines.push(`# CAPGO_IOS_PROVISIONING_MAP=${escapeDotenvValue(provisioningMapRaw)}`)
+    }
   }
 
   lines.push('')

--- a/cli/src/build/credentials-manage.ts
+++ b/cli/src/build/credentials-manage.ts
@@ -34,7 +34,6 @@ interface ManageCredentialsOptions {
   appId?: string
   platform?: 'ios' | 'android'
   local?: boolean
-  perPlatform?: boolean
 }
 
 interface AppEntry {
@@ -461,7 +460,7 @@ export async function manageCredentialsCommand(options: ManageCredentialsOptions
         }
       }
       else if (action === 'export') {
-        const exported = await exportToEnvFile(currentEntry, options.perPlatform === true)
+        const exported = await exportToEnvFile(currentEntry)
         if (!exported)
           pLog.warn('Export cancelled.')
       }
@@ -633,7 +632,7 @@ async function pickAction(entry: AppEntry, canGoBack: boolean, extraIntro?: stri
       '',
       'View    — flat list of every credential across platforms (show, decode, copy, edit, explain, remove).',
       'Add…    — add a new platform via onboarding, or add a configuration option.',
-      'Export  — write a .env file ready for CI/CD secrets (combined across platforms by default; pass --per-platform for separate files).',
+      'Export  — write a .env file ready for CI/CD secrets (combined across platforms; pass --platform to scope to one).',
       'Delete  — wipe all credentials for one platform (asks which if both are configured).',
     ],
     statusLine: canGoBack ? 'Esc = back, Ctrl+C = quit.' : 'Ctrl+C or Esc to quit.',
@@ -1170,22 +1169,21 @@ function summarizeProvisioningMap(raw: string): string {
   }
 }
 
-async function exportToEnvFile(entry: AppEntry, perPlatform: boolean): Promise<boolean> {
+async function exportToEnvFile(entry: AppEntry): Promise<boolean> {
   if (entry.platforms.length === 0) {
     pLog.warn('Nothing to export — no platforms configured for this app.')
     return false
   }
 
-  // Default for multi-platform apps: write a single combined .env file. iOS and
+  // When both platforms are in scope, write a single combined .env file. iOS and
   // Android env-var names are disjoint, so combining them avoids forcing the user
-  // to run `gh secret set -f` (or equivalent) once per platform.
-  if (!perPlatform && entry.platforms.length > 1)
+  // to run `gh secret set -f` (or equivalent) once per platform. Callers that
+  // want a single platform's file pass `--platform ios` (or android) at the
+  // manage command, which narrows the entry to one platform upstream.
+  if (entry.platforms.length > 1)
     return exportCombinedEnvFile(entry)
 
-  const platform = await resolvePlatformChoice(entry, 'Pick which platform to export')
-  if (platform === null)
-    return false
-
+  const platform = entry.platforms[0]
   const creds = entry.saved[platform]
   if (!creds || !hasAnyValue(creds)) {
     pLog.warn('Nothing to export.')

--- a/cli/src/build/credentials-manage.ts
+++ b/cli/src/build/credentials-manage.ts
@@ -1245,6 +1245,30 @@ async function exportCombinedEnvFile(entry: AppEntry): Promise<boolean> {
     return true
   }
 
+  // The manager allows the same key to be stored under both platforms (the View
+  // screen tags these as [SHARED]), and the stored values can drift. When the
+  // combined file gets ingested by `gh secret set -f`, shell sourcing, or any
+  // other dotenv consumer, the LAST occurrence wins — so a drifted key silently
+  // produces wrong CI behaviour for at least one platform. Detect and surface.
+  const conflicts = findCombinedExportConflicts(sections)
+  if (conflicts.length > 0) {
+    pLog.warn(`⚠️  ${conflicts.length} key${conflicts.length === 1 ? '' : 's'} differ across platforms — dotenv ingestion keeps only the LAST value per key, so at least one platform will get the wrong setting:`)
+    for (const { key, occurrences } of conflicts) {
+      const summary = occurrences.map(o => `${o.platform}=${maskConflictValue(o.value)}`).join(', ')
+      pLog.warn(`  • ${key}: ${summary}`)
+    }
+    pLog.info('Fix: cancel and re-export per-platform (`--platform ios`, then `--platform android`), or reconcile the values in the View screen first.')
+
+    const proceed = await pConfirm({
+      message: 'Write the combined file anyway?',
+      initialValue: false,
+    })
+    if (pIsCancel(proceed) || !proceed) {
+      pLog.info('✗ Export cancelled.')
+      return false
+    }
+  }
+
   const defaultName = `.env.capgo.${entry.appId}`
   const target = await resolveExportTarget(entry, 'combined', defaultName)
   if (target === null) {
@@ -1252,7 +1276,7 @@ async function exportCombinedEnvFile(entry: AppEntry): Promise<boolean> {
     return false
   }
 
-  const content = renderEnvFileCombined(entry, sections)
+  const content = renderEnvFileCombined(entry, sections, conflicts)
   await writeFile(target.path, content, { mode: 0o600 })
   await chmod(target.path, 0o600)
 
@@ -1265,6 +1289,44 @@ async function exportCombinedEnvFile(entry: AppEntry): Promise<boolean> {
   pLog.info('Add it to .gitignore — never commit this file.')
   pLog.info('Reference: https://capgo.app/docs/cli/cloud-build/')
   return true
+}
+
+interface CombinedKeyConflict {
+  key: string
+  occurrences: Array<{ platform: 'ios' | 'android', value: string }>
+}
+
+function findCombinedExportConflicts(
+  sections: Array<{ platform: 'ios' | 'android', creds: Partial<BuildCredentials> }>,
+): CombinedKeyConflict[] {
+  if (sections.length < 2)
+    return []
+  const occurrencesByKey = new Map<string, Array<{ platform: 'ios' | 'android', value: string }>>()
+  for (const { platform, creds } of sections) {
+    for (const [key, value] of Object.entries(creds)) {
+      if (typeof value !== 'string' || value.length === 0)
+        continue
+      const list = occurrencesByKey.get(key) ?? []
+      list.push({ platform, value })
+      occurrencesByKey.set(key, list)
+    }
+  }
+  const conflicts: CombinedKeyConflict[] = []
+  for (const [key, occurrences] of occurrencesByKey) {
+    if (occurrences.length < 2)
+      continue
+    const distinctValues = new Set(occurrences.map(o => o.value))
+    if (distinctValues.size > 1)
+      conflicts.push({ key, occurrences })
+  }
+  return conflicts
+}
+
+// Conflicting values are usually short config toggles (booleans, retention
+// strings) where the actual value is what the user needs to see to decide.
+// Mask anything long enough to plausibly be a secret instead.
+function maskConflictValue(value: string): string {
+  return value.length <= 32 ? value : `(${value.length} chars)`
 }
 
 async function resolvePlatformChoice(entry: AppEntry, message: string): Promise<'ios' | 'android' | null> {
@@ -1369,6 +1431,7 @@ function renderEnvFile(entry: AppEntry, platform: 'ios' | 'android', creds: Part
 function renderEnvFileCombined(
   entry: AppEntry,
   sections: Array<{ platform: 'ios' | 'android', creds: Partial<BuildCredentials> }>,
+  conflicts: CombinedKeyConflict[] = [],
 ): string {
   const lines: string[] = []
   const generated = new Date().toISOString()
@@ -1383,6 +1446,14 @@ function renderEnvFileCombined(
   lines.push('#   set -a; . ./this-file; set +a')
   lines.push('#')
   lines.push('# DO NOT commit this file. Add to .gitignore: .env.capgo.*')
+  if (conflicts.length > 0) {
+    lines.push('#')
+    lines.push('# ⚠️  CONFLICTING KEYS: the following appear in multiple platform sections')
+    lines.push('# with different values. Dotenv ingestion (gh secret set -f, shell sourcing)')
+    lines.push('# keeps only the LAST occurrence per key — re-export per-platform to preserve both.')
+    for (const { key, occurrences } of conflicts)
+      lines.push(`#   ${key} (${occurrences.map(o => o.platform).join(' & ')})`)
+  }
 
   for (const { platform, creds } of sections) {
     lines.push('')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -988,13 +988,11 @@ Examples:
   npx @capgo/cli build credentials manage
   npx @capgo/cli build credentials manage --appId com.example.app
   npx @capgo/cli build credentials manage --appId com.example.app --platform ios
-  npx @capgo/cli build credentials manage --local
-  npx @capgo/cli build credentials manage --per-platform`)
+  npx @capgo/cli build credentials manage --local`)
   .action(manageCredentialsCommand)
   .option('--appId <appId>', 'App ID to manage (optional, prompts to pick if omitted)')
   .option('--platform <platform>', 'Platform to manage: ios or android (optional, prompts to pick if omitted)')
   .option('--local', 'Only browse local .capgo-credentials.json')
-  .option('--per-platform', 'When exporting to .env, write one file per platform instead of a single combined file (default: combined when both platforms are configured)')
 
 buildCredentials
   .command('migrate')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -988,11 +988,13 @@ Examples:
   npx @capgo/cli build credentials manage
   npx @capgo/cli build credentials manage --appId com.example.app
   npx @capgo/cli build credentials manage --appId com.example.app --platform ios
-  npx @capgo/cli build credentials manage --local`)
+  npx @capgo/cli build credentials manage --local
+  npx @capgo/cli build credentials manage --per-platform`)
   .action(manageCredentialsCommand)
   .option('--appId <appId>', 'App ID to manage (optional, prompts to pick if omitted)')
   .option('--platform <platform>', 'Platform to manage: ios or android (optional, prompts to pick if omitted)')
   .option('--local', 'Only browse local .capgo-credentials.json')
+  .option('--per-platform', 'When exporting to .env, write one file per platform instead of a single combined file (default: combined when both platforms are configured)')
 
 buildCredentials
   .command('migrate')


### PR DESCRIPTION
## Summary

- `build credentials manage` → **Export to .env** now writes a single `.env.capgo.<appId>` file containing both iOS and Android secrets when both platforms are configured.
- iOS and Android env-var names are disjoint, so combining is conflict-free and removes the need to run `gh secret set -f` (or equivalent) twice in CI setup.
- Want a single-platform file? Use the existing `--platform ios` (or `--platform android`) to narrow the manage scope upstream — the export naturally becomes per-platform.
- **Drift-safe**: shared config keys (`BUILD_OUTPUT_UPLOAD_ENABLED`, `BUILD_OUTPUT_RETENTION_SECONDS`, `SKIP_BUILD_NUMBER_BUMP`, `CAPGO_IOS_DISTRIBUTION`, etc.) can be stored under both platforms and are allowed to diverge. Before writing the combined file, the manager detects any such conflicts, prints them, requires explicit confirmation, and embeds the conflict list as a comment block at the top of the file so future readers can spot it.

## Why

The previous behaviour forced users to pick **Export to .env** twice (once per platform) when configuring CI/CD secrets for an app with both iOS and Android builds. That extra step is invisible from the docs side and confusing in the TUI ("why do I have to do this twice?"). Combining into one file matches the natural `gh secret set -f <env-file>` workflow and gets users from "I have credentials configured locally" to "GitHub Actions can build" in fewer steps.

## File format

```
# Capgo build credentials — CI/CD environment file
# App: com.example.app
# Platforms: ios, android
# Source: global credentials store
# Generated: 2026-05-18T...
#
# Paste these into your CI/CD provider as secrets, or source the file locally:
#   set -a; . ./this-file; set +a
#
# DO NOT commit this file. Add to .gitignore: .env.capgo.*
#
# ⚠️  CONFLICTING KEYS: the following appear in multiple platform sections      # (only present if drift was detected and the user confirmed the write)
# with different values. Dotenv ingestion (gh secret set -f, shell sourcing)
# keeps only the LAST occurrence per key — re-export per-platform to preserve both.
#   BUILD_OUTPUT_RETENTION_SECONDS (ios & android)

# === IOS ===
BUILD_CERTIFICATE_BASE64=...
P12_PASSWORD=...
APPLE_KEY_ID=...
CAPGO_IOS_PROVISIONING_MAP_BASE64=...

# === ANDROID ===
ANDROID_KEYSTORE_FILE=...
KEYSTORE_KEY_ALIAS=...
```

## Behaviour matrix

| Invocation | Both platforms configured | Only one platform configured |
|---|---|---|
| `manage` | Single combined `.env.capgo.<appId>` (warns + confirms on shared-key drift) | Per-platform `.env.capgo.<appId>.<platform>` |
| `manage --platform ios` | iOS only, `.env.capgo.<appId>.ios` | iOS only, `.env.capgo.<appId>.ios` |
| `manage --platform android` | Android only, `.env.capgo.<appId>.android` | Android only, `.env.capgo.<appId>.android` |

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds
- [x] `bun run test:credentials` — 17/17 pass
- [x] `bun run test:credentials-validation` — 13/13 pass
- [x] `node dist/index.js build credentials manage --help` shows expected flags
- [ ] Manual TUI smoke test: two-platform credentials, no drift → combined file written silently
- [ ] Manual TUI smoke test: two-platform credentials with a shared key drifted → warning + confirm prompt, comment block emitted
- [ ] Manual TUI smoke test: `--platform ios` on a two-platform app → per-platform path
- [ ] Manual TUI smoke test: single-platform credentials → degraded per-platform path

## Follow-up

Docs page at `website/src/content/docs/docs/cli/cloud-build/github-actions.mdx` will be updated to match in a separate PR on `Cap-go/website` after this ships in `@capgo/cli@latest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Export now produces a single combined .env by default for apps with multiple platforms, avoiding a platform prompt
  * If only one platform has credentials, export falls back to per-platform behavior
  * Detects conflicting keys across platforms and prompts before proceeding
  * Outputs distinct per-platform sections (including provisioning map variants) and enforces secure file permissions
  * Updated help text and export logging with platform context

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->