### PR TITLE
[codex] fix plugin manifest size preflight

### DIFF
--- a/cloudflare_workers/plugin/index.ts
+++ b/cloudflare_workers/plugin/index.ts
@@ -3,11 +3,13 @@ import { app as stats } from '../../supabase/functions/_backend/plugins/stats.ts
 import { app as updates } from '../../supabase/functions/_backend/plugins/updates.ts'
 import { app as latency } from '../../supabase/functions/_backend/private/latency.ts'
 import { app as ok } from '../../supabase/functions/_backend/public/ok.ts'
-import { createAllCatch, createHono } from '../../supabase/functions/_backend/utils/hono.ts'
+import { createAllCatch, createHono, useCors } from '../../supabase/functions/_backend/utils/hono.ts'
 import { version } from '../../supabase/functions/_backend/utils/version.ts'
 
 const functionName = 'plugin'
 const app = createHono(functionName, version)
+
+app.use('*', useCors)
 
 // TODO: deprecated remove when everyone use the new endpoint
 app.route('/plugin/ok', ok)

--- a/tests/plugin-cors.unit.test.ts
+++ b/tests/plugin-cors.unit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import pluginWorker from '../cloudflare_workers/plugin/index.ts'
+
+describe('cloudflare plugin CORS', () => {
+  it.concurrent('responds to manifest size preflight requests', async () => {
+    const response = await pluginWorker.fetch(new Request('https://api.capgo.app/updates/manifest_size', {
+      method: 'OPTIONS',
+      headers: {
+        'origin': 'https://web.capgo.app',
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type,authorization',
+      },
+    }))
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    expect(response.headers.get('access-control-allow-methods')).toContain('OPTIONS')
+    expect(response.headers.get('access-control-allow-headers')?.toLowerCase()).toContain('content-type')
+  })
+})

--- a/tests/plugin-cors.unit.test.ts
+++ b/tests/plugin-cors.unit.test.ts
@@ -14,7 +14,11 @@ describe('cloudflare plugin CORS', () => {
 
     expect(response.status).toBe(204)
     expect(response.headers.get('access-control-allow-origin')).toBe('*')
-    expect(response.headers.get('access-control-allow-methods')).toContain('OPTIONS')
-    expect(response.headers.get('access-control-allow-headers')?.toLowerCase()).toContain('content-type')
+    const allowMethods = response.headers.get('access-control-allow-methods')?.toLowerCase()
+    const allowHeaders = response.headers.get('access-control-allow-headers')?.toLowerCase()
+    expect(allowMethods).toContain('options')
+    expect(allowMethods).toContain('post')
+    expect(allowHeaders).toContain('content-type')
+    expect(allowHeaders).toContain('authorization')
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Added shared CORS handling at the Cloudflare plugin worker boundary.
- Added a regression test for `OPTIONS /updates/manifest_size`.

## Motivation (AI generated)

Browser requests to `https://api.capgo.app/updates/manifest_size` send a CORS preflight before the POST. The plugin worker did not handle that preflight, so it fell through to the catch-all route and returned `404 Not Found`.

## Business Impact (AI generated)

This restores manifest-size requests from browser clients, preventing console/API users from seeing failed preflight requests for that endpoint while keeping the existing plugin POST behavior unchanged.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bunx eslint cloudflare_workers/plugin/index.ts tests/plugin-cors.unit.test.ts`
- [x] `bunx vitest run tests/plugin-cors.unit.test.ts tests/manifest-size.unit.test.ts`
- [x] Pre-commit typecheck hook: `bun run cli:build && vue-tsc --noEmit`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply global CORS handling so all routes return appropriate cross-origin headers.

* **Tests**
  * Added unit test confirming OPTIONS preflight responses return 204 and include expected CORS headers and allowed methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->