### PR TITLE
feat(admin): add trial plan breakdown chart

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -211,6 +211,8 @@
   "admin-users-email-type-professional": "Professional Emails",
   "admin-users-email-type-professional-description": "Work and company domains",
   "admin-users-email-type-trend": "Email Type Trend",
+  "admin-users-trial-plan-breakdown": "New Trials by Plan",
+  "admin-users-trial-plan-breakdown-description": "Daily new trial organizations in the selected period, grouped by their plan.",
   "admin-users-country-breakdown": "Billing Country Breakdown",
   "admin-users-country-breakdown-description": "Stripe billing countries for organizations created during the selected period.",
   "admin-users-country-chart": "Top Billing Countries",

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -75,12 +75,26 @@ interface CustomerCountryBreakdown {
   }>
 }
 
+interface TrialPlanBreakdown {
+  totals: Array<{
+    plan_name: string
+    total: number
+  }>
+  trend: Array<{
+    date: string
+    total: number
+    plans: Record<string, number>
+  }>
+}
+
 const onboardingFunnelData = ref<OnboardingFunnelData | null>(null)
 const isLoadingOnboardingFunnel = ref(false)
 const emailTypeBreakdown = ref<EmailTypeBreakdown | null>(null)
 const isLoadingEmailTypeBreakdown = ref(false)
 const customerCountryBreakdown = ref<CustomerCountryBreakdown | null>(null)
 const isLoadingCustomerCountryBreakdown = ref(false)
+const trialPlanBreakdown = ref<TrialPlanBreakdown | null>(null)
+const isLoadingTrialPlanBreakdown = ref(false)
 
 // Global stats trend data
 const globalStatsTrendData = ref<Array<{
@@ -431,6 +445,21 @@ async function loadCustomerCountryBreakdown() {
   }
 }
 
