### PR TITLE
fix(r2): abort stale multipart uploads

### DIFF
--- a/cloudflare_workers/r2/README.md
+++ b/cloudflare_workers/r2/README.md
@@ -2,7 +2,10 @@
 
 This directory stores bucket-level R2 lifecycle configuration.
 
-`lifecycle.capgo.json` deletes objects under `deleted-after-7-days/` after 7 days. That prefix must stay aligned with `R2_TRASH_PREFIX` in `supabase/functions/_backend/utils/s3.ts`.
+`lifecycle.capgo.json` defines the `capgo` bucket lifecycle rules:
+
+- Delete objects under `deleted-after-7-days/` after 7 days. That prefix must stay aligned with `R2_TRASH_PREFIX` in `supabase/functions/_backend/utils/s3.ts`.
+- Abort incomplete multipart uploads after 1 day across the bucket.
 
 Apply the tracked config:
 

--- a/cloudflare_workers/r2/lifecycle.capgo.json
+++ b/cloudflare_workers/r2/lifecycle.capgo.json
@@ -12,6 +12,19 @@
           "maxAge": 604800
         }
       }
+    },
+    {
+      "id": "Default Multipart Abort Rule",
+      "enabled": true,
+      "conditions": {
+        "prefix": ""
+      },
+      "abortMultipartUploadsTransition": {
+        "condition": {
+          "type": "Age",
+          "maxAge": 86400
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary (AI generated)

- Add a bucket-wide R2 lifecycle rule named `Default Multipart Abort Rule`.
- Abort incomplete multipart uploads after 1 day using `abortMultipartUploadsTransition`.
- Keep the existing `deleted-after-7-days/` trash cleanup rule unchanged.
- Update the R2 lifecycle README to document both tracked rules.

## Motivation (AI generated)

The bucket already has a 7-day trash cleanup rule for recoverable deletes. The screenshot also shows the default multipart abort rule, and keeping it in the tracked JSON prevents `wrangler r2 bucket lifecycle set` from accidentally replacing it.

## Business Impact (AI generated)

This keeps stale multipart upload parts from lingering in R2 while preserving the 7-day recovery window for intentionally trashed bundle objects.

## Test Plan (AI generated)

- [x] `bunx wrangler r2 bucket lifecycle set --help`
- [x] `git diff --check`
- [x] `bun -e "const fs = require('node:fs'); const config = JSON.parse(fs.readFileSync('cloudflare_workers/r2/lifecycle.capgo.json', 'utf8')); const trash = config.rules.find(rule => rule.id === 'delete-trash-after-7-days'); const multipart = config.rules.find(rule => rule.id === 'Default Multipart Abort Rule'); if (trash?.deleteObjectsTransition?.condition?.maxAge !== 604800) throw new Error('trash maxAge invalid'); if (multipart?.conditions?.prefix !== '') throw new Error('multipart prefix invalid'); if (multipart?.abortMultipartUploadsTransition?.condition?.maxAge !== 86400) throw new Error('multipart maxAge invalid');"`
- [x] `bun run cli:build` via commit hook
- [x] `bun typecheck` via commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated R2 bucket documentation with lifecycle rule specifications.

* **Chores**
  * Configured automatic cleanup of incomplete multipart uploads and aged deleted objects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->