### PR TITLE
feat(cli): persist build output URL + QR via --output-record

### DIFF
--- a/cli/src/build/last-output-command.ts
+++ b/cli/src/build/last-output-command.ts
@@ -1,0 +1,79 @@
+import type { BuildOutputRecord } from './output-record'
+import { readFile } from 'node:fs/promises'
+import { exit, stdout } from 'node:process'
+import { log as clackLog } from '@clack/prompts'
+
+export interface LastOutputOptions {
+  path: string
+  field?: string
+  qr?: boolean
+}
+
+/** Allow-list of fields exposed via --field so typos surface as errors. */
+const PRINTABLE_FIELDS = new Set([
+  'schemaVersion',
+  'jobId',
+  'appId',
+  'platform',
+  'buildMode',
+  'status',
+  'outputUrl',
+  'qrCodeAscii',
+  'qrCodePngPath',
+  'finishedAt',
+])
+
+export async function lastOutputCommand(options: LastOutputOptions): Promise<void> {
+  if (!options.path) {
+    clackLog.error('--path is required.')
+    exit(1)
+  }
+
+  if (options.field !== undefined && options.qr) {
+    clackLog.error('Pass either --field or --qr, not both.')
+    exit(1)
+  }
+
+  const raw = await readFile(options.path, 'utf-8').catch((error: unknown) => {
+    clackLog.error(`Could not read ${options.path}: ${stringifyError(error)}`)
+    exit(1)
+  })
+
+  let record: BuildOutputRecord
+  try {
+    record = JSON.parse(raw) as BuildOutputRecord
+  }
+  catch (error) {
+    clackLog.error(`${options.path} is not valid JSON: ${stringifyError(error)}`)
+    exit(1)
+  }
+
+  if (record?.schemaVersion !== 1) {
+    clackLog.error(`Unsupported record schemaVersion=${String(record?.schemaVersion)} (expected 1). Re-run the build with a matching CLI to refresh the file.`)
+    exit(1)
+  }
+
+  if (options.qr) {
+    stdout.write(`${record.qrCodeAscii ?? ''}\n`)
+    return
+  }
+
+  if (options.field !== undefined) {
+    if (!PRINTABLE_FIELDS.has(options.field)) {
+      clackLog.error(`Unknown field "${options.field}". Available: ${[...PRINTABLE_FIELDS].sort().join(', ')}`)
+      exit(1)
+    }
+    const value = (record as unknown as Record<string, unknown>)[options.field]
+    stdout.write(`${value ?? ''}\n`)
+    return
+  }
+
+  // Default: dump the JSON so callers can pipe to jq.
+  stdout.write(`${JSON.stringify(record, null, 2)}\n`)
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error)
+    return error.message
+  return String(error)
+}

