### PR TITLE
fix(manifest): check upload-encoded storage keys

### DIFF
--- a/scripts/backfill_manifest_file_sizes.mjs
+++ b/scripts/backfill_manifest_file_sizes.mjs
@@ -104,6 +104,7 @@ const FAILED_CSV_HEADERS = [
   'file_name',
   's3_path',
   'attempted_s3_path',
+  'attempted_s3_paths',
   'status',
   'method',
   'reason',
@@ -239,34 +240,47 @@ function decodeStoragePathSegments(s3Path) {
   }
 }
 
-function getLegacyDecodedStoragePath(s3Path) {
-  if (!PERCENT_ENCODED_OCTET_RE.test(s3Path))
-    return null
-
-  const decoded = decodeStoragePathSegments(s3Path)
-  return decoded && decoded !== s3Path ? decoded : null
+function encodeStoragePathSegments(s3Path) {
+  return s3Path.split('/').map(segment => encodeURIComponent(segment)).join('/')
 }
 
-function markDecodedStorageResult(result, attemptedS3Path) {
+function getStorageCandidatePaths(s3Path) {
+  const candidates = [s3Path]
+  if (PERCENT_ENCODED_OCTET_RE.test(s3Path)) {
+    const decoded = decodeStoragePathSegments(s3Path)
+    if (decoded && decoded !== s3Path)
+      candidates.push(decoded)
+
+    const encoded = encodeStoragePathSegments(s3Path)
+    if (encoded !== s3Path)
+      candidates.push(encoded)
+  }
+  return [...new Set(candidates)]
+}
+
+function markStorageCandidateResult(result, attemptedS3Path, attemptedS3Paths) {
+  const suffix = attemptedS3Path === attemptedS3Paths[0] ? '' : '_candidate'
   return {
     ...result,
     attempted_s3_path: attemptedS3Path,
-    method: `${result.method ?? 'unknown'}_decoded`,
-    reason: result.reason ? `${result.reason}_decoded_path` : 'decoded_path',
+    attempted_s3_paths: attemptedS3Paths,
+    method: `${result.method ?? 'unknown'}${suffix}`,
+    reason: suffix && result.reason ? `${result.reason}${suffix}` : result.reason,
   }
 }
 
 async function getObjectSizeWithLegacyFallback(s3, s3Path) {
-  const primary = await getObjectSize(s3, s3Path)
-  if (primary.size > 0)
-    return primary
+  const candidatePaths = getStorageCandidatePaths(s3Path)
+  let lastResult = null
 
-  const fallbackPath = primary.status === 404 ? getLegacyDecodedStoragePath(s3Path) : null
-  if (!fallbackPath)
-    return primary
+  for (const candidatePath of candidatePaths) {
+    const result = markStorageCandidateResult(await getObjectSize(s3, candidatePath), candidatePath, candidatePaths)
+    lastResult = result
+    if (result.size > 0 || shouldRetryStorageResult(result))
+      return result
+  }
 
-  const fallback = await getObjectSize(s3, fallbackPath)
-  return markDecodedStorageResult(fallback, fallbackPath)
+  return lastResult
 }
 
 async function getObjectSize(s3, s3Path) {
@@ -564,6 +578,7 @@ async function processCandidates({ apply, dbAttempts, pool, s3, storageAttempts,
       app_id: result.row.app_id,
       app_version_id: result.row.app_version_id,
       attempted_s3_path: result.storage.attempted_s3_path,
+      attempted_s3_paths: result.storage.attempted_s3_paths,
       attempts: result.storage.attempts,
       error: result.storage.error,
       file_name: result.row.file_name,

--- a/supabase/functions/_backend/files/util.ts
+++ b/supabase/functions/_backend/files/util.ts
@@ -72,10 +72,16 @@ export function encodeR2KeyForUploadLocation(r2Key: string): string {
 }
 
 export function getAttachmentReadCandidateKeys(decodedKey: string, rawRouteKey: string | null | undefined): string[] {
-  if (rawRouteKey && rawRouteKey !== decodedKey)
-    return [decodedKey, rawRouteKey]
+  const candidates = [decodedKey]
+  if (rawRouteKey && rawRouteKey !== decodedKey) {
+    candidates.push(rawRouteKey)
 
-  return [decodedKey]
+    const encodedRawRouteKey = encodeR2KeyForUploadLocation(rawRouteKey)
+    if (encodedRawRouteKey !== rawRouteKey && encodedRawRouteKey !== decodedKey)
+      candidates.push(encodedRawRouteKey)
+  }
+
+  return [...new Set(candidates)]
 }
 
 export function parseAppScopedAttachmentPath(fileId: unknown): AppScopedAttachmentPath | null {

--- a/supabase/functions/_backend/utils/manifest_encoding.ts
+++ b/supabase/functions/_backend/utils/manifest_encoding.ts
@@ -4,7 +4,7 @@ export function encodeManifestPathSegments(path: string): string {
   return path.split('/').map(segment => encodeURIComponent(segment)).join('/')
 }
 
-function decodeManifestPathSegments(path: string): string | null {
+export function decodeManifestPathSegments(path: string): string | null {
   try {
     return path.split('/').map(segment => decodeURIComponent(segment)).join('/')
   }
@@ -35,4 +35,20 @@ export function normalizeLegacyEncodedManifestFileName(fileName: string | null |
     return fileName
 
   return decodedFileName
+}
+
+export function getManifestStorageCandidateKeys(s3Path: string): string[] {
+  const candidates = [s3Path]
+
+  if (PERCENT_ENCODED_OCTET_RE.test(s3Path)) {
+    const decodedPath = decodeManifestPathSegments(s3Path)
+    if (decodedPath && decodedPath !== s3Path)
+      candidates.push(decodedPath)
+
+    const encodedPath = encodeManifestPathSegments(s3Path)
+    if (encodedPath !== s3Path)
+      candidates.push(encodedPath)
+  }
+
+  return [...new Set(candidates)]
 }

--- a/supabase/functions/_backend/utils/s3.ts
+++ b/supabase/functions/_backend/utils/s3.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import type { Database } from '../utils/supabase.types.ts'
 import { S3Client } from '@bradenmacdonald/s3-lite-client'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
+import { getManifestStorageCandidateKeys } from './manifest_encoding.ts'
 import { getEnv } from './utils.ts'
 
 function firstForwardedHeaderValue(value: string | undefined): string | undefined {
@@ -312,8 +313,7 @@ async function getSizeFromRangeFallback(
   }
 }
 
-async function getSize(c: Context, fileId: string) {
-  const client = initS3(c)
+async function getSizeForKey(c: Context, client: ReturnType<typeof initS3>, fileId: string) {
   let size = 0
   let headError: unknown
   let usedFallback = false
@@ -360,6 +360,41 @@ async function getSize(c: Context, fileId: string) {
     usedFallback,
   })
   return size
+}
+
+async function getSize(c: Context, fileId: string) {
+  const client = initS3(c)
+  const candidateKeys = getManifestStorageCandidateKeys(fileId)
+
+  for (const candidateKey of candidateKeys) {
+    const size = await getSizeForKey(c, client, candidateKey)
+    if (size > 0) {
+      if (candidateKey !== fileId) {
+        cloudlog({
+          requestId: c.get('requestId'),
+          message: 'getSize recovered from manifest storage candidate',
+          fileId,
+          candidateKey,
+          candidateKeys,
+          size,
+        })
+      }
+      return size
+    }
+  }
+
+  if (candidateKeys.length > 1) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'getSize failed all manifest storage candidates',
+      fileId,
+      candidateKeys,
+      bucket: getEnv(c, 'S3_BUCKET'),
+      endpoint: getEnv(c, 'S3_ENDPOINT'),
+    })
+  }
+
+  return 0
 }
 
 async function getObject(c: Context, fileId: string): Promise<Response | null> {

--- a/tests/manifest-path-encoding.unit.test.ts
+++ b/tests/manifest-path-encoding.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { getManifestUrl } from '../supabase/functions/_backend/utils/downloadUrl.ts'
-import { normalizeLegacyEncodedManifestFileName } from '../supabase/functions/_backend/utils/manifest_encoding.ts'
+import { getManifestStorageCandidateKeys, normalizeLegacyEncodedManifestFileName } from '../supabase/functions/_backend/utils/manifest_encoding.ts'
 
 describe('manifest path encoding', () => {
   it.concurrent.each([
@@ -53,5 +53,15 @@ describe('manifest path encoding', () => {
       'assets/suite-marketing/images/social-media/sad_post_grey%402x.png',
       'orgs/org-id/apps/com.test.app/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%25402x.png',
     )).toBe('assets/suite-marketing/images/social-media/sad_post_grey%402x.png')
+  })
+
+  it.concurrent('checks legacy percent, decoded, and upload-location encoded storage keys', () => {
+    expect(getManifestStorageCandidateKeys(
+      'orgs/org-id/apps/com.test.app/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%402x.png',
+    )).toEqual([
+      'orgs/org-id/apps/com.test.app/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%402x.png',
+      'orgs/org-id/apps/com.test.app/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey@2x.png',
+      'orgs/org-id/apps/com.test.app/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%25402x.png',
+    ])
   })
 })

--- a/tests/upload-path-encoding.unit.test.ts
+++ b/tests/upload-path-encoding.unit.test.ts
@@ -16,6 +16,7 @@ describe('upload path encoding', () => {
     )).toEqual([
       'orgs/org-id/apps/app-id/delta/hash_sad_post_grey@2x.png',
       'orgs/org-id/apps/app-id/delta/hash_sad_post_grey%402x.png',
+      'orgs/org-id/apps/app-id/delta/hash_sad_post_grey%25402x.png',
     ])
   })
 
@@ -28,24 +29,26 @@ describe('upload path encoding', () => {
     expect(getSafeAttachmentReadCandidateKeys(decodedRouteKey, encodedStoragePath)).toEqual([
       decodedRouteKey,
       encodedStoragePath,
+      'orgs/org-id/apps/app-id/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%25402x.png',
     ])
   })
 
-  it.concurrent('heads legacy raw percent candidates when decoded object keys are missing', async () => {
+  it.concurrent('heads upload-location encoded candidates when decoded and raw percent object keys are missing', async () => {
     const checkedKeys: string[] = []
     const decodedRouteKey = 'orgs/org-id/apps/app-id/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey@2x.png'
     const encodedStoragePath = 'orgs/org-id/apps/app-id/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%402x.png'
+    const uploadLocationEncodedStoragePath = 'orgs/org-id/apps/app-id/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%25402x.png'
     const legacyObjectInfo = { size: 42 }
 
     const objectInfo = await headFirstExistingAttachmentCandidate({
       async head(key: string) {
         checkedKeys.push(key)
-        return key === encodedStoragePath ? legacyObjectInfo : null
+        return key === uploadLocationEncodedStoragePath ? legacyObjectInfo : null
       },
     }, getSafeAttachmentReadCandidateKeys(decodedRouteKey, encodedStoragePath))
 
     expect(objectInfo).toBe(legacyObjectInfo)
-    expect(checkedKeys).toEqual([decodedRouteKey, encodedStoragePath])
+    expect(checkedKeys).toEqual([decodedRouteKey, encodedStoragePath, uploadLocationEncodedStoragePath])
   })
 
   it.concurrent('does not try raw percent route keys outside the authorized app scope', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Add a third manifest storage candidate for upload-location encoded keys such as `%2540` when the database row contains `%40`.
- Use the same candidate list in the manifest size queue path, the Capgo file read path, and the manifest file-size backfill script.
- Extend encoding tests to cover decoded, raw percent, and upload-location encoded R2 keys.

## Motivation (AI generated)

Some legacy manifest rows still report missing metadata after trying both the stored `%40` key and the decoded `@` key. The failed CSV shows the fallback ran, but both candidates 404. The remaining legacy shape is the upload URL encoded key, where `%40` becomes `%2540` during resumable upload routing.

## Business Impact (AI generated)

This makes delta manifest downloads and file-size repair more reliable for old bundles with encoded asset names. It reduces support load and prevents customers from seeing `metadata not found` when the object exists under the upload-location encoded R2 key.

## Test Plan (AI generated)

- [x] `node --check scripts/backfill_manifest_file_sizes.mjs`
- [x] `bun scripts/backfill_manifest_file_sizes.mjs --help`
- [x] `bunx vitest run tests/manifest-path-encoding.unit.test.ts tests/upload-path-encoding.unit.test.ts`
- [x] `bunx eslint --no-ignore scripts/backfill_manifest_file_sizes.mjs supabase/functions/_backend/utils/manifest_encoding.ts supabase/functions/_backend/utils/s3.ts supabase/functions/_backend/files/util.ts tests/manifest-path-encoding.unit.test.ts tests/upload-path-encoding.unit.test.ts`
- [x] `bun lint`
- [x] `bun lint:backend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced file size backfilling with improved path resolution strategy to increase robustness when locating stored objects.
  * Refactored internal utilities to better handle file path variations and encoding formats.
  * Updated test suite to verify robust file retrieval across different path encoding scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->