### PR TITLE
[codex] Drop unused channel devices owner org index

### DIFF
--- a/read_replicate/schema_replicate.sql
+++ b/read_replicate/schema_replicate.sql
@@ -638,13 +638,6 @@ CREATE INDEX finx_channel_devices_channel_id ON public.channel_devices USING btr
 
 
 --
--- Name: finx_channel_devices_owner_org; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX finx_channel_devices_owner_org ON public.channel_devices USING btree (owner_org);
-
-
---
 -- Name: finx_channels_app_id; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/supabase/migrations/20260524123635_drop_channel_devices_owner_org_index.sql
+++ b/supabase/migrations/20260524123635_drop_channel_devices_owner_org_index.sql
@@ -1,0 +1,3 @@
+-- channel_devices runtime lookups use app_id/device_id or channel_id.
+-- Supabase migrations run in a transaction, so this cannot use DROP INDEX CONCURRENTLY.
+DROP INDEX IF EXISTS "public"."finx_channel_devices_owner_org";


### PR DESCRIPTION
## Summary (AI generated)

- Adds a Supabase migration to drop `public.finx_channel_devices_owner_org`.
- Keeps the change scoped to the unused `channel_devices.owner_org` index only.

## Motivation (AI generated)

Live index stats showed `finx_channel_devices_owner_org` had only a handful of scans after the `channel_devices` reindex, and code search found runtime query paths use `app_id`, `device_id`, or `channel_id` instead of `owner_org` as a leading lookup.

## Business Impact (AI generated)

This removes a low-value index from a churn-heavy table, reducing write overhead and keeping database maintenance focused on the indexes used by customer-facing channel/device flows.

## Test Plan (AI generated)

- [x] Ran `bun run lint:backend`.
- [x] Ran `bun run lint`.
- [x] Ran `bun typecheck`.
- [x] Ran `bunx supabase migration list --linked` and confirmed this migration is the only local pending migration.

## Screenshots (AI generated)

Not applicable. Database migration only.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [x] My change does not require a change to the documentation.
- [x] My change does not need E2E test coverage because it only removes an unused database index.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an index from the channel devices table to optimize database performance and update runtime lookup patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->