### PR TITLE
fix(stats): filter legacy download_fail logs

### DIFF
--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import type { AppStats, StatsActions } from '../utils/types.ts'
-import { greaterOrEqual, parse } from '@std/semver'
+import { greaterOrEqual, parse, tryParse } from '@std/semver'
 import { Hono } from 'hono/tiny'
 import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
 import { BRES, simpleError, simpleError200, simpleRateLimit } from '../utils/hono.ts'
@@ -15,6 +15,8 @@ import { createStatsMau, createStatsVersion, onPremStats, sendStatsAndDevice } f
 import { backgroundTask, INVALID_STRING_APP_ID, isLimited, MISSING_STRING_APP_ID, reverseDomainRegex } from '../utils/utils.ts'
 
 const PLAN_ERROR = 'Cannot send stats, upgrade plan to continue to update'
+const DOWNLOAD_FAIL_FIXED_PLUGIN_VERSION = parse('7.17.0')
+const DOWNLOAD_FAIL_FIXED_PLUGIN_VERSION_V6 = parse('6.14.25')
 
 export interface BatchStatsResult {
   status: 'ok' | 'error'
@@ -30,6 +32,22 @@ interface PostResult {
   message?: string
   isOnprem?: boolean
   moreInfo?: Record<string, unknown>
+}
+
+function shouldRecordStatsAction(action: string, pluginVersion: string) {
+  if (action !== 'download_fail')
+    return true
+
+  // Older updater plugins reported download_fail when there was no update to download.
+  if (typeof pluginVersion !== 'string')
+    return false
+
+  const parsedPluginVersion = tryParse(pluginVersion)
+  if (!parsedPluginVersion)
+    return false
+
+  return greaterOrEqual(parsedPluginVersion, DOWNLOAD_FAIL_FIXED_PLUGIN_VERSION)
+    || (pluginVersion.startsWith('6.') && greaterOrEqual(parsedPluginVersion, DOWNLOAD_FAIL_FIXED_PLUGIN_VERSION_V6))
 }
 
 async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient>, body: AppStats): Promise<PostResult> {
@@ -99,6 +117,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   if (!appVersion) {
     return { success: false, error: 'version_not_found', message: 'Version not found', moreInfo: { app_id, version_name } }
   }
+  const shouldRecordAction = shouldRecordStatsAction(action, plugin_version)
   // device.version = appVersion.id
   if (action === 'set' && !device.is_emulator && device.is_prod) {
     // Use versionOnly (from request body) instead of appVersion - no DB read needed for stats
@@ -112,12 +131,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     }
   }
   else if (action.endsWith('_fail')) {
-    // Only exclude download_fail for plugin versions below 7.17.0 and 6.14.25 as the plugin where wrongly reporting it on these versions
-    const shouldCountDownloadFail = action !== 'download_fail'
-      || greaterOrEqual(parse(plugin_version), parse('7.17.0'))
-      || (plugin_version.startsWith('6.') && greaterOrEqual(parse(plugin_version), parse('6.14.25')))
-
-    if (shouldCountDownloadFail) {
+    if (shouldRecordAction) {
       // Use versionOnly (from request body) instead of appVersion - no DB read needed for stats
       await createStatsVersion(c, versionOnly, app_id, 'fail')
       cloudlog({ requestId: c.get('requestId'), message: 'FAIL!' })
@@ -125,7 +139,9 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
       // instead of per-device notifications. See process_daily_fail_ratio_email.
     }
   }
-  statsActions.push({ action: action as Database['public']['Enums']['stats_action'], metadata })
+  if (shouldRecordAction) {
+    statsActions.push({ action: action as Database['public']['Enums']['stats_action'], metadata })
+  }
 
   // Don't update device record on failure actions - the version_name in the request
   // is the failed version, not the actual running version on the device

--- a/supabase/functions/_backend/plugins/stats.ts
+++ b/supabase/functions/_backend/plugins/stats.ts
@@ -103,6 +103,15 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   if (allowDeviceCustomId === false && typeof body.custom_id === 'string' && body.custom_id.trim() !== '') {
     statsActions.push({ action: 'customIdBlocked' })
   }
+  const shouldRecordAction = shouldRecordStatsAction(action, plugin_version)
+
+  if (!shouldRecordAction) {
+    // Legacy plugins can report download_fail for a non-existent target version
+    // when there was no update to download, so skip version validation too.
+    await backgroundTask(c, createStatsMau(c, device.device_id, app_id, appOwner.owner_org, device.platform, device.version_build))
+    await sendStatsAndDevice(c, device, statsActions, action.endsWith('_fail'))
+    return { success: true }
+  }
 
   // Extract version from composite format if present (e.g., "1.2.3:main.js" -> "1.2.3")
   // Composite format is used for file-specific failure stats
@@ -117,7 +126,6 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   if (!appVersion) {
     return { success: false, error: 'version_not_found', message: 'Version not found', moreInfo: { app_id, version_name } }
   }
-  const shouldRecordAction = shouldRecordStatsAction(action, plugin_version)
   // device.version = appVersion.id
   if (action === 'set' && !device.is_emulator && device.is_prod) {
     // Use versionOnly (from request body) instead of appVersion - no DB read needed for stats

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -436,6 +436,7 @@ describe('[POST] /stats', () => {
       { pluginVersion: '7.17.0', shouldRecord: true, createVersion: true },
       { pluginVersion: '6.14.24', shouldRecord: false, createVersion: true },
       { pluginVersion: '6.14.25', shouldRecord: true, createVersion: true },
+      { pluginVersion: 'not-a-version', shouldRecord: false, createVersion: true },
     ]
 
     for (const testCase of cases) {

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -375,6 +375,8 @@ describe('[POST] /stats', () => {
         const baseData = getBaseData(APP_NAME_STATS) as StatsPayload
         baseData.device_id = uuid
         baseData.action = action
+        if (action === 'download_fail')
+          baseData.plugin_version = '7.17.0'
         baseData.version_build = getVersionFromAction(action)
 
         const version = await createAppVersions(baseData.version_build, APP_NAME_STATS)
@@ -424,6 +426,51 @@ describe('[POST] /stats', () => {
           await getSupabaseClient().from('devices').delete().eq('device_id', uuid).eq('app_id', APP_NAME_STATS)
         }
       })
+    }
+  })
+
+  it('filters legacy download_fail before saved stats and logs', async () => {
+    const cases = [
+      { pluginVersion: '7.16.9', shouldRecord: false },
+      { pluginVersion: '7.17.0', shouldRecord: true },
+      { pluginVersion: '6.14.24', shouldRecord: false },
+      { pluginVersion: '6.14.25', shouldRecord: true },
+    ]
+
+    for (const testCase of cases) {
+      const uuid = randomUUID().toLowerCase()
+      const baseData = getBaseData(APP_NAME_STATS) as StatsPayload
+      baseData.device_id = uuid
+      baseData.action = 'download_fail'
+      baseData.plugin_version = testCase.pluginVersion
+      baseData.version_build = `1.0.0-download-fail-${testCase.pluginVersion.replace(/\./g, '-')}`
+      const version = await createAppVersions(baseData.version_build, APP_NAME_STATS)
+      baseData.version_name = version.name
+
+      const response = await postStats(baseData)
+      const responseData = await response.json<StatsRes>()
+      expect(response.status).toBe(200)
+      expect(responseData.status).toBe('ok')
+
+      const { error: statsError, count: statsCount } = await getSupabaseClient()
+        .from('stats')
+        .select('*', { count: 'exact', head: true })
+        .eq('device_id', uuid)
+        .eq('app_id', APP_NAME_STATS)
+        .eq('action', 'download_fail')
+
+      expect(statsError).toBeNull()
+      expect(statsCount).toBe(testCase.shouldRecord ? 1 : 0)
+
+      const { error: versionUsageError, count: versionUsageCount } = await getSupabaseClient()
+        .from('version_usage')
+        .select('*', { count: 'exact', head: true })
+        .eq('app_id', APP_NAME_STATS)
+        .eq('version_name', version.name)
+        .eq('action', 'fail')
+
+      expect(versionUsageError).toBeNull()
+      expect(versionUsageCount).toBe(testCase.shouldRecord ? 1 : 0)
     }
   })
 

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -429,7 +429,7 @@ describe('[POST] /stats', () => {
     }
   })
 
-  it('filters legacy download_fail before saved stats and logs', async () => {
+  it.concurrent('filters legacy download_fail before saved stats and logs', async () => {
     const cases = [
       { pluginVersion: '7.16.9', shouldRecord: false },
       { pluginVersion: '7.17.0', shouldRecord: true },

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -431,10 +431,11 @@ describe('[POST] /stats', () => {
 
   it.concurrent('filters legacy download_fail before saved stats and logs', async () => {
     const cases = [
-      { pluginVersion: '7.16.9', shouldRecord: false },
-      { pluginVersion: '7.17.0', shouldRecord: true },
-      { pluginVersion: '6.14.24', shouldRecord: false },
-      { pluginVersion: '6.14.25', shouldRecord: true },
+      { pluginVersion: '7.16.9', shouldRecord: false, createVersion: true },
+      { pluginVersion: '7.16.9', shouldRecord: false, createVersion: false },
+      { pluginVersion: '7.17.0', shouldRecord: true, createVersion: true },
+      { pluginVersion: '6.14.24', shouldRecord: false, createVersion: true },
+      { pluginVersion: '6.14.25', shouldRecord: true, createVersion: true },
     ]
 
     for (const testCase of cases) {
@@ -443,9 +444,11 @@ describe('[POST] /stats', () => {
       baseData.device_id = uuid
       baseData.action = 'download_fail'
       baseData.plugin_version = testCase.pluginVersion
-      baseData.version_build = `1.0.0-download-fail-${testCase.pluginVersion.replace(/\./g, '-')}`
-      const version = await createAppVersions(baseData.version_build, APP_NAME_STATS)
-      baseData.version_name = version.name
+      baseData.version_build = `1.0.0-download-fail-${testCase.pluginVersion.replace(/\./g, '-')}-${testCase.createVersion ? 'existing' : 'missing'}`
+      const versionName = testCase.createVersion
+        ? (await createAppVersions(baseData.version_build, APP_NAME_STATS)).name
+        : baseData.version_build
+      baseData.version_name = versionName
 
       const response = await postStats(baseData)
       const responseData = await response.json<StatsRes>()
@@ -466,7 +469,7 @@ describe('[POST] /stats', () => {
         .from('version_usage')
         .select('*', { count: 'exact', head: true })
         .eq('app_id', APP_NAME_STATS)
-        .eq('version_name', version.name)
+        .eq('version_name', versionName)
         .eq('action', 'fail')
 
       expect(versionUsageError).toBeNull()


### PR DESCRIPTION
## Summary (AI generated)

- Filters legacy `download_fail` events from updater plugins below `7.17.0` and `6.14.25` before writing user logs.
- Reuses the same filter for fail aggregates so raw logs, update charts, and saved stats stay aligned.
- Adds coverage for ignored and accepted `download_fail` plugin versions.

## Motivation (AI generated)

Old updater plugins could report `download_fail` when there was no update to download. The aggregate fail counter already avoided this in one path, but raw user logs still saved the false failure, which could make chart drilldowns disagree with chart totals.

## Business Impact (AI generated)

Users see cleaner update failure reporting and fewer false alarms from old clients. This improves trust in Capgo update analytics and avoids wasting debugging time on non-actionable failures.

## Test Plan (AI generated)

- [x] `bunx eslint supabase/functions/_backend/plugins/stats.ts tests/stats.test.ts`
- [x] `bun run lint:backend`
- [x] `bunx vitest run tests/stats.test.ts`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined stats collection so download-failure events are only recorded for supported plugin versions, with special handling to exclude legacy v6 and other older versions.

* **Tests**
  * Added concurrent, table-driven tests to verify download-failure events are suppressed for legacy plugin versions and recorded for supported versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->