### PR TITLE
[codex] Localize dashboard dates

### DIFF
--- a/src/components/admin/AdminMultiLineChart.vue
+++ b/src/components/admin/AdminMultiLineChart.vue
@@ -12,11 +12,10 @@ import {
   PointElement,
   Tooltip,
 } from 'chart.js'
-import dayjs from 'dayjs'
 import { computed } from 'vue'
 import { Line } from 'vue-chartjs'
 import { createChartColorWithOpacity, resolveAccessibleChartColor } from '~/services/chartConfig'
-import { formatLocalDate } from '~/services/date'
+import { formatLocalDate, formatLocalMonthYear } from '~/services/date'
 
 interface DataSeries {
   label: string
@@ -63,9 +62,9 @@ const isDark = useDark()
 
 function formatChartDate(date: string) {
   if (props.dateGranularity === 'month') {
-    const parsed = dayjs(date)
-    if (parsed.isValid())
-      return parsed.format('MMM YYYY')
+    const formattedMonth = formatLocalMonthYear(date)
+    if (formattedMonth)
+      return formattedMonth
   }
   return formatLocalDate(date) || date
 }

--- a/src/components/dashboard/AppAccess.vue
+++ b/src/components/dashboard/AppAccess.vue
@@ -13,6 +13,7 @@ import DataTable from '~/components/DataTable.vue'
 import RoleSelect from '~/components/forms/RoleSelect.vue'
 import SearchInput from '~/components/forms/SearchInput.vue'
 import RoleSelectionModal from '~/components/modals/RoleSelectionModal.vue'
+import { formatLocalDate } from '~/services/date'
 import { checkPermissions } from '~/services/permissions'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -524,7 +525,7 @@ onMounted(async () => {
 
       <template #granted_at="{ row }">
         <span class="text-sm text-gray-600">
-          {{ new Date(row.granted_at).toLocaleDateString() }}
+          {{ formatLocalDate(row.granted_at) }}
         </span>
       </template>
 

--- a/src/components/dashboard/Usage.vue
+++ b/src/components/dashboard/Usage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Database } from '~/types/supabase.types'
-import dayjs from 'dayjs'
 import { storeToRefs } from 'pinia'
 import colors from 'tailwindcss/colors'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -24,7 +23,7 @@ import {
   requestOrgChartRefresh,
   shouldAutoRequestChartRefresh,
 } from '~/services/dashboardRefresh'
-import { formatUtcDateTimeAsLocal } from '~/services/date'
+import { formatLocalDate, formatLocalDateTime, formatUtcDateTimeAsLocal } from '~/services/date'
 import { DEMO_APP_NAMES, generateDemoBandwidthData, generateDemoMauData, generateDemoStorageData } from '~/services/demoChartData'
 import { getPlans, useSupabase } from '~/services/supabase'
 import { useDashboardAppsStore } from '~/stores/dashboardApps'
@@ -158,11 +157,11 @@ const { dashboard } = storeToRefs(main)
 
 const subscriptionAnchorStart = computed(() => {
   const start = effectiveOrganization.value?.subscription_start
-  return start ? dayjs(start).format('YYYY/MM/D') : t('unknown')
+  return start ? formatLocalDate(start) || t('unknown') : t('unknown')
 })
 const subscriptionAnchorEnd = computed(() => {
   const end = effectiveOrganization.value?.subscription_end
-  return end ? dayjs(end).format('YYYY/MM/D') : t('unknown')
+  return end ? formatLocalDate(end) || t('unknown') : t('unknown')
 })
 const lastRunDisplay = computed(() => {
   const source = scopeStatsUpdatedAt.value
@@ -170,7 +169,7 @@ const lastRunDisplay = computed(() => {
 })
 const nextRunDisplay = computed(() => {
   const source = effectiveOrganization.value?.next_stats_update_at
-  return source ? dayjs(source).format('MMMM D, YYYY HH:mm') : t('unknown')
+  return source ? formatLocalDateTime(source) || t('unknown') : t('unknown')
 })
 
 // Confirmation logic for cumulative mode in 30-day view

--- a/src/pages/app/[app].channel.[channel].statistics.vue
+++ b/src/pages/app/[app].channel.[channel].statistics.vue
@@ -13,7 +13,7 @@ import IconAlertTriangle from '~icons/lucide/alert-triangle'
 import IconCheckCircle from '~icons/lucide/check-circle'
 import IconTrendingUp from '~icons/lucide/trending-up'
 import { createTooltipConfig } from '~/services/chartTooltip'
-import { formatDistanceToNow } from '~/services/date'
+import { formatDistanceToNow, formatLocalDate, formatLocalDateShort } from '~/services/date'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useAppDetailStore } from '~/stores/appDetail'
 import { useDisplayStore } from '~/stores/display'
@@ -208,7 +208,7 @@ const currentVersionDeployLabel = computed(() => {
   const diffMs = Date.now() - date.getTime()
   if (diffMs < 24 * 60 * 60 * 1000)
     return formatDistanceToNow(date)
-  return date.toLocaleDateString()
+  return formatLocalDate(date) || '-'
 })
 
 function formatPercent(value: number) {
@@ -230,7 +230,7 @@ function formatShortDate(value: string | null | undefined) {
   if (Number.isNaN(date.getTime()))
     return '-'
 
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  return formatLocalDateShort(date) || '-'
 }
 
 const currentVersionDataset = computed(() => {
@@ -331,8 +331,7 @@ const chartData = computed<ChartData<'line'>>(() => {
 
   return {
     labels: stats.value.labels.map((d) => {
-      const date = new Date(d)
-      return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+      return formatLocalDateShort(d) || d
     }),
     datasets: stats.value.datasets.map((dataset, index) => {
       const color = chartPalette[index % chartPalette.length]

--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -16,6 +16,7 @@ import ScaleIcon from '~icons/heroicons/scale'
 import UserGroupIcon from '~icons/heroicons/user-group'
 import AdminOnlyModal from '~/components/AdminOnlyModal.vue'
 import { creditPricingMetricOrder, formatCreditPricingPrice, formatCreditPricingTierLabel } from '~/services/creditPricing'
+import { formatLocalDate } from '~/services/date'
 import { completeCreditTopUp, startCreditTopUp } from '~/services/stripe'
 import { getCreditPricingSteps, useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
@@ -107,7 +108,7 @@ const creditUsagePercent = computed(() => {
 })
 const creditNextExpiration = computed(() => {
   const expiresAt = currentOrganization.value?.credit_next_expiration
-  return expiresAt ? dayjs(expiresAt).format('MMMM D, YYYY') : null
+  return expiresAt ? formatLocalDate(expiresAt) || null : null
 })
 const hasCreditSummary = computed(() => creditTotal.value > 0 || creditAvailable.value > 0)
 
@@ -261,7 +262,7 @@ const dailyTransactions = computed<DailyLedgerRow[]>(() => {
   const groups = new Map<string, DailyLedgerRow>()
   for (const tx of transactions.value) {
     const dateKey = dayjs(tx.occurred_at).format('YYYY-MM-DD')
-    const dateLabel = dayjs(tx.occurred_at).format('MMM D, YYYY')
+    const dateLabel = formatLocalDate(tx.occurred_at) || dateKey
     const existing = groups.get(dateKey)
     if (!existing) {
       const initial: DailyLedgerRow = {

--- a/src/pages/settings/organization/Usage.vue
+++ b/src/pages/settings/organization/Usage.vue
@@ -10,7 +10,7 @@ import { toast } from 'vue-sonner'
 import CreditsCta from '~/components/CreditsCta.vue'
 import Spinner from '~/components/Spinner.vue'
 import { bytesToGb } from '~/services/conversion'
-import { formatUtcDateTimeAsLocal } from '~/services/date'
+import { formatLocalDate, formatLocalDateTime, formatUtcDateTimeAsLocal } from '~/services/date'
 import { calculateCreditCost, getCurrentPlanNameOrg, getPlans, getPlanUsagePercent, getTotalStorage, getUsageCreditDeductions } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -173,8 +173,8 @@ async function getUsage(orgId: string) {
     totalBuildTime,
     detailPlanUsage,
     cycle: {
-      subscription_anchor_start: dayjs(organizationStore.currentOrganization?.subscription_start).format('YYYY/MM/D'),
-      subscription_anchor_end: dayjs(organizationStore.currentOrganization?.subscription_end).format('YYYY/MM/D'),
+      subscription_anchor_start: formatLocalDate(organizationStore.currentOrganization?.subscription_start) || t('unknown'),
+      subscription_anchor_end: formatLocalDate(organizationStore.currentOrganization?.subscription_end) || t('unknown'),
     },
   }
 }
@@ -333,7 +333,7 @@ function nextRunDate() {
   if (!source)
     return `${t('next-run')}: ${t('unknown')}`
 
-  const nextRun = dayjs(source).format('MMMM D, YYYY HH:mm')
+  const nextRun = formatLocalDateTime(source) || t('unknown')
   return `${t('next-run')}: ${nextRun}`
 }
 </script>

--- a/src/services/chartTooltip.ts
+++ b/src/services/chartTooltip.ts
@@ -201,39 +201,9 @@ export function createCustomTooltip(context: TooltipContext, isAccumulated: bool
   if (tooltip.body) {
     const dataPoints = tooltip.dataPoints || []
 
-    // Calculate the formatted date title from the data index
     const dataIndex = dataPoints[0]?.dataIndex ?? 0
-    // Use the actual label from the chart for the tooltip title
-    // This ensures alignment between what's shown on the X-axis and the tooltip
-    const chartLabels = chart.data?.labels || []
-    const labelAtIndex = chartLabels[dataIndex]
-    let formattedTitle: string
-    // Declare tooltipDate at higher scope so it's accessible for click handler
-    let tooltipDate: Date
-
-    if (labelAtIndex !== undefined && dateStartOrUseBillingPeriod instanceof Date) {
-      // Create date using the day number from the label and the month/year from billing start
-      tooltipDate = new Date(dateStartOrUseBillingPeriod)
-      const dayNumber = typeof labelAtIndex === 'number' ? labelAtIndex : Number.parseInt(String(labelAtIndex), 10)
-      if (!Number.isNaN(dayNumber)) {
-        // Handle month transitions - if label day is less than billing start day, it's next month
-        const billingStartDay = dateStartOrUseBillingPeriod.getDate()
-        if (dayNumber < billingStartDay) {
-          // Next month
-          tooltipDate.setMonth(tooltipDate.getMonth() + 1)
-        }
-        tooltipDate.setDate(dayNumber)
-        formattedTitle = formatDateForTooltip(tooltipDate)
-      }
-      else {
-        formattedTitle = String(labelAtIndex)
-      }
-    }
-    else {
-      // Fallback to original calculation
-      tooltipDate = getDateFromIndex(dataIndex, dateStartOrUseBillingPeriod)
-      formattedTitle = formatDateForTooltip(tooltipDate)
-    }
+    const tooltipDate = getDateFromIndex(dataIndex, dateStartOrUseBillingPeriod)
+    const formattedTitle = formatDateForTooltip(tooltipDate)
 
     // Create an array of items with their values, colors, and labels
     const items: ProcessedTooltipItem[] = dataPoints.map((dataPoint, index) => {

--- a/src/services/date.ts
+++ b/src/services/date.ts
@@ -1,7 +1,7 @@
-import dayjs from 'dayjs'
 import { i18n } from '~/modules/i18n'
 
 const ZONELESS_ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/
+const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/
 
 function parseDatePreservingUtc(date: Date | string | undefined | null): Date | null {
   if (!date)
@@ -9,6 +9,24 @@ function parseDatePreservingUtc(date: Date | string | undefined | null): Date | 
 
   if (date instanceof Date)
     return Number.isNaN(date.getTime()) ? null : date
+
+  const dateOnlyMatch = DATE_ONLY_RE.exec(date)
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch
+    const parsedYear = Number(year)
+    const parsedMonth = Number(month)
+    const parsedDay = Number(day)
+    const parsed = new Date(parsedYear, parsedMonth - 1, parsedDay)
+    if (
+      Number.isNaN(parsed.getTime())
+      || parsed.getFullYear() !== parsedYear
+      || parsed.getMonth() !== parsedMonth - 1
+      || parsed.getDate() !== parsedDay
+    ) {
+      return null
+    }
+    return parsed
+  }
 
   const normalized = ZONELESS_ISO_DATETIME_RE.test(date) ? `${date}Z` : date
   const parsed = new Date(normalized)
@@ -26,10 +44,8 @@ function getAppLocale(): string {
  * Format a date using the app's locale (e.g., "12/15/2025" in English, "15/12/2025" in French)
  */
 export function formatLocalDate(date: Date | string | undefined | null): string {
-  if (!date)
-    return ''
-  const d = typeof date === 'string' ? new Date(date) : date
-  if (Number.isNaN(d.getTime()))
+  const d = parseDatePreservingUtc(date)
+  if (!d)
     return ''
   return d.toLocaleDateString(getAppLocale())
 }
@@ -38,12 +54,30 @@ export function formatLocalDate(date: Date | string | undefined | null): string 
  * Format a date with month name and day using the app's locale (e.g., "December 15" in English, "15 décembre" in French)
  */
 export function formatLocalDateLong(date: Date | string | undefined | null): string {
-  if (!date)
-    return ''
-  const d = typeof date === 'string' ? new Date(date) : date
-  if (Number.isNaN(d.getTime()))
+  const d = parseDatePreservingUtc(date)
+  if (!d)
     return ''
   return d.toLocaleDateString(getAppLocale(), { month: 'long', day: 'numeric' })
+}
+
+/**
+ * Format a compact date for dense chart axes using the app's locale (e.g., "Dec 15" in English, "15 déc." in French)
+ */
+export function formatLocalDateShort(date: Date | string | undefined | null): string {
+  const d = parseDatePreservingUtc(date)
+  if (!d)
+    return ''
+  return d.toLocaleDateString(getAppLocale(), { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Format a month/year bucket using the app's locale (e.g., "Dec 2025" in English, "déc. 2025" in French)
+ */
+export function formatLocalMonthYear(date: Date | string | undefined | null): string {
+  const d = parseDatePreservingUtc(date)
+  if (!d)
+    return ''
+  return d.toLocaleDateString(getAppLocale(), { month: 'short', year: 'numeric' })
 }
 
 /**
@@ -56,15 +90,12 @@ export function formatLocalDateTime(date: Date | string | undefined | null): str
   return d.toLocaleString(getAppLocale(), { dateStyle: 'medium', timeStyle: 'short' })
 }
 
-export function formatUtcDateTimeAsLocal(date: Date | string | undefined | null, format = 'MMMM D, YYYY HH:mm'): string {
-  const parsed = parseDatePreservingUtc(date)
-  if (!parsed)
-    return ''
-  return dayjs(parsed).format(format)
+export function formatUtcDateTimeAsLocal(date: Date | string | undefined | null): string {
+  return formatLocalDateTime(date)
 }
 
 export function formatDate(date: string | undefined) {
-  return dayjs(date).format('YYYY-MM-DD HH:mm')
+  return formatLocalDateTime(date)
 }
 
 export function getDaysInCurrentMonth() {
@@ -89,20 +120,23 @@ export function normalizeToStartOfDay(date: Date) {
   return normalized
 }
 
-export function getDayNumbers(startDate: Date, endDate: Date) {
-  const dayNumbers = []
-  const currentDate = new Date(startDate)
-  while (currentDate.getTime() <= endDate.getTime()) {
-    dayNumbers.push(currentDate.getDate())
+function getDatesInRange(startDate: Date, endDate: Date) {
+  const dates = []
+  const currentDate = normalizeToStartOfDay(startDate)
+  const normalizedEndDate = normalizeToStartOfDay(endDate)
+
+  while (currentDate.getTime() <= normalizedEndDate.getTime()) {
+    dates.push(new Date(currentDate))
     currentDate.setDate(currentDate.getDate() + 1)
   }
-  return dayNumbers
+
+  return dates
 }
 
 export function getChartDateRange(useBillingPeriod: boolean, billingStart?: Date | string | null, billingEnd?: Date | string | null) {
   if (useBillingPeriod) {
-    const startDate = new Date(billingStart ?? new Date())
-    const endDate = new Date(billingEnd ?? new Date())
+    const startDate = parseDatePreservingUtc(billingStart) ?? new Date()
+    const endDate = parseDatePreservingUtc(billingEnd) ?? new Date()
     startDate.setHours(0, 0, 0, 0)
     endDate.setHours(0, 0, 0, 0)
     return { startDate, endDate }
@@ -115,37 +149,19 @@ export function getChartDateRange(useBillingPeriod: boolean, billingStart?: Date
 }
 
 export function generateChartDayLabels(useBillingPeriod: boolean, startDate: Date, endDate: Date) {
-  if (!useBillingPeriod) {
-    // Last 30 days mode - generate actual dates
-    const today = new Date()
-    const dates = []
-    for (let i = 29; i >= 0; i--) {
-      const date = new Date(today)
-      date.setDate(date.getDate() - i)
-      dates.push(date.getDate())
-    }
-    return dates
-  }
+  const { startDate: rangeStart, endDate: rangeEnd } = useBillingPeriod
+    ? { startDate, endDate }
+    : getChartDateRange(false)
 
-  // Billing period mode - use the actual billing period end date
-  return getDayNumbers(startDate, endDate)
+  return getDatesInRange(rangeStart, rangeEnd).map(formatLocalDateShort)
 }
 
 export function generateMonthDays(useBillingPeriod: boolean, cycleStart: Date, cycleEnd: Date) {
-  if (!useBillingPeriod) {
-    // Last 30 days mode - generate actual dates
-    const today = new Date()
-    const dates = []
-    for (let i = 29; i >= 0; i--) {
-      const date = new Date(today)
-      date.setDate(date.getDate() - i)
-      dates.push(date.getDate())
-    }
-    return dates
-  }
+  const { startDate, endDate } = useBillingPeriod
+    ? { startDate: cycleStart, endDate: cycleEnd }
+    : getChartDateRange(false)
 
-  // Billing period mode - use the actual billing cycle end date
-  return getDayNumbers(cycleStart, cycleEnd)
+  return getDatesInRange(startDate, endDate).map(formatLocalDateShort)
 }
 
 /**

--- a/tests/date.unit.test.ts
+++ b/tests/date.unit.test.ts
@@ -1,10 +1,18 @@
-import dayjs from 'dayjs'
 import { describe, expect, it } from 'vitest'
-import { formatLocalDateTime, formatUtcDateTimeAsLocal } from '../src/services/date'
+import { i18n } from '../src/modules/i18n'
+import {
+  formatLocalDate,
+  formatLocalDateShort,
+  formatLocalDateTime,
+  formatLocalMonthYear,
+  formatUtcDateTimeAsLocal,
+  generateChartDayLabels,
+  generateMonthDays,
+} from '../src/services/date'
 
 describe('date helpers', () => {
   it.concurrent('treats zone-less UTC stats timestamps as UTC before local formatting', () => {
-    const expected = dayjs(new Date('2026-04-22T20:22:00Z')).format('MMMM D, YYYY HH:mm')
+    const expected = formatLocalDateTime(new Date('2026-04-22T20:22:00Z'))
 
     expect(formatUtcDateTimeAsLocal('2026-04-22T20:22:00')).toBe(expected)
     expect(formatUtcDateTimeAsLocal('2026-04-22T20:22:00Z')).toBe(expected)
@@ -14,7 +22,43 @@ describe('date helpers', () => {
     expect(formatLocalDateTime('2026-04-22T20:22:00')).toBe(formatLocalDateTime('2026-04-22T20:22:00Z'))
   })
 
+  it.concurrent('keeps date-only inputs on the same calendar day', () => {
+    const expected = formatLocalDate(new Date(2026, 3, 22))
+
+    expect(formatLocalDate('2026-04-22')).toBe(expected)
+  })
+
   it.concurrent('returns an empty string for invalid UTC timestamp inputs', () => {
     expect(formatUtcDateTimeAsLocal('not-a-date')).toBe('')
+    expect(formatLocalDate('2026-02-31')).toBe('')
+  })
+
+  it.concurrent('formats month buckets with localized month names', () => {
+    const date = new Date('2026-04-15T12:00:00Z')
+    const expected = new Intl.DateTimeFormat(i18n.global.locale.value || 'en', { month: 'short', year: 'numeric' }).format(date)
+
+    expect(formatLocalMonthYear(date)).toBe(expected)
+  })
+
+  it.concurrent('generates localized labels for chart date ranges', () => {
+    const startDate = new Date(2026, 0, 31)
+    const endDate = new Date(2026, 1, 2)
+
+    expect(generateChartDayLabels(true, startDate, endDate)).toEqual([
+      formatLocalDateShort(startDate),
+      formatLocalDateShort(new Date(2026, 1, 1)),
+      formatLocalDateShort(endDate),
+    ])
+  })
+
+  it.concurrent('generates localized labels for billing-cycle charts', () => {
+    const cycleStart = new Date(2026, 2, 30)
+    const cycleEnd = new Date(2026, 3, 1)
+
+    expect(generateMonthDays(true, cycleStart, cycleEnd)).toEqual([
+      formatLocalDateShort(cycleStart),
+      formatLocalDateShort(new Date(2026, 2, 31)),
+      formatLocalDateShort(cycleEnd),
+    ])
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Localized shared dashboard chart date labels, month buckets, and UTC date-time display helpers.
- Updated admin and dashboard surfaces that still used fixed `dayjs` or browser-default date formats.
- Added date helper coverage for date-only parsing, localized compact labels, month/year buckets, and chart range labels.
- Added a narrow typo-check exclusion for an existing committed migration filename that cannot be safely renamed.

## Motivation (AI generated)

Admin dashboards and chart-heavy views mixed English month formats, browser-default date formats, and day-number-only chart labels. This made dates inconsistent across locales and between chart axes, tooltips, billing-period labels, and usage/credit views.

## Business Impact (AI generated)

This improves the dashboard experience for non-US and multilingual users by making date display consistent with the selected app language and local date conventions. It reduces confusion when reading usage, billing, credit, and release/adoption charts.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run lint:deadcode`
- [x] `bunx typos .`
- [x] `bunx vitest run tests/date.unit.test.ts`
- [x] `bun run typecheck:frontend`
- [x] Commit hook ran full `bun typecheck` successfully

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized date formatting across the application for improved consistency.
  * Enhanced localization support for date displays to better reflect user preferences and regional settings.

* **Tests**
  * Expanded test coverage for date formatting and localization functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->