### PR TITLE
fix(frontend): add subtle pending invite skip

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1518,6 +1518,8 @@
   "pending-invite-joined": "Organization joined",
   "pending-invite-load-failed": "Could not load your organization invitation",
   "pending-invite-logo-alt": "{name} logo",
+  "pending-invite-skip": "Skip for now",
+  "pending-invite-skip-failed": "Could not continue",
   "pending-invite-subtitle": "Review this invitation before continuing. You can join the organization or decline it.",
   "pending-invite-subtitle-multiple": "Review these invitations before continuing. You can join or decline each organization.",
   "pending-invite-summary": "Next step",

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -9,6 +9,7 @@ import { getLocalConfig, useSupabase } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
+import { hasPendingInviteSkip } from '~/utils/pendingInviteSkip'
 import { getPlans, isPlatformAdmin } from './../services/supabase'
 
 async function updateUser(
@@ -215,6 +216,8 @@ async function guard(
     if (!organizationsLoaded)
       return false
     if (to.path.startsWith('/onboarding/invitation'))
+      return false
+    if (hasPendingInviteSkip(sessionUser?.id ?? main.auth?.id))
       return false
     return organizationStore.organizations.some(org => org.role.startsWith('invite'))
   }

--- a/src/pages/onboarding/invitation.vue
+++ b/src/pages/onboarding/invitation.vue
@@ -13,6 +13,7 @@ import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
+import { clearPendingInviteSkip, rememberPendingInviteSkip } from '~/utils/pendingInviteSkip'
 
 const route = useRoute()
 const router = useRouter()
@@ -27,10 +28,11 @@ const isLoading = ref(true)
 const resolvingInvitationId = ref<string | null>(null)
 const resolvingInvitationAction = ref<'accept' | 'decline' | null>(null)
 const isDecliningAll = ref(false)
+const isSkipping = ref(false)
 const errorMessage = ref('')
 
 const hasMultipleInvitations = computed(() => invitations.value.length > 1)
-const isResolvingInvitation = computed(() => resolvingInvitationId.value !== null || isDecliningAll.value)
+const isResolvingInvitation = computed(() => resolvingInvitationId.value !== null || isDecliningAll.value || isSkipping.value)
 const title = computed(() => hasMultipleInvitations.value
   ? t('pending-invite-title-multiple')
   : t('pending-invite-title'))
@@ -47,6 +49,10 @@ const targetPath = computed(() => {
 
 function getPendingInviteOrganizations() {
   return organizationStore.organizations.filter(org => org.role.startsWith('invite'))
+}
+
+function getCurrentUserId() {
+  return main.user?.id ?? main.auth?.id
 }
 
 async function continueAfterInvitationsResolved() {
@@ -105,7 +111,7 @@ async function acceptInvitation(invitation: Organization) {
 }
 
 async function declineInvitation(invitation: Organization) {
-  const userId = main.user?.id ?? main.auth?.id
+  const userId = getCurrentUserId()
   if (!userId)
     throw new Error('missing_user')
 
@@ -124,6 +130,8 @@ async function resolveInvitation(invitation: Organization, action: 'accept' | 'd
   resolvingInvitationAction.value = action
   errorMessage.value = ''
   try {
+    clearPendingInviteSkip(getCurrentUserId())
+
     if (action === 'accept') {
       await acceptInvitation(invitation)
       toast.success(t('pending-invite-joined'))
@@ -152,9 +160,11 @@ async function declineAllInvitations() {
   isDecliningAll.value = true
   errorMessage.value = ''
   try {
-    const userId = main.user?.id ?? main.auth?.id
+    const userId = getCurrentUserId()
     if (!userId)
       throw new Error('missing_user')
+
+    clearPendingInviteSkip(userId)
 
     const inviteOrgIds = invitations.value.map(invitation => invitation.gid)
     const { error } = await supabase
@@ -177,6 +187,22 @@ async function declineAllInvitations() {
   }
   finally {
     isDecliningAll.value = false
+  }
+}
+
+async function skipInvitations() {
+  isSkipping.value = true
+  errorMessage.value = ''
+  try {
+    rememberPendingInviteSkip(getCurrentUserId())
+    await continueAfterInvitationsResolved()
+  }
+  catch (error) {
+    console.error('Failed to skip pending organization invitations', error)
+    errorMessage.value = t('pending-invite-skip-failed')
+  }
+  finally {
+    isSkipping.value = false
   }
 }
 
@@ -284,6 +310,19 @@ onMounted(async () => {
                   <IconLoader v-if="isDecliningAll" class="h-4 w-4 animate-spin" />
                   <IconX v-else class="h-4 w-4" />
                   {{ t('pending-invite-create-org') }}
+                </button>
+              </div>
+
+              <div v-if="!isLoading" class="mt-5 border-t border-white/10 pt-4">
+                <button
+                  type="button"
+                  class="d-btn d-btn-ghost min-h-11 px-3 text-sm font-medium text-slate-400 opacity-75 hover:bg-white/5 hover:text-slate-200 hover:opacity-100 disabled:text-slate-600 disabled:opacity-50"
+                  :disabled="isResolvingInvitation"
+                  data-test="pending-invite-skip"
+                  @click="skipInvitations"
+                >
+                  <IconLoader v-if="isSkipping" class="h-4 w-4 animate-spin" />
+                  {{ t('pending-invite-skip') }}
                 </button>
               </div>
             </div>

--- a/src/utils/pendingInviteSkip.ts
+++ b/src/utils/pendingInviteSkip.ts
@@ -1,0 +1,27 @@
+const PENDING_INVITE_SKIP_STORAGE_KEY = 'capgo:pending-invite-skip-user'
+
+function canUseSessionStorage() {
+  return typeof sessionStorage !== 'undefined'
+}
+
+export function rememberPendingInviteSkip(userId: string | null | undefined) {
+  if (!userId || !canUseSessionStorage())
+    return
+
+  sessionStorage.setItem(PENDING_INVITE_SKIP_STORAGE_KEY, userId)
+}
+
+export function hasPendingInviteSkip(userId: string | null | undefined) {
+  if (!userId || !canUseSessionStorage())
+    return false
+
+  return sessionStorage.getItem(PENDING_INVITE_SKIP_STORAGE_KEY) === userId
+}
+
+export function clearPendingInviteSkip(userId: string | null | undefined) {
+  if (!userId || !canUseSessionStorage())
+    return
+
+  if (sessionStorage.getItem(PENDING_INVITE_SKIP_STORAGE_KEY) === userId)
+    sessionStorage.removeItem(PENDING_INVITE_SKIP_STORAGE_KEY)
+}

--- a/src/utils/pendingInviteSkip.ts
+++ b/src/utils/pendingInviteSkip.ts
@@ -1,27 +1,47 @@
 const PENDING_INVITE_SKIP_STORAGE_KEY = 'capgo:pending-invite-skip-user'
 
 function canUseSessionStorage() {
-  return typeof sessionStorage !== 'undefined'
+  try {
+    return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined'
+  }
+  catch {
+    return false
+  }
 }
 
 export function rememberPendingInviteSkip(userId: string | null | undefined) {
   if (!userId || !canUseSessionStorage())
     return
 
-  sessionStorage.setItem(PENDING_INVITE_SKIP_STORAGE_KEY, userId)
+  try {
+    window.sessionStorage.setItem(PENDING_INVITE_SKIP_STORAGE_KEY, userId)
+  }
+  catch {
+    // Storage can be blocked in private or restricted browsing contexts.
+  }
 }
 
 export function hasPendingInviteSkip(userId: string | null | undefined) {
   if (!userId || !canUseSessionStorage())
     return false
 
-  return sessionStorage.getItem(PENDING_INVITE_SKIP_STORAGE_KEY) === userId
+  try {
+    return window.sessionStorage.getItem(PENDING_INVITE_SKIP_STORAGE_KEY) === userId
+  }
+  catch {
+    return false
+  }
 }
 
 export function clearPendingInviteSkip(userId: string | null | undefined) {
   if (!userId || !canUseSessionStorage())
     return
 
-  if (sessionStorage.getItem(PENDING_INVITE_SKIP_STORAGE_KEY) === userId)
-    sessionStorage.removeItem(PENDING_INVITE_SKIP_STORAGE_KEY)
+  try {
+    if (window.sessionStorage.getItem(PENDING_INVITE_SKIP_STORAGE_KEY) === userId)
+      window.sessionStorage.removeItem(PENDING_INVITE_SKIP_STORAGE_KEY)
+  }
+  catch {
+    // Storage can be blocked in private or restricted browsing contexts.
+  }
 }


### PR DESCRIPTION
## Summary (AI generated)

- Added a low-emphasis "Skip for now" action to the pending invite onboarding page.
- Stores a session-scoped frontend skip marker so choosing skip does not immediately route the user back to the invite page.
- Keeps join/decline as the primary visible actions while preserving an accessible escape route.

## Motivation (AI generated)

Users reported they could not skip the pending invite decision. The flow still should nudge users toward joining the invited org, but it needs a clear fallback for users who want to continue without resolving the invite immediately.

## Business Impact (AI generated)

This reduces onboarding frustration while keeping the intended invite-join path visually preferred, helping invited users continue without getting blocked.

## Screenshots (AI generated)

![Pending invite onboarding with subtle skip action](https://raw.githubusercontent.com/Cap-go/capgo/7015b651bbf639a29e487281fe258646abc94439/docs/pr/pending-invite-skip.png)

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `git diff --check`

## UX Notes (AI generated)

- The skip control is placed below the main actions and styled as a subdued ghost/text action.
- The button remains keyboard-accessible and keeps a 44px+ hit target.
- The bypass is session-scoped, so it does not permanently suppress future invite prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to skip pending invitations during onboarding with a "Skip for now" button
  * Skip preference is now remembered across sessions to prevent repeated prompts
  * Improved error messaging when the skip action fails to complete

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
