### PR TITLE
[codex] fix cron queue health reporting during backlog

### DIFF
--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -79,6 +79,7 @@ interface ProcessedQueueMessage extends Message {
 }
 
 interface QueueProcessResult {
+  actionableFailureCount: number
   archivedCount: number
   failedCount: number
   processedCount: number
@@ -422,6 +423,7 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
       queueName,
     })
     return {
+      actionableFailureCount: 0,
       archivedCount: 0,
       failedCount: 0,
       processedCount: 0,
@@ -462,6 +464,7 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
 
   // Process messages that are still within the retry budget.
   const results = await mapWithConcurrency(messagesToProcess, processConcurrency, async message => processQueueMessage(c, queueName, message))
+  let actionableFailureCount = 0
 
   // Update all messages with their CF IDs
   const cfIdUpdates = results.map(result => ({
@@ -517,6 +520,7 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
     }))
 
     const actionableFailures = getActionableQueueFailures(failureDetails)
+    actionableFailureCount = actionableFailures.length
 
     const groupedByFunction = actionableFailures.reduce((acc, detail) => {
       const key = detail.function_name
@@ -610,6 +614,7 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
   }
 
   return {
+    actionableFailureCount,
     archivedCount: messagesToSkip.length,
     failedCount: messagesFailed.length,
     processedCount: messagesToProcess.length,
@@ -816,29 +821,14 @@ async function maybePingCronHealthcheckStart(
 }
 
 async function maybePingCronHealthcheck(
-  db: ReturnType<typeof getPgClient>,
-  queueName: string,
   processResult: QueueProcessResult,
   healthcheckUrl: string | null,
   fetchImpl: typeof fetch = fetch,
 ): Promise<boolean> {
-  if (!healthcheckUrl || !processResult.success)
+  if (!healthcheckUrl || !processResult.readSucceeded || processResult.skippedCount > 0 || processResult.actionableFailureCount > 0)
     return false
 
-  try {
-    const metrics = await db.query<{ queue_length: string }>(
-      'SELECT queue_length::text FROM pgmq.metrics($1)',
-      [queueName],
-    )
-    const queueLength = Number(metrics.rows[0]?.queue_length ?? 0)
-    if (queueLength !== 0)
-      return false
-
-    return pingCronHealthcheck(healthcheckUrl, fetchImpl)
-  }
-  catch {
-    return false
-  }
+  return pingCronHealthcheck(healthcheckUrl, fetchImpl)
 }
 
 // Helper function to delete multiple messages from the queue in a single batch
@@ -967,7 +957,7 @@ app.post('/sync', async (c) => {
       if (healthcheckUrl !== null)
         await maybePingCronHealthcheckStart(healthcheckUrl)
       const result = await processQueue(c, db, queueName, finalBatchSize)
-      await maybePingCronHealthcheck(db, queueName, result, healthcheckUrl)
+      await maybePingCronHealthcheck(result, healthcheckUrl)
       cloudlog({
         requestId: c.get('requestId'),
         message: result.success

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -3,16 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { __queueConsumerTestUtils__, MAX_QUEUE_READS, messagesArraySchema } from '../supabase/functions/_backend/triggers/queue_consumer.ts'
 import { parseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
 
-function createHealthcheckDb(queueLength: number) {
-  return {
-    db: {
-      query: vi.fn(async <T = Record<string, unknown>>(): Promise<{ rows: T[] }> => ({
-        rows: [{ queue_length: String(queueLength) } as T],
-      })),
-    },
-  }
-}
-
 describe('queue_consumer legacy message compatibility', () => {
   it.concurrent('uses the payload envelope when it is present', () => {
     const [message] = parseSchema(messagesArraySchema, [
@@ -214,14 +204,12 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(details.bodyPreview).toContain('"queueName":"on_manifest_create"')
   })
 
-  it.concurrent('calls the healthcheck URL when the worker succeeds and the queue is empty', async () => {
-    const { db } = createHealthcheckDb(0)
+  it.concurrent('calls the healthcheck URL when the worker succeeds', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch
 
     const reported = await __queueConsumerTestUtils__.maybePingCronHealthcheck(
-      db as never,
-      'cron_email',
       {
+        actionableFailureCount: 0,
         archivedCount: 0,
         failedCount: 0,
         processedCount: 1,
@@ -257,14 +245,12 @@ describe('queue_consumer legacy message compatibility', () => {
     }))
   })
 
-  it.concurrent('does not call the healthcheck URL when queue work remains', async () => {
-    const { db } = createHealthcheckDb(2)
+  it.concurrent('calls the healthcheck URL when successful queue work remains', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch
 
     const reported = await __queueConsumerTestUtils__.maybePingCronHealthcheck(
-      db as never,
-      'cron_email',
       {
+        actionableFailureCount: 0,
         archivedCount: 0,
         failedCount: 0,
         processedCount: 1,
@@ -277,18 +263,16 @@ describe('queue_consumer legacy message compatibility', () => {
       fetchImpl,
     )
 
-    expect(reported).toBe(false)
-    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(reported).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
   it.concurrent('returns false when the healthcheck URL responds with an error', async () => {
-    const { db } = createHealthcheckDb(0)
     const fetchImpl = vi.fn(async () => new Response(null, { status: 500 })) as unknown as typeof fetch
 
     const reported = await __queueConsumerTestUtils__.maybePingCronHealthcheck(
-      db as never,
-      'cron_email',
       {
+        actionableFailureCount: 0,
         archivedCount: 0,
         failedCount: 0,
         processedCount: 1,
@@ -305,14 +289,34 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
-  it.concurrent('does not call the healthcheck URL when the worker failed', async () => {
-    const { db } = createHealthcheckDb(0)
+  it.concurrent('calls the healthcheck URL for retryable message failures', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch
 
     const reported = await __queueConsumerTestUtils__.maybePingCronHealthcheck(
-      db as never,
-      'cron_email',
       {
+        actionableFailureCount: 0,
+        archivedCount: 0,
+        failedCount: 1,
+        processedCount: 1,
+        readSucceeded: true,
+        skippedCount: 0,
+        success: false,
+        successCount: 0,
+      },
+      'https://example.com/healthcheck',
+      fetchImpl,
+    )
+
+    expect(reported).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it.concurrent('does not call the healthcheck URL when the worker had actionable failures', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch
+
+    const reported = await __queueConsumerTestUtils__.maybePingCronHealthcheck(
+      {
+        actionableFailureCount: 1,
         archivedCount: 0,
         failedCount: 1,
         processedCount: 1,


### PR DESCRIPTION
## Summary (AI generated)

- Report queue healthcheck completion when a queue worker run is healthy, even if retryable work or backlog remains.
- Track actionable queue failures separately so exhausted retries still suppress the healthcheck ping.
- Update queue-consumer unit coverage for backlog and retryable-failure healthcheck behavior.

## Motivation (AI generated)

`manifest_create_queue` could be processing successfully while the queue stayed nonempty, especially during a manifest upload burst or retryable manifest size lookup failures. Because the healthcheck completion ping required `pgmq.metrics(queue_length) === 0`, Hyperping could mark the cron down even though the worker was still making progress.

## Business Impact (AI generated)

This reduces false operational incidents for manifest queue processing while preserving alerts for real queue processor failures. It keeps Capgo update delivery monitoring more accurate and avoids unnecessary incident noise during high-volume manifest backlogs.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] `bunx vitest run tests/queue-consumer-message-shape.unit.test.ts`
- [x] `bun typecheck:backend`
- [x] Commit hook typecheck: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Generated with AI