### PR TITLE
fix(frontend): show bundles in dependency compare picker (gate on native_packages, not manifest)

### DIFF
--- a/src/components/bundle/BundleCompareSelect.vue
+++ b/src/components/bundle/BundleCompareSelect.vue
@@ -232,15 +232,17 @@ async function searchCompareVersions(term: string) {
 
   const requestId = ++compareSearchRequestId.value
   compareSearchLoading.value = true
-  const baseQuery = buildCompareBaseQuery()
-    .neq('id', props.currentVersionId)
 
+  // Each chain must start from its own builder: the Supabase query builder is
+  // mutable and returns `this`, so reusing one instance across concurrent
+  // chains would leak filters between the requests.
   const numericId = Number(term)
   let data: VersionRow[] | null = null
   let error: unknown = null
 
   if (Number.isNaN(numericId)) {
-    const response = await baseQuery
+    const response = await buildCompareBaseQuery()
+      .neq('id', props.currentVersionId)
       .ilike('name', `%${term}%`)
       .order('created_at', { ascending: false })
       .limit(5)
@@ -253,11 +255,13 @@ async function searchCompareVersions(term: string) {
   }
   else {
     const [nameResponse, idResponse] = await Promise.all([
-      baseQuery
+      buildCompareBaseQuery()
+        .neq('id', props.currentVersionId)
         .ilike('name', `%${term}%`)
         .order('created_at', { ascending: false })
         .limit(5),
-      baseQuery
+      buildCompareBaseQuery()
+        .neq('id', props.currentVersionId)
         .eq('id', numericId)
         .order('created_at', { ascending: false })
         .limit(5),

--- a/src/components/bundle/BundleCompareSelect.vue
+++ b/src/components/bundle/BundleCompareSelect.vue
@@ -24,10 +24,12 @@ const props = withDefaults(defineProps<{
   noResultsLabel: string
   disabled?: boolean
   showSpinner?: boolean
+  compareMode?: 'manifest' | 'dependencies'
 }>(), {
   modelValue: null,
   disabled: false,
   showSpinner: false,
+  compareMode: 'manifest',
 })
 
 const emit = defineEmits<{
@@ -74,17 +76,26 @@ function selectCompareVersion(option: VersionRow | null) {
   emit('update:modelValue', option)
 }
 
+// The manifest tab compares per-file manifest entries (manifest_count), while the
+// dependencies tab compares native_packages. Only offer bundles that actually carry
+// the data the current tab diffs on, so gate the candidate list per mode.
+function buildCompareBaseQuery() {
+  const query = supabase
+    .from('app_versions')
+    .select('id, name, created_at, manifest_count, app_id')
+    .eq('app_id', props.appId)
+  return props.compareMode === 'dependencies'
+    ? query.not('native_packages', 'is', null)
+    : query.gt('manifest_count', 0)
+}
+
 async function loadLatestCompareVersions() {
   if (!props.appId || !props.currentVersionId) {
     latestCompareVersions.value = []
     return
   }
   const requestId = ++latestCompareRequestId.value
-  const { data, error } = await supabase
-    .from('app_versions')
-    .select('id, name, created_at, manifest_count, app_id')
-    .eq('app_id', props.appId)
-    .gt('manifest_count', 0)
+  const { data, error } = await buildCompareBaseQuery()
     .neq('id', props.currentVersionId)
     .order('created_at', { ascending: false })
     .limit(5)
@@ -191,11 +202,7 @@ async function loadPreferredCompareVersions() {
     return
 
   const uniqueIds = [...new Set(preferredHistory.map(entry => entry.versionId))]
-  const { data: versions, error } = await supabase
-    .from('app_versions')
-    .select('id, name, created_at, manifest_count, app_id')
-    .eq('app_id', props.appId)
-    .gt('manifest_count', 0)
+  const { data: versions, error } = await buildCompareBaseQuery()
     .in('id', uniqueIds)
 
   if (requestId !== preferredCompareRequestId)
@@ -225,11 +232,7 @@ async function searchCompareVersions(term: string) {
 
   const requestId = ++compareSearchRequestId.value
   compareSearchLoading.value = true
-  const baseQuery = supabase
-    .from('app_versions')
-    .select('id, name, created_at, manifest_count, app_id')
-    .eq('app_id', props.appId)
-    .gt('manifest_count', 0)
+  const baseQuery = buildCompareBaseQuery()
     .neq('id', props.currentVersionId)
 
   const numericId = Number(term)

--- a/src/pages/app/[app].bundle.[bundle].dependencies.vue
+++ b/src/pages/app/[app].bundle.[bundle].dependencies.vue
@@ -198,6 +198,7 @@ watchEffect(async () => {
                   v-model="selectedCompareVersion"
                   :app-id="packageId"
                   :current-version-id="id"
+                  compare-mode="dependencies"
                   :label="t('dependencies-compare-label')"
                   :none-label="t('dependencies-compare-none')"
                   :latest-label="t('dependencies-compare-latest')"


### PR DESCRIPTION
## Problem

On a bundle's **Dependencies** tab, the "Compare with bundle" dropdown is empty for many apps, so you can't compare two bundles' native dependencies at all.

The compare selector was originally built for the **Manifest** tab and later extracted into a shared `BundleCompareSelect` component and reused on the **Dependencies** tab (#1557). It carried over the Manifest tab's eligibility filter — `manifest_count > 0` — to all three of its candidate queries (latest / deploy-history / search).

That filter is correct for manifest diffs (a bundle with no manifest has nothing to diff), but **wrong for dependency diffs**:

- The Dependencies tab compares `native_packages` (a `jsonb[]` column on `app_versions`).
- `native_packages` is populated on upload **independently** of the manifest. `manifest`/`manifest_count` is only populated for bundles using the partial-update system.
- So any app whose bundles were uploaded without partial updates has `manifest_count = 0` on every bundle — and the dependency compare picker filters them all out, even though every bundle has perfectly comparable native packages.

### Reproduction / impact (real data)

For one affected app with 13 active bundles, every bundle has `manifest_count = 0` and 3 native packages each:

| Picker filter | Bundles offered |
|---|---|
| `manifest_count > 0` (old) | **0** → empty dropdown |
| `native_packages IS NOT NULL` (new) | **12** |

## Fix

Add a `compareMode` prop (`'manifest' | 'dependencies'`, default `'manifest'`) to `BundleCompareSelect`. A single `buildCompareBaseQuery()` helper now gates candidates on the column each tab actually diffs:

- **Manifest tab** → `manifest_count > 0` (unchanged behavior)
- **Dependencies tab** → `native_packages IS NOT NULL`

The Dependencies page passes `compare-mode="dependencies"`; the Manifest page is untouched and keeps its existing (correct) behavior via the default.

## Scope

- `src/components/bundle/BundleCompareSelect.vue` — add `compareMode` prop + `buildCompareBaseQuery()` helper; route all three candidate queries (latest, deploy-history, search) through it.
- `src/pages/app/[app].bundle.[bundle].dependencies.vue` — pass `compare-mode="dependencies"`.

No schema, backend, or API changes. The actual dependency comparison logic on the page is unchanged — this only fixes which bundles are eligible to appear in the picker.

## Test plan

- [ ] On a bundle whose app has multiple bundles with native packages but `manifest_count = 0`, open **Dependencies** → "Compare with bundle" now lists other bundles (latest + searchable by name/ID).
- [ ] Selecting a bundle shows the native-package diff (changed vs unchanged) as before.
- [ ] **Manifest** tab compare dropdown behaves exactly as before (still gated on `manifest_count > 0`).
- [ ] An app with only one bundle still shows an empty compare list (nothing to compare).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mode-aware bundle comparison that filters comparison candidates by either manifest data or native-package dependencies, showing only relevant bundle versions per mode.
  * Dependencies page now uses the dependencies comparison mode so native-package dependency comparisons surface appropriate versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->