### PR TITLE
fix(rbac): restore channel API key permissions

### DIFF
--- a/RBAC_SYSTEM.md
+++ b/RBAC_SYSTEM.md
@@ -19,32 +19,25 @@ This document explains in detail the Capgo RBAC (Role-Based Access Control) perm
 
 ## Overview
 
-Capgo uses a **hybrid** system that supports two permission management modes:
+Capgo uses RBAC (Role-Based Access Control) as the single authorization system.
+Legacy `org_users` rows still exist as compatibility data for older clients and
+invite flows, but authorization is resolved through `role_bindings` and
+permission checks.
 
-### Legacy System (old)
-- **Main table**: `org_users`
-- **Simple roles**: `super_admin`, `admin`, `write`, `upload`, `read`
-- **Limitation**: one role per user per organization
-- **Granularity**: limited, no control at individual app/channel level
-
-### RBAC System (new)
+### RBAC System
 - **Main tables**: `roles`, `permissions`, `role_bindings`, `role_permissions`
 - **Multiple roles**: a user can have multiple roles at different scopes
 - **Fine granularity**: permissions at org, app, channel, and bundle level
 - **Flexibility**: add/modify permissions without code changes
 
-### Automatic Switching
+### Compatibility
 
-The system automatically switches between legacy and RBAC via:
-- **Org-level flag**: `use_new_rbac` column in the `orgs` table
-- **Global flag**: `rbac_settings` table (singleton) to enable RBAC for all orgs
-- **Auto-detection**: the `rbac_is_enabled_for_org()` function checks both flags
+The old RBAC rollout switches have been removed. `rbac_is_enabled_for_org()`
+is retained only for old code paths and always returns `true`.
 
 ```sql
--- The org uses RBAC if:
--- 1. orgs.use_new_rbac = true OR
--- 2. rbac_settings.use_new_rbac = true
 SELECT rbac_is_enabled_for_org('123e4567-e89b-12d3-a456-426614174000');
+-- true
 ```
 
 ---
@@ -345,31 +338,7 @@ CREATE TABLE public.group_members (
 );
 ```
 
-### 8. `rbac_settings` - Global Configuration
-
-Singleton table to globally enable RBAC.
-
-```sql
-CREATE TABLE public.rbac_settings (
-  id integer PRIMARY KEY DEFAULT 1 CHECK (id = 1),
-  use_new_rbac boolean NOT NULL DEFAULT false,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
-);
-```
-
-**Usage**:
-- Single row with `id = 1`
-- If `use_new_rbac = true`, RBAC enabled for ALL orgs (unless overridden at org level)
-
-### 9. Auxiliary Tables
-
-#### `orgs.use_new_rbac`
-```sql
-ALTER TABLE public.orgs
-ADD COLUMN use_new_rbac boolean NOT NULL DEFAULT false;
-```
-- Org-level flag to enable RBAC for a specific org
+### 8. Auxiliary Tables
 
 #### `apikeys.rbac_id`
 ```sql
@@ -647,9 +616,9 @@ The system defines **40+ atomic permissions** organized by scope.
 
 ## SQL Functions
 
-### 1. `rbac_is_enabled_for_org()` - RBAC Flag Check
+### 1. `rbac_is_enabled_for_org()` - Compatibility Check
 
-Determines if RBAC is enabled for a given organization.
+Compatibility helper for old callers. RBAC is always enabled for organizations.
 
 ```sql
 CREATE OR REPLACE FUNCTION public.rbac_is_enabled_for_org(p_org_id uuid)
@@ -657,26 +626,20 @@ RETURNS boolean
 LANGUAGE plpgsql
 SET search_path = ''
 AS $$
-DECLARE
-  v_org_enabled boolean;
-  v_global_enabled boolean;
 BEGIN
-  SELECT use_new_rbac INTO v_org_enabled FROM public.orgs WHERE id = p_org_id;
-  SELECT use_new_rbac INTO v_global_enabled FROM public.rbac_settings WHERE id = 1;
-
-  RETURN COALESCE(v_org_enabled, false) OR COALESCE(v_global_enabled, false);
+  PERFORM p_org_id;
+  RETURN true;
 END;
 $$;
 ```
 
 **Behavior**:
-- Returns `true` if `orgs.use_new_rbac = true` OR `rbac_settings.use_new_rbac = true`
-- Returns `false` by default (legacy mode)
+- Returns `true` for compatibility.
 
 **Usage**:
 ```sql
 SELECT rbac_is_enabled_for_org('550e8400-e29b-41d4-a716-446655440000');
--- true if RBAC enabled, false otherwise
+-- true
 ```
 
 ### 2. `rbac_permission_for_legacy()` - Legacy → RBAC Mapping
@@ -887,77 +850,15 @@ BEGIN
     LIMIT 1;
   END IF;
 
-  -- Check if RBAC is enabled
-  IF rbac_is_enabled_for_org(v_org_id) THEN
-    -- New RBAC system
-    RETURN rbac_has_permission(
-      v_principal_type,
-      v_principal_id,
-      p_permission_key,
-      v_org_id,
-      p_app_id,
-      p_bundle_id,
-      p_channel_id
-    );
-  ELSE
-    -- Legacy system via check_min_rights
-    DECLARE
-      v_min_right public.user_min_right;
-      v_scope text;
-    BEGIN
-      -- Derive scope from parameters
-      IF p_channel_id IS NOT NULL THEN
-        v_scope := 'channel';
-      ELSIF p_bundle_id IS NOT NULL THEN
-        v_scope := 'bundle';
-      ELSIF p_app_id IS NOT NULL THEN
-        v_scope := 'app';
-      ELSE
-        v_scope := 'org';
-      END IF;
-
-      -- Map permission → legacy min_right
-      -- (inverse logic of rbac_permission_for_legacy)
-      IF p_permission_key LIKE 'org.%' THEN
-        IF p_permission_key IN ('org.update_user_roles', 'org.update_settings') THEN
-          v_min_right := 'admin';
-        ELSE
-          v_min_right := 'read';
-        END IF;
-      ELSIF p_permission_key LIKE 'app.%' THEN
-        IF p_permission_key IN ('app.delete', 'app.update_user_roles') THEN
-          v_min_right := 'admin';
-        ELSIF p_permission_key IN ('app.update_settings', 'app.create_channel') THEN
-          v_min_right := 'write';
-        ELSIF p_permission_key = 'app.upload_bundle' THEN
-          v_min_right := 'upload';
-        ELSE
-          v_min_right := 'read';
-        END IF;
-      ELSIF p_permission_key LIKE 'channel.%' THEN
-        IF p_permission_key IN ('channel.delete') THEN
-          v_min_right := 'admin';
-        ELSIF p_permission_key IN ('channel.update_settings') THEN
-          v_min_right := 'write';
-        ELSIF p_permission_key = 'channel.promote_bundle' THEN
-          v_min_right := 'upload';
-        ELSE
-          v_min_right := 'read';
-        END IF;
-      ELSE
-        v_min_right := 'admin'; -- Default, requires admin
-      END IF;
-
-      -- Call legacy function
-      RETURN check_min_rights_legacy(
-        v_min_right,
-        p_user_id,
-        v_org_id,
-        p_app_id,
-        p_apikey
-      );
-    END;
-  END IF;
+  RETURN rbac_has_permission(
+    v_principal_type,
+    v_principal_id,
+    p_permission_key,
+    v_org_id,
+    p_app_id,
+    p_bundle_id,
+    p_channel_id
+  );
 END;
 $$;
 ```
@@ -994,10 +895,10 @@ $$;
 
 **Advantages**:
 - ✅ Single source of truth for permission checking
-- ✅ Automatic legacy/RBAC routing based on org flag
+- ✅ RBAC-only authorization path
 - ✅ Automatic `org_id` derivation from app/channel/bundle
 - ✅ Support for API keys and users
-- ✅ Graceful fallback to legacy if RBAC not enabled
+- ✅ Compatibility wrappers for old CLI RPC signatures
 
 **Recommended usage**:
 ```sql