--- a/cli/src/build/output-record.ts
+++ b/cli/src/build/output-record.ts
@@ -42,6 +42,11 @@ export async function writeBuildOutputRecord(
   const absoluteRecordPath = resolve(cwd(), recordPath)
   const pngPath = `${absoluteRecordPath}.qr.png`
 
+  // Create the parent directory once up-front so QRCode.toFile (called before
+  // the JSON write below) does not fail with ENOENT for callers who passed
+  // --output-record under a not-yet-created directory.
+  await mkdir(dirname(absoluteRecordPath), { recursive: true })
+
   let qrCodeAscii: string | null = null
   let qrCodePngPath: string | null = null
   if (input.outputUrl) {
@@ -73,7 +78,6 @@ export async function writeBuildOutputRecord(
     finishedAt: new Date().toISOString(),
   }
 
-  await mkdir(dirname(absoluteRecordPath), { recursive: true })
   await writeFile(absoluteRecordPath, `${JSON.stringify(record, null, 2)}\n`, 'utf-8')
 
   return record

--- a/cli/src/build/output-record.ts
+++ b/cli/src/build/output-record.ts
@@ -1,0 +1,86 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { cwd } from 'node:process'
+import QRCode from 'qrcode'
+
+/** Stable shape written to disk; bump schemaVersion if breaking changes are made. */
+export interface BuildOutputRecord {
+  schemaVersion: 1
+  jobId: string
+  appId: string
+  platform: 'ios' | 'android'
+  buildMode: 'debug' | 'release'
+  status: string
+  outputUrl: string | null
+  qrCodeAscii: string | null
+  qrCodePngPath: string | null
+  finishedAt: string
+}
+
+export interface WriteBuildOutputRecordInput {
+  jobId: string
+  appId: string
+  platform: 'ios' | 'android'
+  buildMode: 'debug' | 'release'
+  status: string
+  outputUrl: string | null
+}
+
+/**
+ * Write a build-output record to `recordPath` (JSON) and, when a URL is available,
+ * a PNG QR code to `<recordPath>.qr.png`. Returns the parsed record exactly as
+ * written so callers can log a summary without re-reading the file.
+ *
+ * Failures rendering the PNG are non-fatal — the JSON is always written. The
+ * record's `qrCodePngPath` field is null when the PNG could not be produced.
+ */
+export async function writeBuildOutputRecord(
+  recordPath: string,
+  input: WriteBuildOutputRecordInput,
+  onWarn?: (msg: string) => void,
+): Promise<BuildOutputRecord> {
+  const absoluteRecordPath = resolve(cwd(), recordPath)
+  const pngPath = `${absoluteRecordPath}.qr.png`
+
+  let qrCodeAscii: string | null = null
+  let qrCodePngPath: string | null = null
+  if (input.outputUrl) {
+    try {
+      qrCodeAscii = await QRCode.toString(input.outputUrl, { type: 'utf8', errorCorrectionLevel: 'L' })
+    }
+    catch (error) {
+      onWarn?.(`Failed to render ASCII QR code: ${stringifyError(error)}`)
+    }
+    try {
+      await QRCode.toFile(pngPath, input.outputUrl, { errorCorrectionLevel: 'L', width: 512 })
+      qrCodePngPath = pngPath
+    }
+    catch (error) {
+      onWarn?.(`Failed to render PNG QR code at ${pngPath}: ${stringifyError(error)}`)
+    }
+  }
+
+  const record: BuildOutputRecord = {
+    schemaVersion: 1,
+    jobId: input.jobId,
+    appId: input.appId,
+    platform: input.platform,
+    buildMode: input.buildMode,
+    status: input.status,
+    outputUrl: input.outputUrl ?? null,
+    qrCodeAscii,
+    qrCodePngPath,
+    finishedAt: new Date().toISOString(),
+  }
+
+  await mkdir(dirname(absoluteRecordPath), { recursive: true })
+  await writeFile(absoluteRecordPath, `${JSON.stringify(record, null, 2)}\n`, 'utf-8')
+
+  return record
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error)
+    return error.message
+  return String(error)
+}

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -42,6 +42,7 @@ import pack from '../../package.json'
 import { assertCliPermission, canPromptInteractively, createSupabaseClient, findSavedKey, getConfig, getOrganizationId, sendEvent } from '../utils'
 import { mergeCredentials, MIN_OUTPUT_RETENTION_SECONDS, parseInAppUpdatePriority, parseOptionalBoolean, parseOutputRetentionSeconds } from './credentials'
 import { buildProvisioningMap } from './credentials-command'
+import { writeBuildOutputRecord } from './output-record'
 import { getPlatformDirFromCapacitorConfig } from './platform-paths'
 import { handleCustomMsg } from './qr.js'
 
@@ -1244,7 +1245,23 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
   // Track build time
   const buildStartTime = Date.now()
   const verbose = options.verbose ?? false
-  const log = logger || createDefaultLogger(silent)
+  const baseLogger = logger || createDefaultLogger(silent)
+
+  // Capture the artifact download URL from the qr_download_link custom message so
+  // we can persist it (and a derived QR PNG) when --output-record is set. We wrap
+  // the logger rather than duplicating dispatch logic so the existing print
+  // behaviour stays intact.
+  let capturedOutputUrl: string | null = null
+  const log: BuildLogger = options.outputRecord
+    ? {
+        ...baseLogger,
+        customMsg: async (kind, data) => {
+          if (kind === 'qr_download_link' && typeof data.url === 'string')
+            capturedOutputUrl = data.url
+          await baseLogger.customMsg(kind, data)
+        },
+      }
+    : baseLogger
 
   try {
     options.apikey = options.apikey || findSavedKey(silent)
@@ -1849,6 +1866,31 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       }
       else {
         log.warn(`Build finished with status: ${finalStatus}`)
+      }
+
+      if (options.outputRecord && finalStatus === 'succeeded') {
+        try {
+          const record = await writeBuildOutputRecord(
+            options.outputRecord,
+            {
+              jobId: buildRequest.job_id,
+              appId,
+              platform,
+              buildMode: (options.buildMode ?? 'release') as 'debug' | 'release',
+              status: finalStatus,
+              outputUrl: capturedOutputUrl,
+            },
+            (msg: string) => log.warn(msg),
+          )
+          log.success(`Build output record written to ${options.outputRecord}`)
+          if (!record.outputUrl)
+            log.info('ℹ️  Record contains no download URL — pass --output-upload to publish one.')
+          if (record.qrCodePngPath)
+            log.info(`ℹ️  QR code PNG written to ${record.qrCodePngPath}`)
+        }
+        catch (error) {
+          log.warn(`Failed to write build output record to ${options.outputRecord}: ${error instanceof Error ? error.message : String(error)}`)
+        }
       }
 
       // Calculate build time (in seconds with 2 decimal places, matching upload behavior)

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1837,7 +1837,10 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
           () => {
             showStatusChecks = true
           },
-          silent && !logger ? undefined : log,
+          // Force pass `log` whenever --output-record is set so the customMsg
+          // wrapper that captures the artifact URL fires even in silent mode
+          // without a user-supplied logger.
+          silent && !logger && !options.outputRecord ? undefined : log,
         )
       }
       finally {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { setApp } from './app/set'
 import { setSetting } from './app/setting'
 import { clearCredentialsCommand, listCredentialsCommand, migrateCredentialsCommand, saveCredentialsCommand, updateCredentialsCommand } from './build/credentials-command'
 import { manageCredentialsCommand } from './build/credentials-manage'
+import { lastOutputCommand } from './build/last-output-command'
 import { checkBuildNeeded } from './build/needed'
 import { onboardingBuilderCommand } from './build/onboarding/command'
 import { requestBuildCommand } from './build/request'
@@ -824,12 +825,30 @@ Example: npx @capgo/cli@latest build request com.example.app --platform ios --pa
   .option('--output-upload', 'Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials')
   .option('--no-output-upload', 'Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials')
   .option('--output-retention <duration>', 'Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials')
+  .option('--output-record <path>', 'After a successful build, write a JSON record (jobId, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt) to <path>. A PNG QR code is also written next to it as <path>.qr.png. Read fields back with `build last-output`.')
   .option('--skip-build-number-bump', 'Skip automatic build number/version code incrementing. Uses whatever version is already in the project files.')
   .option('--no-skip-build-number-bump', 'Override saved credentials to re-enable automatic build number incrementing for this build only.')
   .option('-a, --apikey <apikey>', optionDescriptions.apikey)
   .option('--supa-host <supaHost>', optionDescriptions.supaHost)
   .option('--supa-anon <supaAnon>', optionDescriptions.supaAnon)
   .option('--verbose', optionDescriptions.verbose)
+
+build
+  .command('last-output')
+  .description(`Read the build output record written by a previous \`build request --output-record\`.
+
+Prints the full JSON by default, a single field with --field, or the ASCII QR
+code with --qr. Useful in CI to grab the download URL or QR for posting back
+to a PR or issue.
+
+Examples:
+  npx @capgo/cli build last-output --path /tmp/build.json
+  npx @capgo/cli build last-output --path /tmp/build.json --field outputUrl
+  npx @capgo/cli build last-output --path /tmp/build.json --qr`)
+  .action(lastOutputCommand)
+  .option('--path <path>', 'Path to the JSON record written by --output-record (required)')
+  .option('--field <field>', 'Print a single field (one of: jobId, appId, platform, buildMode, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt, schemaVersion)')
+  .option('--qr', 'Print the rendered ASCII QR code (shortcut for --field qrCodeAscii)')
 
 const buildCredentials = build
   .command('credentials')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -757,7 +757,13 @@ const build = program
 📋 BEFORE BUILDING:
    Save your credentials first:
    npx @capgo/cli build credentials save --appId <your-app-id> --platform ios
-   npx @capgo/cli build credentials save --appId <your-app-id> --platform android`)
+   npx @capgo/cli build credentials save --appId <your-app-id> --platform android
+
+📤 CAPTURE THE OUTPUT URL FROM CI:
+   Pass --output-record to persist the download URL + QR code, then read it
+   back with \`build last-output\`:
+   npx @capgo/cli build request <appId> --platform android --output-upload --output-record /tmp/build.json
+   URL=$(npx @capgo/cli build last-output --path /tmp/build.json --field outputUrl)`)
 
 build
   .command('needed [appId]')

