### PR TITLE
fix(cli): offer CI secret upload only after a successful first build

### DIFF
--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -962,12 +962,13 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
           // persisting a one-off flag to progress.json.
           if (randomPasswordGenerated)
             addLog(`  ℹ Your auto-generated keystore password is now in ~/.capgo-credentials/credentials.json — back up that file.`, 'yellow')
+          // Stash CI secret entries for later. We do NOT push to GitHub/GitLab
+          // yet — the wizard now offers that step only AFTER a successful first
+          // build, so users never end up with orphan secrets in a repo whose
+          // build was never proven to work.
           const entries = createCiSecretEntries(credentials)
           setCiSecretEntries(entries)
-          if (entries.length === 0)
-            setStep('ask-build')
-          else
-            setStep('detecting-ci-secrets')
+          setStep('ask-build')
         }
         catch (err) {
           if (!cancelled)
@@ -991,7 +992,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
             }
             for (const note of discovery.notes)
               addLog(`ℹ ${note}`, 'yellow')
-            setStep('ask-build')
+            setStep('build-complete')
             return
           }
           if (discovery.targets.length === 1) {
@@ -1041,7 +1042,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
           const summary = `Uploaded ${ciSecretEntries.length} env var${ciSecretEntries.length === 1 ? '' : 's'} to ${getCiSecretTargetLabel(ciSecretTarget)}`
           setCiSecretUploadSummary(summary)
           addLog(`✔ ${summary}`)
-          setStep('ask-build')
+          setStep('build-complete')
         }
         catch (err) {
           if (!cancelled) {
@@ -1110,6 +1111,13 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
             const url = `https://capgo.app/app/${appId}/builds`
             setBuildUrl(url)
             setBuildOutput(prev => [...prev, '', `✔ Build queued — ${url}`])
+            // Only offer to push CI secrets AFTER we've successfully queued a
+            // build. If the build request failed (else branch) or we never had
+            // any credentials to push (entries empty), skip straight to exit.
+            if (ciSecretEntries.length > 0) {
+              setStep('detecting-ci-secrets')
+              return
+            }
           }
           else {
             setBuildOutput(prev => [...prev, `⚠ ${result.error || 'unknown error'}`])
@@ -1901,7 +1909,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
               { label: 'Skip upload', value: 'skip' },
             ]}
             onChange={(value) => {
-              setStep(value === 'retry' ? 'detecting-ci-secrets' : 'ask-build')
+              setStep(value === 'retry' ? 'detecting-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -1921,12 +1929,12 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
             ]}
             onChange={(value) => {
               if (value === 'skip') {
-                setStep('ask-build')
+                setStep('build-complete')
                 return
               }
               const target = ciSecretTargets.find(candidate => candidate.provider === value) || null
               setCiSecretTarget(target)
-              setStep(target ? 'ask-ci-secrets' : 'ask-build')
+              setStep(target ? 'ask-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -1957,7 +1965,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
               { label: 'Skip', value: 'no' },
             ]}
             onChange={(value) => {
-              setStep(value === 'yes' ? 'checking-ci-secrets' : 'ask-build')
+              setStep(value === 'yes' ? 'checking-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -1982,7 +1990,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
               { label: 'Skip upload', value: 'skip' },
             ]}
             onChange={(value) => {
-              setStep(value === 'replace' ? 'uploading-ci-secrets' : 'ask-build')
+              setStep(value === 'replace' ? 'uploading-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -2004,7 +2012,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
               { label: 'Continue without upload', value: 'continue' },
             ]}
             onChange={(value) => {
-              setStep(value === 'retry' ? (ciSecretTarget ? 'checking-ci-secrets' : 'detecting-ci-secrets') : 'ask-build')
+              setStep(value === 'retry' ? (ciSecretTarget ? 'checking-ci-secrets' : 'detecting-ci-secrets') : 'build-complete')
             }}
           />
         </Box>

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -977,12 +977,13 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
           const credentials = await doSaveCredentials()
           if (cancelled)
             return
+          // Stash CI secret entries for later. We do NOT push to GitHub/GitLab
+          // yet — the wizard now offers that step only AFTER a successful first
+          // build, so users never end up with orphan secrets in a repo whose
+          // build was never proven to work.
           const entries = createCiSecretEntries(credentials)
           setCiSecretEntries(entries)
-          if (entries.length === 0)
-            setStep('ask-build')
-          else
-            setStep('detecting-ci-secrets')
+          setStep('ask-build')
         }
         catch (err) {
           if (!cancelled)
@@ -1006,7 +1007,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
             }
             for (const note of discovery.notes)
               addLog(`ℹ ${note}`, 'yellow')
-            setStep('ask-build')
+            setStep('build-complete')
             return
           }
           if (discovery.targets.length === 1) {
@@ -1056,7 +1057,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
           const summary = `Uploaded ${ciSecretEntries.length} env var${ciSecretEntries.length === 1 ? '' : 's'} to ${getCiSecretTargetLabel(ciSecretTarget)}`
           setCiSecretUploadSummary(summary)
           addLog(`✔ ${summary}`)
-          setStep('ask-build')
+          setStep('build-complete')
         }
         catch (err) {
           if (!cancelled) {
@@ -1118,6 +1119,13 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
             const url = `https://capgo.app/app/${appId}/builds`
             setBuildUrl(url)
             setBuildOutput(prev => [...prev, '', `✔ Build queued — ${url}`])
+            // Only offer to push CI secrets AFTER we've successfully queued a
+            // build. If the build request failed (else branch) or we never had
+            // any credentials to push (entries empty), skip straight to exit.
+            if (ciSecretEntries.length > 0) {
+              setStep('detecting-ci-secrets')
+              return
+            }
           }
           else {
             setBuildOutput(prev => [...prev, `⚠ ${result.error || 'unknown error'}`])
@@ -2128,7 +2136,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
               { label: 'Skip upload', value: 'skip' },
             ]}
             onChange={(value) => {
-              setStep(value === 'retry' ? 'detecting-ci-secrets' : 'ask-build')
+              setStep(value === 'retry' ? 'detecting-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -2148,12 +2156,12 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
             ]}
             onChange={(value) => {
               if (value === 'skip') {
-                setStep('ask-build')
+                setStep('build-complete')
                 return
               }
               const target = ciSecretTargets.find(candidate => candidate.provider === value) || null
               setCiSecretTarget(target)
-              setStep(target ? 'ask-ci-secrets' : 'ask-build')
+              setStep(target ? 'ask-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -2184,7 +2192,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
               { label: 'Skip', value: 'no' },
             ]}
             onChange={(value) => {
-              setStep(value === 'yes' ? 'checking-ci-secrets' : 'ask-build')
+              setStep(value === 'yes' ? 'checking-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -2211,7 +2219,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
               { label: 'Skip upload', value: 'skip' },
             ]}
             onChange={(value) => {
-              setStep(value === 'replace' ? 'uploading-ci-secrets' : 'ask-build')
+              setStep(value === 'replace' ? 'uploading-ci-secrets' : 'build-complete')
             }}
           />
         </Box>
@@ -2235,7 +2243,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
               { label: 'Continue without upload', value: 'continue' },
             ]}
             onChange={(value) => {
-              setStep(value === 'retry' ? (ciSecretTarget ? 'checking-ci-secrets' : 'detecting-ci-secrets') : 'ask-build')
+              setStep(value === 'retry' ? (ciSecretTarget ? 'checking-ci-secrets' : 'detecting-ci-secrets') : 'build-complete')
             }}
           />
         </Box>


### PR DESCRIPTION
## Summary

Defers GitHub Actions / GitLab CI secret upload in the `build onboarding` wizard until **after** a build has been successfully queued, instead of before. Resolves the UX issue surfaced after [#2306](https://github.com/Cap-go/capgo/pull/2306) merged.

Original concern: pushing repository secrets before any build has been validated leaves orphan secrets in the user's repo if the credentials turn out to be wrong, and gates user trust on an unproven setup. Discussed with @riderx — agreed to move the step to post-build-success.

## What changed

Touches the two onboarding state machines:

- `cli/src/build/onboarding/ui/app.tsx` (iOS)
- `cli/src/build/onboarding/android/ui/app.tsx` (Android)

New ordering on both tracks:

```
save credentials
  → ask-build
    ├─ user skips build  → exit (no secrets pushed)
    ├─ build request OK  → detecting-ci-secrets (if entries) → … → exit
    └─ build request err → exit (no secrets pushed)
```

Concretely:

1. The `saving-credentials` handler no longer branches to `detecting-ci-secrets`. It always proceeds to `ask-build`, just stashes the CI secret entries in state for later.
2. In `requesting-build`, after a successful build dispatch (`result.success`), the wizard now routes to `detecting-ci-secrets` if there are entries to push; otherwise straight to `build-complete`.
3. On build failure (either the inline `else` branch or the outer `catch`), the wizard goes directly to `build-complete` — secrets are never offered for a failed build.
4. Every "skip" / "skip upload" / "continue without upload" exit inside the ci-secrets-* flow used to fall back to `ask-build`. They now fall back to `build-complete`, because by the time those paths fire the build has already been dispatched.

The `ciSecretUploadSummary` was already rendered inside the `build-complete` JSX, so users still see the "Uploaded N env vars to …" confirmation after the post-build path runs.

## Why this is a strict UX improvement

- No more orphan secrets in repos whose build never ran or failed.
- No more secrets pushed for a workflow file that doesn't exist yet, which felt cargo-cult.
- Build failure path is shorter and more honest: we don't pretend the user is ready for CI/CD when we haven't even managed to dispatch the build.
- Skipping the build (`ask-build` → "no") now correctly skips the secrets step too — credentials still get saved locally, exactly as before.

## What this PR is _not_

Out of scope by design (each could be its own follow-up):

- ❌ Pre-flight `gh auth status` + repo write-access check before collecting credentials
- ❌ Diff-and-confirm UX when the secret name already exists in the target repo (`gh secret set` silently clobbers today)
- ❌ Cap on AI-debug retry loops on build failure
- ❌ `.github/workflows/capgo-build.yml` generator
- ❌ Extraction of the secrets-push step into a standalone `capgo ci setup` command

## Test plan

- [x] `bun run cli:check` (lint + typecheck + build + test) green locally
- [x] `bun test/test-ci-secrets.mjs` — all 8 existing helpers tests still pass; this PR doesn't touch `ci-secrets.ts` itself
- [ ] Manual: `capgo build init --platform ios` on a fresh repo with no Capgo credentials — confirm wizard goes save credentials → ask-build, and only offers secret upload after the build is queued
- [ ] Manual: same on Android
- [ ] Manual: choose "no" at `ask-build` — confirm wizard exits cleanly without offering secrets
- [ ] Manual: cause a build request failure (invalid API key) — confirm wizard exits via `build-complete` and does NOT offer secrets
- [ ] Manual: with no detectable GitHub/GitLab remote — confirm wizard exits via `build-complete` after the empty discovery, not back into the (no-longer-reachable from this path) `ask-build`

cc @riderx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Deferred CI secret upload/detection until after a build is successfully queued on iOS and Android.
  * Skipping CI setup, target selection, or secret upload now completes onboarding (goes to build complete) instead of prompting another build.
  * Retry after CI secret failures now re-runs CI secret checks rather than returning to the build request step.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->