### PR TITLE
fix(db): speed up apikey bundle upload RLS

### DIFF
--- a/read_replicate/schema_replicate.sql
+++ b/read_replicate/schema_replicate.sql
@@ -890,6 +890,13 @@ CREATE INDEX org_users_app_id_idx ON public.org_users USING btree (app_id);
 
 
 --
+-- Name: orgs_enforce_hashed_api_keys_true_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX orgs_enforce_hashed_api_keys_true_idx ON public.orgs USING btree (id) WHERE (enforce_hashed_api_keys = true);
+
+
+--
 -- Name: orgs_updated_at_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/supabase/migrations/20260528023934_optimize_apikey_hashed_enforcement.sql
+++ b/supabase/migrations/20260528023934_optimize_apikey_hashed_enforcement.sql
@@ -1,0 +1,81 @@
+CREATE INDEX IF NOT EXISTS "orgs_enforce_hashed_api_keys_true_idx"
+ON "public"."orgs" ("id")
+WHERE "enforce_hashed_api_keys" = true;
+
+CREATE OR REPLACE FUNCTION "public"."check_apikey_hashed_key_enforcement"("apikey_row" "public"."apikeys") RETURNS boolean
+LANGUAGE "plpgsql" SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  scoped_enforced_org_exists boolean;
+BEGIN
+  IF apikey_row.key IS NULL AND apikey_row.key_hash IS NOT NULL THEN
+    RETURN true;
+  END IF;
+
+  IF apikey_row.rbac_id IS NULL THEN
+    RETURN true;
+  END IF;
+
+  WITH enforced_orgs AS (
+    SELECT public.orgs.id
+    FROM public.orgs
+    WHERE public.orgs.enforce_hashed_api_keys = true
+  )
+  SELECT EXISTS (
+    SELECT 1
+    FROM enforced_orgs
+    WHERE EXISTS (
+        SELECT 1
+        FROM public.role_bindings rb
+        WHERE rb.principal_type = public.rbac_principal_apikey()
+          AND rb.principal_id = apikey_row.rbac_id
+          AND rb.scope_type = public.rbac_scope_org()
+          AND rb.org_id = enforced_orgs.id
+          AND (rb.expires_at IS NULL OR rb.expires_at > now())
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.role_bindings rb
+        JOIN public.apps apps
+          ON apps.id = rb.app_id
+          AND apps.owner_org = enforced_orgs.id
+        WHERE rb.principal_type = public.rbac_principal_apikey()
+          AND rb.principal_id = apikey_row.rbac_id
+          AND rb.scope_type = public.rbac_scope_app()
+          AND rb.app_id IS NOT NULL
+          AND (rb.expires_at IS NULL OR rb.expires_at > now())
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.role_bindings rb
+        JOIN public.channels channels
+          ON channels.rbac_id = rb.channel_id
+          AND channels.owner_org = enforced_orgs.id
+        WHERE rb.principal_type = public.rbac_principal_apikey()
+          AND rb.principal_id = apikey_row.rbac_id
+          AND rb.scope_type = public.rbac_scope_channel()
+          AND rb.channel_id IS NOT NULL
+          AND (rb.expires_at IS NULL OR rb.expires_at > now())
+      )
+  )
+  INTO scoped_enforced_org_exists;
+
+  IF scoped_enforced_org_exists THEN
+    PERFORM public.pg_log(
+      'deny: ORG_REQUIRES_HASHED_API_KEY',
+      jsonb_build_object('apikey_id', apikey_row.id, 'user_id', apikey_row.user_id)
+    );
+    RETURN false;
+  END IF;
+
+  RETURN true;
+END;
+$$;
+
+ALTER FUNCTION "public"."check_apikey_hashed_key_enforcement"("public"."apikeys") OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."check_apikey_hashed_key_enforcement"("public"."apikeys") FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."check_apikey_hashed_key_enforcement"("public"."apikeys") TO "service_role";
+
+COMMENT ON FUNCTION "public"."check_apikey_hashed_key_enforcement"("public"."apikeys") IS
+'Rejects plaintext API keys when any scoped org requires hashed API keys. The lookup starts from enforcing orgs and indexed RBAC bindings so broad API keys do not scan every app binding on each permission check.';

--- a/supabase/tests/56_test_apikey_v2_scope_and_rls.sql
+++ b/supabase/tests/56_test_apikey_v2_scope_and_rls.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(41);
+SELECT plan(43);
 
 SELECT tests.authenticate_as_service_role();
 SELECT tests.create_supabase_user('apikey_v2_scope_owner', 'apikey_v2_scope_owner@test.local');
@@ -491,6 +491,86 @@ SELECT is(
   'app_versions readable app helper keeps app-admin API keys app-scoped'
 );
 