--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -61,6 +61,7 @@ export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   // Output control
   outputUpload: z.boolean().optional(),
   outputRetention: z.string().optional(),
+  outputRecord: z.string().optional(),
   skipBuildNumberBump: z.boolean().optional(),
   playstoreUpload: z.boolean().optional(),
   verbose: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Previously the artifact download URL and QR code arrived as a transient WebSocket message and were only printed to stdout, forcing CI users to scrape build logs with brittle regex pipelines (e.g. `tee /dev/stderr | grep -oE 'https://[^ ]+\.apk'`). This PR adds first-class persistence and retrieval.

## New flags / commands

### `build request --output-record <path>`
After a successful build, writes:
- A JSON record to `<path>` containing the full build context and artifact info.
- A PNG QR code alongside at `<path>.qr.png` (handy for inline posting on PR/issue comments and Slack).

PNG generation failures are non-fatal — the JSON is always written, with `qrCodePngPath: null` to signal the miss. When `--output-upload` is not set, the record is still written but `outputUrl` is `null` (callers can branch on it).

### `build last-output --path <file>`
Ergonomic reader. No new lookup magic — just JSON + a small printer.
- Default: prints the full JSON (pipe to `jq` if you want).
- `--field <name>`: prints a single field's value, newline-terminated. Drop-in for `URL=$(... --field outputUrl)`.
- `--qr`: shortcut for `--field qrCodeAscii`, ready to paste inside a markdown code fence.

