### PR TITLE
[codex] Fix false account disabled redirects

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -146,14 +146,14 @@ async function isDisabledAccount(supabase: SupabaseClient, userId: string | null
 
     if (error) {
       console.error('Error checking account status:', error)
-      return true
+      return false
     }
 
     return !!isDisabled
   }
   catch (error) {
     console.error('Error checking if account is disabled:', error)
-    return true
+    return false
   }
 }
 

--- a/tests/auth-sso-provisioning.unit.test.ts
+++ b/tests/auth-sso-provisioning.unit.test.ts
@@ -325,7 +325,7 @@ describe('auth guard SSO provisioning', () => {
     })
   })
 
-  it.concurrent('fails closed when the disabled-account RPC errors', async () => {
+  it.concurrent('continues navigation when the disabled-account RPC errors', async () => {
     await withTestContext(async (context) => {
       context.mockRpc.mockResolvedValueOnce({
         data: null,
@@ -341,13 +341,42 @@ describe('auth guard SSO provisioning', () => {
         next,
       )
 
-      expect(context.organizationStore.fetchOrganizations).not.toHaveBeenCalled()
-      expect(next).toHaveBeenCalledWith({
+      expect(context.organizationStore.fetchOrganizations).toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith()
+      expect(next).not.toHaveBeenCalledWith(expect.objectContaining({
         path: '/accountDisabled',
-        query: {
-          to: '/dashboard',
-        },
+      }))
+    })
+  })
+
+  it.concurrent('redirects active users away from the recovery page when the disabled-account check errors', async () => {
+    await withTestContext(async (context) => {
+      context.mainStore.auth = {
+        id: 'user-123',
+        email: 'user@managed.test',
+        email_confirmed_at: '2026-04-15T10:00:00.000Z',
+      }
+      context.mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: new Error('rpc failed'),
       })
+
+      const guard = await getGuard()
+      const next = vi.fn()
+
+      await guard(
+        {
+          path: '/accountDisabled',
+          fullPath: '/accountDisabled?to=/apps/app-123',
+          meta: { middleware: 'auth' },
+          query: { to: '/apps/app-123' },
+        },
+        { path: '/apps/app-123', fullPath: '/apps/app-123', meta: { middleware: 'auth' }, query: {} },
+        next,
+      )
+
+      expect(next).toHaveBeenCalledTimes(1)
+      expect(next).toHaveBeenCalledWith('/apps/app-123')
     })
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- Changed the auth guard so `/accountDisabled` is only reached when the disabled-account RPC explicitly returns `true`.
- Added regression coverage for RPC failures and stale browser history entries pointing to the recovery page.

## Motivation (AI generated)

Users could land on the account-deletion recovery page while still authenticated because transient account-status check failures were treated as disabled accounts. The page then could not find a deletion date because the account was not actually pending deletion.

## Business Impact (AI generated)

This avoids alarming active users with a false account deletion message and reduces support risk from intermittent console navigation failures.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bunx vitest run tests/auth-sso-provisioning.unit.test.ts`
- [x] Commit hook: `bun run cli:build && vue-tsc --noEmit`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during account status verification in the authentication flow. When account status checks encounter errors, authentication now proceeds with standard validation instead of blocking access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->