### PR TITLE
feat: add manifest download size endpoint

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1188,6 +1188,7 @@
   "manifest-status-diff": "Showing {count} files that differ from {bundle} ({unchanged} files unchanged).",
   "manifest-status-full": "Showing full manifest for this bundle.",
   "manifest-summary-files": "Files",
+  "manifest-size-partial": "{size} + {unknown} unknown",
   "manifest-to-download": "To download",
   "manifest-total-bundle": "Total bundle",
   "mau": "Monthly active users",

--- a/src/pages/app/[app].bundle.[bundle].manifest.vue
+++ b/src/pages/app/[app].bundle.[bundle].manifest.vue
@@ -6,12 +6,25 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import IconAlertCircle from '~icons/lucide/alert-circle'
 import { formatBytes } from '~/services/conversion'
-import { useSupabase } from '~/services/supabase'
+import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 
 type ManifestEntry = Database['public']['Tables']['manifest']['Row']
 
 type VersionRow = Pick<Database['public']['Tables']['app_versions']['Row'], 'id' | 'name' | 'created_at' | 'manifest_count' | 'app_id'>
+
+interface ManifestDownloadSizeResult {
+  totalSize: number
+  knownFiles: number
+  unknownFiles: number
+  files: Array<{
+    file_name: string | null
+    file_hash: string | null
+    download_url: string | null
+    size?: number
+    error?: string
+  }>
+}
 
 const route = useRoute('/app/[app].bundle.[bundle].manifest')
 const router = useRouter()
@@ -27,6 +40,9 @@ const manifestEntries = ref<ManifestEntry[]>([])
 const selectedCompareVersion = ref<VersionRow | null>(null)
 const compareManifestEntries = ref<ManifestEntry[]>([])
 const compareManifestCache = ref<Record<number, ManifestEntry[]>>({})
+const diffDownloadSize = ref<ManifestDownloadSizeResult | null>(null)
+const diffDownloadSizeLoading = ref(false)
+const diffDownloadSizeRequestId = ref(0)
 const search = ref('')
 const currentPage = ref(1)
 const MANIFEST_PAGE_SIZE = 1000
@@ -124,7 +140,27 @@ function formatSizeLabel(entries: ManifestEntry[]): string {
   return hasSize ? formatBytes(totalSize) : t('metadata-not-found')
 }
 
-const downloadSizeLabel = computed(() => formatSizeLabel(diffEntries.value))
+function formatManifestDownloadSize(result: ManifestDownloadSizeResult): string {
+  if (result.files.length === 0)
+    return formatBytes(0)
+  if (result.knownFiles === 0)
+    return t('metadata-not-found')
+
+  const size = formatBytes(result.totalSize)
+  if (result.unknownFiles > 0)
+    return t('manifest-size-partial', { size, unknown: result.unknownFiles })
+  return size
+}
+
+const downloadSizeLabel = computed(() => {
+  if (!compareVersionId.value)
+    return formatSizeLabel(diffEntries.value)
+  if (diffDownloadSizeLoading.value)
+    return t('loading')
+  if (diffDownloadSize.value)
+    return formatManifestDownloadSize(diffDownloadSize.value)
+  return formatSizeLabel(diffEntries.value)
+})
 const unchangedSizeLabel = computed(() => formatSizeLabel(unchangedEntries.value))
 const totalBundleSizeLabel = computed(() => formatSizeLabel(manifestEntries.value))
 
@@ -173,6 +209,52 @@ async function fetchManifestEntries(versionId: number) {
   }
 
   return allEntries