Unknown fields and unsupported `schemaVersion` exit non-zero with a clear error.

## Record shape

```json
{
  "schemaVersion": 1,
  "jobId": "job-abc",
  "appId": "com.example.app",
  "platform": "android",
  "buildMode": "debug",
  "status": "succeeded",
  "outputUrl": "https://capgo.app/d/abc",
  "qrCodeAscii": "███ ▄▄▄ ███\n...",
  "qrCodePngPath": "/tmp/build.json.qr.png",
  "finishedAt": "2026-05-18T22:14:03.121Z"
}
```

`schemaVersion` is a literal `1` so future breaking changes can be detected by readers and fail loudly instead of misbehaving.

## CI example

```yaml
- name: Build
  env:
    CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
    # …credentials…
  run: |
    npx @capgo/cli@latest build com.example.app \
      --platform android --build-mode debug \
      --output-upload --output-record /tmp/build.json

- name: Comment on PR with build URL
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    URL=$(npx @capgo/cli build last-output --path /tmp/build.json --field outputUrl)
    if [ -n "$URL" ]; then
      gh pr comment ${{ github.event.pull_request.number }} --body "Debug build ready: $URL"
    fi
```

## Implementation notes

- The URL is captured by wrapping the existing `BuildLogger.customMsg` handler in `requestBuildInternal` rather than refactoring stream-handling internals. Existing print behaviour stays intact; the wrapper is only installed when `--output-record` is set.
- JSON + PNG live in their own module (`src/build/output-record.ts`) so the writer is reusable and easy to test in isolation later.
- The reader (`src/build/last-output-command.ts`) keeps a printable-field allow-list so typos surface as `Unknown field "..."` instead of mysteriously empty output.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds
- [x] `bun run test:credentials` — 17/17 pass
- [x] `bun run test:credentials-validation` — 13/13 pass
- [x] `bun run test:build-platform-selection` — pass
- [x] `node dist/index.js build last-output --help` shows the new flags + examples
- [x] Smoke test — `--field outputUrl` prints just the URL
- [x] Smoke test — `--qr` prints the ASCII QR
- [x] Smoke test — `--field nonexistent` errors with the allow-list listed
- [x] Smoke test — missing file errors with a clean ENOENT message
- [ ] Manual end-to-end: real build with `--output-upload --output-record /tmp/r.json`, verify JSON + PNG land and `last-output` reads them back

## Follow-up

Docs page at `apps/docs/.../cli/cloud-build/github-actions.mdx` (currently in [Cap-go/website#704](https://github.com/Cap-go/website/pull/704)) still references a regex-based "capture build URL" pattern. Once this ships, the docs PR can be updated to use `--output-record` + `build last-output` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--output-record` to save build metadata and QR codes (ASCII + PNG) after successful builds
  * Added `build last-output` to read saved records and print full JSON, an allowed single field, or an ASCII QR (`--qr`)

* **Bug Fixes / Reliability**
  * Improved option validation, error/warning messages, and resiliency when reading/writing records or generating QR PNGs

* **Documentation**
  * Updated build command docs with end-to-end usage examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->