### PR TITLE
[codex] Fix files upload API key auth source

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -1013,7 +1013,7 @@ async function checkWriteAppAccess(c: Context, next: Next) {
 }
 
 app.options(`/upload/${ATTACHMENT_PREFIX}`, optionsHandler)
-app.post(`/upload/${ATTACHMENT_PREFIX}`, middlewareKey(['all', 'write', 'upload'], true), setKeyFromMetadata, checkWriteAppAccess, (c) => {
+app.post(`/upload/${ATTACHMENT_PREFIX}`, middlewareKey(['all', 'write', 'upload'], true, false), setKeyFromMetadata, checkWriteAppAccess, (c) => {
   if (getRuntimeKey() !== 'workerd') {
     return supabaseTusCreateHandler(c)
   }
@@ -1024,7 +1024,7 @@ app.options(`/upload/${ATTACHMENT_PREFIX}/:id{.+}`, optionsHandler)
 // Combined GET/HEAD handler for TUS uploads - Hono tiny routes HEAD to GET
 app.get(
   `/upload/${ATTACHMENT_PREFIX}/:id{.+}`,
-  middlewareKey(['all', 'write', 'upload'], true),
+  middlewareKey(['all', 'write', 'upload'], true, false),
   setKeyFromIdParam,
   checkWriteAppAccess,
   (c) => {
@@ -1046,7 +1046,7 @@ app.get(
   },
 )
 app.get(`/read/${ATTACHMENT_PREFIX}/:id{.+}`, setKeyFromIdParam, getHandler)
-app.patch(`/upload/${ATTACHMENT_PREFIX}/:id{.+}`, middlewareKey(['all', 'write', 'upload'], true), setKeyFromIdParam, checkWriteAppAccess, (c) => {
+app.patch(`/upload/${ATTACHMENT_PREFIX}/:id{.+}`, middlewareKey(['all', 'write', 'upload'], true, false), setKeyFromIdParam, checkWriteAppAccess, (c) => {
   if (getRuntimeKey() !== 'workerd') {
     return supabaseTusPatchHandler(c)
   }

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -457,6 +457,7 @@ async function resolveApiKey(
   key: string,
   rights: Database['public']['Enums']['key_mode'][],
   usePostgres: boolean,
+  readOnly = true,
 ) {
   if (!usePostgres) {
     return checkKey(c, key, supabaseAdmin(c), rights)
@@ -464,7 +465,7 @@ async function resolveApiKey(
 
   let pgClient: ReturnType<typeof getPgClient> | null = null
   try {
-    pgClient = getPgClient(c, true)
+    pgClient = getPgClient(c, readOnly)
     const drizzleClient = getDrizzleClient(pgClient)
     return await checkKeyPg(c, key, rights, drizzleClient)
   }
@@ -481,6 +482,7 @@ async function resolveSubkey(
   rights: Database['public']['Enums']['key_mode'][],
   usePostgres: boolean,
   expectedUserId?: string,
+  readOnly = true,
 ) {
   if (!usePostgres) {
     return checkKeyById(c, subkeyId, supabaseAdmin(c), rights, expectedUserId)
@@ -488,7 +490,7 @@ async function resolveSubkey(
 
   let subkeyPgClient: ReturnType<typeof getPgClient> | null = null
   try {
-    subkeyPgClient = getPgClient(c, true)
+    subkeyPgClient = getPgClient(c, readOnly)
     const drizzleClient = getDrizzleClient(subkeyPgClient)
     return await checkKeyByIdPg(c, subkeyId, rights, drizzleClient, expectedUserId)
   }
@@ -613,8 +615,9 @@ export function middlewareV2(rights: Database['public']['Enums']['key_mode'][]) 
  *
  * @param rights - Required key modes for the route.
  * @param usePostgres - When true, performs key lookups via Postgres instead of Supabase client.
+ * @param readOnly - When using Postgres, choose replica-safe read-only connections by default; latency-sensitive write flows can force primary auth.
  */
-export function middlewareKey(rights: Database['public']['Enums']['key_mode'][], usePostgres = false) {
+export function middlewareKey(rights: Database['public']['Enums']['key_mode'][], usePostgres = false, readOnly = true) {
   const subMiddlewareKey = honoFactory.createMiddleware(async (c, next) => {
     // Check if IP is rate limited due to failed auth attempts
     const ipRateLimited = await isIPRateLimited(c)
@@ -642,7 +645,7 @@ export function middlewareKey(rights: Database['public']['Enums']['key_mode'][],
       return quickError(401, 'no_key_provided', 'No key provided')
     }
 
-    const apikey = await resolveApiKey(c, key, rights, usePostgres)
+    const apikey = await resolveApiKey(c, key, rights, usePostgres, readOnly)
 
     if (!apikey) {
       cloudlog({ requestId: c.get('requestId'), message: 'Invalid apikey', keyPrefix: maskSecret(key), method: c.req.method, url: c.req.url })
@@ -664,7 +667,7 @@ export function middlewareKey(rights: Database['public']['Enums']['key_mode'][],
     setApiKeyAuthContext(c, apikey, key)
 
     if (subkey_id !== null) {
-      const subkey = await resolveSubkey(c, subkey_id, rights, usePostgres, apikey.user_id)
+      const subkey = await resolveSubkey(c, subkey_id, rights, usePostgres, apikey.user_id, readOnly)
 
       if (!subkey) {
         cloudlog({ requestId: c.get('requestId'), message: 'Invalid subkey', subkey_id })

--- a/tests/files-upload-auth-primary.unit.test.ts
+++ b/tests/files-upload-auth-primary.unit.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const executeMock = vi.fn()
+const getPgClientMock = vi.fn((_c: unknown, _readOnly?: boolean) => ({}))
+const getDrizzleClientMock = vi.fn(() => ({
+  execute: executeMock,
+}))
+
+vi.mock('hono/adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('hono/adapter')>()
+  return {
+    ...actual,
+    getRuntimeKey: () => 'node',
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/discord.ts', () => ({
+  sendDiscordAlert500: () => Promise.resolve(),
+  sendDiscordAlert: () => Promise.resolve(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: () => Promise.resolve(),
+  getAppByIdPg: vi.fn(),
+  getDrizzleClient: getDrizzleClientMock,
+  getPgClient: getPgClientMock,
+  logPgError: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg_files.ts', () => ({
+  getAppByAppIdPg: vi.fn(),
+  getUserIdFromApikey: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rate_limit.ts', () => ({
+  isAPIKeyRateLimited: vi.fn(async () => ({ limited: false })),
+  isIPRateLimited: vi.fn(async () => ({ limited: false })),
+  recordAPIKeyUsage: vi.fn(async () => undefined),
+  recordFailedAuth: vi.fn(async () => undefined),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermissionPg: vi.fn(async () => true),
+}))
+
+describe('files upload auth', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    executeMock.mockResolvedValue({
+      rows: [{
+        id: 123,
+        created_at: new Date().toISOString(),
+        user_id: '00000000-0000-0000-0000-000000000001',
+        key: 'valid-upload-key',
+        key_hash: null,
+        mode: 'all',
+        updated_at: null,
+        name: 'test key',
+        limited_to_orgs: null,
+        limited_to_apps: null,
+        expires_at: null,
+      }],
+    })
+  })
+
+  it('checks upload API keys against the primary database before reading upload metadata', async () => {
+    const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+
+    const response = await files.fetch(
+      new Request('http://localhost/upload/attachments', {
+        method: 'POST',
+        headers: {
+          Authorization: 'valid-upload-key',
+        },
+      }),
+      {},
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(404)
+    expect(getPgClientMock).toHaveBeenCalledTimes(1)
+    expect(getPgClientMock.mock.calls[0][1]).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Added a primary-database option to the API-key middleware used by Postgres-backed auth paths.
- Switched TUS bundle upload routes to validate upload API keys against the primary database.
- Added a regression test that verifies files upload auth does not use a read-replica connection.

## Motivation (AI generated)

A valid API key could pass the main Capgo API path, then fail on `files.capgo.app` during TUS upload with `invalid_apikey` if the files worker authenticated against a lagging read replica. The CLI then had already created the bundle row, which made the failure look like a partial upload and confused the actual cause.

## Business Impact (AI generated)

This reduces failed OTA deploy attempts for customers using fresh or recently changed API keys, avoids confusing orphaned bundle records after upload failures, and improves trust in Capgo's deploy workflow during native migration releases.

## Test Plan (AI generated)

- [x] `bun run typecheck:backend`
- [x] `bunx vitest run tests/files-upload-auth-primary.unit.test.ts`
- [x] `bun run lint:backend`

Generated with AI