### PR TITLE
fix: prevent manifest page query reload loop

### DIFF
--- a/src/pages/app/[app].bundle.[bundle].manifest.vue
+++ b/src/pages/app/[app].bundle.[bundle].manifest.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TableColumn } from '~/components/comp_def'
 import type { Database } from '~/types/supabase.types'
-import { computed, h, ref, watch, watchEffect } from 'vue'
+import { computed, h, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import IconAlertCircle from '~icons/lucide/alert-circle'
@@ -43,6 +43,7 @@ const compareManifestCache = ref<Record<number, ManifestEntry[]>>({})
 const diffDownloadSize = ref<ManifestDownloadSizeResult | null>(null)
 const diffDownloadSizeLoading = ref(false)
 const diffDownloadSizeRequestId = ref(0)
+const pageLoadRequestId = ref(0)
 const search = ref('')
 const currentPage = ref(1)
 const MANIFEST_PAGE_SIZE = 1000
@@ -58,6 +59,10 @@ const directUpdateConfigSnippet = `{
   }
 }`
 const differentialsDocUrl = 'https://capgo.app/docs/live-updates/differentials/'
+
+function getRouteParam(value: string | string[]): string {
+  return Array.isArray(value) ? value[0] ?? '' : value
+}
 
 function hideHash(hash: string) {
   if (!hash)
@@ -373,19 +378,27 @@ watch([diffEntries, compareVersionId, tableLoading], async ([entries, compareId,
   }
 })
 
-watchEffect(async () => {
-  if (route.path.includes('/bundle/') && route.path.includes('/manifest')) {
+watch(
+  () => [route.params.app, route.params.bundle] as const,
+  async ([appParam, bundleParam]) => {
+    const requestId = ++pageLoadRequestId.value
     loading.value = true
-    packageId.value = route.params.app as string
-    id.value = Number(route.params.bundle as string)
+    packageId.value = getRouteParam(appParam)
+    id.value = Number(getRouteParam(bundleParam))
+    version.value = undefined
+    manifestEntries.value = []
     resetCompareSelection()
     await Promise.all([getVersion(), loadManifest()])
+    if (requestId !== pageLoadRequestId.value)
+      return
     loading.value = false
-    if (!version.value?.name)
+    const loadedVersion = version.value as Database['public']['Tables']['app_versions']['Row'] | undefined
+    if (!loadedVersion?.name)
       displayStore.NavTitle = t('bundle')
     displayStore.defaultBack = `/app/${packageId.value}/bundles`
-  }
-})
+  },
+  { immediate: true },
+)
 </script>
 
 <template>


### PR DESCRIPTION
## What
- Narrow the manifest page loader to only rerun when the app or bundle route params change.
- Keep stale async page-load responses from updating the page after a newer bundle load starts.

## Why
- Query-only table updates can change the page URL parameter. The previous broad route watcher could treat that as a page load, unmount DataTable, and make DataTable remove/re-add the page query param repeatedly.

## How
- Replace the broad watcher with an explicit watcher over the app and bundle route params.
- Reset bundle state only for real bundle route changes.

## Testing
- bun run lint
- bun run typecheck
- bun run build

## Not Tested
- Manual production console session with a real authenticated app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal route parameter handling and state management for better reliability with page navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->