### PR TITLE
ci: use env credentials for mobile builds

### DIFF
--- a/.github/workflows/build_mobile_android.yml
+++ b/.github/workflows/build_mobile_android.yml
@@ -42,40 +42,16 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Resolve app id
-        id: app_config
-        run: echo "app_id=$(bun -e \"import config from './capacitor.config.ts'; console.log(config.appId)\")" >> "$GITHUB_OUTPUT"
       - name: Prepare mobile project
         run: bun run build:mobile
-      - name: Save Android build credentials for Capgo CLI
+      - name: Request Android build through Capgo CLI
         env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
           ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
           PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
           KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
           KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          keystore_path="$RUNNER_TEMP/android_keystore.keystore"
-          play_config_path="$RUNNER_TEMP/serviceAccount.json"
-
-          printf '%s' "$ANDROID_KEYSTORE_FILE" | base64 --decode > "$keystore_path"
-          printf '%s' "$PLAY_CONFIG_JSON" | base64 --decode > "$play_config_path"
-
-          bunx @capgo/cli@latest build credentials save \
-            --local \
-            --appId "${{ steps.app_config.outputs.app_id }}" \
-            --platform android \
-            --keystore "$keystore_path" \
-            --keystore-alias "$KEYSTORE_KEY_ALIAS" \
-            --keystore-key-password "$KEYSTORE_KEY_PASSWORD" \
-            --keystore-store-password "$KEYSTORE_STORE_PASSWORD" \
-            --play-config "$play_config_path" \
-            --output-upload \
-            --output-retention 7d
-      - name: Request Android build through Capgo CLI
-        env:
-          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
-        run: bunx @capgo/cli@latest build request "${{ steps.app_config.outputs.app_id }}" --platform android --path . --output-upload --output-retention 7d
+          BUILD_OUTPUT_UPLOAD_ENABLED: "true"
+          BUILD_OUTPUT_RETENTION_SECONDS: "7d"
+        run: bunx @capgo/cli@latest build request --platform android --path .

--- a/.github/workflows/build_mobile_android.yml
+++ b/.github/workflows/build_mobile_android.yml
@@ -53,5 +53,5 @@ jobs:
           KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
           KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
           BUILD_OUTPUT_UPLOAD_ENABLED: "true"
-          BUILD_OUTPUT_RETENTION_SECONDS: "7d"
+          BUILD_OUTPUT_RETENTION_SECONDS: "604800"
         run: bunx @capgo/cli@latest build request --platform android --path .

--- a/.github/workflows/build_mobile_ios.yml
+++ b/.github/workflows/build_mobile_ios.yml
@@ -54,5 +54,5 @@ jobs:
           APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           BUILD_OUTPUT_UPLOAD_ENABLED: "true"
-          BUILD_OUTPUT_RETENTION_SECONDS: "7d"
+          BUILD_OUTPUT_RETENTION_SECONDS: "604800"
         run: bunx @capgo/cli@latest build request --platform ios --path .

--- a/.github/workflows/build_mobile_ios.yml
+++ b/.github/workflows/build_mobile_ios.yml
@@ -41,53 +41,18 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Resolve app id
-        id: app_config
-        run: echo "app_id=$(bun -e \"import config from './capacitor.config.ts'; console.log(config.appId)\")" >> "$GITHUB_OUTPUT"
       - name: Prepare mobile project
         run: bun run build:mobile
-      - name: Save iOS build credentials for Capgo CLI
+      - name: Request iOS build through Capgo CLI
         env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
           APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
           APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
           APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          certificate_path="$RUNNER_TEMP/build_certificate.p12"
-          provisioning_profile_path="$RUNNER_TEMP/build_profile.mobileprovision"
-          apple_key_path="$RUNNER_TEMP/AuthKey.p8"
-
-          printf '%s' "$BUILD_CERTIFICATE_BASE64" | base64 --decode > "$certificate_path"
-          printf '%s' "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode > "$provisioning_profile_path"
-          printf '%s' "$APPLE_KEY_CONTENT" | base64 --decode > "$apple_key_path"
-
-          args=(
-            build credentials save
-            --local
-            --appId "${{ steps.app_config.outputs.app_id }}"
-            --platform ios
-            --apple-team-id "$APP_STORE_CONNECT_TEAM_ID"
-            --apple-key "$apple_key_path"
-            --apple-key-id "$APPLE_KEY_ID"
-            --apple-issuer-id "$APPLE_ISSUER_ID"
-            --certificate "$certificate_path"
-            --ios-provisioning-profile "$provisioning_profile_path"
-            --output-upload
-            --output-retention 7d
-          )
-
-          if [[ -n "${P12_PASSWORD:-}" ]]; then
-            args+=(--p12-password "$P12_PASSWORD")
-          fi
-
-          bunx @capgo/cli@latest "${args[@]}"
-      - name: Request iOS build through Capgo CLI
-        env:
-          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
-        run: bunx @capgo/cli@latest build request "${{ steps.app_config.outputs.app_id }}" --platform ios --path . --output-upload --output-retention 7d
+          BUILD_OUTPUT_UPLOAD_ENABLED: "true"
+          BUILD_OUTPUT_RETENTION_SECONDS: "7d"
+        run: bunx @capgo/cli@latest build request --platform ios --path .


### PR DESCRIPTION
## Summary (AI generated)

- Remove the mobile workflow `build credentials save` steps.
- Pass Android and iOS signing credentials directly to `build request` through environment variables.
- Remove the app-id Bash helper steps and let the Capgo CLI infer the app id from the Capacitor project config.
- Keep the build request command as a single command per platform.

## Motivation (AI generated)

The iOS and Android GitHub Actions should not write local Capgo CLI build credentials in CI. The workflows should use GitHub secrets as environment variables on the build request itself, and the command should stay simple instead of running Bash helpers around it.

## Business Impact (AI generated)

This restores the manual native mobile build workflows while keeping CI credential handling simpler: signing material stays in GitHub Actions environment variables for the single build request instead of being written into local Capgo CLI credential storage.

## Test Plan (AI generated)

- [x] `bun install --frozen-lockfile`
- [x] `bun run lint:backend`
- [x] `bun lint`
- [x] Commit hook typecheck: `bun run cli:build && vue-tsc --noEmit`
- [x] Parsed both changed workflow YAML files successfully.
- [x] Confirmed no `shell: bash`, `set -euo`, app-config step references, legacy provisioning profile secret, or `build credentials` command remains in the mobile build workflows.
- [x] `git diff --check -- .github/workflows/build_mobile_android.yml .github/workflows/build_mobile_ios.yml`
- [x] Checked published `@capgo/cli@latest build request --help` for supported build request credential fields.

## Screenshots (AI generated)

Not applicable. This is a GitHub Actions workflow change.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified and consolidated Android and iOS mobile build workflows to use a single, environment-driven build request.
  * Removed local handling of resolved app identifiers and credential save steps; signing inputs are now provided directly at build time.
  * Standardized artifact upload and retention behavior via environment-configured settings for more consistent deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->