+}
+
+function isManifestDownloadSizeResult(value: unknown): value is ManifestDownloadSizeResult {
+  if (!value || typeof value !== 'object')
+    return false
+  const result = value as ManifestDownloadSizeResult
+  return typeof result.totalSize === 'number'
+    && typeof result.knownFiles === 'number'
+    && typeof result.unknownFiles === 'number'
+    && Array.isArray(result.files)
+}
+
+async function fetchManifestDownloadSize(entries: ManifestEntry[]): Promise<ManifestDownloadSizeResult | null> {
+  if (!defaultApiHost || !packageId.value || !version.value?.name)
+    return null
+
+  const response = await fetch(`${defaultApiHost}/updates/manifest_size`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      app_id: packageId.value,
+      device_id: '00000000-0000-0000-0000-000000000000',
+      version_name: '0.0.0',
+      version_build: '0.0.0',
+      version_os: '18.0',
+      is_emulator: false,
+      is_prod: true,
+      platform: 'ios',
+      plugin_version: '8.47.0',
+      version: version.value.name,
+      version_id: id.value,
+      manifest: entries.map(entry => ({
+        file_name: entry.file_name,
+        file_hash: entry.file_hash,
+        download_url: null,
+      })),
+    }),
+  })
+
+  if (!response.ok)
+    throw new Error(`Manifest size request failed with ${response.status}`)
+
+  const result = await response.json()
+  return isManifestDownloadSizeResult(result) ? result : null
 }
 
 async function getVersion() {
@@ -226,6 +308,9 @@ async function reloadManifest() {
 function resetCompareSelection() {
   selectedCompareVersion.value = null
   compareManifestEntries.value = []
+  diffDownloadSize.value = null
+  diffDownloadSizeLoading.value = false
+  diffDownloadSizeRequestId.value += 1
   tableLoading.value = false
 }
 
@@ -252,6 +337,40 @@ watch(compareVersionId, async (value) => {
   compareManifestCache.value[value] = entries
   compareManifestEntries.value = entries
   tableLoading.value = false
+})
+
+watch([diffEntries, compareVersionId, tableLoading], async ([entries, compareId, isTableLoading]) => {
+  const requestId = ++diffDownloadSizeRequestId.value
+  diffDownloadSize.value = null
+  if (!compareId || isTableLoading) {
+    diffDownloadSizeLoading.value = false
+    return
+  }
+  if (entries.length === 0) {
+    diffDownloadSize.value = {
+      totalSize: 0,
+      knownFiles: 0,
+      unknownFiles: 0,
+      files: [],
+    }
+    diffDownloadSizeLoading.value = false
+    return
+  }
+
+  diffDownloadSizeLoading.value = true
+  try {
+    const result = await fetchManifestDownloadSize(entries)
+    if (requestId !== diffDownloadSizeRequestId.value)
+      return
+    diffDownloadSize.value = result
+  }
+  catch (error) {
+    console.error('Failed to load manifest download size', error)
+  }
+  finally {
+    if (requestId === diffDownloadSizeRequestId.value)
+      diffDownloadSizeLoading.value = false
+  }
 })
 
 watchEffect(async () => {

--- a/supabase/functions/_backend/plugins/updates.ts
+++ b/supabase/functions/_backend/plugins/updates.ts
@@ -3,6 +3,7 @@ import type { AppInfos } from '../utils/types.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, parseBody, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { getManifestDownloadSize } from '../utils/manifest_size.ts'
 import { parsePluginBody } from '../utils/plugin_parser.ts'
 import { updateRequestSchema } from '../utils/plugin_validation.ts'
 import { update } from '../utils/update.ts'
@@ -27,6 +28,29 @@ app.post('/', async (c) => {
     return simpleRateLimit({ app_id: body.app_id })
   }
   return update(c, parsePluginBody<AppInfos>(c, body, updateRequestSchema))
+})
+
+app.post('/manifest_size', async (c) => {
+  const body = await parseBody<AppInfos & {
+    manifest?: unknown
+    files?: unknown
+    version?: string
+  }>(c)
+  const files = body.manifest ?? body.files
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'post updates manifest_size body',
+    app_id: body.app_id,
+    device_id: body.device_id,
+    version: body.version,
+    files_count: Array.isArray(files) ? files.length : 0,
+  })
+  if (isLimited(c, body.app_id))
+    return simpleRateLimit({ app_id: body.app_id })
+
+  const parsedBody = parsePluginBody<AppInfos>(c, body, updateRequestSchema)
+  const size = await getManifestDownloadSize(c, parsedBody.app_id, typeof body.version === 'string' ? body.version : undefined, files)
+  return c.json(size)
 })
 
 app.get('/', (c) => {

--- a/supabase/functions/_backend/plugins/updates.ts
+++ b/supabase/functions/_backend/plugins/updates.ts
@@ -3,7 +3,7 @@ import type { AppInfos } from '../utils/types.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, parseBody, simpleRateLimit } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { getManifestDownloadSize } from '../utils/manifest_size.ts'
+import { getManifestDownloadSize, parseManifestSizeVersionId } from '../utils/manifest_size.ts'
 import { parsePluginBody } from '../utils/plugin_parser.ts'
 import { updateRequestSchema } from '../utils/plugin_validation.ts'
 import { update } from '../utils/update.ts'
@@ -35,6 +35,7 @@ app.post('/manifest_size', async (c) => {
     manifest?: unknown
     files?: unknown
     version?: string
+    version_id?: unknown
   }>(c)
   const files = body.manifest ?? body.files
   cloudlog({
@@ -43,13 +44,14 @@ app.post('/manifest_size', async (c) => {
     app_id: body.app_id,
     device_id: body.device_id,
     version: body.version,
+    version_id: body.version_id,
     files_count: Array.isArray(files) ? files.length : 0,
   })
   if (isLimited(c, body.app_id))
     return simpleRateLimit({ app_id: body.app_id })
 
   const parsedBody = parsePluginBody<AppInfos>(c, body, updateRequestSchema)
-  const size = await getManifestDownloadSize(c, parsedBody.app_id, typeof body.version === 'string' ? body.version : undefined, files)
+  const size = await getManifestDownloadSize(c, parsedBody.app_id, typeof body.version === 'string' ? body.version : undefined, parseManifestSizeVersionId(body.version_id), files)
   return c.json(size)
 })
 

--- a/supabase/functions/_backend/utils/manifest_size.ts
+++ b/supabase/functions/_backend/utils/manifest_size.ts
@@ -29,8 +29,6 @@ export interface ManifestDownloadSizeResult {
   files: ManifestSizeResultFile[]
 }
 
-const MAX_MANIFEST_SIZE_FILES = 10000
-
 function versionIdFromDownloadUrl(downloadUrl: string | null | undefined): number | null {
   if (!downloadUrl)
     return null
@@ -54,7 +52,7 @@ export function normalizeManifestSizeFiles(files: unknown): NormalizedManifestSi
 
   const normalized: NormalizedManifestSizeFile[] = []
   const seen = new Set<string>()
-  for (const file of files.slice(0, MAX_MANIFEST_SIZE_FILES)) {
+  for (const file of files) {
     if (!file || typeof file !== 'object')
       continue
 

--- a/supabase/functions/_backend/utils/manifest_size.ts
+++ b/supabase/functions/_backend/utils/manifest_size.ts
@@ -1,0 +1,188 @@
+import type { Context } from 'hono'
+import { closeClient, getPgClient } from './pg.ts'
+
+export interface ManifestSizeRequestFile {
+  file_name?: string | null
+  file_hash?: string | null
+  download_url?: string | null
+}
+
+export interface NormalizedManifestSizeFile {
+  file_name: string | null
+  file_hash: string
+  download_url: string | null
+  version_id: number | null
+}
+
+export interface ManifestSizeResultFile {
+  file_name: string | null
+  file_hash: string
+  download_url: string | null
+  size?: number
+  error?: string
+}
+
+export interface ManifestDownloadSizeResult {
+  totalSize: number
+  knownFiles: number
+  unknownFiles: number
+  files: ManifestSizeResultFile[]
+}
+
+const MAX_MANIFEST_SIZE_FILES = 10000
+
+function versionIdFromDownloadUrl(downloadUrl: string | null | undefined): number | null {
+  if (!downloadUrl)
+    return null
+
+  try {
+    const parsed = new URL(downloadUrl)
+    const key = parsed.searchParams.get('key')
+    if (!key)
+      return null
+    const versionId = Number.parseInt(key, 10)
+    return Number.isSafeInteger(versionId) && versionId > 0 ? versionId : null
+  }
+  catch {
+    return null
+  }
+}
+
+export function normalizeManifestSizeFiles(files: unknown): NormalizedManifestSizeFile[] {
+  if (!Array.isArray(files))
+    return []
+
+  const normalized: NormalizedManifestSizeFile[] = []
+  const seen = new Set<string>()
+  for (const file of files.slice(0, MAX_MANIFEST_SIZE_FILES)) {
+    if (!file || typeof file !== 'object')
+      continue
+
+    const entry = file as ManifestSizeRequestFile
+    if (typeof entry.file_hash !== 'string' || !entry.file_hash)
+      continue
+
+    const fileName = typeof entry.file_name === 'string' ? entry.file_name : null
+    const downloadUrl = typeof entry.download_url === 'string' ? entry.download_url : null
+    const key = `${fileName ?? ''}\u0000${entry.file_hash}\u0000${downloadUrl ?? ''}`
+    if (seen.has(key))
+      continue
+
+    seen.add(key)
+    normalized.push({
+      file_name: fileName,
+      file_hash: entry.file_hash,
+      download_url: downloadUrl,
+      version_id: versionIdFromDownloadUrl(downloadUrl),
+    })
+  }
+  return normalized
+}
+
+export function buildManifestDownloadSizeResult(
+  files: NormalizedManifestSizeFile[],
+  rows: Array<{ file_hash: string, version_id: number | null, file_size: number | string | null }>,
+): ManifestDownloadSizeResult {
+  const sizesByVersionAndHash = new Map<string, number>()
+  const sizesByHash = new Map<string, number>()
+
+  for (const row of rows) {
+    const size = typeof row.file_size === 'string' ? Number.parseInt(row.file_size, 10) : row.file_size
+    if (!Number.isFinite(size) || size === null || size <= 0)
+      continue
+
+    if (row.version_id)
+      sizesByVersionAndHash.set(`${row.version_id}:${row.file_hash}`, size)
+    sizesByHash.set(row.file_hash, Math.max(sizesByHash.get(row.file_hash) ?? 0, size))
+  }
+
+  let totalSize = 0
+  let knownFiles = 0
+  let unknownFiles = 0
+  const resultFiles = files.map((file): ManifestSizeResultFile => {
+    const size = file.version_id
+      ? sizesByVersionAndHash.get(`${file.version_id}:${file.file_hash}`) ?? sizesByHash.get(file.file_hash)
+      : sizesByHash.get(file.file_hash)
+
+    if (typeof size === 'number' && size > 0) {
+      totalSize += size
+      knownFiles += 1
+      return {
+        file_name: file.file_name,
+        file_hash: file.file_hash,
+        download_url: file.download_url,
+        size,
+      }
+    }
+
+    unknownFiles += 1
+    return {
+      file_name: file.file_name,
+      file_hash: file.file_hash,
+      download_url: file.download_url,
+      error: 'size_unknown',
+    }
+  })
+
+  return {
+    totalSize,
+    knownFiles,
+    unknownFiles,
+    files: resultFiles,
+  }
+}
+
+export async function getManifestDownloadSize(
+  c: Context,
+  appId: string,
+  versionName: string | undefined,
+  filesInput: unknown,
+): Promise<ManifestDownloadSizeResult> {
+  const files = normalizeManifestSizeFiles(filesInput)
+  if (files.length === 0) {
+    return {
+      totalSize: 0,
+      knownFiles: 0,
+      unknownFiles: 0,
+      files: [],
+    }
+  }
+
+  const pgClient = getPgClient(c, true)
+  try {
+    const result = await pgClient.query<{ file_hash: string, version_id: number | null, file_size: number | string | null }>(
+      `
+      WITH requested AS (
+        SELECT file_hash, version_id
+        FROM jsonb_to_recordset($1::jsonb) AS request_files(file_hash text, version_id bigint)
+        WHERE file_hash IS NOT NULL
+      )
+      SELECT
+        requested.file_hash,
+        app_versions.id AS version_id,
+        MAX(manifest.file_size) AS file_size
+      FROM requested
+      INNER JOIN public.manifest
+        ON manifest.file_hash = requested.file_hash
+      INNER JOIN public.app_versions
+        ON app_versions.id = manifest.app_version_id
+        AND app_versions.app_id = $2
+        AND app_versions.deleted = false
+      WHERE (
+        requested.version_id IS NOT NULL
+        AND app_versions.id = requested.version_id
+      ) OR (
+        requested.version_id IS NULL
+        AND ($3::text IS NULL OR app_versions.name = $3)
+      )
+      GROUP BY requested.file_hash, app_versions.id
+      `,
+      [JSON.stringify(files), appId, versionName || null],
+    )
+
+    return buildManifestDownloadSizeResult(files, result.rows)
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
+}

--- a/supabase/functions/_backend/utils/manifest_size.ts
+++ b/supabase/functions/_backend/utils/manifest_size.ts
@@ -162,19 +162,21 @@ export async function getManifestDownloadSize(
         app_versions.id AS version_id,
         MAX(manifest.file_size) AS file_size
       FROM requested
-      INNER JOIN public.manifest
-        ON manifest.file_hash = requested.file_hash
       INNER JOIN public.app_versions
-        ON app_versions.id = manifest.app_version_id
-        AND app_versions.app_id = $2
+        ON app_versions.app_id = $2
         AND app_versions.deleted = false
-      WHERE (
-        requested.version_id IS NOT NULL
-        AND app_versions.id = requested.version_id
-      ) OR (
-        requested.version_id IS NULL
-        AND ($3::text IS NULL OR app_versions.name = $3)
-      )
+        AND (
+          (
+            requested.version_id IS NOT NULL
+            AND app_versions.id = requested.version_id
+          ) OR (
+            requested.version_id IS NULL
+            AND ($3::text IS NULL OR app_versions.name = $3)
+          )
+        )
+      INNER JOIN public.manifest
+        ON manifest.app_version_id = app_versions.id
+        AND manifest.file_hash = requested.file_hash
       GROUP BY requested.file_hash, app_versions.id
       `,
       [JSON.stringify(files), appId, versionName ?? null],

--- a/supabase/functions/_backend/utils/manifest_size.ts
+++ b/supabase/functions/_backend/utils/manifest_size.ts
@@ -35,15 +35,25 @@ function versionIdFromDownloadUrl(downloadUrl: string | null | undefined): numbe
 
   try {
     const parsed = new URL(downloadUrl)
-    const key = parsed.searchParams.get('key')
-    if (!key)
-      return null
-    const versionId = Number.parseInt(key, 10)
-    return Number.isSafeInteger(versionId) && versionId > 0 ? versionId : null
+    return parseManifestSizeVersionId(parsed.searchParams.get('key')) ?? null
   }
   catch {
     return null
   }
+}
+
+export function parseManifestSizeVersionId(value: unknown): number | undefined {
+  if (typeof value === 'number')
+    return Number.isSafeInteger(value) && value > 0 ? value : undefined
+  if (typeof value !== 'string')
+    return undefined
+
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed))
+    return undefined
+
+  const versionId = Number.parseInt(trimmed, 10)
+  return Number.isSafeInteger(versionId) && versionId > 0 ? versionId : undefined
 }
 
 export function normalizeManifestSizeFiles(files: unknown): NormalizedManifestSizeFile[] {
@@ -134,6 +144,7 @@ export async function getManifestDownloadSize(
   c: Context,
   appId: string,
   versionName: string | undefined,
+  versionId: number | undefined,
   filesInput: unknown,
 ): Promise<ManifestDownloadSizeResult> {
   const files = normalizeManifestSizeFiles(filesInput)
@@ -169,7 +180,15 @@ export async function getManifestDownloadSize(
             AND app_versions.id = requested.version_id
           ) OR (
             requested.version_id IS NULL
-            AND ($3::text IS NULL OR app_versions.name = $3)
+            AND (
+              (
+                $3::bigint IS NOT NULL
+                AND app_versions.id = $3
+              ) OR (
+                $3::bigint IS NULL
+                AND ($4::text IS NULL OR app_versions.name = $4)
+              )
+            )
           )
         )
       INNER JOIN public.manifest
@@ -177,7 +196,7 @@ export async function getManifestDownloadSize(
         AND manifest.file_hash = requested.file_hash
       GROUP BY requested.file_hash, app_versions.id
       `,
-      [JSON.stringify(files), appId, versionName ?? null],
+      [JSON.stringify(files), appId, versionId ?? null, versionName ?? null],
     )
 
     return buildManifestDownloadSizeResult(files, result.rows)

--- a/supabase/functions/_backend/utils/manifest_size.ts
+++ b/supabase/functions/_backend/utils/manifest_size.ts
@@ -177,7 +177,7 @@ export async function getManifestDownloadSize(
       )
       GROUP BY requested.file_hash, app_versions.id
       `,
-      [JSON.stringify(files), appId, versionName || null],
+      [JSON.stringify(files), appId, versionName ?? null],
     )
 
     return buildManifestDownloadSizeResult(files, result.rows)

--- a/supabase/functions/updates/index.ts
+++ b/supabase/functions/updates/index.ts
@@ -1,10 +1,11 @@
 import { app } from '../_backend/plugins/updates.ts'
-import { createAllCatch, createHono } from '../_backend/utils/hono.ts'
+import { createAllCatch, createHono, useCors } from '../_backend/utils/hono.ts'
 import { version } from '../_backend/utils/version.ts'
 
 const functionName = 'updates'
 const appGlobal = createHono(functionName, version)
 
+appGlobal.use('*', useCors)
 appGlobal.route('/', app)
 createAllCatch(appGlobal, functionName)
 Deno.serve(appGlobal.fetch)

--- a/tests/manifest-size.unit.test.ts
+++ b/tests/manifest-size.unit.test.ts
@@ -40,6 +40,23 @@ describe('manifest download size helpers', () => {
     ])
   })
 
+  it.concurrent('does not truncate large manifests', () => {
+    const input = Array.from({ length: 10050 }, (_, index) => ({
+      file_name: `file-${index}.js`,
+      file_hash: `hash-${index}`,
+    }))
+
+    const files = normalizeManifestSizeFiles(input)
+
+    expect(files).toHaveLength(input.length)
+    expect(files.at(-1)).toEqual({
+      file_name: 'file-10049.js',
+      file_hash: 'hash-10049',
+      download_url: null,
+      version_id: null,
+    })
+  })
+
   it.concurrent('sums known file sizes and marks missing metadata as unknown', () => {
     const files = normalizeManifestSizeFiles([
       {

--- a/tests/manifest-size.unit.test.ts
+++ b/tests/manifest-size.unit.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { buildManifestDownloadSizeResult, normalizeManifestSizeFiles } from '../supabase/functions/_backend/utils/manifest_size.ts'
+import { buildManifestDownloadSizeResult, normalizeManifestSizeFiles, parseManifestSizeVersionId } from '../supabase/functions/_backend/utils/manifest_size.ts'
 
 describe('manifest download size helpers', () => {
+  it.concurrent('parses explicit bundle ids for console manifest size requests', () => {
+    expect(parseManifestSizeVersionId(42)).toBe(42)
+    expect(parseManifestSizeVersionId('42')).toBe(42)
+    expect(parseManifestSizeVersionId(' 42 ')).toBe(42)
+    expect(parseManifestSizeVersionId(0)).toBeUndefined()
+    expect(parseManifestSizeVersionId('42-file')).toBeUndefined()
+  })
+
   it.concurrent('normalizes valid manifest files and extracts version ids from download urls', () => {
     const files = normalizeManifestSizeFiles([
       {

--- a/tests/manifest-size.unit.test.ts
+++ b/tests/manifest-size.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { buildManifestDownloadSizeResult, normalizeManifestSizeFiles } from '../supabase/functions/_backend/utils/manifest_size.ts'
+
+describe('manifest download size helpers', () => {
+  it.concurrent('normalizes valid manifest files and extracts version ids from download urls', () => {
+    const files = normalizeManifestSizeFiles([
+      {
+        file_name: 'index.html.br',
+        file_hash: 'hash-a',
+        download_url: 'https://plugin.capgo.test/files/read/attachments/path/index.html.br?key=42&device_id=device',
+      },
+      {
+        file_name: 'index.html.br',
+        file_hash: 'hash-a',
+        download_url: 'https://plugin.capgo.test/files/read/attachments/path/index.html.br?key=42&device_id=device',
+      },
+      {
+        file_name: 'main.js',
+        file_hash: 'hash-b',
+      },
+      {
+        file_name: 'bad.js',
+        file_hash: '',
+      },
+    ])
+
+    expect(files).toEqual([
+      {
+        file_name: 'index.html.br',
+        file_hash: 'hash-a',
+        download_url: 'https://plugin.capgo.test/files/read/attachments/path/index.html.br?key=42&device_id=device',
+        version_id: 42,
+      },
+      {
+        file_name: 'main.js',
+        file_hash: 'hash-b',
+        download_url: null,
+        version_id: null,
+      },
+    ])
+  })
+
+  it.concurrent('sums known file sizes and marks missing metadata as unknown', () => {
+    const files = normalizeManifestSizeFiles([
+      {
+        file_name: 'index.html.br',
+        file_hash: 'hash-a',
+        download_url: 'https://plugin.capgo.test/files/read/attachments/path/index.html.br?key=42',
+      },
+      {
+        file_name: 'main.js',
+        file_hash: 'hash-b',
+      },
+      {
+        file_name: 'style.css',
+        file_hash: 'hash-c',
+      },
+    ])
+
+    const result = buildManifestDownloadSizeResult(files, [
+      { file_hash: 'hash-a', version_id: 42, file_size: 100 },
+      { file_hash: 'hash-b', version_id: null, file_size: '50' },
+      { file_hash: 'hash-c', version_id: null, file_size: 0 },
+    ])
+
+    expect(result.totalSize).toBe(150)
+    expect(result.knownFiles).toBe(2)
+    expect(result.unknownFiles).toBe(1)
+    expect(result.files).toEqual([
+      {
+        file_name: 'index.html.br',
+        file_hash: 'hash-a',
+        download_url: 'https://plugin.capgo.test/files/read/attachments/path/index.html.br?key=42',
+        size: 100,
+      },
+      {
+        file_name: 'main.js',
+        file_hash: 'hash-b',
+        download_url: null,
+        size: 50,
+      },
+      {
+        file_name: 'style.css',
+        file_hash: 'hash-c',
+        download_url: null,
+        error: 'size_unknown',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## What
- Add a plugin endpoint at `POST /updates/manifest_size`.
- Accept missing manifest files from the plugin and return total known download bytes plus per-file size metadata.
- Add unit coverage for manifest normalization and size aggregation.

## Why
- Apps need partial update size estimates before download without issuing one HEAD request per file.

## How
- Reuse the existing plugin update request validation and rate limiting.
- Normalize and dedupe submitted manifest entries, extract version ids from existing manifest download URLs, and query stored `manifest.file_size` rows in one read-only Postgres query.
- Return unknown file entries when size metadata is unavailable instead of falling back to storage HEAD requests.
- Implemented with Codex.

## Testing
- `bunx vitest run tests/manifest-size.unit.test.ts`
- `bun run lint:backend`
- Commit hook ran `bun run cli:build && vue-tsc --noEmit`

## Not Tested
- Full `bun run test:backend` suite was not run.
- Live endpoint call against a seeded Supabase instance was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API endpoint to compute total download size for a manifest or list of files, with support for version-specific sizing, automatic file deduplication, and graceful handling of unknown sizes.

* **Tests**
  * Added unit tests covering normalization, aggregation, large inputs, and unknown-size handling for the manifest size utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->