### PR TITLE
ci: pin supabase CLI to 2.98.2 (v2.99.0 broke asset naming)

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -52,8 +52,14 @@ jobs:
         run: bun install
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2.0.0
+        # Pinned to 2.98.2 because Supabase CLI v2.99.0 (2026-05-18) ships
+        # release assets with version in the filename (supabase_2.99.0_linux_amd64.tar.gz)
+        # while setup-cli@v2.0.0 hardcodes the unversioned name
+        # (supabase_linux_amd64.tar.gz) for any version >= 1.28.0, causing 404.
+        # Revert to `latest` once setup-cli ships a fix or Supabase restores
+        # the unversioned assets. Tracking: https://github.com/supabase/setup-cli
         with:
-          version: latest
+          version: 2.98.2
       - name: Show Supabase CLI version
         run: supabase --version
       - name: Prepare Supabase


### PR DESCRIPTION
## Why this is failing

Supabase CLI **v2.99.0**, released today at 09:29Z, changed the release-asset naming back to embedding the version in the filename:

| Release | `supabase_linux_amd64.tar.gz` (unversioned) | `supabase_<ver>_linux_amd64.tar.gz` (versioned) |
|---|---|---|
| v2.99.0 (today) | ❌ missing | ✅ present |
| v2.98.2 → v2.91.0 | ✅ present | ✅ present |

The `supabase/setup-cli@v2.0.0` action hardcodes the **unversioned** name for any CLI version ≥ 1.28.0 ([source](https://github.com/supabase/setup-cli/blob/df56b21/src/main.ts#L174)):

```ts
return `.../v${version}/supabase_${platform}_${arch}.tar.gz`
```

So with `version: latest` the action requests:

```
https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz
```

which now redirects to v2.99.0 and 404s because that asset doesn't exist anymore.

This broke `capgo-12.139.0` deploy at the `Install Supabase CLI` step at 09:45Z:
https://github.com/Cap-go/capgo/actions/runs/26025913204/job/76500232864

Same break is hitting every repo on GitHub using `supabase/setup-cli@v2.0.0` + `version: latest` today.

## The fix

One-line pin: \`version: latest\` → \`version: 2.98.2\` in `.github/workflows/build_and_deploy.yml`. v2.98.2 is the most recent CLI release that still ships the unversioned asset, so the action's hardcoded URL resolves successfully.

## Revert plan

Switch back to \`version: latest\` once either:

- Supabase restores the unversioned `supabase_<platform>_<arch>.tar.gz` asset in future releases, **or**
- `supabase/setup-cli` ships a v2.0.1+ that understands the versioned-only naming.

Tracking: https://github.com/supabase/setup-cli (no open issue yet — this regression is ~1 hour old).

## Test plan

- [ ] CI passes on this PR (CodeQL etc.; doesn't exercise the workflow itself)
- [ ] After merge: the next bump → tag → `build_and_deploy.yml` deploy reaches `Apply Supabase Migrations` step and succeeds
- [ ] Unblocks PR #2285 (already-merged migration) actually landing on the DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved deployment pipeline compatibility issues by pinning the CLI version to a stable release that works reliably with the current infrastructure, preventing build timeouts and deployment failures.

* **Documentation**
  * Added detailed notes in the deployment configuration explaining why the version constraint is necessary and outlining the plan to remove it once upstream issues are resolved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->