### PR TITLE
[codex] flag at-risk organizations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1360,6 +1360,7 @@
   "open-source-updates": "Open Source Updates",
   "open-your-portal": "Open your portal",
   "organization-insights": "Organization insights",
+  "organization-attention-high-fail-rate": "High update fail rate: {failRate} ({failed} of {total} attempts failed)",
   "org-changes-saved": "Organization updated successfully",
   "org-changes-set-email-not-unique": "The management email is not unique, please select a different one",
   "org-changes-set-email-other-error": "Cannot set the management email, please contact support",

--- a/src/pages/admin/dashboard/organizations.vue
+++ b/src/pages/admin/dashboard/organizations.vue
@@ -213,11 +213,13 @@ const organizationColumns = computed<TableColumn[]>(() => [
 
       return h('div', { class: 'flex min-w-0 items-start gap-2' }, [
         attentionLabel
-          ? h('span', {
-              'class': 'mt-1.5 inline-flex h-2 w-2 shrink-0 rounded-full bg-amber-500 ring-4 ring-amber-500/10 dark:bg-amber-300 dark:ring-amber-300/10',
-              'title': attentionLabel,
-              'aria-label': attentionLabel,
-            })
+          ? h('span', { class: 'inline-flex shrink-0 items-start' }, [
+              h('span', {
+                'class': 'mt-1.5 inline-flex h-2 w-2 shrink-0 rounded-full bg-amber-500 ring-4 ring-amber-500/10 dark:bg-amber-300 dark:ring-amber-300/10',
+                'aria-hidden': 'true',
+              }),
+              h('span', { class: 'sr-only' }, attentionLabel),
+            ])
           : null,
         h('div', { class: 'min-w-0' }, [
           h('p', { class: 'truncate font-medium text-slate-900 dark:text-white' }, item.org_name),

--- a/src/pages/admin/dashboard/organizations.vue
+++ b/src/pages/admin/dashboard/organizations.vue
@@ -26,6 +26,10 @@ interface OrganizationInsight {
   billing_type: BillingType | null
   upload_count: number
   build_count: number
+  failed_update_count: number
+  install_count: number
+  update_attempt_count: number
+  needs_attention: boolean
   fail_rate: number
   mau: number
   members_count: number
@@ -82,6 +86,21 @@ function formatBillingTypeLabel(billingType: OrganizationInsight['billing_type']
 
 function formatDateOrNever(value: string | null) {
   return formatLocalDateTime(value) || t('never')
+}
+
+function getOrganizationAttentionLabel(item: OrganizationInsight) {
+  const failRate = Number(item.fail_rate || 0)
+  const failedUpdateCount = Number(item.failed_update_count || 0)
+  const updateAttemptCount = Number(item.update_attempt_count || 0)
+
+  if (!item.needs_attention)
+    return null
+
+  return t('organization-attention-high-fail-rate', {
+    failRate: formatPercent(failRate),
+    failed: formatNumber(failedUpdateCount),
+    total: formatNumber(updateAttemptCount),
+  })
 }
 
 async function loadOrganizations() {
@@ -189,10 +208,23 @@ const organizationColumns = computed<TableColumn[]>(() => [
     mobile: true,
     head: true,
     sortable: false,
-    renderFunction: (item: OrganizationInsight) => h('div', { class: 'min-w-0' }, [
-      h('p', { class: 'truncate font-medium text-slate-900 dark:text-white' }, item.org_name),
-      h('p', { class: 'truncate text-xs font-normal text-slate-500 dark:text-slate-400' }, item.management_email),
-    ]),
+    renderFunction: (item: OrganizationInsight) => {
+      const attentionLabel = getOrganizationAttentionLabel(item)
+
+      return h('div', { class: 'flex min-w-0 items-start gap-2' }, [
+        attentionLabel
+          ? h('span', {
+              'class': 'mt-1.5 inline-flex h-2 w-2 shrink-0 rounded-full bg-amber-500 ring-4 ring-amber-500/10 dark:bg-amber-300 dark:ring-amber-300/10',
+              'title': attentionLabel,
+              'aria-label': attentionLabel,
+            })
+          : null,
+        h('div', { class: 'min-w-0' }, [
+          h('p', { class: 'truncate font-medium text-slate-900 dark:text-white' }, item.org_name),
+          h('p', { class: 'truncate text-xs font-normal text-slate-500 dark:text-slate-400' }, item.management_email),
+        ]),
+      ])
+    },
   },
   {
     label: t('plan'),

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1761,6 +1761,10 @@ export interface AdminOrganizationInsightRow {
   billing_type: 'monthly' | 'yearly' | null
   upload_count: number
   build_count: number
+  failed_update_count: number
+  install_count: number
+  update_attempt_count: number
+  needs_attention: boolean
   fail_rate: number
   mau: number
   members_count: number
@@ -1785,6 +1789,10 @@ interface AdminOrganizationInsightsFilters {
   paid_only?: boolean
   search?: string
 }
+
+const ADMIN_ORG_ATTENTION_FAIL_RATE_PERCENT = 20
+const ADMIN_ORG_ATTENTION_MIN_FAILED_UPDATES = 2
+const ADMIN_ORG_ATTENTION_MIN_UPDATE_ATTEMPTS = 10
 
 /**
  * Fetches admin organization rows with selected-period usage rollups.
@@ -1834,7 +1842,7 @@ export async function getAdminOrganizationInsights(
       : sql``
 
     const dataQuery = sql`
-      WITH filtered_orgs AS (
+      WITH filtered_orgs_all AS (
         SELECT
           o.id AS org_id,
           o.name AS org_name,
@@ -1851,7 +1859,64 @@ export async function getAdminOrganizationInsights(
           ${billingFilter}
           ${paidFilter}
           ${searchFilter}
-        ORDER BY o.created_at DESC NULLS LAST, o.id
+      ),
+      version_usage_totals AS (
+        SELECT
+          a.owner_org AS org_id,
+          COALESCE(SUM(COALESCE(dv.fail, 0)), 0)::bigint AS failed_update_count,
+          COALESCE(SUM(COALESCE(dv.install, 0)), 0)::bigint AS install_count
+        FROM filtered_orgs_all filtered
+        INNER JOIN apps a ON a.owner_org = filtered.org_id
+        INNER JOIN daily_version dv ON dv.app_id = a.app_id
+        WHERE dv.date >= ${startDateOnly}::date
+          AND dv.date <= ${endDateOnly}::date
+        GROUP BY a.owner_org
+      ),
+      version_usage_rank AS (
+        SELECT
+          vut.org_id,
+          vut.failed_update_count,
+          vut.install_count,
+          (vut.install_count + vut.failed_update_count)::bigint AS update_attempt_count,
+          CASE
+            WHEN vut.install_count + vut.failed_update_count > 0
+              THEN (vut.failed_update_count::float / (vut.install_count + vut.failed_update_count)::float) * 100
+            ELSE 0
+          END::float AS fail_rate
+        FROM version_usage_totals vut
+      ),
+      filtered_orgs_scored AS (
+        SELECT
+          filtered.org_id,
+          filtered.org_name,
+          filtered.management_email,
+          filtered.registered_at,
+          filtered.paid_at,
+          filtered.plan_name,
+          filtered.billing_type,
+          COALESCE(vur.failed_update_count, 0)::bigint AS failed_update_count,
+          COALESCE(vur.install_count, 0)::bigint AS install_count,
+          COALESCE(vur.update_attempt_count, 0)::bigint AS update_attempt_count,
+          COALESCE(vur.fail_rate, 0)::float AS fail_rate,
+          (
+            COALESCE(vur.fail_rate, 0) >= ${ADMIN_ORG_ATTENTION_FAIL_RATE_PERCENT}
+            AND COALESCE(vur.failed_update_count, 0) >= ${ADMIN_ORG_ATTENTION_MIN_FAILED_UPDATES}
+            AND COALESCE(vur.update_attempt_count, 0) >= ${ADMIN_ORG_ATTENTION_MIN_UPDATE_ATTEMPTS}
+          )::boolean AS needs_attention
+        FROM filtered_orgs_all filtered
+        LEFT JOIN version_usage_rank vur ON vur.org_id = filtered.org_id
+      ),
+      filtered_orgs AS (
+        SELECT *
+        FROM filtered_orgs_scored
+        ORDER BY
+          needs_attention DESC,
+          CASE
+            WHEN needs_attention THEN fail_rate
+            ELSE NULL
+          END DESC,
+          registered_at DESC NULLS LAST,
+          org_id
         LIMIT ${safeLimit}
         OFFSET ${safeOffset}
       ),
@@ -1881,18 +1946,6 @@ export async function getAdminOrganizationInsights(
         INNER JOIN daily_mau dm ON dm.app_id = a.app_id
         WHERE dm.date >= ${startDateOnly}::date
           AND dm.date <= ${endDateOnly}::date
-        GROUP BY a.owner_org
-      ),
-      version_usage_by_org AS (
-        SELECT
-          a.owner_org AS org_id,
-          COALESCE(SUM(COALESCE(dv.fail, 0)), 0)::bigint AS fails,
-          COALESCE(SUM(COALESCE(dv.install, 0)), 0)::bigint AS installs
-        FROM filtered_orgs filtered
-        INNER JOIN apps a ON a.owner_org = filtered.org_id
-        INNER JOIN daily_version dv ON dv.app_id = a.app_id
-        WHERE dv.date >= ${startDateOnly}::date
-          AND dv.date <= ${endDateOnly}::date
         GROUP BY a.owner_org
       ),
       build_usage_by_org AS (
@@ -1935,11 +1988,11 @@ export async function getAdminOrganizationInsights(
         filtered.billing_type,
         COALESCE(buo.upload_count, 0)::int AS upload_count,
         COALESCE(bu.build_count, 0)::bigint AS build_count,
-        CASE
-          WHEN COALESCE(vu.installs, 0) + COALESCE(vu.fails, 0) > 0
-            THEN (COALESCE(vu.fails, 0)::float / (COALESCE(vu.installs, 0) + COALESCE(vu.fails, 0))::float) * 100
-          ELSE 0
-        END::float AS fail_rate,
+        filtered.failed_update_count,
+        filtered.install_count,
+        filtered.update_attempt_count,
+        filtered.needs_attention,
+        filtered.fail_rate,
         COALESCE(mau.mau, 0)::bigint AS mau,
         COALESCE(members.members_count, 0)::int AS members_count,
         COALESCE(apps.apps_count, 0)::int AS apps_count,
@@ -1951,11 +2004,17 @@ export async function getAdminOrganizationInsights(
       LEFT JOIN apps_by_org apps ON apps.org_id = filtered.org_id
       LEFT JOIN members_by_org members ON members.org_id = filtered.org_id
       LEFT JOIN mau_by_org mau ON mau.org_id = filtered.org_id
-      LEFT JOIN version_usage_by_org vu ON vu.org_id = filtered.org_id
       LEFT JOIN build_usage_by_org bu ON bu.org_id = filtered.org_id
       LEFT JOIN bundle_uploads_by_org buo ON buo.org_id = filtered.org_id
       LEFT JOIN last_builds_by_org lb ON lb.org_id = filtered.org_id
-      ORDER BY filtered.registered_at DESC NULLS LAST, filtered.org_id
+      ORDER BY
+        filtered.needs_attention DESC,
+        CASE
+          WHEN filtered.needs_attention THEN filtered.fail_rate
+          ELSE NULL
+        END DESC,
+        filtered.registered_at DESC NULLS LAST,
+        filtered.org_id
     `
 
     const countQuery = sql`
@@ -1991,6 +2050,10 @@ export async function getAdminOrganizationInsights(
       billing_type: row.billing_type ?? null,
       upload_count: Number(row.upload_count) || 0,
       build_count: Number(row.build_count) || 0,
+      failed_update_count: Number(row.failed_update_count) || 0,
+      install_count: Number(row.install_count) || 0,
+      update_attempt_count: Number(row.update_attempt_count) || 0,
+      needs_attention: row.needs_attention === true,
       fail_rate: Number(row.fail_rate) || 0,
       mau: Number(row.mau) || 0,
       members_count: Number(row.members_count) || 0,

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -551,6 +551,10 @@ describe('/private/admin_stats', () => {
           billing_type: 'monthly' | 'yearly' | null
           upload_count: number
           build_count: number
+          failed_update_count: number
+          install_count: number
+          update_attempt_count: number
+          needs_attention: boolean
           fail_rate: number
           mau: number
           members_count: number
@@ -569,6 +573,10 @@ describe('/private/admin_stats', () => {
     expect(organization?.billing_type).toBe('monthly')
     expect(organization?.upload_count).toBe(1)
     expect(organization?.build_count).toBe(1)
+    expect(organization?.failed_update_count).toBe(2)
+    expect(organization?.install_count).toBe(8)
+    expect(organization?.update_attempt_count).toBe(10)
+    expect(organization?.needs_attention).toBe(true)
     expect(organization?.fail_rate).toBe(20)
     expect(organization?.mau).toBe(7)
     expect(organization?.members_count).toBe(1)

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -639,7 +639,7 @@ describe('/private/admin_stats', () => {
     if (!soloPlan)
       throw new Error('Expected Solo plan to be loaded')
 
-    const response = await fetchWithRetry(`${BASE_URL}/private/admin_stats`, {
+    const response = await fetchWithRetry(getEndpointUrl('/private/admin_stats'), {
       method: 'POST',
       headers: adminHeaders,
       body: JSON.stringify({

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -18,6 +18,10 @@ const INSIGHTS_END = '2026-04-30T23:59:59.000Z'
 const INSIGHTS_UPLOAD_AT = '2026-04-10T10:00:00.000Z'
 const INSIGHTS_LAST_BUILD_AT = '2026-04-11T12:00:00.000Z'
 const INSIGHTS_BUILD_ID = `admin-stats-build-${TRIAL_ORG_ID.slice(0, 8)}`
+const ATTENTION_SORT_HEALTHY_ORG_ID = randomUUID()
+const ATTENTION_SORT_HEALTHY_CUSTOMER_ID = `cus_admin_stats_attention_sort_${ATTENTION_SORT_HEALTHY_ORG_ID.slice(0, 8)}`
+const ATTENTION_SORT_TOKEN = `attention-sort-${TRIAL_ORG_ID.slice(0, 8)}`
+const ATTENTION_SORT_HEALTHY_ORG_CREATED_AT = new Date(NOW + DAY_IN_MS).toISOString()
 
 const CANCELLED_YEARLY_ORG_ID = randomUUID()
 const CANCELLED_YEARLY_CUSTOMER_ID = `cus_admin_stats_cancelled_yearly_${CANCELLED_YEARLY_ORG_ID.slice(0, 8)}`
@@ -167,6 +171,17 @@ beforeAll(async () => {
       subscription_anchor_end: '2026-05-01T00:00:00.000Z',
     },
     {
+      customer_id: ATTENTION_SORT_HEALTHY_CUSTOMER_ID,
+      status: 'created',
+      product_id: soloPlan.stripe_id,
+      price_id: soloPlan.price_m_id,
+      trial_at: TRIAL_END_DATE,
+      is_good_plan: false,
+      plan_usage: 2,
+      subscription_anchor_start: '2026-04-01T00:00:00.000Z',
+      subscription_anchor_end: '2026-05-01T00:00:00.000Z',
+    },
+    {
       customer_id: CANCELLED_YEARLY_CUSTOMER_ID,
       status: 'canceled',
       product_id: soloPlan.stripe_id,
@@ -240,11 +255,19 @@ beforeAll(async () => {
   const { error: orgError } = await supabase.from('orgs').insert([
     {
       id: TRIAL_ORG_ID,
-      name: `Admin Stats Trial ${TRIAL_ORG_ID.slice(0, 8)}`,
+      name: `Admin Stats Trial ${ATTENTION_SORT_TOKEN}`,
       created_by: USER_ID,
       management_email: TEST_EMAIL,
       customer_id: TRIAL_CUSTOMER_ID,
       created_at: TRIAL_ORG_CREATED_AT,
+    },
+    {
+      id: ATTENTION_SORT_HEALTHY_ORG_ID,
+      name: `Admin Stats Healthy ${ATTENTION_SORT_TOKEN}`,
+      created_by: USER_ID,
+      management_email: TEST_EMAIL,
+      customer_id: ATTENTION_SORT_HEALTHY_CUSTOMER_ID,
+      created_at: ATTENTION_SORT_HEALTHY_ORG_CREATED_AT,
     },
     {
       id: CANCELLED_YEARLY_ORG_ID,
@@ -450,8 +473,8 @@ afterAll(async () => {
   await supabase.from('channels').delete().in('app_id', [ONBOARDING_APP_ID, ONBOARDING_LATE_SUBSCRIPTION_APP_ID])
   await supabase.from('app_versions').delete().in('app_id', [TRIAL_APP_ID, ONBOARDING_APP_ID, ONBOARDING_LATE_SUBSCRIPTION_APP_ID])
   await supabase.from('apps').delete().in('app_id', [TRIAL_APP_ID, ONBOARDING_APP_ID, ONBOARDING_LATE_SUBSCRIPTION_APP_ID])
-  await supabase.from('orgs').delete().in('id', [TRIAL_ORG_ID, CANCELLED_YEARLY_ORG_ID, CANCELLED_MONTHLY_ORG_ID, ONBOARDING_ORG_ID, ONBOARDING_NO_BUNDLE_ORG_ID, ONBOARDING_LATE_SUBSCRIPTION_ORG_ID])
-  await supabase.from('stripe_info').delete().in('customer_id', [TRIAL_CUSTOMER_ID, CANCELLED_YEARLY_CUSTOMER_ID, CANCELLED_MONTHLY_CUSTOMER_ID, ONBOARDING_CUSTOMER_ID, ONBOARDING_NO_BUNDLE_CUSTOMER_ID, ONBOARDING_LATE_SUBSCRIPTION_CUSTOMER_ID])
+  await supabase.from('orgs').delete().in('id', [TRIAL_ORG_ID, ATTENTION_SORT_HEALTHY_ORG_ID, CANCELLED_YEARLY_ORG_ID, CANCELLED_MONTHLY_ORG_ID, ONBOARDING_ORG_ID, ONBOARDING_NO_BUNDLE_ORG_ID, ONBOARDING_LATE_SUBSCRIPTION_ORG_ID])
+  await supabase.from('stripe_info').delete().in('customer_id', [TRIAL_CUSTOMER_ID, ATTENTION_SORT_HEALTHY_CUSTOMER_ID, CANCELLED_YEARLY_CUSTOMER_ID, CANCELLED_MONTHLY_CUSTOMER_ID, ONBOARDING_CUSTOMER_ID, ONBOARDING_NO_BUNDLE_CUSTOMER_ID, ONBOARDING_LATE_SUBSCRIPTION_CUSTOMER_ID])
 }, 90000)
 
 describe('/private/admin_stats', () => {
@@ -610,6 +633,44 @@ describe('/private/admin_stats', () => {
     expect(paidOnlyPayload.success).toBe(true)
     expect(paidOnlyPayload.data.organizations).toEqual([])
     expect(paidOnlyPayload.data.total).toBe(0)
+  })
+
+  it.concurrent('prioritizes organizations needing attention before pagination', async () => {
+    if (!soloPlan)
+      throw new Error('Expected Solo plan to be loaded')
+
+    const response = await fetchWithRetry(`${BASE_URL}/private/admin_stats`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        metric_category: 'organization_insights',
+        start_date: INSIGHTS_START,
+        end_date: INSIGHTS_END,
+        plan_name: soloPlan.name,
+        billing_type: 'monthly',
+        search: ATTENTION_SORT_TOKEN,
+        limit: 1,
+        offset: 0,
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json() as {
+      success: boolean
+      data: {
+        organizations: Array<{
+          org_id: string
+          needs_attention: boolean
+        }>
+        total: number
+      }
+    }
+
+    expect(payload.success).toBe(true)
+    expect(payload.data.total).toBe(2)
+    expect(payload.data.organizations).toHaveLength(1)
+    expect(payload.data.organizations[0]?.org_id).toBe(TRIAL_ORG_ID)
+    expect(payload.data.organizations[0]?.needs_attention).toBe(true)
   })
 
   it.concurrent('returns cancellation billing metadata and subscription-or-signup dates', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Adds a backend `needs_attention` signal to admin organization insights when update failure volume and rate cross the attention threshold.
- Sorts at-risk organizations before normal rows so urgent accounts are visible on the first page.
- Adds a discreet amber dot in the organization name cell with a hover label showing failed attempts and fail rate.
- Covers the new response fields in the admin stats test.

## Motivation (AI generated)

The admin organizations page was sorted by registration date, which could hide customers with urgent update failure risk on later pages. Support needs a subtle signal that brings risky accounts into view without making the table noisy.

## Business Impact (AI generated)

This helps Capgo identify customers at risk of churn sooner, improving support response time and reducing the chance that an account with high update failures goes unnoticed.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/admin-stats.test.ts` passed once before final cleanup
- [x] Commit hook reran CLI build and Vue typecheck successfully
- [ ] Final focused test rerun was attempted, but the local Supabase gateway stopped responding to health requests and blocked before assertions

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard shows per-organization update health metrics (failed updates, installs, update attempts) and an attention indicator when fail rate is high; visually marked and accessible.
  * Organizations needing attention are prioritized in admin listings to surface issues sooner.

* **Documentation**
  * Added localized message for the high-fail-rate alert.

* **Tests**
  * Expanded tests to cover new metrics, attention sorting, and related behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->