### PR TITLE
fix(types): add delivery_version to webhooks + webhook_deliveries (main typecheck broken)

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -2776,6 +2776,7 @@ export type Database = {
           audit_log_id: number | null
           completed_at: string | null
           created_at: string
+          delivery_version: string
           duration_ms: number | null
           event_type: string
           id: string
@@ -2794,6 +2795,7 @@ export type Database = {
           audit_log_id?: number | null
           completed_at?: string | null
           created_at?: string
+          delivery_version?: string
           duration_ms?: number | null
           event_type: string
           id?: string
@@ -2812,6 +2814,7 @@ export type Database = {
           audit_log_id?: number | null
           completed_at?: string | null
           created_at?: string
+          delivery_version?: string
           duration_ms?: number | null
           event_type?: string
           id?: string
@@ -2846,6 +2849,7 @@ export type Database = {
         Row: {
           created_at: string
           created_by: string
+          delivery_version: string
           enabled: boolean
           events: string[]
           id: string
@@ -2858,6 +2862,7 @@ export type Database = {
         Insert: {
           created_at?: string
           created_by: string
+          delivery_version?: string
           enabled?: boolean
           events: string[]
           id?: string
@@ -2870,6 +2875,7 @@ export type Database = {
         Update: {
           created_at?: string
           created_by?: string
+          delivery_version?: string
           enabled?: boolean
           events?: string[]
           id?: string

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -2776,6 +2776,7 @@ export type Database = {
           audit_log_id: number | null
           completed_at: string | null
           created_at: string
+          delivery_version: string
           duration_ms: number | null
           event_type: string
           id: string
@@ -2794,6 +2795,7 @@ export type Database = {
           audit_log_id?: number | null
           completed_at?: string | null
           created_at?: string
+          delivery_version?: string
           duration_ms?: number | null
           event_type: string
           id?: string
@@ -2812,6 +2814,7 @@ export type Database = {
           audit_log_id?: number | null
           completed_at?: string | null
           created_at?: string
+          delivery_version?: string
           duration_ms?: number | null
           event_type?: string
           id?: string
@@ -2846,6 +2849,7 @@ export type Database = {
         Row: {
           created_at: string
           created_by: string
+          delivery_version: string
           enabled: boolean
           events: string[]
           id: string
@@ -2858,6 +2862,7 @@ export type Database = {
         Insert: {
           created_at?: string
           created_by: string
+          delivery_version?: string
           enabled?: boolean
           events: string[]
           id?: string
@@ -2870,6 +2875,7 @@ export type Database = {
         Update: {
           created_at?: string
           created_by?: string
+          delivery_version?: string
           enabled?: boolean
           events?: string[]
           id?: string


### PR DESCRIPTION
## Main is currently red

Run: https://github.com/Cap-go/capgo/actions/runs/26091284919/job/76718009686

```
src/components/WebhookForm.vue(36,44): error TS2339: Property 'delivery_version' does not exist on type 'Webhook'.
src/pages/settings/organization/Webhooks.vue(271,18): error TS2339: ...
supabase/functions/_backend/public/webhooks/post.ts(53,6): error TS2769: ...
supabase/functions/_backend/triggers/webhook_delivery.ts(113,70): error TS2339: ...
supabase/functions/_backend/triggers/webhook_dispatcher.ts(84,73): error TS2339: ...
supabase/functions/_backend/utils/webhook.ts(220,6): error TS2769: ...
... and more in webhooks/put.ts, webhooks/test.ts
```

## Root cause

Migration [20260518121000_standard_webhook_secrets.sql](https://github.com/Cap-go/capgo/blob/main/supabase/migrations/20260518121000_standard_webhook_secrets.sql) added `delivery_version` columns to both `webhooks` and `webhook_deliveries` tables. The webhook code (Vue components, edge functions, triggers, utils) was updated to reference these columns. But neither `supabase.types.ts` (backend nor frontend copy) was regenerated alongside the migration, so the type system doesn't know the column exists.

This broke main's typecheck. Because typecheck is part of `build_and_deploy.yml`, the consequence is downstream:

- `supabase_deploy` ✗ (typecheck failure)
- `deploy_webapp` / `deploy_files` / `deploy_api` / Plugin / Translation deploys ⏭ (all skipped)

So the AI build analytics feature that just merged in #2284 has NOT actually deployed to prod yet, and won't until typecheck is green.

## Fix

Surgical additions to both supabase.types.ts copies — `delivery_version: string` on the Row, `delivery_version?: string` on Insert + Update (it has a `DEFAULT 'legacy'` so it's optional), for both `webhooks` and `webhook_deliveries`. Same approach we used for `ai_analyzed` earlier — avoids the unrelated drift a full `supabase gen types` regen would introduce.

8 simple field additions, +12 lines / -0 lines.

## Test plan

- [x] Local typecheck passes (`bun typecheck`)
- [ ] CI typecheck passes on this branch
- [ ] After merge → next bump+tag → `build_and_deploy.yml` reaches `Apply Supabase Migrations` and downstream deploys succeed
- [ ] Confirm AI analytics feature is finally live in prod after the deploy chain completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database schema to support version tracking for webhook deliveries and webhooks, enabling better management and traceability of webhook operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->