### PR TITLE
fix(dashboard): remove BETA badge from native build setup

### DIFF
--- a/src/components/dashboard/StepsBuild.vue
+++ b/src/components/dashboard/StepsBuild.vue
@@ -355,9 +355,6 @@ onUnmounted(() => {
                 <h2 class="text-2xl font-semibold text-slate-950 dark:text-white sm:text-3xl">
                   {{ t('build-setup-command-title') }}
                 </h2>
-                <span class="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-200">
-                  BETA
-                </span>
               </div>
               <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base">
                 {{ t('build-setup-command-subtitle') }}


### PR DESCRIPTION
## Summary

Capgo Build has left beta, so the **BETA** badge next to the build-setup title in the dashboard is no longer accurate — we announce GA while the console still renders a beta tag. This removes the amber `BETA` pill from `src/components/dashboard/StepsBuild.vue`; the title ("Start a native build") and everything else are unchanged.

It's the **only** `BETA`/`Beta` badge in the frontend, and there's no "beta" wording in `messages/en.json` or on the builds page, so this single removal fully de-betas the dashboard build feature.

Pairs with the website announcement **Cap-go/website#740** ("Capgo Build leaves beta"). Opened as a **draft** so it lands together with that announcement once Build is officially GA, rather than removing the tag early.

## Test plan

- Open the dashboard → an app → start the native build flow (the "Start a native build" step, `StepsBuild`).
- Confirm the title renders **without** the amber **BETA** pill beside it; the layout is otherwise unchanged.

## Screenshots

Static-markup change only — it removes:

```html
<span class="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-200">
  BETA
</span>
```

Before: "Start a native build" + amber **BETA** pill. After: "Start a native build" (no pill). A live screenshot requires the authenticated dashboard.

## Checklist

- [ ] `bun run lint:backend && bun run lint` — not run locally (pure static-template deletion, no logic change); CI lint will validate.
- [ ] My change requires a change to the documentation. — N/A.
- [ ] I have updated the documentation accordingly. — N/A (the website announcement is the paired change).
- [ ] My change has adequate E2E test coverage. — N/A (removes a static badge).
- [x] I verified this is the only beta indicator in the frontend (grep across `src/` + `messages/`) and the template remains balanced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Removed the "BETA" badge from the build setup header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->