+SELECT tests.authenticate_as_service_role();
+SELECT set_config('request.headers', '{}', true);
+
+INSERT INTO public.apps (app_id, icon_url, user_id, name, last_version, owner_org)
+SELECT
+  'com.test.apikeyv2scope.perf.' || gs::text,
+  '',
+  tests.get_supabase_uid('apikey_v2_scope_owner'),
+  'API key V2 perf app ' || gs::text,
+  '1.0.0-apikey-v2-perf',
+  '71000000-0000-4000-8000-000000000056'::uuid
+FROM generate_series(1, 75) gs
+ON CONFLICT (app_id) DO NOTHING;
+
+INSERT INTO public.app_versions (
+  app_id,
+  name,
+  owner_org,
+  storage_provider,
+  comment
+)
+SELECT
+  'com.test.apikeyv2scope.perf.' || gs::text,
+  '1.0.0-apikey-v2-perf',
+  '71000000-0000-4000-8000-000000000056'::uuid,
+  'r2-direct',
+  'perf seed'
+FROM generate_series(1, 75) gs
+ON CONFLICT (name, app_id) DO UPDATE
+SET
+  storage_provider = EXCLUDED.storage_provider,
+  r2_path = NULL,
+  comment = EXCLUDED.comment;
+
+INSERT INTO public.role_bindings (
+  principal_type,
+  principal_id,
+  role_id,
+  scope_type,
+  org_id,
+  app_id,
+  granted_by,
+  reason,
+  is_direct
+)
+SELECT
+  public.rbac_principal_apikey(),
+  apikeys.rbac_id,
+  roles.id,
+  public.rbac_scope_app(),
+  apps.owner_org,
+  apps.id,
+  tests.get_supabase_uid('apikey_v2_scope_owner'),
+  'pgTAP broad app-scoped API key performance regression',
+  true
+FROM public.apikeys
+JOIN public.roles ON roles.name = public.rbac_role_app_admin()
+JOIN public.apps ON apps.app_id LIKE 'com.test.apikeyv2scope.perf.%'
+WHERE apikeys.key = 'apikey-v2-scope-all-app-key'
+ON CONFLICT DO NOTHING;
+
+SELECT tests.clear_authentication();
+SELECT set_config('request.headers', '{"capgkey":"apikey-v2-scope-all-app-key"}', true);
+SELECT set_config('request.method', 'PATCH', true);
+
+WITH updated_rows AS (
+  UPDATE public.app_versions
+  SET r2_path = 'orgs/71000000-0000-4000-8000-000000000056/apps/com.test.apikeyv2scope.perf.1/1.0.0-apikey-v2-perf.zip'
+  WHERE app_id = 'com.test.apikeyv2scope.perf.1'
+    AND name = '1.0.0-apikey-v2-perf'
+  RETURNING 1
+)
+SELECT is(
+  (SELECT count(*)::int FROM updated_rows),
+  1,
+  'broad app-scoped API key can finish the indexed app_versions upload update'
+);
+
+SELECT set_config('request.method', '', true);
+
 SELECT ok(
   position(
     'rbac_check_permission_direct'
@@ -505,6 +585,14 @@ SELECT ok(
     in pg_get_functiondef('public.app_versions_has_app_permission(public.user_min_right,uuid,character varying,uuid,text)'::regprocedure)
   ) = 0,
   'app_versions targeted permission helper does not call generic per-app RBAC checks'
+);
+
+SELECT ok(
+  position(
+    'enforced_orgs'
+    in pg_get_functiondef('public.check_apikey_hashed_key_enforcement(public.apikeys)'::regprocedure)
+  ) > 0,
+  'API key hashed-key enforcement starts from enforcing orgs instead of every scoped app binding'
 );
 
 SELECT ok(


### PR DESCRIPTION
## Summary (AI generated)

- Add a post-main migration that optimizes `check_apikey_hashed_key_enforcement` for broad V2 API keys by starting from orgs that actually enforce hashed keys and indexed RBAC bindings.
- Add the partial `orgs_enforce_hashed_api_keys_true_idx` index and update the read-replica schema snapshot for it.
- Extend pgTAP coverage for broad app-scoped API-key bundle upload completion on top of the mainline `app_versions_has_app_permission` policy.

## Motivation (AI generated)

TUS upload was completing, then timing out on the final `app_versions.r2_path` update with a broad V2 API key. Main now bounds the `app_versions` RLS path with a targeted helper; this PR removes the remaining expensive plaintext-key enforcement path that could still inspect every scoped app binding when resolving the API key.

## Business Impact (AI generated)

This restores reliable bundle upload completion for customers using broad V2 API keys without requiring any CLI change. Old CLI behavior stays compatible because the PostgREST update shape and existing function signatures remain unchanged.

## Test Plan (AI generated)

- [x] `bun run supabase:db:reset`
- [x] `bun lint:backend`
- [x] `MAIN_SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:59912/postgres PGSSLMODE=disable bun run readreplicate:check-schema`
- [x] `PGSSLMODE=disable bunx supabase test db --db-url postgresql://postgres:postgres@127.0.0.1:59912/postgres supabase/tests/00-supabase_test_helpers.sql supabase/tests/56_test_apikey_v2_scope_and_rls.sql`
- [x] `bun run supabase:with-env -- bunx vitest run tests/cli.test.ts -t "should test upload with org-limited API key"`
- [x] `bun run cli:typecheck`
- [x] `bun run typecheck:backend`
- [x] `bun run typecheck:frontend`

## Performance Notes (AI generated)

RLS execution model:
- `app_versions` write/select policy: reached by PostgREST `PATCH` during CLI upload completion.
- Frequency: row-targeted checks via `app_versions_has_app_permission`; API key resolution still calls hashed-key enforcement.
- Roles: `anon` API-key traffic and `authenticated` user traffic.
- Index path: target update uses `idx_app_id_name_app_versions`; RBAC checks use indexed `role_bindings`; hashed-key enforcement now also uses `orgs_enforce_hashed_api_keys_true_idx` and starts from enforcing orgs instead of all scoped app bindings.

Local stress check with broad app-scoped API-key bindings:
- The targeted upload completion update succeeds through RLS for a broad app-scoped key.
- `app_versions` SELECT policy no longer materializes `app_versions_readable_app_ids` during targeted writes.
- `check_apikey_hashed_key_enforcement` now starts from `enforced_orgs`, avoiding a broad scan of every app binding on each API-key permission check.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization-level hashed API key enforcement: organizations can now enforce the use of hashed API keys, restricting plaintext keys where configured.

* **Performance**
  * Optimized database queries for API key enforcement checks using targeted indexing for improved query performance.

* **Tests**
  * Added test coverage for API key enforcement validation across organization scopes and performance scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->