### PR TITLE
fix(cli): hide Capgo AI model name

### DIFF
--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -2032,7 +2032,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
           // @clack/prompts spinner appends its own animated dots — don't add an
           // ellipsis here or the user sees "…..." (6 dots: our 1-char ellipsis
           // plus the spinner's cycling 3-dot animation).
-          aiSpinner?.start('Analyzing build log with Capgo AI (Kimi K2.5)')
+          aiSpinner?.start('Analyzing build log with Capgo AI')
 
           let result: PostAnalyzeResult
           try {
@@ -2110,7 +2110,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
           const choice = await select({
             message: 'Choose AI analysis',
             options: [
-              { value: 'capgo', label: 'Capgo AI (Kimi K2.5)' },
+              { value: 'capgo', label: 'Capgo AI' },
               { value: 'local', label: 'Local AI (write prompt to file)' },
               { value: 'skip', label: 'Skip' },
             ],


### PR DESCRIPTION
## Summary (AI generated)

- Remove the specific model name from the CLI Capgo AI spinner text.
- Remove the specific model name from the interactive Capgo AI menu option.

## Motivation (AI generated)

The CLI should not expose a deprecated or implementation-specific AI model name to users.

## Business Impact (AI generated)

Keeps CLI messaging accurate while allowing Capgo to change AI providers or models without customer-facing copy churn.

## Test Plan (AI generated)

- [x] `bun install --frozen-lockfile`
- [x] `bun run --cwd cli lint`
- [x] `bun run --cwd cli build`
- [x] `bun run --cwd cli test:mcp`
- [x] `bun run --cwd cli test:bundle`
- [x] Commit hook ran `bun typecheck` successfully

Generated with AI