### PR TITLE
[codex] fix delete email OTP captcha

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -33,6 +33,9 @@ extend-exclude = [
   "supabase/.branches/",
   "supabase/.temp/",
   "supabase/schemas/prod.sql",
+  # Keep this committed migration filename stable even though it contains
+  # "indexs"; the migration timestamp is already part of history.
+  "supabase/migrations/20260528113224_missing_indexs.sql",
 
   # Assets and data files
   "*.json",

--- a/read_replicate/schema_replicate.sql
+++ b/read_replicate/schema_replicate.sql
@@ -785,6 +785,13 @@ CREATE INDEX idx_app_versions_retention_cleanup ON public.app_versions USING btr
 
 
 --
+-- Name: idx_apps_default_upload_channel; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_apps_default_upload_channel ON public.apps USING btree (default_upload_channel);
+
+
+--
 -- Name: idx_channels_app_id_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -824,6 +831,13 @@ CREATE INDEX idx_manifest_app_version_id ON public.manifest USING btree (app_ver
 --
 
 CREATE INDEX idx_manifest_file_hash ON public.manifest USING btree (file_hash);
+
+
+--
+-- Name: idx_manifest_file_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_manifest_file_name ON public.manifest USING btree (file_name);
 
 
 --

--- a/src/pages/resend_email.vue
+++ b/src/pages/resend_email.vue
@@ -5,6 +5,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
+import VueTurnstile from 'vue-turnstile'
 import iconEmail from '~icons/oui/email?raw'
 import { authGhostButtonClass, authInsetCardClass, authPanelClass, authPrimaryButtonClass } from '~/components/auth/pageStyles'
 import { getRecentEmailOtpVerification, sendEmailOtpVerification, verifyEmailOtp } from '~/services/emailOtp'
@@ -20,8 +21,11 @@ const main = useMainStore()
 const isLoading = ref(false)
 const isLoadingMain = ref(false)
 const otpSending = ref(false)
+const otpCaptchaToken = ref('')
+const otpCaptchaRef = ref<InstanceType<typeof VueTurnstile> | null>(null)
 const otpVerificationCode = ref('')
 const otpVerificationLoading = ref(false)
+const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
 const currentUserId = ref('')
 const currentUserEmail = ref('')
 const emailVerificationBlockingReason = computed(() => route.query.reason === 'email_not_verified')
@@ -70,12 +74,19 @@ async function sendOtpCode() {
   if (!currentUserEmail.value || otpSending.value)
     return
 
+  if (captchaKey.value && !otpCaptchaToken.value) {
+    toast.error(t('captcha-required'))
+    return
+  }
+
   otpSending.value = true
-  const { error } = await sendEmailOtpVerification(supabase, currentUserEmail.value)
+  const { error } = await sendEmailOtpVerification(supabase, currentUserEmail.value, otpCaptchaToken.value)
   otpSending.value = false
+  otpCaptchaToken.value = ''
+  otpCaptchaRef.value?.reset()
 
   if (error) {
-    toast.error(t('verification-failed'))
+    toast.error(error.message.toLowerCase().includes('captcha') ? t('captcha-fail') : t('verification-failed'))
     console.error('Cannot send email OTP', error)
     return
   }
@@ -144,6 +155,18 @@ onMounted(async () => {
           <p class="text-xs leading-5">
             {{ t('email-otp-code-required') }}
           </p>
+        </div>
+
+        <div v-if="captchaKey" class="space-y-2">
+          <p class="text-sm font-medium text-slate-700 dark:text-slate-100">
+            {{ t('captcha') }}
+          </p>
+          <VueTurnstile
+            ref="otpCaptchaRef"
+            v-model="otpCaptchaToken"
+            size="flexible"
+            :site-key="captchaKey"
+          />
         </div>
 
         <button


### PR DESCRIPTION
## Summary (AI generated)

- Added Turnstile to the account-delete email OTP verification flow.
- Pass the captcha token into Supabase `signInWithOtp` and show captcha-specific send failures.
- Added a targeted typos exclude for an already-committed migration filename containing `indexs`, keeping the migration filename stable.
- Updated `read_replicate/schema_replicate.sql` for indexes introduced by the existing latest migration.

## Motivation (AI generated)

The delete-account flow requires recent email OTP verification, but its OTP send path did not provide a captcha token. In production, Supabase captcha enforcement can reject the send request, leaving users stuck on a generic verification failure toast. The CI-only updates let the existing base migration pass typo and read-replica schema checks without renaming a committed migration.

## Business Impact (AI generated)

This unblocks users who need to verify email ownership before deleting an account, including cases where they need to reuse an app ID from an old account. It should reduce support load while preserving captcha protection on the OTP send action.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun run typecheck:frontend`
- [x] `bun run build`
- [x] `bunx typos .`
- [x] `MAIN_SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:56082/postgres bun run readreplicate:check-schema`
- [x] Commit hook full typecheck: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
