### PR TITLE
feat(db): add ai_analyzed flag to build_requests

### DIFF
--- a/supabase/migrations/20260518120000_add_ai_analyzed_to_build_requests.sql
+++ b/supabase/migrations/20260518120000_add_ai_analyzed_to_build_requests.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.build_requests
+  ADD COLUMN ai_analyzed BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN public.build_requests.ai_analyzed IS
+  'Set true after a successful AI analysis of this failed build. Enforces one-analysis-per-job for cost control.';


### PR DESCRIPTION
## Summary

Adds a single boolean column `ai_analyzed` (NOT NULL, DEFAULT FALSE) on `public.build_requests`. Used by the upcoming AI build analytics feature for one-analysis-per-job idempotency.

```sql
ALTER TABLE public.build_requests
  ADD COLUMN ai_analyzed BOOLEAN NOT NULL DEFAULT FALSE;
```

## Why split out

This migration was originally part of [PR #2284](https://github.com/Cap-go/capgo/pull/2284) (AI build analytics — adds CLI flag, edge function, and worker endpoint). It's split into its own PR so the DB schema change can be reviewed and applied independently from the feature code.

The feature PR will still merge after this one — the edge function in #2284 reads/writes the column, but no application code on \`main\` references it yet, so applying this migration ahead of feature code is safe.

## Safety properties

- Additive: only ADDs a column; doesn't drop, rename, or modify existing schema
- NOT NULL with DEFAULT: existing rows get \`false\` automatically — no backfill needed
- No RLS change: existing \`build_requests\` policies already restrict by org/app membership
- No code on \`main\` reads this column, so applying it before #2284 merges has no behavioral effect

## Test plan

- [ ] CI passes (\`supabase db push\` step in \`build_and_deploy.yml\` succeeds)
- [ ] Manual: verify column exists on preprod with the expected default
- [ ] After merge, [PR #2284](https://github.com/Cap-go/capgo/pull/2284) can rebase and drop its own copy of this migration file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database infrastructure to track AI analysis status for build requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->