### PR TITLE
[codex] Fix update failure log filters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -374,7 +374,7 @@ jobs:
         name: Start Playwright frontend
         env:
           BACKGROUND_SERVICE_NAME: Playwright frontend
-          BACKGROUND_RUN_COMMAND: CAPTCHA_KEY='' bun run serve:worktree
+          BACKGROUND_RUN_COMMAND: bun run supabase:with-env -- bun scripts/playwright-frontend-preview.ts
           BACKGROUND_WAIT_ON: |
             http-get://localhost:5173
           BACKGROUND_LOG_PATH: ${{ runner.temp }}/playwright-frontend.log

--- a/scripts/playwright-frontend-preview.ts
+++ b/scripts/playwright-frontend-preview.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process'
+
+const supabaseUrl = process.env.SUPABASE_URL
+if (!supabaseUrl) {
+  console.error('SUPABASE_URL is required for Playwright frontend preview')
+  process.exit(1)
+}
+
+const normalizedSupabaseHost = supabaseUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+const apiDomain = `${normalizedSupabaseHost}/functions/v1`
+
+const env = {
+  ...process.env,
+  API_DOMAIN: apiDomain,
+  CAPTCHA_KEY: '',
+  ENV: 'local',
+  SUPA_ANON: process.env.SUPABASE_ANON_KEY || '',
+  SUPA_URL: supabaseUrl,
+}
+
+const build = spawnSync('bun', ['run', 'build'], { env, stdio: 'inherit' })
+if ((build.status ?? 1) !== 0)
+  process.exit(build.status ?? 1)
+
+const preview = spawnSync('bunx', ['vite', 'preview', '--host', '127.0.0.1', '--port', '5173'], {
+  env,
+  stdio: 'inherit',
+})
+
+process.exit(preview.status ?? 1)

--- a/src/components/dashboard/UpdateStatsChart.vue
+++ b/src/components/dashboard/UpdateStatsChart.vue
@@ -59,11 +59,27 @@ const cycleEnd = computed(() => {
 
 const DAY_IN_MS = 1000 * 60 * 60 * 24
 
-// Map action display names back to action filter keys for navigation
-const actionToFilterKey: Record<string, string> = {
-  requested: 'get',
-  install: 'set',
-  fail: 'set_fail',
+const UPDATE_FAILURE_ACTIONS = [
+  'set_fail',
+  'update_fail',
+  'download_fail',
+  'windows_path_fail',
+  'canonical_path_fail',
+  'directory_path_fail',
+  'unzip_fail',
+  'low_mem_fail',
+  'download_manifest_file_fail',
+  'download_manifest_checksum_fail',
+  'download_manifest_brotli_fail',
+  'decrypt_fail',
+  'checksum_fail',
+] as const
+
+// Map chart buckets back to the log actions they aggregate.
+const actionToLogActions: Record<string, readonly string[]> = {
+  requested: ['get'],
+  install: ['set'],
+  fail: UPDATE_FAILURE_ACTIONS,
 }
 
 // Click handler for tooltip items - navigates to logs page filtered by action type and date
@@ -81,11 +97,11 @@ const tooltipClickHandler = computed<TooltipClickHandler | undefined>(() => {
     onAppClick: (actionKey: string, clickContext?: { date: Date, dataIndex: number }) => {
       // Navigate to logs page with action filter and date range
       // The actionKey here is the internal key like 'requested', 'install', 'fail'
-      const filterAction = actionToFilterKey[actionKey] || actionKey
+      const filterActions = actionToLogActions[actionKey] ?? [actionKey]
       const params = new URLSearchParams()
-      params.set('action', filterAction)
+      filterActions.forEach(action => params.append('action', action))
 
-      // Add date range if provided (start of day to end of day)
+      // Add date range if provided (selected day)
       if (clickContext?.date) {
         const startOfDay = dayjs(clickContext.date).startOf('day')
         const endOfDay = dayjs(clickContext.date).endOf('day')

--- a/src/components/tables/LogTable.vue
+++ b/src/components/tables/LogTable.vue
@@ -145,14 +145,16 @@ function formatAction(elem: Element): string {
 
 // Initialize action filters from URL query parameter
 function initializeActionFilters(): void {
-  const actionParam = route.query.action
-  if (actionParam && typeof actionParam === 'string') {
-    // Find the filter key for this action
-    const filterKey = actionToFilter[actionParam]
+  const actionParams = [route.query.action]
+    .flat()
+    .filter((action): action is string => typeof action === 'string')
+
+  actionParams.forEach((action) => {
+    const filterKey = actionToFilter[action]
     if (filterKey && actionFilters.value[filterKey] !== undefined) {
       actionFilters.value[filterKey] = true
     }
-  }
+  })
 }
 
 // Compute active actions based on filters


### PR DESCRIPTION
## Summary (AI generated)

- Updated the Updates statistics chart log navigation so the `fail` bucket opens logs filtered by every `*_fail` event it aggregates.
- Added repeated `action` query parameter support on the logs page so multiple filters are restored from URL state.
- Kept chart-click log navigation scoped to the clicked day.
- Switched CI Playwright frontend startup to build the app and serve it with `vite preview`, avoiding the Vite dependency optimizer hang seen in the duplicate push run.

## Motivation (AI generated)

Clicking `fail` in Updates statistics previously opened logs for only one failure action, so most users saw no matching events even though the chart counted failures from several event types. The CI frontend change keeps Playwright checks stable while preserving full browser coverage.

## Business Impact (AI generated)

This makes update failure investigation reliable from the dashboard, reducing support/debug time and helping users identify real OTA update failure causes faster. The CI hardening also avoids wasting review time on unrelated Playwright startup flakes.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run build`
- [x] `bun build scripts/playwright-frontend-preview.ts --outdir /tmp/capgo-playwright-preview-check`
- [x] Parsed `.github/workflows/tests.yml` with the repo YAML parser

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart tooltips now filter logs by multiple action types simultaneously.
  * Log table filters correctly initialize from query parameters that include one or more actions.

* **Chores**
  * Updated Playwright test workflow to use a new local frontend preview runner and adjusted preview/startup automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->