+async function loadTrialPlanBreakdown() {
+  isLoadingTrialPlanBreakdown.value = true
+  try {
+    const data = await adminStore.fetchStats('trial_plan_breakdown')
+    trialPlanBreakdown.value = data as TrialPlanBreakdown
+  }
+  catch (error) {
+    console.error('[Admin Dashboard Users] Error loading trial plan breakdown:', error)
+    trialPlanBreakdown.value = null
+  }
+  finally {
+    isLoadingTrialPlanBreakdown.value = false
+  }
+}
+
 const countryDisplayNames = computed(() => {
   try {
     return new Intl.DisplayNames([locale.value || 'en'], { type: 'region' })
@@ -542,6 +571,42 @@ const leadingCustomerCountrySubtitle = computed(() => {
 
 const customerCountryChartLabels = computed(() => topCustomerCountryEntries.value.map(country => `${getCountryFlag(country.country_code)} ${getCountryLabel(country.country_code)}`))
 const customerCountryChartValues = computed(() => topCustomerCountryEntries.value.map(country => country.organizations))
+
+const trialPlanBreakdownTotal = computed(() => {
+  const totals = trialPlanBreakdown.value?.totals ?? []
+  return totals.reduce((sum, plan) => sum + plan.total, 0)
+})
+
+const trialPlanBreakdownPlanNames = computed(() => {
+  const totals = trialPlanBreakdown.value?.totals ?? []
+  return totals.map(plan => plan.plan_name)
+})
+
+function getTrialPlanChartColor(planName: string) {
+  const colors = ['#119eff', '#10b981', '#f59e0b', '#ec4899', '#8b5cf6', '#14b8a6', '#ef4444']
+  let hash = 0
+  for (let index = 0; index < planName.length; index++)
+    hash = (hash * 31 + planName.charCodeAt(index)) >>> 0
+
+  return colors[hash % colors.length]
+}
+
+const trialPlanBreakdownTrendSeries = computed(() => {
+  const trend = trialPlanBreakdown.value?.trend ?? []
+  if (trend.length === 0 || trialPlanBreakdownPlanNames.value.length === 0)
+    return []
+
+  return trialPlanBreakdownPlanNames.value
+    .map(planName => ({
+      label: planName,
+      data: trend.map(item => ({
+        date: item.date,
+        value: item.plans[planName] ?? 0,
+      })),
+      color: getTrialPlanChartColor(planName),
+    }))
+    .filter(series => series.data.some(item => item.value > 0))
+})
 
 const registrationsTrendSeries = computed(() => {
   if (globalStatsTrendData.value.length === 0)
@@ -774,6 +839,7 @@ watch(() => adminStore.activeDateRange, () => {
   loadOnboardingFunnel()
   loadEmailTypeBreakdown()
   loadCustomerCountryBreakdown()
+  loadTrialPlanBreakdown()
   loadCancelledOrganizations()
 }, { deep: true })
 
@@ -783,6 +849,7 @@ watch(() => adminStore.refreshTrigger, () => {
   loadOnboardingFunnel()
   loadEmailTypeBreakdown()
   loadCustomerCountryBreakdown()
+  loadTrialPlanBreakdown()
   loadTrialOrganizations()
   loadCancelledOrganizations()
 })
@@ -795,7 +862,7 @@ onMounted(async () => {
   }
 
   isLoading.value = true
-  await Promise.all([loadGlobalStatsTrend(), loadOnboardingFunnel(), loadEmailTypeBreakdown(), loadCustomerCountryBreakdown(), loadTrialOrganizations(), loadCancelledOrganizations()])
+  await Promise.all([loadGlobalStatsTrend(), loadOnboardingFunnel(), loadEmailTypeBreakdown(), loadCustomerCountryBreakdown(), loadTrialPlanBreakdown(), loadTrialOrganizations(), loadCancelledOrganizations()])
   isLoading.value = false
 
   displayStore.NavTitle = t('users-and-revenue')
@@ -1118,6 +1185,28 @@ displayStore.defaultBack = '/dashboard'
               </div>
             </div>
           </div>
+
+          <ChartCard
+            :title="t('admin-users-trial-plan-breakdown')"
+            :total="trialPlanBreakdownTotal"
+            :is-loading="isLoadingTrialPlanBreakdown"
+            :has-data="trialPlanBreakdownTrendSeries.length > 0"
+          >
+            <template #header>
+              <div class="min-w-0">
+                <h2 class="text-xl font-semibold leading-tight text-slate-900 dark:text-white sm:text-2xl">
+                  {{ t('admin-users-trial-plan-breakdown') }}
+                </h2>
+                <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                  {{ t('admin-users-trial-plan-breakdown-description') }}
+                </p>
+              </div>
+            </template>
+            <AdminMultiLineChart
+              :series="trialPlanBreakdownTrendSeries"
+              :is-loading="isLoadingTrialPlanBreakdown"
+            />
+          </ChartCard>
 
           <!-- Trial Organizations Table -->
           <div class="p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">

--- a/src/stores/adminDashboard.ts
+++ b/src/stores/adminDashboard.ts
@@ -2,7 +2,7 @@ import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 
-export type MetricCategory = 'uploads' | 'distribution' | 'failures' | 'success_rate' | 'platform_overview' | 'org_metrics' | 'mau_trend' | 'success_rate_trend' | 'apps_trend' | 'bundles_trend' | 'deployments_trend' | 'storage_trend' | 'bandwidth_trend' | 'global_stats_trend' | 'plugin_breakdown' | 'trial_organizations' | 'onboarding_funnel' | 'cancelled_users' | 'email_type_breakdown' | 'customer_country_breakdown' | 'organization_insights'
+export type MetricCategory = 'uploads' | 'distribution' | 'failures' | 'success_rate' | 'platform_overview' | 'org_metrics' | 'mau_trend' | 'success_rate_trend' | 'apps_trend' | 'bundles_trend' | 'deployments_trend' | 'storage_trend' | 'bandwidth_trend' | 'global_stats_trend' | 'plugin_breakdown' | 'trial_organizations' | 'trial_plan_breakdown' | 'onboarding_funnel' | 'cancelled_users' | 'email_type_breakdown' | 'customer_country_breakdown' | 'organization_insights'
 export type DateRangeMode = '30day' | '90day' | 'quarter' | '6month' | '12month' | 'custom'
 
 interface DateRange {

--- a/supabase/functions/_backend/private/admin_stats.ts
+++ b/supabase/functions/_backend/private/admin_stats.ts
@@ -6,7 +6,7 @@ import { literalUnion, safeParseSchema } from '../utils/ark_validation.ts'
 import { getAdminAppsTrend, getAdminBandwidthTrend, getAdminBundlesTrend, getAdminDistributionMetrics, getAdminFailureMetrics, getAdminMauTrend, getAdminOrgMetrics, getAdminPlatformOverview, getAdminStorageTrend, getAdminSuccessRate, getAdminSuccessRateTrend, getAdminUploadMetrics } from '../utils/cloudflare.ts'
 import { middlewareAuth, parseBody, simpleError, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { getAdminCancelledOrganizations, getAdminCustomerCountryBreakdown, getAdminDeploymentsTrend, getAdminEmailTypeBreakdown, getAdminGlobalStatsTrend, getAdminOnboardingFunnel, getAdminOrganizationInsights, getAdminPluginBreakdown, getAdminTrialOrganizations } from '../utils/pg.ts'
+import { getAdminCancelledOrganizations, getAdminCustomerCountryBreakdown, getAdminDeploymentsTrend, getAdminEmailTypeBreakdown, getAdminGlobalStatsTrend, getAdminOnboardingFunnel, getAdminOrganizationInsights, getAdminPluginBreakdown, getAdminTrialOrganizations, getAdminTrialPlanBreakdown } from '../utils/pg.ts'
 import { getCancellationDetails } from '../utils/stripe.ts'
 import { supabaseClient as useSupabaseClient } from '../utils/supabase.ts'
 
@@ -32,6 +32,7 @@ const metricCategories = [
   'global_stats_trend',
   'plugin_breakdown',
   'trial_organizations',
+  'trial_plan_breakdown',
   'onboarding_funnel',
   'cancelled_users',
   'email_type_breakdown',
@@ -245,6 +246,10 @@ app.post('/', middlewareAuth, async (c) => {
 
       case 'trial_organizations':
         result = await getAdminTrialOrganizations(c, limit || 20, offset || 0)
+        break
+
+      case 'trial_plan_breakdown':
+        result = await getAdminTrialPlanBreakdown(c, start_date, end_date)
         break
 
       case 'cancelled_users': {

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1413,6 +1413,32 @@ export interface AdminEmailTypeBreakdown {
   }>
 }
 
+interface AdminUtcDateRange {
+  startDay: Date
+  seriesEndDay: Date
+  endExclusive: Date
+}
+
+function getAdminUtcDateRange(start_date: string, end_date: string): AdminUtcDateRange {
+  const startTimestamp = new Date(start_date)
+  const endTimestamp = new Date(end_date)
+  const startDay = new Date(Date.UTC(startTimestamp.getUTCFullYear(), startTimestamp.getUTCMonth(), startTimestamp.getUTCDate()))
+  const endDay = new Date(Date.UTC(endTimestamp.getUTCFullYear(), endTimestamp.getUTCMonth(), endTimestamp.getUTCDate()))
+  const endIsExactUtcDayBoundary = endTimestamp.getTime() === endDay.getTime()
+  const seriesEndDay = new Date(endDay)
+
+  if (endIsExactUtcDayBoundary)
+    seriesEndDay.setUTCDate(seriesEndDay.getUTCDate() - 1)
+
+  return {
+    startDay,
+    seriesEndDay,
+    endExclusive: endIsExactUtcDayBoundary
+      ? endTimestamp
+      : new Date(endDay.getTime() + 24 * 60 * 60 * 1000),
+  }
+}
+
 export async function getAdminEmailTypeBreakdown(
   c: Context,
   start_date: string,
@@ -1431,17 +1457,7 @@ export async function getAdminEmailTypeBreakdown(
   try {
     const pgClient = getPgClient(c, true)
     const drizzleClient = getDrizzleClient(pgClient)
-    const startTimestamp = new Date(start_date)
-    const endTimestamp = new Date(end_date)
-    const startDay = new Date(Date.UTC(startTimestamp.getUTCFullYear(), startTimestamp.getUTCMonth(), startTimestamp.getUTCDate()))
-    const endDay = new Date(Date.UTC(endTimestamp.getUTCFullYear(), endTimestamp.getUTCMonth(), endTimestamp.getUTCDate()))
-    const endIsExactUtcDayBoundary = endTimestamp.getTime() === endDay.getTime()
-    const seriesEndDay = new Date(endDay)
-    if (endIsExactUtcDayBoundary)
-      seriesEndDay.setUTCDate(seriesEndDay.getUTCDate() - 1)
-    const endExclusive = endIsExactUtcDayBoundary
-      ? endTimestamp
-      : new Date(endDay.getTime() + 24 * 60 * 60 * 1000)
+    const { startDay, seriesEndDay, endExclusive } = getAdminUtcDateRange(start_date, end_date)
 
     const personalDomainsSql = sql.join(PERSONAL_EMAIL_DOMAINS.map(domain => sql`${domain}`), sql`, `)
     const disposableDomainsSql = sql.join(DISPOSABLE_EMAIL_DOMAINS.map(domain => sql`${domain}`), sql`, `)
@@ -2241,6 +2257,129 @@ export async function getAdminTrialOrganizations(
   catch (e: unknown) {
     logPgError(c, 'getAdminTrialOrganizations', e)
     return { organizations: [], total: 0 }
+  }
+}
+
+export interface AdminTrialPlanBreakdown {
+  totals: Array<{
+    plan_name: string
+    total: number
+  }>
+  trend: Array<{
+    date: string
+    total: number
+    plans: Record<string, number>
+  }>
+}
+
+function createAdminTrialPlanTrendDay(date: string): AdminTrialPlanBreakdown['trend'][number] {
+  return { date, total: 0, plans: {} }
+}
+
+export async function getAdminTrialPlanBreakdown(
+  c: Context,
+  start_date: string,
+  end_date: string,
+): Promise<AdminTrialPlanBreakdown> {
+  const emptyResult: AdminTrialPlanBreakdown = {
+    totals: [],
+    trend: [],
+  }
+
+  let pgClient: ReturnType<typeof getPgClient> | undefined
+  try {
+    // The admin dashboard needs plans.name, and plans is not available on every read replica.
+    pgClient = getPgClient(c)
+    const drizzleClient = getDrizzleClient(pgClient)
+    const { startDay, seriesEndDay, endExclusive } = getAdminUtcDateRange(start_date, end_date)
+
+    const query = sql`
+      WITH date_series AS (
+        SELECT generate_series(
+          ${startDay.toISOString()}::timestamptz::date,
+          ${seriesEndDay.toISOString()}::timestamptz::date,
+          interval '1 day'
+        )::date AS date
+      ),
+      daily_trials AS (
+        SELECT
+          (o.created_at AT TIME ZONE 'UTC')::date AS date,
+          COALESCE(NULLIF(BTRIM(p.name), ''), 'Unknown') AS plan_name,
+          COUNT(DISTINCT o.id)::int AS trials
+        FROM orgs o
+        INNER JOIN stripe_info si ON si.customer_id = o.customer_id
+        LEFT JOIN plans p ON p.stripe_id = si.product_id
+        WHERE o.created_at >= ${startDay.toISOString()}::timestamptz
+          AND o.created_at < ${endExclusive.toISOString()}::timestamptz
+          AND si.trial_at IS NOT NULL
+        GROUP BY (o.created_at AT TIME ZONE 'UTC')::date, COALESCE(NULLIF(BTRIM(p.name), ''), 'Unknown')
+      ),
+      plan_names AS (
+        SELECT BTRIM(name) AS plan_name
+        FROM plans
+        WHERE BTRIM(name) != ''
+        UNION
+        SELECT plan_name
+        FROM daily_trials
+      ),
+      filled AS (
+        SELECT
+          ds.date,
+          plan_name_set.plan_name,
+          COALESCE(dt.trials, 0)::int AS trials
+        FROM date_series ds
+        CROSS JOIN plan_names plan_name_set
+        LEFT JOIN daily_trials dt ON dt.date = ds.date AND dt.plan_name = plan_name_set.plan_name
+      )
+      SELECT
+        date,
+        plan_name,
+        trials
+      FROM filled
+      ORDER BY date ASC, plan_name ASC
+    `
+
+    const result = await drizzleClient.execute(query)
+    const totalsByPlan = new Map<string, number>()
+    const trendByDate = new Map<string, { date: string, total: number, plans: Record<string, number> }>()
+
+    for (const row of result.rows as any[]) {
+      const date = row.date instanceof Date ? row.date.toISOString().split('T')[0] : String(row.date)
+      const planName = String(row.plan_name || 'Unknown')
+      const trials = Number(row.trials) || 0
+      const day = trendByDate.get(date) ?? createAdminTrialPlanTrendDay(date)
+
+      day.plans[planName] = trials
+      day.total += trials
+      trendByDate.set(date, day)
+      totalsByPlan.set(planName, (totalsByPlan.get(planName) ?? 0) + trials)
+    }
+
+    const totals = Array.from(totalsByPlan.entries())
+      .map(([plan_name, total]) => ({ plan_name, total }))
+      .sort((a, b) => b.total - a.total || a.plan_name.localeCompare(b.plan_name))
+
+    const trend = Array.from(trendByDate.values())
+
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'getAdminTrialPlanBreakdown result',
+      resultCount: trend.length,
+      planCount: totals.length,
+    })
+
+    return {
+      totals,
+      trend,
+    }
+  }
+  catch (e: unknown) {
+    logPgError(c, 'getAdminTrialPlanBreakdown', e)
+    return emptyResult
+  }
+  finally {
+    if (pgClient)
+      await closeClient(c, pgClient)
   }
 }
 

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, fetchWithRetry, getAuthHeadersForCredentials, getSupabaseClient, PRODUCT_ID, TEST_EMAIL, USER_ADMIN_EMAIL, USER_ID } from './test-utils.ts'
+import { BASE_URL, fetchWithRetry, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, PRODUCT_ID, TEST_EMAIL, USER_ADMIN_EMAIL, USER_ID } from './test-utils.ts'
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000
 const NOW = Date.now()
@@ -687,5 +687,37 @@ describe('/private/admin_stats', () => {
       new_orgs: 3,
       orgs_subscribed: 1,
     })
+  })
+
+  it.concurrent('returns daily new trial organizations grouped by plan', async () => {
+    const response = await fetchWithRetry(getEndpointUrl('/private/admin_stats'), {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        metric_category: 'trial_plan_breakdown',
+        start_date: '2026-02-01T00:00:00.000Z',
+        end_date: '2026-02-02T00:00:00.000Z',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json() as {
+      success: boolean
+      data: {
+        totals: Array<{ plan_name: string, total: number }>
+        trend: Array<{
+          date: string
+          total: number
+          plans: Record<string, number>
+        }>
+      }
+    }
+
+    expect(payload.success).toBe(true)
+    expect(payload.data.trend).toHaveLength(1)
+    expect(payload.data.trend[0]?.date).toBe('2026-02-01')
+    expect(payload.data.trend[0]?.total).toBe(3)
+    expect(payload.data.trend[0]?.plans[soloPlan?.name ?? 'Solo']).toBe(3)
+    expect(payload.data.totals.find(plan => plan.plan_name === (soloPlan?.name ?? 'Solo'))?.total).toBe(3)
   })
 })

--- a/tests/admin-stats.unit.test.ts
+++ b/tests/admin-stats.unit.test.ts
@@ -49,6 +49,15 @@ describe('admin stats validation', () => {
     expect(parsed.success).toBe(true)
   })
 
+  it.concurrent('accepts the trial plan breakdown metric', () => {
+    const parsed = safeParseSchema(adminStatsBodySchema, {
+      ...baseBody,
+      metric_category: 'trial_plan_breakdown',
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
   it.concurrent('accepts organization insights filters', () => {
     const parsed = safeParseSchema(adminStatsBodySchema, {
       ...baseBody,


### PR DESCRIPTION
## Summary (AI generated)

- Add a new admin stats metric for daily new trial organizations grouped by plan.
- Render a New Trials by Plan chart on the admin users dashboard.
- Cover the metric schema and endpoint behavior with admin stats tests.

## Motivation (AI generated)

Admins need to see which plans are driving new trials over time from the users dashboard, instead of only seeing aggregate trial counts.

## Business Impact (AI generated)

This improves visibility into trial acquisition by plan, helping Capgo understand plan demand and onboarding quality across the selected period.

## Test Plan (AI generated)

- [x] bun lint
- [x] bunx eslint supabase/functions/_backend/private/admin_stats.ts supabase/functions/_backend/utils/pg.ts tests/admin-stats.unit.test.ts tests/admin-stats.test.ts
- [x] bun typecheck
- [x] bun run supabase:with-env -- bunx vitest run tests/admin-stats.unit.test.ts tests/admin-stats.test.ts
- [x] Browser smoke check: loaded /admin/dashboard/users locally and verified the New Trials by Plan chart title and description render

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Trial Plan Breakdown" visualization to the admin dashboard, showing daily new trial organizations by plan and aggregate totals across date ranges.
  * Dashboard trend chart displays per-plan series and totals for selected periods.
  * Added localization strings for the Trial Plan Breakdown.

* **Tests**
  * Added integration and unit tests for the trial plan breakdown analytics endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->