### PR TITLE
fix(auth): sync paid website cookie

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -7,6 +7,7 @@ import { isSsoUser, provisionSsoUser } from '~/services/ssoProvisioning'
 import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getLocalConfig, useSupabase } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
+import { clearWebsitePaidUserCookie } from '~/services/websiteAuthCookie'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 import { hasPendingInviteSkip } from '~/utils/pendingInviteSkip'
@@ -408,6 +409,21 @@ async function guard(
 }
 
 export const install: UserModule = ({ router }) => {
+  const supabase = useSupabase()
+  supabase.auth.getSession()
+    .then(({ data }) => {
+      if (!data.session)
+        clearWebsitePaidUserCookie()
+    })
+    .catch(error => console.error('Failed to clear website paid user cookie', error))
+
+  if (typeof supabase.auth.onAuthStateChange === 'function') {
+    supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session)
+        clearWebsitePaidUserCookie()
+    })
+  }
+
   router.beforeEach(async (to, from, next) => {
     if (to.meta.middleware) {
       await guard(next, to, from)

--- a/src/services/websiteAuthCookie.ts
+++ b/src/services/websiteAuthCookie.ts
@@ -1,0 +1,81 @@
+import { getLocalConfig } from '~/services/supabase'
+
+const WEBSITE_PAID_USER_COOKIE_NAME = 'capgo_paid_user'
+const LEGACY_WEBSITE_AUTH_COOKIE_NAME = 'capgo_logged_in'
+const WEBSITE_PAID_USER_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+interface WebsiteAuthOrganization {
+  paying?: boolean | null
+  role?: string | null
+}
+
+function getWebsiteCookieDomain() {
+  try {
+    const { hostWeb } = getLocalConfig()
+    const hostname = new URL(hostWeb).hostname.replace(/^www\./, '')
+    if (!hostname || hostname === 'localhost' || /^[\d.]+$/.test(hostname))
+      return null
+
+    return `.${hostname}`
+  }
+  catch {
+    return null
+  }
+}
+
+function getCookieAttributes(maxAgeSeconds: number, domain?: string | null) {
+  const attributes = [
+    'Path=/',
+    `Max-Age=${maxAgeSeconds}`,
+    'SameSite=Lax',
+  ]
+
+  if (domain)
+    attributes.push(`Domain=${domain}`)
+
+  if (globalThis.location.protocol === 'https:')
+    attributes.push('Secure')
+
+  return attributes.join('; ')
+}
+
+function writeWebsiteCookie(name: string, value: string, maxAgeSeconds: number, domain?: string | null) {
+  document.cookie = `${name}=${value}; ${getCookieAttributes(maxAgeSeconds, domain)}`
+}
+
+function clearWebsiteCookie(name: string, domain?: string | null) {
+  writeWebsiteCookie(name, '', 0, domain)
+  if (domain)
+    writeWebsiteCookie(name, '', 0)
+}
+
+export function clearWebsitePaidUserCookie() {
+  if (typeof document === 'undefined')
+    return
+
+  const domain = getWebsiteCookieDomain()
+  clearWebsiteCookie(WEBSITE_PAID_USER_COOKIE_NAME, domain)
+  clearWebsiteCookie(LEGACY_WEBSITE_AUTH_COOKIE_NAME, domain)
+}
+
+export function setWebsitePaidUserCookie(isPaidUser: boolean) {
+  if (typeof document === 'undefined')
+    return
+
+  if (!isPaidUser) {
+    clearWebsitePaidUserCookie()
+    return
+  }
+
+  const domain = getWebsiteCookieDomain()
+  writeWebsiteCookie(WEBSITE_PAID_USER_COOKIE_NAME, '1', WEBSITE_PAID_USER_COOKIE_MAX_AGE_SECONDS, domain)
+  clearWebsiteCookie(LEGACY_WEBSITE_AUTH_COOKIE_NAME, domain)
+}
+
+export function syncWebsitePaidUserCookieFromOrganizations(organizations: WebsiteAuthOrganization[]) {
+  const hasPaidOrganization = organizations.some((organization) => {
+    return !organization.role?.includes('invite') && !!organization.paying
+  })
+
+  setWebsitePaidUserCookie(hasPaidOrganization)
+}

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import { createSignedImageUrl, getImmediateImageUrl, resolveImagePath } from '~/services/storage'
 import { stripeEnabled, useSupabase } from '~/services/supabase'
+import { clearWebsitePaidUserCookie, syncWebsitePaidUserCookieFromOrganizations } from '~/services/websiteAuthCookie'
 import { createDeferredPromise } from '../utils/promise'
 import { useDashboardAppsStore } from './dashboardApps'
 import { useDisplayStore } from './display'
@@ -461,6 +462,7 @@ export const useOrganizationStore = defineStore('organization', () => {
       const listener = supabase.auth.onAuthStateChange((event: any) => {
         if (event === 'SIGNED_OUT') {
           listener.data.subscription.unsubscribe()
+          clearWebsitePaidUserCookie()
           // Remove all from orgs
           _organizations.value = new Map()
           _organizationsByAppId.value = new Map()
@@ -479,6 +481,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 
     if (error) {
       console.error('Cannot get orgs!', error)
+      clearWebsitePaidUserCookie()
       throw error
     }
 
@@ -495,6 +498,7 @@ export const useOrganizationStore = defineStore('organization', () => {
       } as Organization & { id: number }
     })
 
+    syncWebsitePaidUserCookieFromOrganizations(mappedData)
     _organizations.value = new Map(mappedData.map(item => [item.gid, item as Organization]))
     loadOrganizationLogos(mappedData, logoLoadRun)
 

--- a/tests/website-auth-cookie.unit.test.ts
+++ b/tests/website-auth-cookie.unit.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearWebsitePaidUserCookie, syncWebsitePaidUserCookieFromOrganizations } from '../src/services/websiteAuthCookie.ts'
+
+vi.mock('~/services/supabase', () => ({
+  getLocalConfig: () => ({ hostWeb: 'https://www.capgo.app' }),
+}))
+
+describe('website paid user cookie', () => {
+  let cookieWrites: string[]
+
+  beforeEach(() => {
+    cookieWrites = []
+    vi.stubGlobal('document', {
+      get cookie() {
+        return ''
+      },
+      set cookie(value: string) {
+        cookieWrites.push(value)
+      },
+    })
+    vi.stubGlobal('location', {
+      protocol: 'https:',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('sets a 30 day cookie for paid non-invite organizations', () => {
+    syncWebsitePaidUserCookieFromOrganizations([
+      { paying: false, role: 'owner' },
+      { paying: true, role: 'read' },
+    ])
+
+    expect(cookieWrites).toContain('capgo_paid_user=1; Path=/; Max-Age=2592000; SameSite=Lax; Domain=.capgo.app; Secure')
+  })
+
+  it('clears the cookie when paid access is only from an invite', () => {
+    syncWebsitePaidUserCookieFromOrganizations([
+      { paying: true, role: 'invite_read' },
+    ])
+
+    expect(cookieWrites).toContain('capgo_paid_user=; Path=/; Max-Age=0; SameSite=Lax; Domain=.capgo.app; Secure')
+    expect(cookieWrites).toContain('capgo_paid_user=; Path=/; Max-Age=0; SameSite=Lax; Secure')
+  })
+
+  it('also clears the previous logged-in cookie name', () => {
+    clearWebsitePaidUserCookie()
+
+    expect(cookieWrites).toContain('capgo_logged_in=; Path=/; Max-Age=0; SameSite=Lax; Domain=.capgo.app; Secure')
+    expect(cookieWrites).toContain('capgo_logged_in=; Path=/; Max-Age=0; SameSite=Lax; Secure')
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Add a shared `capgo_paid_user` cookie for website header personalization.
- Set the cookie only when the logged-in user has a non-invite organization with `paying = true`.
- Cap the cookie at 30 days and clear the previous `capgo_logged_in` cookie name.

## Motivation (AI generated)

The website header should stay simple for paying Capgo users without showing the Console shortcut to free, trial-only, credits-only, or invited-but-not-accepted users.

## Business Impact (AI generated)

Paying customers get a cleaner path back to the console from the marketing site, while non-paying visitors still see the acquisition CTAs.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun run typecheck:frontend`
- [x] `bunx vitest run tests/website-auth-cookie.unit.test.ts tests/auth-sso-provisioning.unit.test.ts`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`