@@ -1187,7 +1088,7 @@ app.post('/channel/:channelId/promote', middlewareKey(['all', 'upload']), async 
 
 **Advantages**:
 - ✅ **Type-safe**: Strict `Permission` type with autocomplete
-- ✅ **Auto-routing**: Legacy/RBAC based on org flag (transparent)
+- ✅ **RBAC-only**: Same authorization model for every org
 - ✅ **Logging**: Automatic logs in CloudFlare/Supabase
 - ✅ **Fail-closed**: Returns `false` on error (secure)
 - ✅ **Context-aware**: Automatically uses `c.get('auth')` and `c.get('apikey')`
@@ -1273,8 +1174,7 @@ if (orgStore.hasPermissionsInRole('write', ['app_developer', 'org_admin'], orgId
 ```
 
 **Behavior**:
-- If `use_new_rbac` enabled: checks cached `role_bindings`
-- If legacy: checks `org_users.user_right`
+- Checks cached RBAC role bindings.
 
 **Limitations**:
 - ❌ Checks **role names**, not granular permissions
@@ -1407,7 +1307,7 @@ export async function checkPermissionsBatch(
 
 **Benefits**:
 - ✅ **Single source of truth**: calls the backend directly
-- ✅ **Auto-routing**: legacy/RBAC handled server-side (transparent)
+- ✅ **RBAC-only**: one authorization model for UI and API keys
 - ✅ **Type-safe**: strict `Permission` type with autocomplete
 - ✅ **Flexible**: permission changes in DB, no frontend deploy needed
 - ✅ **Always up to date**: no stale cache
@@ -1592,7 +1492,7 @@ To facilitate migration, here's the mapping between current role checks and equi
 
 ```sql
 SELECT rbac_is_enabled_for_org('123e4567-e89b-12d3-a456-426614174000');
--- true if RBAC enabled, false if legacy
+-- true
 ```
 
 #### 2. View all role_bindings for a user
@@ -1825,7 +1725,7 @@ const allowed = await check_min_rights_legacy('upload', userId, orgId, appId)
 const allowed = await checkPermission(c, 'app.upload_bundle', { appId })
 ```
 
-**Reason**: Automatic legacy/RBAC routing, structured logs, type-safety
+**Reason**: one RBAC permission path, structured logs, type-safety
 
 #### ✅ Specify the most precise permission possible
 

--- a/cli/src/channel/add.ts
+++ b/cli/src/channel/add.ts
@@ -1,15 +1,15 @@
 import type { ChannelAddOptions } from '../schemas/channel'
 import { intro, log, outro } from '@clack/prompts'
-import { check2FAComplianceForApp, checkAppExists } from '../api/app'
+import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import { createChannel } from '../api/channels'
 import {
-  assertCliPermission,
   createSupabaseClient,
   findSavedKey,
   formatError,
   getAppId,
   getConfig,
   getOrganizationId,
+  OrganizationPerm,
   resolveUserIdFromApiKey,
   sendEvent,
 } from '../utils'
@@ -36,22 +36,14 @@ export async function addChannelInternal(channelId: string, appId: string, optio
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon, silent)
   await check2FAComplianceForApp(supabase, appId, silent)
-  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
-  if (!(await checkAppExists(supabase, appId))) {
-    const msg = `App ${appId} does not exist`
-    if (!silent)
-      log.error(msg)
-    throw new Error(msg)
-  }
-  await assertCliPermission(supabase, options.apikey, 'app.create_channel', { appId }, {
-    message: `Insufficient permissions to create channel for app ${appId}`,
-    silent,
-  })
+  await resolveUserIdFromApiKey(supabase, options.apikey)
+  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
 
   if (!silent)
     log.info(`Creating channel ${appId}#${channelId} to Capgo`)
 
   const orgId = await getOrganizationId(supabase, appId)
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   const res = await createChannel(supabase, {
     name: channelId,

--- a/cli/src/channel/add.ts
+++ b/cli/src/channel/add.ts
@@ -1,15 +1,15 @@
 import type { ChannelAddOptions } from '../schemas/channel'
 import { intro, log, outro } from '@clack/prompts'
-import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import { check2FAComplianceForApp, checkAppExists } from '../api/app'
 import { createChannel } from '../api/channels'
 import {
+  assertCliPermission,
   createSupabaseClient,
   findSavedKey,
   formatError,
   getAppId,
   getConfig,
   getOrganizationId,
-  OrganizationPerm,
   resolveUserIdFromApiKey,
   sendEvent,
 } from '../utils'
@@ -36,14 +36,22 @@ export async function addChannelInternal(channelId: string, appId: string, optio
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon, silent)
   await check2FAComplianceForApp(supabase, appId, silent)
-  await resolveUserIdFromApiKey(supabase, options.apikey)
-  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
+  if (!(await checkAppExists(supabase, appId))) {
+    const msg = `App ${appId} does not exist`
+    if (!silent)
+      log.error(msg)
+    throw new Error(msg)
+  }
+  await assertCliPermission(supabase, options.apikey, 'app.create_channel', { appId }, {
+    message: `Insufficient permissions to create channel for app ${appId}`,
+    silent,
+  })
 
   if (!silent)
     log.info(`Creating channel ${appId}#${channelId} to Capgo`)
 
   const orgId = await getOrganizationId(supabase, appId)
-  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   const res = await createChannel(supabase, {
     name: channelId,

--- a/cli/src/channel/delete.ts
+++ b/cli/src/channel/delete.ts
@@ -1,16 +1,16 @@
 import type { ChannelDeleteOptions } from '../schemas/channel'
 import { intro, log, outro } from '@clack/prompts'
-import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import { check2FAComplianceForApp, checkAppExists } from '../api/app'
 import { delChannel, delChannelDevices, findBundleIdByChannelName, findChannel } from '../api/channels'
 import { deleteAppVersion } from '../api/versions'
 import {
+  assertCliPermission,
   createSupabaseClient,
   findSavedKey,
   formatError,
   getAppId,
   getConfig,
   getOrganizationId,
-  OrganizationPerm,
   resolveUserIdFromApiKey,
   sendEvent,
 } from '../utils'
@@ -39,17 +39,11 @@ export async function deleteChannelInternal(channelId: string, appId: string, op
   await check2FAComplianceForApp(supabase, appId, silent)
   const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
-  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
-
-  if (options.deleteBundle && !silent)
-    log.info(`Deleting bundle ${appId}#${channelId} from Capgo`)
-
-  if (options.deleteBundle) {
-    const bundle = await findBundleIdByChannelName(supabase, appId, channelId)
-    if (bundle?.name && !silent)
-      log.info(`Deleting bundle ${bundle.name} from Capgo`)
-    if (bundle?.name)
-      await deleteAppVersion(supabase, appId, bundle.name)
+  if (!(await checkAppExists(supabase, appId))) {
+    const msg = `App ${appId} does not exist`
+    if (!silent)
+      log.error(msg)
+    throw new Error(msg)
   }
 
   const { data: channel, error: channelError } = await findChannel(supabase, appId, channelId)
@@ -64,6 +58,22 @@ export async function deleteChannelInternal(channelId: string, appId: string, op
     }
 
     throw new Error(`Channel ${channelId} not found`)
+  }
+
+  await assertCliPermission(supabase, options.apikey, 'channel.delete', { appId, channelId: channel.id }, {
+    message: `Insufficient permissions to delete channel ${channelId} for app ${appId}`,
+    silent,
+  })
+
+  if (options.deleteBundle && !silent)
+    log.info(`Deleting bundle ${appId}#${channelId} from Capgo`)
+
+  if (options.deleteBundle) {
+    const bundle = await findBundleIdByChannelName(supabase, appId, channelId)
+    if (bundle?.name && !silent)
+      log.info(`Deleting bundle ${bundle.name} from Capgo`)
+    if (bundle?.name)
+      await deleteAppVersion(supabase, appId, bundle.name)
   }
 
   const { error: delDevicesError } = await delChannelDevices(supabase, appId, channel.id)

--- a/cli/src/channel/delete.ts
+++ b/cli/src/channel/delete.ts
@@ -1,16 +1,16 @@
 import type { ChannelDeleteOptions } from '../schemas/channel'
 import { intro, log, outro } from '@clack/prompts'
-import { check2FAComplianceForApp, checkAppExists } from '../api/app'
+import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import { delChannel, delChannelDevices, findBundleIdByChannelName, findChannel } from '../api/channels'
 import { deleteAppVersion } from '../api/versions'
 import {
-  assertCliPermission,
   createSupabaseClient,
   findSavedKey,
   formatError,
   getAppId,
   getConfig,
   getOrganizationId,
+  OrganizationPerm,
   resolveUserIdFromApiKey,
   sendEvent,
 } from '../utils'
@@ -39,11 +39,17 @@ export async function deleteChannelInternal(channelId: string, appId: string, op
   await check2FAComplianceForApp(supabase, appId, silent)
   const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
-  if (!(await checkAppExists(supabase, appId))) {
-    const msg = `App ${appId} does not exist`
-    if (!silent)
-      log.error(msg)
-    throw new Error(msg)
+  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
+
+  if (options.deleteBundle && !silent)
+    log.info(`Deleting bundle ${appId}#${channelId} from Capgo`)
+
+  if (options.deleteBundle) {
+    const bundle = await findBundleIdByChannelName(supabase, appId, channelId)
+    if (bundle?.name && !silent)
+      log.info(`Deleting bundle ${bundle.name} from Capgo`)
+    if (bundle?.name)
+      await deleteAppVersion(supabase, appId, bundle.name)
   }
 
   const { data: channel, error: channelError } = await findChannel(supabase, appId, channelId)
@@ -58,22 +64,6 @@ export async function deleteChannelInternal(channelId: string, appId: string, op
     }
 
     throw new Error(`Channel ${channelId} not found`)
-  }
-
-  await assertCliPermission(supabase, options.apikey, 'channel.delete', { appId, channelId: channel.id }, {
-    message: `Insufficient permissions to delete channel ${channelId} for app ${appId}`,
-    silent,
-  })
-
-  if (options.deleteBundle && !silent)
-    log.info(`Deleting bundle ${appId}#${channelId} from Capgo`)
-
-  if (options.deleteBundle) {
-    const bundle = await findBundleIdByChannelName(supabase, appId, channelId)
-    if (bundle?.name && !silent)
-      log.info(`Deleting bundle ${bundle.name} from Capgo`)
-    if (bundle?.name)
-      await deleteAppVersion(supabase, appId, bundle.name)
   }
 
   const { error: delDevicesError } = await delChannelDevices(supabase, appId, channel.id)

--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -3,9 +3,8 @@ import type { Database } from '../types/supabase.types'
 import type { Compatibility } from '../utils'
 import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
-import { check2FAComplianceForApp, checkAppExists } from '../api/app'
+import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import {
-  assertCliPermission,
   checkCompatibilityNativePackages,
   checkPlanValid,
   createSupabaseClient,
@@ -16,6 +15,7 @@ import {
   getConfig,
   getOrganizationId,
   isCompatible,
+  OrganizationPerm,
   resolveUserIdFromApiKey,
   sendEvent,
   updateOrCreateChannel,
@@ -80,13 +80,7 @@ export async function setChannelInternal(channel: string, appId: string, options
   await check2FAComplianceForApp(supabase, appId, silent)
   const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
-  if (!(await checkAppExists(supabase, appId))) {
-    const msg = `App ${appId} does not exist`
-    if (!silent)
-      log.error(msg)
-    throw new Error(msg)
-  }
-
+  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
   const orgId = await getOrganizationId(supabase, appId)
 
   const {
@@ -153,9 +147,9 @@ export async function setChannelInternal(channel: string, appId: string, options
     version: undefined as any,
   }
 
-  const { data: existingChannel, error: channelError } = await supabase
+  const { error: channelError } = await supabase
     .from('channels')
-    .select('id')
+    .select()
     .eq('app_id', appId)
     .eq('name', channel)
     .single()
@@ -165,11 +159,6 @@ export async function setChannelInternal(channel: string, appId: string, options
       log.error(`Cannot find channel ${channel}`)
     throw new Error(`Cannot find channel ${channel}`)
   }
-
-  await assertCliPermission(supabase, options.apikey, 'channel.update_settings', { appId, channelId: existingChannel.id }, {
-    message: `Insufficient permissions to update channel ${channel} for app ${appId}`,
-    silent,
-  })
 
   const resolvedBundleVersion = latest
     ? (extConfig?.config?.plugins?.CapacitorUpdater?.version || getBundleVersion('', options.packageJson))
@@ -220,11 +209,6 @@ export async function setChannelInternal(channel: string, appId: string, options
       }
     }
 
-    await assertCliPermission(supabase, options.apikey, 'channel.promote_bundle', { appId, channelId: existingChannel.id }, {
-      message: `Insufficient permissions to set a bundle on channel ${channel} for app ${appId}`,
-      silent,
-    })
-
     if (!silent)
       log.info(`Set ${appId} channel: ${channel} to @${resolvedBundleVersion}`)
 
@@ -268,11 +252,6 @@ export async function setChannelInternal(channel: string, appId: string, options
         throw new Error(`Latest remote bundle is not compatible with ${channel} channel`)
       }
     }
-
-    await assertCliPermission(supabase, options.apikey, 'channel.promote_bundle', { appId, channelId: existingChannel.id }, {
-      message: `Insufficient permissions to set a bundle on channel ${channel} for app ${appId}`,
-      silent,
-    })
 
     if (!silent)
       log.info(`Set ${appId} channel: ${channel} to @${data.name}`)

--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -3,8 +3,9 @@ import type { Database } from '../types/supabase.types'
 import type { Compatibility } from '../utils'
 import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
-import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import { check2FAComplianceForApp, checkAppExists } from '../api/app'
 import {
+  assertCliPermission,
   checkCompatibilityNativePackages,
   checkPlanValid,
   createSupabaseClient,
@@ -15,7 +16,6 @@ import {
   getConfig,
   getOrganizationId,
   isCompatible,
-  OrganizationPerm,
   resolveUserIdFromApiKey,
   sendEvent,
   updateOrCreateChannel,
@@ -80,7 +80,13 @@ export async function setChannelInternal(channel: string, appId: string, options
   await check2FAComplianceForApp(supabase, appId, silent)
   const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
-  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
+  if (!(await checkAppExists(supabase, appId))) {
+    const msg = `App ${appId} does not exist`
+    if (!silent)
+      log.error(msg)
+    throw new Error(msg)
+  }
+
   const orgId = await getOrganizationId(supabase, appId)
 
   const {
@@ -147,9 +153,9 @@ export async function setChannelInternal(channel: string, appId: string, options
     version: undefined as any,
   }
 
-  const { error: channelError } = await supabase
+  const { data: existingChannel, error: channelError } = await supabase
     .from('channels')
-    .select()
+    .select('id')
     .eq('app_id', appId)
     .eq('name', channel)
     .single()
@@ -159,6 +165,11 @@ export async function setChannelInternal(channel: string, appId: string, options
       log.error(`Cannot find channel ${channel}`)
     throw new Error(`Cannot find channel ${channel}`)
   }
+
+  await assertCliPermission(supabase, options.apikey, 'channel.update_settings', { appId, channelId: existingChannel.id }, {
+    message: `Insufficient permissions to update channel ${channel} for app ${appId}`,
+    silent,
+  })
 
   const resolvedBundleVersion = latest
     ? (extConfig?.config?.plugins?.CapacitorUpdater?.version || getBundleVersion('', options.packageJson))
@@ -209,6 +220,11 @@ export async function setChannelInternal(channel: string, appId: string, options
       }
     }
 
+    await assertCliPermission(supabase, options.apikey, 'channel.promote_bundle', { appId, channelId: existingChannel.id }, {
+      message: `Insufficient permissions to set a bundle on channel ${channel} for app ${appId}`,
+      silent,
+    })
+
     if (!silent)
       log.info(`Set ${appId} channel: ${channel} to @${resolvedBundleVersion}`)
 
@@ -252,6 +268,11 @@ export async function setChannelInternal(channel: string, appId: string, options
         throw new Error(`Latest remote bundle is not compatible with ${channel} channel`)
       }
     }
+
+    await assertCliPermission(supabase, options.apikey, 'channel.promote_bundle', { appId, channelId: existingChannel.id }, {
+      message: `Insufficient permissions to set a bundle on channel ${channel} for app ${appId}`,
+      silent,
+    })
 
     if (!silent)
       log.info(`Set ${appId} channel: ${channel} to @${data.name}`)

--- a/cli/src/types/supabase.types.ts
+++ b/cli/src/types/supabase.types.ts
@@ -1694,7 +1694,6 @@ export type Database = {
           stats_refresh_requested_at: string | null
           stats_updated_at: string | null
           updated_at: string | null
-          use_new_rbac: boolean
           website: string | null
         }
         Insert: {
@@ -1718,7 +1717,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Update: {
@@ -1742,7 +1740,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Relationships: [

--- a/read_replicate/schema_replicate.sql
+++ b/read_replicate/schema_replicate.sql
@@ -349,7 +349,6 @@ CREATE TABLE public.orgs (
     customer_id character varying,
     stats_updated_at timestamp without time zone,
     last_stats_updated_at timestamp without time zone,
-    use_new_rbac boolean DEFAULT true NOT NULL,
     enforcing_2fa boolean DEFAULT false NOT NULL,
     email_preferences jsonb DEFAULT '{"onboarding": true, "usage_limit": true, "credit_usage": true, "device_error": true, "weekly_stats": true, "monthly_stats": true, "bundle_created": true, "bundle_deployed": true, "deploy_stats_24h": true, "billing_period_stats": true, "channel_self_rejected": true}'::jsonb NOT NULL,
     enforce_hashed_api_keys boolean DEFAULT false NOT NULL,

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1811,7 +1811,6 @@ export type Database = {
           stats_refresh_requested_at: string | null
           stats_updated_at: string | null
           updated_at: string | null
-          use_new_rbac: boolean
           website: string | null
         }
         Insert: {
@@ -1835,7 +1834,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Update: {
@@ -1859,7 +1857,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Relationships: [

--- a/supabase/functions/_backend/public/channel/delete.ts
+++ b/supabase/functions/_backend/public/channel/delete.ts
@@ -29,10 +29,6 @@ export async function deleteChannel(c: Context<MiddlewareKeyVariables>, body: Ch
   if (!isValidAppId(body.app_id)) {
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
-  // Auth context is already set by middlewareKey
-  if (!(await checkPermission(c, 'channel.delete', { appId: body.app_id }))) {
-    throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
-  }
   if (!body.channel) {
     throw simpleError('missing_channel_name', 'You must provide a channel name')
   }
@@ -46,6 +42,10 @@ export async function deleteChannel(c: Context<MiddlewareKeyVariables>, body: Ch
     .single()
   if (dbError || !dataChannel) {
     throw simpleError('cannot_find_channel', 'Cannot find channel', { supabaseError: dbError })
+  }
+  // Auth context is already set by middlewareKey.
+  if (!(await checkPermission(c, 'channel.delete', { appId: body.app_id, channelId: dataChannel.id }))) {
+    throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
   }
   await supabaseApikey(c, apikey.key)
     .from('channels')

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -4,7 +4,7 @@ import type { Database } from '../../utils/supabase.types.ts'
 import { BRES, simpleError } from '../../utils/hono.ts'
 import { cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
-import { supabaseAdmin, supabaseApikey, updateOrCreateChannel } from '../../utils/supabase.ts'
+import { supabaseApikey } from '../../utils/supabase.ts'
 import { isInternalVersionName, isValidAppId } from '../../utils/utils.ts'
 
 interface ChannelSet {
@@ -47,29 +47,40 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   if (!isValidAppId(body.app_id)) {
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
-  const { data: existingChannel } = await supabaseAdmin(c)
+  const apiClient = supabaseApikey(c, apikey.key)
+  const { data: existingChannel } = await apiClient
     .from('channels')
-    .select('id, version')
+    .select('*')
     .eq('app_id', body.app_id)
     .eq('name', body.channel)
     .maybeSingle()
 
   if (existingChannel) {
     const canUpdateChannel = await checkPermission(c, 'channel.update_settings', { appId: body.app_id, channelId: existingChannel.id })
-    if (!canUpdateChannel) {
+    if (!canUpdateChannel)
       throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
-    }
-    if ((body.version !== undefined || existingChannel.version !== null) && !(await checkPermission(c, 'channel.promote_bundle', { appId: body.app_id, channelId: existingChannel.id }))) {
-      throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
-    }
   }
   else if (!(await checkPermission(c, 'app.create_channel', { appId: body.app_id }))) {
     throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
   }
-  const { data: org, error } = await supabaseApikey(c, apikey.key).from('apps').select('owner_org').eq('app_id', body.app_id).single()
+
+  const { data: org, error } = await apiClient.from('apps').select('owner_org').eq('app_id', body.app_id).single()
   if (error || !org) {
     throw simpleError('invalid_app_id', 'You can\'t access this app', { app_id: body.app_id })
   }
+
+  const nextVersion = body.version && !isInternalVersionName(body.version)
+    ? await findVersion(c, body.app_id, body.version, org.owner_org, apikey)
+    : null
+
+  if (existingChannel) {
+    if (nextVersion !== existingChannel.version && !(await checkPermission(c, 'channel.promote_bundle', { appId: body.app_id, channelId: existingChannel.id })))
+      throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
+  }
+  else if (nextVersion !== null && !(await checkPermission(c, 'channel.promote_bundle', { appId: body.app_id }))) {
+    throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
+  }
+
   const inferredElectron = body.electron ?? (body.public && body.ios !== body.android ? false : undefined)
   const channel: Database['public']['Tables']['channels']['Insert'] = {
     created_by: apikey.user_id,
@@ -86,13 +97,26 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
     ...(body.ios == null ? {} : { ios: body.ios }),
     ...(body.android == null ? {} : { android: body.android }),
     ...(inferredElectron == null ? {} : { electron: inferredElectron }),
-    version: null,
+    version: nextVersion,
     owner_org: org.owner_org,
   }
 
-  if (body.version && !isInternalVersionName(body.version))
-    channel.version = await findVersion(c, body.app_id, body.version, org.owner_org, apikey)
+  const upsertPayload = {
+    ...channel,
+    created_by: existingChannel?.created_by ?? channel.created_by,
+  }
+  if (existingChannel) {
+    const fieldsDiffer = Object.keys(upsertPayload).some(key =>
+      (upsertPayload as any)[key] !== (existingChannel as any)[key] && key !== 'created_at' && key !== 'updated_at',
+    )
+    if (!fieldsDiffer)
+      return c.json(BRES)
+  }
 
-  await updateOrCreateChannel(c, channel)
+  await apiClient
+    .from('channels')
+    .upsert(upsertPayload, { onConflict: 'app_id, name' })
+    .throwOnError()
+
   return c.json(BRES)
 }

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -4,7 +4,7 @@ import type { Database } from '../../utils/supabase.types.ts'
 import { BRES, simpleError } from '../../utils/hono.ts'
 import { cloudlogErr } from '../../utils/logging.ts'
 import { checkPermission } from '../../utils/rbac.ts'
-import { supabaseApikey, updateOrCreateChannel } from '../../utils/supabase.ts'
+import { supabaseAdmin, supabaseApikey, updateOrCreateChannel } from '../../utils/supabase.ts'
 import { isInternalVersionName, isValidAppId } from '../../utils/utils.ts'
 
 interface ChannelSet {
@@ -47,8 +47,23 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   if (!isValidAppId(body.app_id)) {
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
-  // Auth context is already set by middlewareKey
-  if (!(await checkPermission(c, 'app.create_channel', { appId: body.app_id }))) {
+  const { data: existingChannel } = await supabaseAdmin(c)
+    .from('channels')
+    .select('id, version')
+    .eq('app_id', body.app_id)
+    .eq('name', body.channel)
+    .maybeSingle()
+
+  if (existingChannel) {
+    const canUpdateChannel = await checkPermission(c, 'channel.update_settings', { appId: body.app_id, channelId: existingChannel.id })
+    if (!canUpdateChannel) {
+      throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
+    }
+    if ((body.version !== undefined || existingChannel.version !== null) && !(await checkPermission(c, 'channel.promote_bundle', { appId: body.app_id, channelId: existingChannel.id }))) {
+      throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
+    }
+  }
+  else if (!(await checkPermission(c, 'app.create_channel', { appId: body.app_id }))) {
     throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
   }
   const { data: org, error } = await supabaseApikey(c, apikey.key).from('apps').select('owner_org').eq('app_id', body.app_id).single()

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -69,51 +69,34 @@ async function resolveOrgIdForRbac(c: Context, options?: RbacContextOptions) {
 
 async function setRbacContextForOrg(c: Context, orgId: string) {
   c.set('resolvedOrgId', orgId)
-  let pgClient
-  try {
-    pgClient = getPgClient(c, true)
-    const drizzleClient = getDrizzleClient(pgClient)
-    const result = await drizzleClient.execute(
-      sql`SELECT public.rbac_is_enabled_for_org(${orgId}::uuid) as enabled`,
-    )
-    const enabled = (result.rows[0] as any)?.enabled === true
-    c.set('rbacEnabled', enabled)
+  c.set('rbacEnabled', true)
 
-    cloudlog({
-      requestId: c.get('requestId'),
-      message: 'middlewareRbacContext: resolved',
-      orgId,
-      rbacEnabled: enabled,
-    })
-  }
-  catch (e) {
-    logPgError(c, 'middlewareRbacContext:checkRbacEnabled', e)
-    c.set('rbacEnabled', false)
-  }
-  finally {
-    if (pgClient) {
-      await closeClient(c, pgClient)
-    }
-  }
-}
-
-function setRbacContextLegacy(c: Context) {
-  c.set('rbacEnabled', false)
   cloudlog({
     requestId: c.get('requestId'),
-    message: 'middlewareRbacContext: no orgId resolved, defaulting to legacy',
+    message: 'middlewareRbacContext: resolved',
+    orgId,
+    rbacEnabled: true,
+  })
+}
+
+function setRbacContextWithoutOrg(c: Context) {
+  c.set('rbacEnabled', true)
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'middlewareRbacContext: no orgId resolved',
+    rbacEnabled: true,
   })
 }
 
 /**
- * Middleware that resolves and caches the RBAC feature flag for the current org.
+ * Middleware that resolves and caches the RBAC context for the current org.
  * Should be used after authentication middleware and when orgId is known.
  *
  * Usage:
  *   app.use('/app/*', middlewareV2(['all']), middlewareRbacContext())
  *
  * After this middleware runs:
- *   - c.get('rbacEnabled') - boolean indicating if RBAC is enabled for the org
+ *   - c.get('rbacEnabled') - true; RBAC is the only authorization system
  *   - c.get('resolvedOrgId') - the resolved org ID (if provided)
  */
 export function middlewareRbacContext(options?: RbacContextOptions) {
@@ -123,7 +106,7 @@ export function middlewareRbacContext(options?: RbacContextOptions) {
       await setRbacContextForOrg(c, orgId)
     }
     else {
-      setRbacContextLegacy(c)
+      setRbacContextWithoutOrg(c)
     }
 
     await next()

--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -20,7 +20,7 @@ import type { MiddlewareKeyVariables } from './hono.ts'
 import type { Database } from './supabase.types.ts'
 import { sql } from 'drizzle-orm'
 import { cloudlog, cloudlogErr } from './logging.ts'
-import { closeClient, getDrizzleClient, getPgClient, logPgError } from './pg.ts'
+import { closeClient, getDrizzleClient, getPgClient } from './pg.ts'
 
 // =============================================================================
 // Types
@@ -148,46 +148,22 @@ const PERMISSION_TO_LEGACY_RIGHT: Record<Permission, Database['public']['Enums']
 // =============================================================================
 
 /**
- * Check if RBAC is enabled for an organization.
- * Caches the result in context to avoid repeated queries.
+ * Check if RBAC applies to an organization.
+ * RBAC is always enabled for resolved organizations; this helper only preserves
+ * the old call site contract.
  */
 export async function isRbacEnabledForOrg(
   c: Context<MiddlewareKeyVariables>,
   orgId: string | null,
 ): Promise<boolean> {
-  // Check cache first
   const cached = c.get('rbacEnabled')
   if (cached !== undefined) {
     return cached
   }
 
-  if (!orgId) {
-    return false
-  }
-
-  let pgClient
-  try {
-    pgClient = getPgClient(c)
-    const drizzleClient = getDrizzleClient(pgClient)
-
-    const result = await drizzleClient.execute(
-      sql`SELECT public.rbac_is_enabled_for_org(${orgId}::uuid) as enabled`,
-    )
-
-    const enabled = (result.rows[0] as any)?.enabled === true
-    // Cache the result
-    c.set('rbacEnabled', enabled)
-    return enabled
-  }
-  catch (e) {
-    logPgError(c, 'isRbacEnabledForOrg', e)
-    return false
-  }
-  finally {
-    if (pgClient) {
-      closeClient(c, pgClient)
-    }
-  }
+  c.set('rbacEnabled', true)
+  void orgId
+  return true
 }
 
 /**

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1811,7 +1811,6 @@ export type Database = {
           stats_refresh_requested_at: string | null
           stats_updated_at: string | null
           updated_at: string | null
-          use_new_rbac: boolean
           website: string | null
         }
         Insert: {
@@ -1835,7 +1834,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Update: {
@@ -1859,7 +1857,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Relationships: [

--- a/supabase/migrations/20260528122747_fix_channel_rbac_permissions.sql
+++ b/supabase/migrations/20260528122747_fix_channel_rbac_permissions.sql
@@ -1,11 +1,64 @@
--- Keep legacy write/developer API keys compatible with channel creation while
--- preserving destructive channel deletes for admin-capable roles only.
+-- Keep channel API key permissions compatible with old CLI builds while moving
+-- authoritative channel mutations to RBAC-backed RLS and endpoint checks.
 INSERT INTO public.role_permissions (role_id, permission_id)
 SELECT roles.id, permissions.id
 FROM public.roles
 JOIN public.permissions ON permissions.key = public.rbac_perm_app_create_channel()
 WHERE roles.name = public.rbac_role_app_developer()
 ON CONFLICT DO NOTHING;
+
+CREATE OR REPLACE FUNCTION "public"."normalize_public_channel_overlap"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  IF NEW.public IS DISTINCT FROM true THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND NEW.public IS NOT DISTINCT FROM OLD.public
+    AND NEW.ios IS NOT DISTINCT FROM OLD.ios
+    AND NEW.android IS NOT DISTINCT FROM OLD.android
+    AND NEW.electron IS NOT DISTINCT FROM OLD.electron
+    AND NEW.app_id IS NOT DISTINCT FROM OLD.app_id
+  THEN
+    RETURN NEW;
+  END IF;
+
+  -- Row-level UPDATE triggers run after the target row is locked. Do not wait
+  -- behind another same-app normalizer here; the partial unique indexes will
+  -- reject the rare concurrent conflict instead of letting API calls deadlock.
+  IF NOT pg_catalog.pg_try_advisory_xact_lock(pg_catalog.hashtext(NEW.app_id)) THEN
+    RETURN NEW;
+  END IF;
+
+  WITH target AS (
+    SELECT existing.id
+    FROM public.channels AS existing
+    WHERE existing.app_id = NEW.app_id
+      AND existing.public = true
+      AND existing.id IS DISTINCT FROM NEW.id
+      AND (
+        (NEW.ios = true AND existing.ios = true)
+        OR (NEW.android = true AND existing.android = true)
+        OR (NEW.electron = true AND existing.electron = true)
+      )
+    ORDER BY existing.id
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.channels AS existing
+  SET public = false
+  FROM target
+  WHERE existing.id = target.id
+    AND existing.public = true;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."normalize_public_channel_overlap"() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."normalize_public_channel_overlap"() FROM PUBLIC;
 
 DROP POLICY IF EXISTS "Allow insert for auth, api keys (write, all) (admin+)" ON public.channels;
 
@@ -24,6 +77,15 @@ WITH CHECK (
     owner_org,
     app_id,
     NULL::bigint
+  )
+  AND (
+    version IS NULL
+    OR public.rbac_check_permission_request(
+      public.rbac_perm_channel_promote_bundle(),
+      owner_org,
+      app_id,
+      NULL::bigint
+    )
   )
 );
 
@@ -53,12 +115,6 @@ WITH CHECK (
     owner_org,
     app_id,
     id
-  )
-  AND public.rbac_check_permission_request(
-    public.rbac_perm_channel_update_settings(),
-    owner_org,
-    app_id,
-    NULL::bigint
   )
 );
 
@@ -109,15 +165,18 @@ BEGIN
     RETURN 'perm_owner';
   END IF;
 
+  -- Old CLI builds ask this coarse helper for admin before channel create/set/delete
+  -- because they cannot pass an action name. Return admin for channel-mutating RBAC
+  -- permissions so old CLI reaches the authoritative RLS/endpoint checks below.
   IF public.rbac_check_permission_direct(public.rbac_perm_app_update_user_roles(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
     OR public.rbac_check_permission_direct(public.rbac_perm_channel_delete(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+    OR public.rbac_check_permission_direct(public.rbac_perm_app_create_channel(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+    OR public.rbac_check_permission_direct(public.rbac_perm_channel_update_settings(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
   THEN
     RETURN 'perm_admin';
   END IF;
 
   IF public.rbac_check_permission_direct(public.rbac_perm_app_update_settings(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
-    OR public.rbac_check_permission_direct(public.rbac_perm_app_create_channel(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
-    OR public.rbac_check_permission_direct(public.rbac_perm_channel_update_settings(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
   THEN
     RETURN 'perm_write';
   END IF;
@@ -216,3 +275,299 @@ END;
 $$;
 
 ALTER FUNCTION "public"."get_org_perm_for_apikey_v2"("apikey" "text", "app_id" "text") OWNER TO "postgres";
+
+-- RBAC is now always enabled. Keep compatibility RPC names/shapes but remove the
+-- per-org rollout column and any runtime dependency on it.
+CREATE OR REPLACE FUNCTION "public"."rbac_is_enabled_for_org"("p_org_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" STABLE
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  PERFORM p_org_id;
+  RETURN true;
+END;
+$$;
+
+ALTER FUNCTION "public"."rbac_is_enabled_for_org"("p_org_id" "uuid") OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."rbac_is_enabled_for_org"("p_org_id" "uuid") IS 'Compatibility helper retained for old callers. RBAC is always enabled.';
+
+CREATE OR REPLACE FUNCTION "public"."rbac_enable_for_org"("p_org_id" "uuid", "p_granted_by" "uuid" DEFAULT NULL::"uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_migration_result jsonb;
+BEGIN
+  v_migration_result := public.rbac_migrate_org_users_to_bindings(p_org_id, p_granted_by);
+
+  RETURN jsonb_build_object(
+    'status', 'already_enabled',
+    'org_id', p_org_id,
+    'migration_result', v_migration_result,
+    'rbac_enabled', true
+  );
+END;
+$$;
+
+ALTER FUNCTION "public"."rbac_enable_for_org"("p_org_id" "uuid", "p_granted_by" "uuid") OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."rbac_enable_for_org"("p_org_id" "uuid", "p_granted_by" "uuid") IS 'Compatibility RPC. RBAC is always enabled; this only resyncs legacy org_users bindings.';
+
+CREATE OR REPLACE FUNCTION "public"."rbac_rollback_org"("p_org_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'status', 'success',
+    'org_id', p_org_id,
+    'rbac_enabled', true,
+    'rollback_performed', false,
+    'message', 'RBAC is always enabled and cannot be rolled back'
+  );
+END;
+$$;
+
+ALTER FUNCTION "public"."rbac_rollback_org"("p_org_id" "uuid") OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."rbac_rollback_org"("p_org_id" "uuid") IS 'Compatibility RPC. RBAC rollback is a no-op because RBAC is always enabled.';
+
+CREATE OR REPLACE FUNCTION "public"."resync_org_user_role_bindings"(
+  "p_user_id" "uuid",
+  "p_org_id" "uuid"
+) RETURNS void
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+DECLARE
+  v_org_user "public"."org_users"%ROWTYPE;
+  role_name_to_bind text;
+  role_id_to_bind uuid;
+  org_member_role_id uuid;
+  app_role_name text;
+  app_role_id uuid;
+  v_app RECORD;
+  v_app_uuid uuid;
+  v_channel_uuid uuid;
+  v_granted_by uuid;
+  v_sync_reason text := 'Synced from org_users';
+BEGIN
+  DELETE FROM "public"."role_bindings" rb
+  WHERE rb."principal_type" = "public"."rbac_principal_user"()
+    AND rb."principal_id" = p_user_id
+    AND rb."org_id" = p_org_id
+    AND rb."reason" IN (
+      'Synced from org_users',
+      'Updated from org_users',
+      'Migrated from org_users (legacy)'
+    )
+    AND NOT (
+      rb."scope_type" = "public"."rbac_scope_org"()
+      AND EXISTS (
+        SELECT 1
+        FROM "public"."roles" r
+        WHERE r."id" = rb."role_id"
+          AND r."name" = "public"."rbac_role_org_super_admin"()
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM "public"."org_users" ou
+        WHERE ou."user_id" = p_user_id
+          AND ou."org_id" = p_org_id
+          AND ou."app_id" IS NULL
+          AND ou."channel_id" IS NULL
+          AND ou."rbac_role_name" IS NULL
+          AND ou."user_right" = "public"."rbac_right_super_admin"()
+      )
+    );
+
+  FOR v_org_user IN
+    SELECT *
+    FROM "public"."org_users"
+    WHERE "user_id" = p_user_id
+      AND "org_id" = p_org_id
+      AND "rbac_role_name" IS NULL
+  LOOP
+    v_granted_by := COALESCE("auth"."uid"(), v_org_user.user_id);
+
+    IF v_org_user.app_id IS NULL AND v_org_user.channel_id IS NULL THEN
+      IF v_org_user.user_right IN ("public"."rbac_right_super_admin"(), "public"."rbac_right_admin"()) THEN
+        CASE v_org_user.user_right
+          WHEN "public"."rbac_right_super_admin"() THEN role_name_to_bind := "public"."rbac_role_org_super_admin"();
+          WHEN "public"."rbac_right_admin"() THEN role_name_to_bind := "public"."rbac_role_org_admin"();
+        END CASE;
+
+        SELECT id INTO role_id_to_bind
+        FROM "public"."roles"
+        WHERE "name" = role_name_to_bind
+        LIMIT 1;
+
+        IF role_id_to_bind IS NOT NULL THEN
+          INSERT INTO "public"."role_bindings" (
+            "principal_type", "principal_id", "role_id", "scope_type", "org_id",
+            "granted_by", "granted_at", "reason", "is_direct"
+          ) VALUES (
+            "public"."rbac_principal_user"(), v_org_user.user_id, role_id_to_bind, "public"."rbac_scope_org"(), v_org_user.org_id,
+            v_granted_by, now(), v_sync_reason, true
+          ) ON CONFLICT DO NOTHING;
+        END IF;
+      ELSIF v_org_user.user_right IN ("public"."rbac_right_read"(), "public"."rbac_right_upload"(), "public"."rbac_right_write"()) THEN
+        SELECT id INTO org_member_role_id
+        FROM "public"."roles"
+        WHERE "name" = "public"."rbac_role_org_member"()
+        LIMIT 1;
+
+        IF org_member_role_id IS NOT NULL THEN
+          INSERT INTO "public"."role_bindings" (
+            "principal_type", "principal_id", "role_id", "scope_type", "org_id",
+            "granted_by", "granted_at", "reason", "is_direct"
+          ) VALUES (
+            "public"."rbac_principal_user"(), v_org_user.user_id, org_member_role_id, "public"."rbac_scope_org"(), v_org_user.org_id,
+            v_granted_by, now(), v_sync_reason, true
+          ) ON CONFLICT DO NOTHING;
+        END IF;
+
+        CASE v_org_user.user_right
+          WHEN "public"."rbac_right_read"() THEN app_role_name := "public"."rbac_role_app_reader"();
+          WHEN "public"."rbac_right_upload"() THEN app_role_name := "public"."rbac_role_app_uploader"();
+          WHEN "public"."rbac_right_write"() THEN app_role_name := "public"."rbac_role_app_developer"();
+        END CASE;
+
+        SELECT id INTO app_role_id
+        FROM "public"."roles"
+        WHERE "name" = app_role_name
+        LIMIT 1;
+
+        IF app_role_id IS NOT NULL THEN
+          FOR v_app IN
+            SELECT id
+            FROM "public"."apps"
+            WHERE "owner_org" = v_org_user.org_id
+          LOOP
+            INSERT INTO "public"."role_bindings" (
+              "principal_type", "principal_id", "role_id", "scope_type", "org_id", "app_id",
+              "granted_by", "granted_at", "reason", "is_direct"
+            ) VALUES (
+              "public"."rbac_principal_user"(), v_org_user.user_id, app_role_id, "public"."rbac_scope_app"(), v_org_user.org_id, v_app.id,
+              v_granted_by, now(), v_sync_reason, true
+            ) ON CONFLICT DO NOTHING;
+          END LOOP;
+        END IF;
+      END IF;
+    ELSIF v_org_user.app_id IS NOT NULL AND v_org_user.channel_id IS NULL THEN
+      CASE v_org_user.user_right
+        WHEN "public"."rbac_right_super_admin"() THEN role_name_to_bind := "public"."rbac_role_app_admin"();
+        WHEN "public"."rbac_right_admin"() THEN role_name_to_bind := "public"."rbac_role_app_admin"();
+        WHEN "public"."rbac_right_write"() THEN role_name_to_bind := "public"."rbac_role_app_developer"();
+        WHEN "public"."rbac_right_upload"() THEN role_name_to_bind := "public"."rbac_role_app_uploader"();
+        WHEN "public"."rbac_right_read"() THEN role_name_to_bind := "public"."rbac_role_app_reader"();
+        ELSE role_name_to_bind := "public"."rbac_role_app_reader"();
+      END CASE;
+
+      SELECT id INTO role_id_to_bind
+      FROM "public"."roles"
+      WHERE "name" = role_name_to_bind
+      LIMIT 1;
+
+      SELECT id INTO v_app_uuid
+      FROM "public"."apps"
+      WHERE "app_id" = v_org_user.app_id
+      LIMIT 1;
+
+      IF role_id_to_bind IS NOT NULL AND v_app_uuid IS NOT NULL THEN
+        INSERT INTO "public"."role_bindings" (
+          "principal_type", "principal_id", "role_id", "scope_type", "org_id", "app_id",
+          "granted_by", "granted_at", "reason", "is_direct"
+        ) VALUES (
+          "public"."rbac_principal_user"(), v_org_user.user_id, role_id_to_bind, "public"."rbac_scope_app"(), v_org_user.org_id, v_app_uuid,
+          v_granted_by, now(), v_sync_reason, true
+        ) ON CONFLICT DO NOTHING;
+      END IF;
+    ELSIF v_org_user.app_id IS NOT NULL AND v_org_user.channel_id IS NOT NULL THEN
+      CASE v_org_user.user_right
+        WHEN "public"."rbac_right_super_admin"() THEN role_name_to_bind := "public"."rbac_role_channel_admin"();
+        WHEN "public"."rbac_right_admin"() THEN role_name_to_bind := "public"."rbac_role_channel_admin"();
+        WHEN "public"."rbac_right_write"() THEN role_name_to_bind := 'channel_developer';
+        WHEN "public"."rbac_right_upload"() THEN role_name_to_bind := 'channel_uploader';
+        WHEN "public"."rbac_right_read"() THEN role_name_to_bind := "public"."rbac_role_channel_reader"();
+        ELSE role_name_to_bind := "public"."rbac_role_channel_reader"();
+      END CASE;
+
+      SELECT id INTO role_id_to_bind
+      FROM "public"."roles"
+      WHERE "name" = role_name_to_bind
+      LIMIT 1;
+
+      SELECT id INTO v_app_uuid
+      FROM "public"."apps"
+      WHERE "app_id" = v_org_user.app_id
+      LIMIT 1;
+
+      SELECT "rbac_id" INTO v_channel_uuid
+      FROM "public"."channels"
+      WHERE "id" = v_org_user.channel_id
+      LIMIT 1;
+
+      IF role_id_to_bind IS NOT NULL AND v_app_uuid IS NOT NULL AND v_channel_uuid IS NOT NULL THEN
+        INSERT INTO "public"."role_bindings" (
+          "principal_type", "principal_id", "role_id", "scope_type", "org_id", "app_id", "channel_id",
+          "granted_by", "granted_at", "reason", "is_direct"
+        ) VALUES (
+          "public"."rbac_principal_user"(), v_org_user.user_id, role_id_to_bind, "public"."rbac_scope_channel"(), v_org_user.org_id, v_app_uuid, v_channel_uuid,
+          v_granted_by, now(), v_sync_reason, true
+        ) ON CONFLICT DO NOTHING;
+      END IF;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+ALTER FUNCTION "public"."resync_org_user_role_bindings"("p_user_id" "uuid", "p_org_id" "uuid") OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."resync_org_user_role_bindings"("p_user_id" "uuid", "p_org_id" "uuid") IS 'Compatibility sync from legacy org_users rows into RBAC role_bindings. RBAC invite rows are ignored.';
+
+CREATE OR REPLACE FUNCTION "public"."sync_org_user_role_binding_on_update"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  IF NEW.rbac_role_name IS NOT NULL OR OLD.rbac_role_name IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF OLD.user_right IS DISTINCT FROM NEW.user_right THEN
+    PERFORM "public"."resync_org_user_role_bindings"(NEW.user_id, NEW.org_id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."sync_org_user_role_binding_on_update"() OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."sync_org_user_role_binding_on_update"() IS 'Updates role_bindings when legacy org_users.user_right changes. RBAC invite rows are ignored.';
+
+CREATE OR REPLACE FUNCTION "public"."sync_org_user_to_role_binding"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  IF NEW.rbac_role_name IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM "public"."resync_org_user_role_bindings"(NEW.user_id, NEW.org_id);
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."sync_org_user_to_role_binding"() OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."sync_org_user_to_role_binding"() IS 'Creates role_bindings when legacy org_users rows are inserted. RBAC invite rows are ignored.';
+
+DROP POLICY IF EXISTS "Allow admin to select webhooks" ON "public"."webhooks";
+DROP POLICY IF EXISTS "Allow admin to insert webhooks" ON "public"."webhooks";
+DROP POLICY IF EXISTS "Allow admin to update webhooks" ON "public"."webhooks";
+DROP POLICY IF EXISTS "Allow admin to delete webhooks" ON "public"."webhooks";
+DROP POLICY IF EXISTS "Allow org members to select webhook_deliveries" ON "public"."webhook_deliveries";
+DROP POLICY IF EXISTS "Allow admin to insert webhook_deliveries" ON "public"."webhook_deliveries";
+DROP POLICY IF EXISTS "Allow admin to update webhook_deliveries" ON "public"."webhook_deliveries";
+
+ALTER TABLE "public"."orgs"
+  DROP COLUMN IF EXISTS "use_new_rbac";

--- a/supabase/migrations/20260528122747_fix_channel_rbac_permissions.sql
+++ b/supabase/migrations/20260528122747_fix_channel_rbac_permissions.sql
@@ -1,0 +1,218 @@
+-- Keep legacy write/developer API keys compatible with channel creation while
+-- preserving destructive channel deletes for admin-capable roles only.
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM public.roles
+JOIN public.permissions ON permissions.key = public.rbac_perm_app_create_channel()
+WHERE roles.name = public.rbac_role_app_developer()
+ON CONFLICT DO NOTHING;
+
+DROP POLICY IF EXISTS "Allow insert for auth, api keys (write, all) (admin+)" ON public.channels;
+
+CREATE POLICY "Allow insert for auth, api keys (create_channel)" ON public.channels
+FOR INSERT
+TO anon, authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM public.apps
+    WHERE apps.app_id = channels.app_id
+      AND apps.owner_org = channels.owner_org
+  )
+  AND public.rbac_check_permission_request(
+    public.rbac_perm_app_create_channel(),
+    owner_org,
+    app_id,
+    NULL::bigint
+  )
+);
+
+DROP POLICY IF EXISTS "Allow update for auth, api keys (write, all) (write+)" ON public.channels;
+
+CREATE POLICY "Allow update for auth, api keys (channel write)"
+ON public.channels
+FOR UPDATE
+TO anon, authenticated
+USING (
+  public.rbac_check_permission_request(
+    public.rbac_perm_channel_update_settings(),
+    owner_org,
+    app_id,
+    id
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM public.apps
+    WHERE apps.app_id = channels.app_id
+      AND apps.owner_org = channels.owner_org
+  )
+  AND public.rbac_check_permission_request(
+    public.rbac_perm_channel_update_settings(),
+    owner_org,
+    app_id,
+    id
+  )
+  AND public.rbac_check_permission_request(
+    public.rbac_perm_channel_update_settings(),
+    owner_org,
+    app_id,
+    NULL::bigint
+  )
+);
+
+DROP POLICY IF EXISTS "Allow delete for auth (admin+) (all apikey)" ON public.channels;
+
+CREATE POLICY "Allow delete for auth, api keys (channel.delete)"
+ON public.channels
+FOR DELETE
+TO anon, authenticated
+USING (
+  public.rbac_check_permission_request(
+    public.rbac_perm_channel_delete(),
+    owner_org,
+    app_id,
+    id
+  )
+);
+
+CREATE OR REPLACE FUNCTION "public"."get_org_perm_for_apikey"("apikey" "text", "app_id" "text") RETURNS "text"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+<<get_org_perm_for_apikey>>
+DECLARE
+  apikey_user_id uuid;
+  org_id uuid;
+BEGIN
+  SELECT user_id INTO apikey_user_id
+  FROM public.find_apikey_by_value(apikey)
+  LIMIT 1;
+
+  IF apikey_user_id IS NULL THEN
+    PERFORM public.pg_log('deny: INVALID_APIKEY', jsonb_build_object('app_id', get_org_perm_for_apikey.app_id));
+    RETURN 'INVALID_APIKEY';
+  END IF;
+
+  SELECT owner_org INTO org_id
+  FROM public.apps
+  WHERE apps.app_id = get_org_perm_for_apikey.app_id
+  LIMIT 1;
+
+  IF org_id IS NULL THEN
+    PERFORM public.pg_log('deny: NO_APP', jsonb_build_object('app_id', get_org_perm_for_apikey.app_id));
+    RETURN 'NO_APP';
+  END IF;
+
+  IF public.rbac_check_permission_direct(public.rbac_perm_app_transfer(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey) THEN
+    RETURN 'perm_owner';
+  END IF;
+
+  IF public.rbac_check_permission_direct(public.rbac_perm_app_update_user_roles(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+    OR public.rbac_check_permission_direct(public.rbac_perm_channel_delete(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+  THEN
+    RETURN 'perm_admin';
+  END IF;
+
+  IF public.rbac_check_permission_direct(public.rbac_perm_app_update_settings(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+    OR public.rbac_check_permission_direct(public.rbac_perm_app_create_channel(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+    OR public.rbac_check_permission_direct(public.rbac_perm_channel_update_settings(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey)
+  THEN
+    RETURN 'perm_write';
+  END IF;
+
+  IF public.rbac_check_permission_direct(public.rbac_perm_app_upload_bundle(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey) THEN
+    RETURN 'perm_upload';
+  END IF;
+
+  IF public.rbac_check_permission_direct(public.rbac_perm_app_read(), apikey_user_id, org_id, get_org_perm_for_apikey.app_id, NULL::bigint, apikey) THEN
+    RETURN 'perm_read';
+  END IF;
+
+  PERFORM public.pg_log('deny: perm_none', jsonb_build_object('org_id', org_id, 'apikey_user_id', apikey_user_id));
+  RETURN 'perm_none';
+END;
+$$;
+
+ALTER FUNCTION "public"."get_org_perm_for_apikey"("apikey" "text", "app_id" "text") OWNER TO "postgres";
+
+CREATE OR REPLACE FUNCTION "public"."get_org_perm_for_apikey_v2"("apikey" "text", "app_id" "text") RETURNS "text"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_user_id uuid;
+  v_org_id uuid;
+BEGIN
+  SELECT user_id INTO v_user_id
+  FROM public.find_apikey_by_value(get_org_perm_for_apikey_v2.apikey)
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RETURN 'INVALID_APIKEY';
+  END IF;
+
+  SELECT owner_org INTO v_org_id
+  FROM public.apps
+  WHERE public.apps.app_id = get_org_perm_for_apikey_v2.app_id
+  LIMIT 1;
+
+  IF v_org_id IS NULL THEN
+    RETURN 'NO_APP';
+  END IF;
+
+  IF public.rbac_check_permission_direct(
+    public.rbac_perm_app_transfer(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+    get_org_perm_for_apikey_v2.apikey
+  ) THEN
+    RETURN 'perm_owner';
+  END IF;
+
+  IF public.rbac_check_permission_direct(
+    public.rbac_perm_app_update_user_roles(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+    get_org_perm_for_apikey_v2.apikey
+  )
+    OR public.rbac_check_permission_direct(
+      public.rbac_perm_channel_delete(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+      get_org_perm_for_apikey_v2.apikey
+    )
+  THEN
+    RETURN 'perm_admin';
+  END IF;
+
+  IF public.rbac_check_permission_direct(
+    public.rbac_perm_app_update_settings(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+    get_org_perm_for_apikey_v2.apikey
+  )
+    OR public.rbac_check_permission_direct(
+      public.rbac_perm_app_create_channel(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+      get_org_perm_for_apikey_v2.apikey
+    )
+    OR public.rbac_check_permission_direct(
+      public.rbac_perm_channel_update_settings(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+      get_org_perm_for_apikey_v2.apikey
+    )
+  THEN
+    RETURN 'perm_write';
+  END IF;
+
+  IF public.rbac_check_permission_direct(
+    public.rbac_perm_app_upload_bundle(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+    get_org_perm_for_apikey_v2.apikey
+  ) THEN
+    RETURN 'perm_upload';
+  END IF;
+
+  IF public.rbac_check_permission_direct(
+    public.rbac_perm_app_read(), v_user_id, v_org_id, get_org_perm_for_apikey_v2.app_id::varchar, NULL,
+    get_org_perm_for_apikey_v2.apikey
+  ) THEN
+    RETURN 'perm_read';
+  END IF;
+
+  RETURN 'perm_none';
+END;
+$$;
+
+ALTER FUNCTION "public"."get_org_perm_for_apikey_v2"("apikey" "text", "app_id" "text") OWNER TO "postgres";

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -278,25 +278,24 @@ BEGIN
     ('2022-06-03 05:54:15+00', '', 'delete', 'fresh', NULL, 'delete-user-fresh@capgo.app', 'c8b2e0f5-8c90-4f4d-9f3c-2b3c4d5e6f70', NOW(), 't', 't');
 
     ALTER TABLE public.orgs DISABLE TRIGGER generate_org_user_stripe_info_on_org_create;
-    INSERT INTO "public"."orgs" ("id", "created_by", "created_at", "updated_at", "logo", "name", "management_email", "customer_id", "use_new_rbac") VALUES
-    ('22dbad8a-b885-4309-9b3b-a09f8460fb6d', 'c591b04e-cf29-4945-b9a0-776d0672061a', NOW(), NOW(), '', 'Admin org', 'admin@capgo.app', 'cus_Pa0k8TO6HVln6A', false),
-    ('046a36ac-e03c-4590-9257-bd6c9dba9ee8', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Demo org', 'test@capgo.app', 'cus_Q38uE91NP8Ufqc', false),
-    ('34a8c55d-2d0f-4652-a43f-684c7a9403ac', '6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5', NOW(), NOW(), '', 'Test2 org', 'test2@capgo.app', 'cus_Pa0f3M6UCQ8g5Q', false),
-    ('a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', '6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5', NOW(), NOW(), '', 'Non-Owner Org', 'test2@capgo.app', 'cus_NonOwner', false),
-    ('b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e', '7a1b2c3d-4e5f-4a6b-7c8d-9e0f1a2b3c4d', NOW(), NOW(), '', 'Stats Test Org', 'stats@capgo.app', 'cus_StatsTest', false),
-    ('c3d4e5f6-a7b8-4c9d-8e0f-1a2b3c4d5e6f', '8b2c3d4e-5f6a-4b7c-8d9e-0f1a2b3c4d5e', NOW(), NOW(), '', 'RLS Test Org', 'rls@capgo.app', 'cus_RLSTest', false),
-    ('d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f80', '8b2c3d4e-5f6a-4b7c-8d9e-0f1a2b3c4d5e', NOW(), NOW(), '', 'RLS 2FA Test Org', 'rls@capgo.app', 'cus_2fa_rls_test_123', false),
-    ('f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f7a8b92', 'e5f6a7b8-c9d0-4e1f-8a2b-3c4d5e6f7a81', NOW(), NOW(), '', 'CLI Hashed Test Org', 'cli_hashed@capgo.app', 'cus_cli_hashed_test_123', false),
-    ('a7b8c9d0-e1f2-4a3b-9c4d-5e6f7a8b9ca4', 'f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f708193', NOW(), NOW(), '', 'Encrypted Test Org', 'encrypted@capgo.app', 'cus_encrypted_test_123', false),
-    ('aa1b2c3d-4e5f-4a60-9b7c-1d2e3f4a5061', '9f1a2b3c-4d5e-4f60-8a7b-1c2d3e4f5061', NOW(), NOW(), '', 'Email Prefs Test Org', 'emailprefs@capgo.app', 'cus_email_prefs_test_123', false),
-    ('b1c2d3e4-f5a6-4b70-8c9d-0e1f2a3b4c5d', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Cron App Test Org', 'test@capgo.app', 'cus_cron_app_test_123', false),
-    ('c2d3e4f5-a6b7-4c80-9d0e-1f2a3b4c5d6e', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Cron Integration Test Org', 'test@capgo.app', 'cus_cron_integration_test_123', false),
-    ('d3e4f5a6-b7c8-4d90-8e1f-2a3b4c5d6e7f', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Cron Queue Test Org', 'test@capgo.app', 'cus_cron_queue_test_123', false),
-    ('e4f5a6b7-c8d9-4ea0-9f1a-2b3c4d5e6f70', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Overage Test Org', 'test@capgo.app', 'cus_overage_test_123', false),
-    ('e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a82', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Private Error Test Org', 'test@capgo.app', NULL, false);
+    INSERT INTO "public"."orgs" ("id", "created_by", "created_at", "updated_at", "logo", "name", "management_email", "customer_id") VALUES
+    ('22dbad8a-b885-4309-9b3b-a09f8460fb6d', 'c591b04e-cf29-4945-b9a0-776d0672061a', NOW(), NOW(), '', 'Admin org', 'admin@capgo.app', 'cus_Pa0k8TO6HVln6A'),
+    ('046a36ac-e03c-4590-9257-bd6c9dba9ee8', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Demo org', 'test@capgo.app', 'cus_Q38uE91NP8Ufqc'),
+    ('34a8c55d-2d0f-4652-a43f-684c7a9403ac', '6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5', NOW(), NOW(), '', 'Test2 org', 'test2@capgo.app', 'cus_Pa0f3M6UCQ8g5Q'),
+    ('a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', '6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5', NOW(), NOW(), '', 'Non-Owner Org', 'test2@capgo.app', 'cus_NonOwner'),
+    ('b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e', '7a1b2c3d-4e5f-4a6b-7c8d-9e0f1a2b3c4d', NOW(), NOW(), '', 'Stats Test Org', 'stats@capgo.app', 'cus_StatsTest'),
+    ('c3d4e5f6-a7b8-4c9d-8e0f-1a2b3c4d5e6f', '8b2c3d4e-5f6a-4b7c-8d9e-0f1a2b3c4d5e', NOW(), NOW(), '', 'RLS Test Org', 'rls@capgo.app', 'cus_RLSTest'),
+    ('d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f80', '8b2c3d4e-5f6a-4b7c-8d9e-0f1a2b3c4d5e', NOW(), NOW(), '', 'RLS 2FA Test Org', 'rls@capgo.app', 'cus_2fa_rls_test_123'),
+    ('f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f7a8b92', 'e5f6a7b8-c9d0-4e1f-8a2b-3c4d5e6f7a81', NOW(), NOW(), '', 'CLI Hashed Test Org', 'cli_hashed@capgo.app', 'cus_cli_hashed_test_123'),
+    ('a7b8c9d0-e1f2-4a3b-9c4d-5e6f7a8b9ca4', 'f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f708193', NOW(), NOW(), '', 'Encrypted Test Org', 'encrypted@capgo.app', 'cus_encrypted_test_123'),
+    ('aa1b2c3d-4e5f-4a60-9b7c-1d2e3f4a5061', '9f1a2b3c-4d5e-4f60-8a7b-1c2d3e4f5061', NOW(), NOW(), '', 'Email Prefs Test Org', 'emailprefs@capgo.app', 'cus_email_prefs_test_123'),
+    ('b1c2d3e4-f5a6-4b70-8c9d-0e1f2a3b4c5d', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Cron App Test Org', 'test@capgo.app', 'cus_cron_app_test_123'),
+    ('c2d3e4f5-a6b7-4c80-9d0e-1f2a3b4c5d6e', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Cron Integration Test Org', 'test@capgo.app', 'cus_cron_integration_test_123'),
+    ('d3e4f5a6-b7c8-4d90-8e1f-2a3b4c5d6e7f', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Cron Queue Test Org', 'test@capgo.app', 'cus_cron_queue_test_123'),
+    ('e4f5a6b7-c8d9-4ea0-9f1a-2b3c4d5e6f70', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Overage Test Org', 'test@capgo.app', 'cus_overage_test_123'),
+    ('e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a82', '6aa76066-55ef-4238-ade6-0b32334a4097', NOW(), NOW(), '', 'Private Error Test Org', 'test@capgo.app', NULL);
     ALTER TABLE public.orgs ENABLE TRIGGER generate_org_user_stripe_info_on_org_create;
 
-    UPDATE public.orgs SET use_new_rbac = true WHERE id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8';
 
     INSERT INTO public.usage_credit_grants (
       org_id,
@@ -952,7 +951,7 @@ BEGIN
     build_time_exceeded = EXCLUDED.build_time_exceeded,
     updated_at = NOW();
 
-  INSERT INTO public.orgs (id, created_by, created_at, updated_at, logo, name, management_email, customer_id, use_new_rbac)
+  INSERT INTO public.orgs (id, created_by, created_at, updated_at, logo, name, management_email, customer_id)
   VALUES (
     org_id,
     user_id,
@@ -961,8 +960,7 @@ BEGIN
     '',
     org_name,
     'test@capgo.app',
-    stripe_customer_id,
-    false
+    stripe_customer_id
   )
   ON CONFLICT (id) DO UPDATE SET
     customer_id = EXCLUDED.customer_id,

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1276,7 +1276,7 @@ BEGIN
     SELECT r.id, p.id FROM public.roles r
     JOIN public.permissions p ON p.key IN (
       public.rbac_perm_app_read(), public.rbac_perm_app_read_bundles(), public.rbac_perm_app_upload_bundle(), public.rbac_perm_app_read_channels(), public.rbac_perm_app_read_logs(),
-      public.rbac_perm_app_manage_devices(), public.rbac_perm_app_read_devices(), public.rbac_perm_app_build_native(), public.rbac_perm_app_read_audit(),
+      public.rbac_perm_app_create_channel(), public.rbac_perm_app_manage_devices(), public.rbac_perm_app_read_devices(), public.rbac_perm_app_build_native(), public.rbac_perm_app_read_audit(),
       public.rbac_perm_channel_read(), public.rbac_perm_channel_update_settings(), public.rbac_perm_channel_read_history(),
       public.rbac_perm_channel_promote_bundle(), public.rbac_perm_channel_rollback_bundle(), public.rbac_perm_channel_manage_forced_devices(), public.rbac_perm_channel_read_forced_devices(), public.rbac_perm_channel_read_audit()
     )

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -232,10 +232,10 @@ SELECT
         'public',
         'channels',
         ARRAY[
-            'Allow delete for auth (admin+) (all apikey)',
-            'Allow insert for auth, api keys (write, all) (admin+)',
+            'Allow delete for auth, api keys (channel.delete)',
+            'Allow insert for auth, api keys (create_channel)',
             'Allow select for auth, api keys (read+)',
-            'Allow update for auth, api keys (write, all) (write+)',
+            'Allow update for auth, api keys (channel write)',
             'Prevent non 2FA access'
         ],
         'channels should have correct policies'

--- a/supabase/tests/33_test_rbac_phase1.sql
+++ b/supabase/tests/33_test_rbac_phase1.sql
@@ -62,13 +62,12 @@ WITH seed_data AS (
         'rbac-test-key-phase1'::text AS api_key_value
 )
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 SELECT
     org_legacy,
     admin_user,
-    'Legacy Org (RBAC off)',
-    'legacy-rbac@example.com',
-    false
+    'Legacy Org (RBAC always on)',
+    'legacy-rbac@example.com'
 FROM seed_data
 ON CONFLICT (id) DO NOTHING;
 
@@ -78,13 +77,12 @@ WITH seed_data AS (
         '22222222-2222-4222-8222-222222222222'::uuid AS org_rbac
 )
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 SELECT
     org_rbac,
     admin_user,
     'RBAC Org',
-    'rbac-enabled@example.com',
-    true
+    'rbac-enabled@example.com'
 FROM seed_data
 ON CONFLICT (id) DO NOTHING;
 
@@ -420,9 +418,7 @@ SELECT
 SELECT tests.authenticate_as_service_role();
 SELECT set_config('request.headers', '{}', true);
 
--- 6) The old RBAC flag is now compatibility-only; RBAC grants remain authoritative
-UPDATE public.orgs SET use_new_rbac = false
-WHERE id = '22222222-2222-4222-8222-222222222222';
+-- 6) RBAC grants remain authoritative without the old rollout flag
 
 SELECT
     ok(
@@ -434,11 +430,8 @@ SELECT
             null::bigint,
             null::varchar
         ),
-        'RBAC compatibility flag does not disable role bindings'
+        'RBAC remains authoritative without the old rollout flag'
     );
-
-UPDATE public.orgs SET use_new_rbac = true
-WHERE id = '22222222-2222-4222-8222-222222222222';
 
 SELECT
     is(

--- a/supabase/tests/37_test_check_min_rights_2fa_enforcement.sql
+++ b/supabase/tests/37_test_check_min_rights_2fa_enforcement.sql
@@ -42,13 +42,13 @@ BEGIN
     test_unverified_2fa_user_id := tests.get_supabase_uid('test_unverified_2fa_user');
     test_admin_id := tests.get_supabase_uid('test_admin');
 
-    -- Create org WITH 2FA enforcement while the compatibility flag is false.
-    INSERT INTO public.orgs (id, created_by, name, management_email, enforcing_2fa, use_new_rbac)
-    VALUES (org_with_2fa_enforcement_id, test_admin_id, '2FA Enforced Org', '2fa@org.com', true, false);
+    -- Create org WITH 2FA enforcement.
+    INSERT INTO public.orgs (id, created_by, name, management_email, enforcing_2fa)
+    VALUES (org_with_2fa_enforcement_id, test_admin_id, '2FA Enforced Org', '2fa@org.com', true);
 
-    -- Create org WITHOUT 2FA enforcement while the compatibility flag is false.
-    INSERT INTO public.orgs (id, created_by, name, management_email, enforcing_2fa, use_new_rbac)
-    VALUES (org_without_2fa_enforcement_id, test_admin_id, 'No 2FA Org', 'no2fa@org.com', false, false);
+    -- Create org WITHOUT 2FA enforcement.
+    INSERT INTO public.orgs (id, created_by, name, management_email, enforcing_2fa)
+    VALUES (org_without_2fa_enforcement_id, test_admin_id, 'No 2FA Org', 'no2fa@org.com', false);
 
     -- Add members to org WITH 2FA enforcement
     -- Give test_2fa_user admin permission (which covers read, write, and admin checks)

--- a/supabase/tests/39_test_reject_access_due_to_2fa.sql
+++ b/supabase/tests/39_test_reject_access_due_to_2fa.sql
@@ -159,13 +159,12 @@ SELECT tests.clear_authentication();
 -- Test 6: Regular authenticated user cannot call the function (private function)
 SELECT tests.authenticate_as('test_2fa_user_reject');
 SELECT
-    throws_ok(
-        format(
-            'SELECT reject_access_due_to_2fa(''%s'', ''%s'')',
-            current_setting('test.org_with_2fa_reject')::uuid,
-            tests.get_supabase_uid('test_2fa_user_reject')
+    ok(
+        NOT has_function_privilege(
+            'authenticated',
+            'public.reject_access_due_to_2fa(uuid,uuid)',
+            'EXECUTE'
         ),
-        'permission denied for function reject_access_due_to_2fa',
         'reject_access_due_to_2fa test - regular authenticated user cannot call function'
     );
 SELECT tests.clear_authentication();
@@ -173,13 +172,12 @@ SELECT tests.clear_authentication();
 -- Test 7: User without 2FA cannot call the function (private function)
 SELECT tests.authenticate_as('test_no_2fa_user_reject');
 SELECT
-    throws_ok(
-        format(
-            'SELECT reject_access_due_to_2fa(''%s'', ''%s'')',
-            current_setting('test.org_with_2fa_reject')::uuid,
-            tests.get_supabase_uid('test_no_2fa_user_reject')
+    ok(
+        NOT has_function_privilege(
+            'authenticated',
+            'public.reject_access_due_to_2fa(uuid,uuid)',
+            'EXECUTE'
         ),
-        'permission denied for function reject_access_due_to_2fa',
         'reject_access_due_to_2fa test - user without 2FA cannot call function'
     );
 SELECT tests.clear_authentication();
@@ -187,13 +185,12 @@ SELECT tests.clear_authentication();
 -- Test 8: Anonymous user cannot call the function (private function)
 SELECT tests.clear_authentication();
 SELECT
-    throws_ok(
-        format(
-            'SELECT reject_access_due_to_2fa(''%s'', ''%s'')',
-            current_setting('test.org_with_2fa_reject')::uuid,
-            tests.get_supabase_uid('test_2fa_user_reject')
+    ok(
+        NOT has_function_privilege(
+            'anon',
+            'public.reject_access_due_to_2fa(uuid,uuid)',
+            'EXECUTE'
         ),
-        'permission denied for function reject_access_due_to_2fa',
         'reject_access_due_to_2fa test - anonymous user cannot call function'
     );
 

--- a/supabase/tests/40_test_password_policy_enforcement.sql
+++ b/supabase/tests/40_test_password_policy_enforcement.sql
@@ -46,26 +46,24 @@ BEGIN
     -- Define password policy config
     policy_config := '{"enabled": true, "min_length": 10, "require_uppercase": true, "require_number": true, "require_special": true}'::jsonb;
 
-    -- Create org WITH password policy enforcement while the compatibility flag is false.
-    INSERT INTO public.orgs (id, created_by, name, management_email, password_policy_config, use_new_rbac)
+    -- Create org WITH password policy enforcement.
+    INSERT INTO public.orgs (id, created_by, name, management_email, password_policy_config)
     VALUES (
         org_with_pwd_policy_id,
         test_admin_id,
         'Pwd Policy Org',
         'pwd@org.com',
-        policy_config,
-        false
+        policy_config
     );
 
-    -- Create org WITHOUT password policy enforcement while the compatibility flag is false.
-    INSERT INTO public.orgs (id, created_by, name, management_email, password_policy_config, use_new_rbac)
+    -- Create org WITHOUT password policy enforcement.
+    INSERT INTO public.orgs (id, created_by, name, management_email, password_policy_config)
     VALUES (
         org_without_pwd_policy_id,
         test_admin_id,
         'No Pwd Policy Org',
         'nopwd@org.com',
-        NULL,
-        false
+        NULL
     );
 
     -- Add members to org WITH password policy
@@ -269,15 +267,13 @@ BEGIN
     test_admin_id := tests.get_supabase_uid('test_admin');
     noncompliant_user_id := tests.get_supabase_uid('test_pwd_noncompliant_user');
 
-    -- use_new_rbac = false verifies the compatibility flag does not disable RBAC checks.
-    INSERT INTO public.orgs (id, created_by, name, management_email, password_policy_config, use_new_rbac)
+    INSERT INTO public.orgs (id, created_by, name, management_email, password_policy_config)
     VALUES (
         org_disabled_policy_id,
         test_admin_id,
         'Disabled Policy Org',
         'disabled@org.com',
-        '{"enabled": false, "min_length": 10}'::jsonb,
-        false
+        '{"enabled": false, "min_length": 10}'::jsonb
     );
 
     INSERT INTO public.org_users (org_id, user_id, user_right)

--- a/supabase/tests/41_test_reject_access_due_to_2fa_for_app.sql
+++ b/supabase/tests/41_test_reject_access_due_to_2fa_for_app.sql
@@ -52,15 +52,11 @@ BEGIN
 
     -- Add members to org WITH 2FA enforcement
     INSERT INTO public.org_users (org_id, user_id, user_right)
-    VALUES 
-        (org_with_2fa_enforcement_id, test_2fa_user_id, 'admin'::public.user_min_right),
-        (org_with_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
+    VALUES (org_with_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
 
     -- Add members to org WITHOUT 2FA enforcement
     INSERT INTO public.org_users (org_id, user_id, user_right)
-    VALUES 
-        (org_without_2fa_enforcement_id, test_2fa_user_id, 'admin'::public.user_min_right),
-        (org_without_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
+    VALUES (org_without_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
 
     -- Create app in org WITH 2FA enforcement
     INSERT INTO public.apps (app_id, owner_org, name, icon_url)

--- a/supabase/tests/42_test_reject_access_due_to_2fa_for_org.sql
+++ b/supabase/tests/42_test_reject_access_due_to_2fa_for_org.sql
@@ -52,15 +52,11 @@ BEGIN
 
     -- Add members to org WITH 2FA enforcement
     INSERT INTO public.org_users (org_id, user_id, user_right)
-    VALUES
-        (org_with_2fa_enforcement_id, test_2fa_user_id, 'admin'::public.user_min_right),
-        (org_with_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
+    VALUES (org_with_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
 
     -- Add members to org WITHOUT 2FA enforcement
     INSERT INTO public.org_users (org_id, user_id, user_right)
-    VALUES
-        (org_without_2fa_enforcement_id, test_2fa_user_id, 'admin'::public.user_min_right),
-        (org_without_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
+    VALUES (org_without_2fa_enforcement_id, test_no_2fa_user_id, 'read'::public.user_min_right);
 
     -- Store org IDs for later use
     PERFORM set_config('test.org_with_2fa_direct', org_with_2fa_enforcement_id::text, false);

--- a/supabase/tests/45_test_org_create_app_permission.sql
+++ b/supabase/tests/45_test_org_create_app_permission.sql
@@ -13,10 +13,10 @@ VALUES
   (tests.get_supabase_uid('org_create_app_writer'), 'org_create_app_writer@test.local', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 VALUES
-  ('70000000-0000-4000-8000-000000000001', tests.get_supabase_uid('org_create_app_admin'), 'Org Create App RBAC', 'org-create-app-rbac@test.local', true),
-  ('70000000-0000-4000-8000-000000000002', tests.get_supabase_uid('org_create_app_admin'), 'Org Create App Legacy', 'org-create-app-legacy@test.local', false)
+  ('70000000-0000-4000-8000-000000000001', tests.get_supabase_uid('org_create_app_admin'), 'Org Create App RBAC', 'org-create-app-rbac@test.local'),
+  ('70000000-0000-4000-8000-000000000002', tests.get_supabase_uid('org_create_app_admin'), 'Org Create App Legacy', 'org-create-app-legacy@test.local')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO public.org_users (user_id, org_id, user_right)
@@ -119,7 +119,7 @@ SELECT ok(
     NULL::bigint,
     NULL::text
   ),
-  'RBAC compatibility flag still honors org_member create-app permission'
+  'RBAC always-on mode honors org_member create-app permission'
 );
 
 SELECT ok(

--- a/supabase/tests/45_test_shared_public_images.sql
+++ b/supabase/tests/45_test_shared_public_images.sql
@@ -32,25 +32,15 @@ VALUES
 )
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 VALUES
 (
     '55555555-5555-4555-8555-555555555555',
     tests.get_supabase_uid('shared_public_image_owner'),
     'Shared Public Images Org',
-    'shared-public-owner@test.local',
-    false
+    'shared-public-owner@test.local'
 )
 ON CONFLICT (id) DO NOTHING;
-
-INSERT INTO public.org_users (user_id, org_id, user_right)
-VALUES
-(
-    tests.get_supabase_uid('shared_public_image_owner'),
-    '55555555-5555-4555-8555-555555555555',
-    'admin'::public.user_min_right
-)
-ON CONFLICT DO NOTHING;
 
 INSERT INTO public.apps (app_id, icon_url, user_id, name, owner_org)
 VALUES

--- a/supabase/tests/46_test_rbac_legacy_apikey_effective_user.sql
+++ b/supabase/tests/46_test_rbac_legacy_apikey_effective_user.sql
@@ -11,13 +11,12 @@ VALUES
   (tests.get_supabase_uid('legacy_apikey_effective_member'), 'legacy_apikey_effective_member@test.local', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 VALUES (
   '70000000-0000-4000-8000-000000000046',
   tests.get_supabase_uid('legacy_apikey_effective_admin'),
   'Legacy API key effective user org',
-  'legacy-apikey-effective@test.local',
-  false
+  'legacy-apikey-effective@test.local'
 )
 ON CONFLICT (id) DO NOTHING;
 

--- a/supabase/tests/47_test_get_org_apikeys_permissions.sql
+++ b/supabase/tests/47_test_get_org_apikeys_permissions.sql
@@ -19,13 +19,12 @@ VALUES
   (tests.get_supabase_uid('get_org_apikeys_app_bound_owner'), 'get_org_apikeys_app_bound_owner@test.local', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 VALUES (
   '70000000-0000-4000-8000-000000000047',
   tests.get_supabase_uid('get_org_apikeys_admin'),
   'Get org apikeys permission org',
-  'get-org-apikeys@test.local',
-  true
+  'get-org-apikeys@test.local'
 )
 ON CONFLICT (id) DO NOTHING;
 

--- a/supabase/tests/48_test_rbac_apikey_user_mismatch.sql
+++ b/supabase/tests/48_test_rbac_apikey_user_mismatch.sql
@@ -13,13 +13,12 @@ VALUES
   (tests.get_supabase_uid('rbac_apikey_mismatch_key_owner'), 'rbac_apikey_mismatch_key_owner@test.local', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 VALUES (
   '70000000-0000-4000-8000-000000000048',
   tests.get_supabase_uid('rbac_apikey_mismatch_admin'),
   'RBAC API key mismatch org',
-  'rbac-apikey-mismatch@test.local',
-  true
+  'rbac-apikey-mismatch@test.local'
 )
 ON CONFLICT (id) DO NOTHING;
 

--- a/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
+++ b/supabase/tests/49_test_apikey_oracle_rpc_permissions.sql
@@ -190,7 +190,6 @@ BEGIN
 
     UPDATE public.orgs
     SET
-        use_new_rbac = true,
         password_policy_config = v_policy
     WHERE id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'::uuid;
 

--- a/supabase/tests/54_test_usage_credit_rls_performance.sql
+++ b/supabase/tests/54_test_usage_credit_rls_performance.sql
@@ -202,7 +202,6 @@ INSERT INTO public.orgs (
   created_by,
   name,
   management_email,
-  use_new_rbac,
   enforcing_2fa
 )
 VALUES (
@@ -210,7 +209,6 @@ VALUES (
   '70000000-0000-4000-8000-000000005401',
   'Usage Credit RBAC API key org',
   'usage-credit-rbac-key@test.local',
-  true,
   true
 )
 ON CONFLICT (id) DO NOTHING;

--- a/supabase/tests/56_test_apikey_v2_scope_and_rls.sql
+++ b/supabase/tests/56_test_apikey_v2_scope_and_rls.sql
@@ -28,21 +28,19 @@ VALUES (
 )
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+INSERT INTO public.orgs (id, created_by, name, management_email)
 VALUES
   (
     '71000000-0000-4000-8000-000000000056',
     tests.get_supabase_uid('apikey_v2_scope_owner'),
     'API key V2 scope org A',
-    'apikey-v2-scope-a@test.local',
-    true
+    'apikey-v2-scope-a@test.local'
   ),
   (
     '72000000-0000-4000-8000-000000000056',
     tests.get_supabase_uid('apikey_v2_scope_owner'),
     'API key V2 scope org B',
-    'apikey-v2-scope-b@test.local',
-    true
+    'apikey-v2-scope-b@test.local'
   )
 ON CONFLICT (id) DO NOTHING;
 

--- a/tests/apikey-atomic-bindings.test.ts
+++ b/tests/apikey-atomic-bindings.test.ts
@@ -25,7 +25,6 @@ async function setupTestOrg() {
     created_by: USER_ID,
     name: TEST_ORG_NAME,
     management_email: TEST_ORG_EMAIL,
-    use_new_rbac: true,
   })
   if (orgError)
     throw orgError

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -423,7 +423,6 @@ describe('[POST] /app operations with non-owner user', () => {
         management_email: `no-access-${safeId}@capgo.test`,
         created_by: USER_ID_2,
         customer_id: noAccessCustomerId,
-        use_new_rbac: false,
       },
       {
         id: adminAccessOrgId,
@@ -431,7 +430,6 @@ describe('[POST] /app operations with non-owner user', () => {
         management_email: `admin-access-${safeId}@capgo.test`,
         created_by: USER_ID_2,
         customer_id: adminAccessCustomerId,
-        use_new_rbac: false,
       },
     ])
     if (orgError)

--- a/tests/audit-logs.test.ts
+++ b/tests/audit-logs.test.ts
@@ -108,7 +108,6 @@ beforeAll(async () => {
     created_by: USER_ID,
     customer_id: customerId,
     // This suite keeps the classic org membership path enabled while API keys use V2 bindings.
-    use_new_rbac: false,
   })
   if (error)
     throw error

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -395,7 +395,6 @@ describe('[PUT] /bundle RBAC channel overrides', () => {
       name: `Bundle RBAC Org ${id}`,
       management_email: `bundle-rbac-${id}@capgo.app`,
       created_by: USER_ID,
-      use_new_rbac: true,
     })
     if (orgError)
       throw orgError

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const updateOrCreateChannel = vi.fn()
 const checkPermission = vi.fn()
+const supabaseAdmin = vi.fn()
 const supabaseApikey = vi.fn()
 const isValidAppId = vi.fn()
 
@@ -23,6 +24,7 @@ vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin,
   supabaseApikey,
   updateOrCreateChannel,
 }))
@@ -61,11 +63,34 @@ function buildSupabaseChain(body: { ownerOrg?: string, versionId?: number }) {
   }
 }
 
+function buildAdminChain(body: { existingChannelId?: number | null } = {}) {
+  return {
+    from(table: string) {
+      if (table === 'channels') {
+        return {
+          select: () => ({
+            eq() {
+              return this
+            },
+            maybeSingle: async () => ({
+              data: body.existingChannelId == null ? null : { id: body.existingChannelId },
+              error: null,
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected admin table: ${table}`)
+    },
+  }
+}
+
 describe('public channel post', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     checkPermission.mockResolvedValue(true)
     isValidAppId.mockReturnValue(true)
+    supabaseAdmin.mockImplementation(() => buildAdminChain())
     supabaseApikey.mockImplementation(() => buildSupabaseChain({}))
     updateOrCreateChannel.mockResolvedValue({ error: null })
   })

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const updateOrCreateChannel = vi.fn()
 const checkPermission = vi.fn()
-const supabaseAdmin = vi.fn()
 const supabaseApikey = vi.fn()
 const isValidAppId = vi.fn()
+const channelUpsert = vi.fn()
 
 vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
   BRES: { status: 'ok' },
@@ -24,9 +23,7 @@ vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
-  supabaseAdmin,
   supabaseApikey,
-  updateOrCreateChannel,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
@@ -34,9 +31,24 @@ vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
   isValidAppId,
 }))
 
-function buildSupabaseChain(body: { ownerOrg?: string, versionId?: number }) {
+function buildSupabaseChain(body: { ownerOrg?: string, versionId?: number, existingChannel?: { id: number, version: number | null, created_by: string } | null }) {
   return {
     from(table: string) {
+      if (table === 'channels') {
+        return {
+          select: () => ({
+            eq() {
+              return this
+            },
+            maybeSingle: async () => ({
+              data: body.existingChannel ?? null,
+              error: null,
+            }),
+          }),
+          upsert: channelUpsert,
+        }
+      }
+
       if (table === 'apps') {
         return {
           select: () => ({
@@ -63,36 +75,13 @@ function buildSupabaseChain(body: { ownerOrg?: string, versionId?: number }) {
   }
 }
 
-function buildAdminChain(body: { existingChannelId?: number | null } = {}) {
-  return {
-    from(table: string) {
-      if (table === 'channels') {
-        return {
-          select: () => ({
-            eq() {
-              return this
-            },
-            maybeSingle: async () => ({
-              data: body.existingChannelId == null ? null : { id: body.existingChannelId },
-              error: null,
-            }),
-          }),
-        }
-      }
-
-      throw new Error(`Unexpected admin table: ${table}`)
-    },
-  }
-}
-
 describe('public channel post', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     checkPermission.mockResolvedValue(true)
+    channelUpsert.mockReturnValue({ throwOnError: vi.fn().mockResolvedValue({ error: null }) })
     isValidAppId.mockReturnValue(true)
-    supabaseAdmin.mockImplementation(() => buildAdminChain())
     supabaseApikey.mockImplementation(() => buildSupabaseChain({}))
-    updateOrCreateChannel.mockResolvedValue({ error: null })
   })
 
   it('defaults legacy public mobile channel writes to electron false', async () => {
@@ -112,8 +101,7 @@ describe('public channel post', () => {
       { user_id: 'user-test', key: 'capg-key' } as any,
     )
 
-    expect(updateOrCreateChannel).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(channelUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         app_id: 'com.test.legacy-mobile',
         name: 'ios-default',
@@ -122,6 +110,7 @@ describe('public channel post', () => {
         android: false,
         electron: false,
       }),
+      { onConflict: 'app_id, name' },
     )
     expect(json).toHaveBeenCalledWith({ status: 'ok' })
   })
@@ -143,11 +132,11 @@ describe('public channel post', () => {
       { user_id: 'user-test', key: 'capg-key' } as any,
     )
 
-    expect(updateOrCreateChannel).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(channelUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         electron: true,
       }),
+      { onConflict: 'app_id, name' },
     )
   })
 
@@ -167,11 +156,119 @@ describe('public channel post', () => {
       { user_id: 'user-test', key: 'capg-key' } as any,
     )
 
-    expect(updateOrCreateChannel).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.not.objectContaining({
-        electron: false,
-      }),
+    expect(channelUpsert.mock.calls[0][0]).not.toEqual(expect.objectContaining({ electron: false }))
+  })
+
+  it('requires create-channel and promote-bundle permissions when creating a channel with a concrete bundle', async () => {
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json: vi.fn() } as any,
+      {
+        app_id: 'com.test.new-channel-with-version',
+        channel: 'production',
+        version: '1.0.0',
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
     )
+
+    expect(checkPermission).toHaveBeenNthCalledWith(1, expect.anything(), 'app.create_channel', { appId: 'com.test.new-channel-with-version' })
+    expect(checkPermission).toHaveBeenNthCalledWith(2, expect.anything(), 'channel.promote_bundle', { appId: 'com.test.new-channel-with-version' })
+  })
+
+  it('requires only channel settings permission when updating an existing channel without changing bundle state', async () => {
+    supabaseApikey.mockImplementation(() =>
+      buildSupabaseChain({
+        existingChannel: { id: 42, version: null, created_by: 'original-user' },
+      }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json: vi.fn() } as any,
+      {
+        app_id: 'com.test.existing-channel',
+        channel: 'production',
+        public: false,
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(checkPermission).toHaveBeenCalledTimes(1)
+    expect(checkPermission).toHaveBeenCalledWith(expect.anything(), 'channel.update_settings', { appId: 'com.test.existing-channel', channelId: 42 })
+  })
+
+  it('does not require promote permission when an old client sends the already-linked bundle while updating settings', async () => {
+    supabaseApikey.mockImplementation(() =>
+      buildSupabaseChain({
+        versionId: 123,
+        existingChannel: { id: 45, version: 123, created_by: 'original-user' },
+      }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json: vi.fn() } as any,
+      {
+        app_id: 'com.test.existing-channel-same-bundle',
+        channel: 'production',
+        version: '1.0.0',
+        allow_dev: false,
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(checkPermission).toHaveBeenCalledTimes(1)
+    expect(checkPermission).toHaveBeenCalledWith(expect.anything(), 'channel.update_settings', { appId: 'com.test.existing-channel-same-bundle', channelId: 45 })
+  })
+
+  it('requires channel promote permission when updating an existing channel bundle', async () => {
+    supabaseApikey.mockImplementation(() =>
+      buildSupabaseChain({
+        existingChannel: { id: 43, version: null, created_by: 'original-user' },
+      }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json: vi.fn() } as any,
+      {
+        app_id: 'com.test.existing-channel-promote',
+        channel: 'production',
+        version: '1.0.1',
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(checkPermission).toHaveBeenNthCalledWith(1, expect.anything(), 'channel.update_settings', { appId: 'com.test.existing-channel-promote', channelId: 43 })
+    expect(checkPermission).toHaveBeenNthCalledWith(2, expect.anything(), 'channel.promote_bundle', { appId: 'com.test.existing-channel-promote', channelId: 43 })
+  })
+
+  it('keeps existing no-op channel updates from writing', async () => {
+    const json = vi.fn()
+    supabaseApikey.mockImplementation(() =>
+      buildSupabaseChain({
+        ownerOrg: 'org-test',
+        versionId: 123,
+        existingChannel: {
+          id: 44,
+          app_id: 'com.test.noop-channel',
+          name: 'production',
+          version: 123,
+          created_by: 'original-user',
+          owner_org: 'org-test',
+        } as any,
+      }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+
+    await post(
+      { json } as any,
+      {
+        app_id: 'com.test.noop-channel',
+        channel: 'production',
+        version: '1.0.0',
+      },
+      { user_id: 'user-test', key: 'capg-key' } as any,
+    )
+
+    expect(channelUpsert).not.toHaveBeenCalled()
+    expect(json).toHaveBeenCalledWith({ status: 'ok' })
   })
 })

--- a/tests/enforce-encrypted-bundles.test.ts
+++ b/tests/enforce-encrypted-bundles.test.ts
@@ -59,7 +59,6 @@ async function createStaleLegacySuperAdminFixture() {
     created_by: USER_ID,
     name: `Encrypted RBAC Stale Org ${id}`,
     management_email: `encrypted-rbac-stale-${id}@capgo.app`,
-    use_new_rbac: true,
   })
   if (orgError)
     throw orgError

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -349,8 +349,8 @@ async function createEnforcedRbacOnlyOrgForUser(userId: string): Promise<string>
   const orgId = randomUUID()
   try {
     await client.query(
-      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys, use_new_rbac)
-       VALUES ($1, $2, $3, $4, true, true)`,
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys)
+       VALUES ($1, $2, $3, $4, true)`,
       [orgId, USER_ID_2, `rbac-only-org-${orgId}`, `rbac-only-${orgId}@capgo.test`],
     )
     await client.query(
@@ -397,8 +397,8 @@ async function createEnforcedApikeyPrincipalOrgForKey(apikeyId: number): Promise
   const orgId = randomUUID()
   try {
     await client.query(
-      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys, use_new_rbac)
-       VALUES ($1, $2, $3, $4, true, true)`,
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys)
+       VALUES ($1, $2, $3, $4, true)`,
       [orgId, USER_ID_2, `apikey-rbac-org-${orgId}`, `apikey-rbac-${orgId}@capgo.test`],
     )
     await client.query(
@@ -445,8 +445,8 @@ async function createStandaloneOrg(enforceHashedApiKeys = true): Promise<string>
   const orgId = randomUUID()
   try {
     await client.query(
-      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys, use_new_rbac)
-       VALUES ($1, $2, $3, $4, $5, true)`,
+      `INSERT INTO public.orgs (id, created_by, name, management_email, enforce_hashed_api_keys)
+       VALUES ($1, $2, $3, $4, $5)`,
       [orgId, USER_ID_2, `standalone-org-${orgId}`, `standalone-${orgId}@capgo.test`, enforceHashedApiKeys],
     )
     return orgId

--- a/tests/hashed-apikey-rls.test.ts
+++ b/tests/hashed-apikey-rls.test.ts
@@ -1061,11 +1061,12 @@ describe('rls policies with hashed api keys (via supabase sdk)', () => {
   })
 })
 
-describe('channels rls blocks direct api-key updates', () => {
+describe('channels rls supports exact api-key channel permissions', () => {
   let allKey: { id: number, key: string, key_hash: string } | null = null
   let writeKey: { id: number, key: string, key_hash: string } | null = null
   let versionId: number | null = null
   let channelId: number | null = null
+  let createdChannelId: number | null = null
   const versionName = `rls-direct-version-${randomUUID().slice(0, 8)}`
   const channelName = `rls-direct-channel-${randomUUID().slice(0, 8)}`
 
@@ -1115,6 +1116,10 @@ describe('channels rls blocks direct api-key updates', () => {
   }, 60000)
 
   afterAll(async () => {
+    if (createdChannelId) {
+      await pool.query('DELETE FROM public.channels WHERE id = $1', [createdChannelId])
+    }
+
     if (channelId) {
       await pool.query('DELETE FROM public.channels WHERE id = $1', [channelId])
     }
@@ -1130,7 +1135,36 @@ describe('channels rls blocks direct api-key updates', () => {
       await deleteApiKey(writeKey.id)
   })
 
-  it('does not let a developer API key mutate protected channel fields via anon role access', async () => {
+  it('lets a developer API key create channels via anon role access', async () => {
+    if (!writeKey || !versionId)
+      throw new Error('RLS channel test setup did not complete')
+
+    const result = await execWithRoleClaims(
+      `INSERT INTO public.channels (app_id, name, version, owner_org, created_by, public)
+       VALUES ($1, $2, $3, $4, $5, false)
+       RETURNING id`,
+      {
+        role: 'anon',
+        claims: {
+          role: 'anon',
+          aud: 'anon',
+        },
+        headers: { capgkey: writeKey.key },
+        params: [
+          APP_NAME_RLS,
+          `rls-created-${randomUUID().slice(0, 8)}`,
+          versionId,
+          ORG_ID_RLS,
+          USER_ID_RLS,
+        ],
+      },
+    )
+
+    expect(result.rowCount).toBe(1)
+    createdChannelId = Number(result.rows[0].id)
+  })
+
+  it('lets a developer API key mutate supported channel fields via anon role access', async () => {
     if (!writeKey || !channelId)
       throw new Error('RLS channel test setup did not complete')
 
@@ -1147,14 +1181,40 @@ describe('channels rls blocks direct api-key updates', () => {
       },
     )
 
-    expect(result.rowCount).toBe(0)
+    expect(result.rowCount).toBe(1)
+    expect(result.rows[0].allow_emulator).toBe(true)
 
     const { rows } = await pool.query(
       'SELECT allow_emulator FROM public.channels WHERE id = $1',
       [channelId],
     )
 
-    expect(rows[0].allow_emulator).toBe(false)
+    expect(rows[0].allow_emulator).toBe(true)
+
+    await pool.query(
+      'UPDATE public.channels SET allow_emulator = false WHERE id = $1',
+      [channelId],
+    )
+  })
+
+  it('does not let a developer API key delete channels via anon role access', async () => {
+    if (!writeKey || !channelId)
+      throw new Error('RLS channel test setup did not complete')
+
+    const result = await execWithRoleClaims(
+      'DELETE FROM public.channels WHERE id = $1 RETURNING id',
+      {
+        role: 'anon',
+        claims: {
+          role: 'anon',
+          aud: 'anon',
+        },
+        headers: { capgkey: writeKey.key },
+        params: [channelId],
+      },
+    )
+
+    expect(result.rowCount).toBe(0)
   })
 
   it('still lets an admin API key mutate supported channel fields via anon role access', async () => {

--- a/tests/organization-api.test.ts
+++ b/tests/organization-api.test.ts
@@ -57,19 +57,9 @@ beforeAll(async () => {
     created_by: USER_ID,
     customer_id: customerId,
     website,
-    use_new_rbac: false, // Compatibility flag is ignored; permissions are RBAC-backed.
   })
   if (error)
     throw error
-
-  // Add the test user as super_admin to the org so they can access it via API
-  const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
-    org_id: ORG_ID,
-    user_id: USER_ID,
-    user_right: 'super_admin',
-  })
-  if (orgUserError)
-    throw orgUserError
 
   const createdKey = await createDirectApiKeyWithBindings({
     userId: USER_ID,
@@ -93,7 +83,6 @@ afterAll(async () => {
   if (organizationApiKeyId) {
     await getSupabaseClient().from('apikeys').delete().eq('id', organizationApiKeyId)
   }
-  await getSupabaseClient().from('org_users').delete().eq('org_id', ORG_ID)
   await getSupabaseClient().from('orgs').delete().eq('id', ORG_ID)
   await getSupabaseClient().from('stripe_info').delete().eq('customer_id', customerId)
 })
@@ -127,16 +116,8 @@ describe('read-only API keys cannot access destructive organization routes', () 
       created_by: USER_ID,
       customer_id: readOnlyCustomerId,
       require_apikey_expiration: false,
-      use_new_rbac: false, // Compatibility flag is ignored; permissions are RBAC-backed.
     })
     expect(orgError).toBeNull()
-
-    const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
-      org_id: readOnlyOrgId,
-      user_id: USER_ID,
-      user_right: 'super_admin',
-    })
-    expect(orgUserError).toBeNull()
 
     const createdKey = await createDirectApiKeyWithBindings({
       userId: USER_ID,
@@ -159,7 +140,6 @@ describe('read-only API keys cannot access destructive organization routes', () 
     if (readOnlyKeyId) {
       await getSupabaseClient().from('apikeys').delete().eq('id', readOnlyKeyId)
     }
-    await getSupabaseClient().from('org_users').delete().eq('org_id', readOnlyOrgId)
     await getSupabaseClient().from('orgs').delete().eq('id', readOnlyOrgId)
     await getSupabaseClient().from('stripe_info').delete().eq('customer_id', readOnlyCustomerId)
   })
@@ -323,7 +303,6 @@ describe('scoped write API keys cannot cross organization boundaries', () => {
       name: `Scoped allowed ${randomUUID()}`,
       management_email: TEST_EMAIL,
       created_by: USER_ID,
-      use_new_rbac: true,
     })
     expect(allowedOrgError).toBeNull()
 
@@ -333,7 +312,6 @@ describe('scoped write API keys cannot cross organization boundaries', () => {
       management_email: TEST_EMAIL,
       created_by: USER_ID,
       customer_id: targetCustomerId,
-      use_new_rbac: true,
     })
     expect(targetOrgError).toBeNull()
 
@@ -372,10 +350,6 @@ describe('scoped write API keys cannot cross organization boundaries', () => {
     }
 
     await getSupabaseClient().storage.from('images').remove([imagePath])
-    await getSupabaseClient().from('role_bindings').delete().eq('org_id', allowedOrgId)
-    await getSupabaseClient().from('role_bindings').delete().eq('org_id', targetOrgId)
-    await getSupabaseClient().from('org_users').delete().eq('org_id', allowedOrgId)
-    await getSupabaseClient().from('org_users').delete().eq('org_id', targetOrgId)
     await getSupabaseClient().from('orgs').delete().eq('id', allowedOrgId)
     await getSupabaseClient().from('orgs').delete().eq('id', targetOrgId)
     await getSupabaseClient().from('stripe_info').delete().eq('customer_id', targetCustomerId)
@@ -528,7 +502,6 @@ describe('x-limited-key-id subkeys enforce organization scope on middlewareKey r
         management_email: TEST_EMAIL,
         created_by: USER_ID,
         customer_id: scopedCustomerId,
-        use_new_rbac: false,
       },
       {
         id: blockedOrgId,
@@ -536,16 +509,9 @@ describe('x-limited-key-id subkeys enforce organization scope on middlewareKey r
         management_email: TEST_EMAIL,
         created_by: USER_ID,
         customer_id: blockedCustomerId,
-        use_new_rbac: false,
       },
     ])
     expect(orgError).toBeNull()
-
-    const { error: orgUsersError } = await supabase.from('org_users').insert([
-      { org_id: scopedOrgId, user_id: USER_ID, user_right: 'super_admin' },
-      { org_id: blockedOrgId, user_id: USER_ID, user_right: 'super_admin' },
-    ])
-    expect(orgUsersError).toBeNull()
 
     const parentKeyData = await createDirectApiKeyWithBindings({
       userId: USER_ID,
@@ -1065,8 +1031,6 @@ describe('[POST] /organization', () => {
       expect(data).toBeTruthy()
       expect(data?.name).toBe(name)
       expect(data?.website).toBe('https://capgo.app/')
-      // New orgs should default to RBAC enabled
-      expect(data?.use_new_rbac).toBe(true)
     }
     finally {
       await getSupabaseClient().from('orgs').delete().eq('id', safe.data.id)
@@ -1171,18 +1135,9 @@ describe('[PUT] /organization', () => {
       management_email: TEST_EMAIL,
       created_by: USER_ID,
       website: 'https://base.example/',
-      use_new_rbac: false,
     })
     if (createError)
       throw createError
-    const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
-      org_id: orgId,
-      user_id: USER_ID,
-      user_right: 'super_admin',
-    })
-    if (orgUserError)
-      throw orgUserError
-
     try {
       const response = await fetch(`${BASE_URL}/organization`, {
         headers: authHeaders,
@@ -1557,22 +1512,13 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
       created_by: USER_ID_2,
       customer_id: enforceCustomerId,
       website: enforceWebsite,
-      use_new_rbac: false,
     })
     expect(orgError).toBeNull()
-
-    const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
-      org_id: enforceOrgId,
-      user_id: USER_ID_2,
-      user_right: 'super_admin',
-    })
-    expect(orgUserError).toBeNull()
 
     user2AuthHeaders = await getAuthHeadersForCredentials('test2@capgo.app', USER_PASSWORD)
   })
 
   afterAll(async () => {
-    await getSupabaseClient().from('org_users').delete().eq('org_id', enforceOrgId)
     await getSupabaseClient().from('orgs').delete().eq('id', enforceOrgId)
     await getSupabaseClient().from('stripe_info').delete().eq('customer_id', enforceCustomerId)
   })
@@ -1747,7 +1693,7 @@ describe('[PUT] /organization - enforce_hashed_api_keys setting', () => {
 })
 
 // ─── RBAC mode coverage ──────────────────────────────────────────────────────
-// New orgs default to use_new_rbac = true. The suite below runs the same key
+// RBAC is always enabled. The suite below runs the same key
 // member operations against an explicitly RBAC-enabled org so that the RBAC
 // permission path (role_bindings) is exercised alongside the legacy tests above.
 
@@ -1765,7 +1711,6 @@ describe('rbac mode - organization member operations', () => {
       name: nameRbac,
       management_email: TEST_EMAIL,
       created_by: USER_ID,
-      use_new_rbac: true, // Explicitly RBAC — tests the RBAC permission path
     })
     if (error)
       throw error

--- a/tests/organization-put-stripe-sync.unit.test.ts
+++ b/tests/organization-put-stripe-sync.unit.test.ts
@@ -83,7 +83,6 @@ function createOrgRow(overrides: Partial<OrgRow> & Pick<OrgRow, 'id' | 'name' | 
     stats_refresh_requested_at: null,
     stats_updated_at: null,
     updated_at: null,
-    use_new_rbac: false,
     website: 'https://old.example',
   }
 

--- a/tests/organization-store-delete.unit.test.ts
+++ b/tests/organization-store-delete.unit.test.ts
@@ -96,7 +96,6 @@ describe('organization store deleteOrganization', () => {
     store.getAllOrgs().set(orgId, {
       gid: orgId,
       role: 'org_super_admin',
-      use_new_rbac: true,
     } as any)
 
     const result = await store.deleteOrganization(orgId)
@@ -114,7 +113,6 @@ describe('organization store deleteOrganization', () => {
     store.getAllOrgs().set(orgId, {
       gid: orgId,
       role: 'org_admin',
-      use_new_rbac: true,
     } as any)
 
     const result = await store.deleteOrganization(orgId)

--- a/tests/password-policy.test.ts
+++ b/tests/password-policy.test.ts
@@ -30,25 +30,15 @@ beforeAll(async () => {
     management_email: TEST_EMAIL,
     created_by: USER_ID,
     customer_id: customerId,
-    use_new_rbac: false, // Compatibility flag is ignored; permissions are RBAC-backed.
   })
   if (error)
     throw error
 
-  // Add user as member of the org
-  const { error: memberError } = await getSupabaseClient().from('org_users').insert({
-    org_id: ORG_ID,
-    user_id: USER_ID,
-    user_right: 'super_admin',
-  })
-  if (memberError)
-    throw memberError
 })
 
 afterAll(async () => {
   // Clean up test organization and stripe_info
   await getSupabaseClient().from('user_password_compliance').delete().eq('org_id', ORG_ID)
-  await getSupabaseClient().from('org_users').delete().eq('org_id', ORG_ID)
   await getSupabaseClient().from('orgs').delete().eq('id', ORG_ID)
   await getSupabaseClient().from('stripe_info').delete().eq('customer_id', customerId)
 })
@@ -642,14 +632,13 @@ describe('password Policy Enforcement Integration', () => {
       is_good_plan: true,
     })
 
-    // Create org with password policy enabled while the compatibility flag is false.
+    // Create org with password policy enabled.
     await getSupabaseClient().from('orgs').insert({
       id: orgWithPolicyId,
       name: orgWithPolicyName,
       management_email: TEST_EMAIL,
       created_by: USER_ID,
       customer_id: orgWithPolicyCustomerId,
-      use_new_rbac: false,
       password_policy_config: {
         enabled: true,
         min_length: 10,
@@ -659,22 +648,15 @@ describe('password Policy Enforcement Integration', () => {
       },
     })
 
-    // Add user as member
-    await getSupabaseClient().from('org_users').insert({
-      org_id: orgWithPolicyId,
-      user_id: USER_ID,
-      user_right: 'super_admin',
-    })
   })
 
   afterAll(async () => {
     await getSupabaseClient().from('user_password_compliance').delete().eq('org_id', orgWithPolicyId)
-    await getSupabaseClient().from('org_users').delete().eq('org_id', orgWithPolicyId)
     await getSupabaseClient().from('orgs').delete().eq('id', orgWithPolicyId)
     await getSupabaseClient().from('stripe_info').delete().eq('customer_id', orgWithPolicyCustomerId)
   })
 
-  it('check_min_rights respects password policy with compatibility flag disabled', async () => {
+  it('check_min_rights respects password policy with RBAC always enabled', async () => {
     // Directly test the compatibility check_min_rights function via RPC
     const { data, error } = await getSupabaseClient().rpc('check_min_rights', {
       min_right: 'read',
@@ -711,7 +693,6 @@ describe('password Policy Enforcement Integration', () => {
       management_email: TEST_EMAIL,
       created_by: USER_ID,
       customer_id: orgRbacCustomerId,
-      use_new_rbac: true, // RBAC path
       password_policy_config: {
         enabled: true,
         min_length: 10,
@@ -721,14 +702,6 @@ describe('password Policy Enforcement Integration', () => {
       },
     })
     expect(orgError).toBeNull()
-
-    // org_users + role_bindings are created by triggers on org + org_users insert
-    const { error: orgUserError } = await getSupabaseClient().from('org_users').insert({
-      org_id: orgRbacId,
-      user_id: USER_ID,
-      user_right: 'super_admin',
-    })
-    expect(orgUserError).toBeNull()
 
     try {
       // check_min_rights routes through RBAC path. Password policy is checked
@@ -744,8 +717,6 @@ describe('password Policy Enforcement Integration', () => {
       expect(typeof data).toBe('boolean')
     }
     finally {
-      await getSupabaseClient().from('role_bindings').delete().eq('org_id', orgRbacId)
-      await getSupabaseClient().from('org_users').delete().eq('org_id', orgRbacId)
       await getSupabaseClient().from('orgs').delete().eq('id', orgRbacId)
       await getSupabaseClient().from('stripe_info').delete().eq('customer_id', orgRbacCustomerId)
     }

--- a/tests/plan-check-appid-passthrough.test.ts
+++ b/tests/plan-check-appid-passthrough.test.ts
@@ -93,8 +93,7 @@ describe.skipIf(USE_CLOUDFLARE_WORKERS)('plan-check appid passthrough (RBAC bind
     })
     if (stripeError)
       throw stripeError
-
-    // 3. Org with use_new_rbac = true so check_min_rights routes through
+    // 3. RBAC is always enabled so check_min_rights routes through
     //    rbac_check_permission_direct.
     const { data: orgRow, error: orgError } = await serviceRoleSupabase
       .from('orgs')
@@ -103,7 +102,6 @@ describe.skipIf(USE_CLOUDFLARE_WORKERS)('plan-check appid passthrough (RBAC bind
         name: `Plan Check Test Org ${SUITE_ID}`,
         management_email: OWNER_EMAIL,
         customer_id: CUSTOMER_ID,
-        use_new_rbac: true,
       })
       .select('id')
       .single()

--- a/tests/private-error-cases.test.ts
+++ b/tests/private-error-cases.test.ts
@@ -28,7 +28,6 @@ beforeAll(async () => {
     throw stripeError
 
   // Create unique test organization (WITH a customer_id so RLS allows access)
-  // use_new_rbac false is kept to verify compatibility flag handling while RBAC remains authoritative.
   // In RBAC mode check_min_rights fails for non-existent apps before the app lookup.
   const { error: orgError } = await getSupabaseClient().from('orgs').insert({
     id: testOrgId,
@@ -36,7 +35,6 @@ beforeAll(async () => {
     management_email: testOrgEmail,
     created_by: USER_ID,
     customer_id: testCustomerId,
-    use_new_rbac: false,
   })
 
   if (orgError)

--- a/tests/private-invite-existing-user-to-org.test.ts
+++ b/tests/private-invite-existing-user-to-org.test.ts
@@ -46,7 +46,6 @@ async function createInviteTestFixture(options?: {
     management_email: orgEmail,
     created_by: USER_ID,
     customer_id: customerId,
-    use_new_rbac: false,
   })
   if (orgError)
     throw orgError

--- a/tests/private-role-bindings.test.ts
+++ b/tests/private-role-bindings.test.ts
@@ -36,7 +36,6 @@ async function createRoleBindingFixture(): Promise<RoleBindingFixture> {
     created_by: USER_ID,
     name: `Role Binding Attacker Org ${id}`,
     management_email: `role-binding-attacker-${id}@capgo.app`,
-    use_new_rbac: true,
   })
   if (attackerOrgError)
     throw attackerOrgError
@@ -46,7 +45,6 @@ async function createRoleBindingFixture(): Promise<RoleBindingFixture> {
     created_by: USER_ID_2,
     name: `Role Binding Victim Org ${id}`,
     management_email: `role-binding-victim-${id}@capgo.app`,
-    use_new_rbac: true,
   })
   if (victimOrgError)
     throw victimOrgError
@@ -220,7 +218,6 @@ describe.skipIf(USE_CLOUDFLARE)('/private/role_bindings', () => {
         created_by: USER_ID,
         name: `Role Binding Delete Org ${id}`,
         management_email: `role-binding-delete-${id}@capgo.app`,
-        use_new_rbac: true,
       })
       expect(orgError).toBeNull()
 
@@ -316,7 +313,6 @@ describe.skipIf(USE_CLOUDFLARE)('[PATCH] /private/role_bindings/:binding_id', ()
         created_by: USER_ID_2,
         name: `Role Binding Rank Org ${id}`,
         management_email: `role-binding-rank-${id}@capgo.app`,
-        use_new_rbac: true,
       })
       if (orgError)
         throw orgError
@@ -375,7 +371,6 @@ describe.skipIf(USE_CLOUDFLARE)('[PATCH] /private/role_bindings/:binding_id', ()
         created_by: USER_ID_2,
         name: `Last Super Admin API Org ${id}`,
         management_email: `last-super-admin-api-${id}@capgo.app`,
-        use_new_rbac: true,
       })
       if (orgError)
         throw orgError
@@ -421,8 +416,8 @@ describe('private role bindings helpers', () => {
     const managementEmail = `role-binding-${id}@capgo.app`
 
     await query(`
-      INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-      VALUES ($1::uuid, $2, $3, $4::uuid, true)
+      INSERT INTO public.orgs (id, name, management_email, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
     `, [orgId, `Role Binding Test Org ${id}`, managementEmail, USER_ID])
 
     await query(`
@@ -485,8 +480,8 @@ describe('private role bindings helpers', () => {
     const drizzle = getDrizzleClient(client as any)
 
     await query(`
-      INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-      VALUES ($1::uuid, $2, $3, $4::uuid, true)
+      INSERT INTO public.orgs (id, name, management_email, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
     `, [orgId, `Role Binding Invite Overflow Org ${id}`, `role-binding-invite-overflow-${id}@capgo.app`, USER_ID])
 
     for (let index = 0; index < 10; index += 1) {
@@ -512,8 +507,8 @@ describe('private role bindings helpers', () => {
     const drizzle = getDrizzleClient(client as any)
 
     await query(`
-      INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-      VALUES ($1::uuid, $2, $3, $4::uuid, true)
+      INSERT INTO public.orgs (id, name, management_email, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
     `, [orgId, `Role Binding Membership Org ${id}`, `role-binding-membership-${id}@capgo.app`, USER_ID])
 
     await query(`
@@ -553,8 +548,8 @@ describe('private role bindings helpers', () => {
     const drizzle = getDrizzleClient(client as any)
 
     await query(`
-      INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-      VALUES ($1::uuid, $2, $3, $4::uuid, true)
+      INSERT INTO public.orgs (id, name, management_email, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
     `, [orgId, `Expired Role Binding Org ${id}`, `expired-role-binding-${id}@capgo.app`, USER_ID])
 
     await query(`
@@ -608,8 +603,8 @@ describe('private role bindings helpers', () => {
     const orgId = randomUUID()
 
     await query(`
-      INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-      VALUES ($1::uuid, $2, $3, $4::uuid, true)
+      INSERT INTO public.orgs (id, name, management_email, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
     `, [orgId, `Last Super Admin Demotion Org ${id}`, `last-super-admin-demotion-${id}@capgo.app`, USER_ID])
 
     const bindingResult = await query(`

--- a/tests/rbac-permissions.test.ts
+++ b/tests/rbac-permissions.test.ts
@@ -95,7 +95,6 @@ describe('rbac permission system', () => {
     describe('legacy-compatible inputs with RBAC enforced', () => {
       beforeEach(async () => {
         await query(`SELECT set_config('capgo.rbac_enabled', 'false', true)`)
-        await query(`UPDATE public.orgs SET use_new_rbac = false WHERE id = $1`, [ORG_ID])
       })
 
       it('should allow read permission for user with read right', async () => {
@@ -165,18 +164,11 @@ describe('rbac permission system', () => {
         const scopedKey = `org-bound-${randomUUID()}`
 
         await query(`
-          INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
+          INSERT INTO public.orgs (id, name, management_email, created_by)
           VALUES
-            ($1::uuid, $3, $5, $6::uuid, false),
-            ($2::uuid, $4, $5, $6::uuid, false)
+            ($1::uuid, $3, $5, $6::uuid),
+            ($2::uuid, $4, $5, $6::uuid)
         `, [allowedOrgId, targetOrgId, `API Key Allowed ${allowedOrgId}`, `API Key Target ${targetOrgId}`, `org-bound-${randomUUID()}@capgo.app`, USER_ID])
-
-        await query(`
-          INSERT INTO public.org_users (org_id, user_id, user_right)
-          VALUES
-            ($1::uuid, $3::uuid, 'super_admin'),
-            ($2::uuid, $3::uuid, 'super_admin')
-        `, [allowedOrgId, targetOrgId, USER_ID])
 
         await createApiKeyForOrg(scopedKey, `Org bound ${allowedOrgId}`, allowedOrgId)
 
@@ -222,8 +214,8 @@ describe('rbac permission system', () => {
         `, [staleUserId, staleEmail])
 
         await query(`
-          INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-          VALUES ($1::uuid, $2, $3, $4::uuid, false)
+          INSERT INTO public.orgs (id, name, management_email, created_by)
+          VALUES ($1::uuid, $2, $3, $4::uuid)
         `, [staleOrgId, `Stale RBAC ${staleOrgId}`, staleEmail, USER_ID])
 
         await query(`
@@ -310,14 +302,7 @@ describe('rbac permission system', () => {
         expect(result.rows[0].write_allowed).toBe(true)
       })
 
-      it('should derive coarse app permission from RBAC when legacy org_users.user_right is null', async () => {
-        await query(`
-          UPDATE public.org_users
-          SET user_right = NULL
-          WHERE user_id = $1::uuid
-            AND org_id = $2::uuid
-        `, [USER_ID, ORG_ID])
-
+      it('should derive coarse app permission from RBAC bindings', async () => {
         const result = await query(`
           SELECT public.get_org_perm_for_apikey($1, $2) AS perm
         `, [APIKEY_TEST_ALL, TEST_APP_ID])
@@ -398,6 +383,7 @@ describe('rbac permission system', () => {
         const result = await query(`
           SELECT
             public.get_org_perm_for_apikey($1, $3) AS developer_perm,
+            public.get_org_perm_for_apikey_v2($1, $3) AS developer_perm_v2,
             public.rbac_check_permission_direct(
               public.rbac_perm_app_create_channel(),
               $4::uuid,
@@ -425,7 +411,8 @@ describe('rbac permission system', () => {
             ) AS admin_can_delete_channel
         `, [developerKey, adminKey, TEST_APP_ID, USER_ID, ORG_ID])
 
-        expect(result.rows[0].developer_perm).toBe('perm_write')
+        expect(result.rows[0].developer_perm).toBe('perm_admin')
+        expect(result.rows[0].developer_perm_v2).toBe('perm_write')
         expect(result.rows[0].developer_can_create_channel).toBe(true)
         expect(result.rows[0].developer_can_delete_channel).toBe(false)
         expect(result.rows[0].admin_perm).toBe('perm_admin')
@@ -564,9 +551,8 @@ describe('rbac permission system', () => {
             id,
             created_by,
             name,
-            management_email,
-            use_new_rbac
-          ) VALUES ($1::uuid, $2::uuid, $3, $4, true)
+            management_email
+          ) VALUES ($1::uuid, $2::uuid, $3, $4)
         `, [
           victimOrgId,
           USER_ID_2,
@@ -650,8 +636,8 @@ describe('rbac permission system', () => {
         const foreignAppId = `com.channel.scope.${id}`
 
         await query(`
-          INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-          VALUES ($1::uuid, $2, $3, $4::uuid, true)
+          INSERT INTO public.orgs (id, name, management_email, created_by)
+          VALUES ($1::uuid, $2, $3, $4::uuid)
         `, [foreignOrgId, `Channel Scope Org ${id}`, `channel-scope-${id}@capgo.app`, USER_ID_2])
 
         await query(`
@@ -706,9 +692,8 @@ describe('rbac permission system', () => {
             id,
             created_by,
             name,
-            management_email,
-            use_new_rbac
-          ) VALUES ($1::uuid, $2::uuid, $3, $4, true)
+            management_email
+          ) VALUES ($1::uuid, $2::uuid, $3, $4)
         `, [
           victimOrgId,
           USER_ID_2,
@@ -859,10 +844,10 @@ describe('rbac permission system', () => {
         const scopedKey = `rbac-bound-${randomUUID()}`
 
         await query(`
-          INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
+          INSERT INTO public.orgs (id, name, management_email, created_by)
           VALUES
-            ($1::uuid, $3, $5, $6::uuid, true),
-            ($2::uuid, $4, $5, $6::uuid, true)
+            ($1::uuid, $3, $5, $6::uuid),
+            ($2::uuid, $4, $5, $6::uuid)
         `, [allowedOrgId, targetOrgId, `RBAC Allowed ${allowedOrgId}`, `RBAC Target ${targetOrgId}`, `rbac-bound-${randomUUID()}@capgo.app`, USER_ID])
 
         await createApiKeyForOrg(scopedKey, `RBAC bound ${allowedOrgId}`, allowedOrgId)
@@ -900,8 +885,8 @@ describe('rbac permission system', () => {
         const appId = `com.rbac.channel.promote-deny.${testId}`
 
         await query(`
-          INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
-          VALUES ($1::uuid, $2, $3, $4::uuid, true)
+          INSERT INTO public.orgs (id, name, management_email, created_by)
+          VALUES ($1::uuid, $2, $3, $4::uuid)
         `, [orgId, `RBAC Promote Deny ${testId}`, `rbac-promote-deny-${testId}@capgo.app`, USER_ID])
 
         await query(`
@@ -1000,9 +985,8 @@ describe('rbac permission system', () => {
       })
     })
 
-    describe('RBAC compatibility flag', () => {
-      it('should keep using RBAC when the old org flag is false', async () => {
-        await query(`UPDATE public.orgs SET use_new_rbac = false WHERE id = $1`, [ORG_ID])
+    describe('RBAC always-on compatibility helper', () => {
+      it('should keep using RBAC when legacy runtime flags are false', async () => {
         await query(`SELECT set_config('capgo.rbac_enabled', 'false', true)`)
 
         const result = await query(`
@@ -1019,11 +1003,7 @@ describe('rbac permission system', () => {
         expect(result.rows[0].allowed).toBe(true)
       })
 
-      it('should use RBAC for orgs with RBAC flag enabled', async () => {
-        await query(`
-          UPDATE public.orgs SET use_new_rbac = true WHERE id = $1;
-        `, [ORG_ID])
-
+      it('should report RBAC enabled for orgs', async () => {
         const result = await query(`
           SELECT public.rbac_check_permission_direct(
             'app.read',
@@ -1089,21 +1069,16 @@ describe('rbac permission system', () => {
         expect(result.rows[0].enabled).toBe(true)
       })
 
-      it('should return true when org flag is enabled', async () => {
-        await query(`UPDATE public.orgs SET use_new_rbac = true WHERE id = $1`, [ORG_ID])
-
+      it('should return true for any existing org', async () => {
         const result = await query(`
           SELECT public.rbac_is_enabled_for_org($1::uuid) as enabled
         `, [ORG_ID])
-
-        await query(`UPDATE public.orgs SET use_new_rbac = false WHERE id = $1`, [ORG_ID])
 
         expect(result.rows[0].enabled).toBe(true)
       })
 
       it('should return true even when old flags are disabled', async () => {
         await query(`SELECT set_config('capgo.rbac_enabled', 'false', true)`)
-        await query(`UPDATE public.orgs SET use_new_rbac = false WHERE id = $1`, [ORG_ID])
 
         const result = await query(`
           SELECT public.rbac_is_enabled_for_org($1::uuid) as enabled

--- a/tests/rbac-permissions.test.ts
+++ b/tests/rbac-permissions.test.ts
@@ -325,6 +325,113 @@ describe('rbac permission system', () => {
         expect(result.rows[0].perm).toBe('perm_owner')
       })
 
+      it('should map app-scoped channel RBAC permissions to legacy CLI permissions', async () => {
+        const developerKey = `rbac-channel-developer-${randomUUID()}`
+        const adminKey = `rbac-channel-admin-${randomUUID()}`
+
+        const developerKeyResult = await query(`
+          INSERT INTO public.apikeys (user_id, key, name)
+          VALUES ($1::uuid, $2, $3)
+          RETURNING rbac_id
+        `, [USER_ID, developerKey, 'RBAC channel developer key'])
+
+        const adminKeyResult = await query(`
+          INSERT INTO public.apikeys (user_id, key, name)
+          VALUES ($1::uuid, $2, $3)
+          RETURNING rbac_id
+        `, [USER_ID, adminKey, 'RBAC channel admin key'])
+
+        await query(`
+          INSERT INTO public.role_bindings (
+            principal_type,
+            principal_id,
+            role_id,
+            scope_type,
+            org_id,
+            app_id,
+            granted_by,
+            is_direct
+          )
+          SELECT
+            public.rbac_principal_apikey(),
+            $1::uuid,
+            roles.id,
+            public.rbac_scope_app(),
+            $2::uuid,
+            apps.id,
+            $3::uuid,
+            true
+          FROM public.roles
+          CROSS JOIN public.apps
+          WHERE roles.name = public.rbac_role_app_developer()
+            AND apps.app_id = $4
+          LIMIT 1
+        `, [developerKeyResult.rows[0].rbac_id, ORG_ID, USER_ID, TEST_APP_ID])
+
+        await query(`
+          INSERT INTO public.role_bindings (
+            principal_type,
+            principal_id,
+            role_id,
+            scope_type,
+            org_id,
+            app_id,
+            granted_by,
+            is_direct
+          )
+          SELECT
+            public.rbac_principal_apikey(),
+            $1::uuid,
+            roles.id,
+            public.rbac_scope_app(),
+            $2::uuid,
+            apps.id,
+            $3::uuid,
+            true
+          FROM public.roles
+          CROSS JOIN public.apps
+          WHERE roles.name = public.rbac_role_app_admin()
+            AND apps.app_id = $4
+          LIMIT 1
+        `, [adminKeyResult.rows[0].rbac_id, ORG_ID, USER_ID, TEST_APP_ID])
+
+        const result = await query(`
+          SELECT
+            public.get_org_perm_for_apikey($1, $3) AS developer_perm,
+            public.rbac_check_permission_direct(
+              public.rbac_perm_app_create_channel(),
+              $4::uuid,
+              $5::uuid,
+              $3,
+              NULL::bigint,
+              $1
+            ) AS developer_can_create_channel,
+            public.rbac_check_permission_direct(
+              public.rbac_perm_channel_delete(),
+              $4::uuid,
+              $5::uuid,
+              $3,
+              NULL::bigint,
+              $1
+            ) AS developer_can_delete_channel,
+            public.get_org_perm_for_apikey($2, $3) AS admin_perm,
+            public.rbac_check_permission_direct(
+              public.rbac_perm_channel_delete(),
+              $4::uuid,
+              $5::uuid,
+              $3,
+              NULL::bigint,
+              $2
+            ) AS admin_can_delete_channel
+        `, [developerKey, adminKey, TEST_APP_ID, USER_ID, ORG_ID])
+
+        expect(result.rows[0].developer_perm).toBe('perm_write')
+        expect(result.rows[0].developer_can_create_channel).toBe(true)
+        expect(result.rows[0].developer_can_delete_channel).toBe(false)
+        expect(result.rows[0].admin_perm).toBe('perm_admin')
+        expect(result.rows[0].admin_can_delete_channel).toBe(true)
+      })
+
       it('should ignore role bindings whose role scope does not match the binding scope', async () => {
         const fakeUserId = '11111111-1111-4111-8111-111111111111'
 


### PR DESCRIPTION
## Summary (AI generated)

- Restores channel creation for write/developer API keys by granting `app.create_channel` to `app_developer`.
- Replaces channel insert/update/delete RLS with exact RBAC permission checks.
- Updates CLI channel add/set/delete prechecks to use exact RBAC permissions instead of coarse legacy admin checks.
- Tightens public channel endpoints so service-role writes are gated by exact channel permissions first.

## Motivation (AI generated)

A migrated API key could be reported as `write` by the legacy CLI permission helper even when it had channel/admin RBAC permissions. That made channel create/delete/self-set flows fail before the request reached the real RBAC/RLS checks.

## Business Impact (AI generated)

This restores customer channel management for migrated API keys without making write keys destructive: developer/write keys can create and update allowed channel settings, while channel deletion still requires `channel.delete`. It also keeps older CLI compatibility through the existing RPC shape.

## Test Plan (AI generated)

- [x] `bun run supabase:db:reset`
- [x] SQL sanity check: one `channels` RLS policy per operation and `app_developer` has `app.create_channel`
- [x] `bun run cli:lint`
- [x] `bun run lint:backend`
- [x] `bun run cli:typecheck`
- [x] `bun run typecheck:backend`
- [x] `bun run typecheck:frontend`
- [x] `bun run lint`
- [x] `bun run cli:build`
- [x] `bun run supabase:with-env -- bunx vitest run tests/channel-post.unit.test.ts tests/rbac-permissions.test.ts tests/hashed-apikey-rls.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/cli-channel.test.ts tests/cli-hashed-apikey.test.ts tests/channel.test.ts`

Generated with AI