### PR TITLE
fix(frontend): exclude deleted bundles from the bundle compare picker

### DIFF
--- a/src/components/bundle/BundleCompareSelect.vue
+++ b/src/components/bundle/BundleCompareSelect.vue
@@ -171,7 +171,12 @@ async function loadPreferredCompareVersions() {
   if (channelIds.size === 0)
     return
 
-  const preferredHistory: Array<{ versionId: number, deployedAt: string | null }> = []
+  // Fetch several recent prior deployments per channel (not just one): if the
+  // most recent points to a now-deleted bundle, the deleted filter below would
+  // otherwise leave the channel with no baseline. Keeping a small lookback lets
+  // us fall back to the next older non-deleted deployment instead.
+  const PREFERRED_LOOKBACK = 20
+  const candidatesByChannel: Array<Array<{ versionId: number, deployedAt: string | null }>> = []
   for (const channelId of channelIds) {
     const cutoff = deployedAtByChannel.get(channelId)
     let query = supabase
@@ -186,7 +191,7 @@ async function loadPreferredCompareVersions() {
 
     const { data, error } = await query
       .order('created_at', { ascending: false })
-      .limit(1)
+      .limit(PREFERRED_LOOKBACK)
 
     if (requestId !== preferredCompareRequestId)
       return
@@ -196,19 +201,18 @@ async function loadPreferredCompareVersions() {
       continue
     }
 
-    const entry = (data ?? [])[0] as DeployHistoryRow | undefined
-    if (!entry)
-      continue
-    preferredHistory.push({
+    const candidates = ((data ?? []) as DeployHistoryRow[]).map(entry => ({
       versionId: entry.version_id,
       deployedAt: entry.created_at ?? entry.deployed_at ?? null,
-    })
+    }))
+    if (candidates.length)
+      candidatesByChannel.push(candidates)
   }
 
-  if (!preferredHistory.length)
+  if (!candidatesByChannel.length)
     return
 
-  const uniqueIds = [...new Set(preferredHistory.map(entry => entry.versionId))]
+  const uniqueIds = [...new Set(candidatesByChannel.flat().map(entry => entry.versionId))]
   const { data: versions, error } = await buildCompareBaseQuery()
     .in('id', uniqueIds)
 
@@ -221,11 +225,20 @@ async function loadPreferredCompareVersions() {
   }
 
   const versionMap = new Map((versions ?? []).map(version => [version.id, version]))
-  const sorted = preferredHistory
-    .filter(entry => versionMap.has(entry.versionId))
+  // Per channel, keep the most recent deployment whose bundle survived the
+  // deleted filter (candidates are already ordered newest-first).
+  const seen = new Set<number>()
+  preferredCompareVersions.value = candidatesByChannel
+    .map(candidates => candidates.find(entry => versionMap.has(entry.versionId)))
+    .filter((entry): entry is { versionId: number, deployedAt: string | null } => Boolean(entry))
     .sort((a, b) => (b.deployedAt ?? '').localeCompare(a.deployedAt ?? ''))
-
-  preferredCompareVersions.value = sorted
+    .filter((entry) => {
+      // Dedupe: the same bundle can be the surviving pick for multiple channels.
+      if (seen.has(entry.versionId))
+        return false
+      seen.add(entry.versionId)
+      return true
+    })
     .map(entry => versionMap.get(entry.versionId))
     .filter((version): version is VersionRow => Boolean(version))
 }

--- a/src/components/bundle/BundleCompareSelect.vue
+++ b/src/components/bundle/BundleCompareSelect.vue
@@ -82,12 +82,15 @@ function selectCompareVersion(option: VersionRow | null) {
 
 // The manifest tab compares per-file manifest entries (manifest_count), while the
 // dependencies tab compares native_packages. Only offer bundles that actually carry
-// the data the current tab diffs on, so gate the candidate list per mode.
+// the data the current tab diffs on, so gate the candidate list per mode. Deleted
+// bundles are excluded — their storage may be gone (and is purged after 90 days),
+// so they are not meaningful comparison targets.
 function buildCompareBaseQuery() {
   const query = supabase
     .from('app_versions')
     .select('id, name, created_at, manifest_count, app_id')
     .eq('app_id', props.appId)
+    .eq('deleted', false)
   return props.compareMode === 'dependencies'
     ? query.not('native_packages', 'is', null)
     : query.gt('manifest_count', 0)


### PR DESCRIPTION
## Problem

The bundle **compare picker** (`BundleCompareSelect`, shown on the Dependencies and Manifest tabs) lists **soft-deleted bundles** as comparison targets. It never filtered on `deleted`, so any soft-deleted version with the relevant data still appears in the dropdown and search results.

Deleted bundles are poor comparison baselines: their storage may already be gone, and the cleanup job permanently purges soft-deleted versions after 90 days — so an old deleted bundle can fail to load entirely.

### Impact (real data)

For `me.wcaleniewolny.test.ionic.vue2`, the dependencies picker currently offers **16** candidates, **4** of which are soft-deleted (`1.0.4-a/b/c/d`). After this fix it offers **12** — only the live bundles.

## Fix

Add `.eq('deleted', false)` to `buildCompareBaseQuery()`, the single helper that feeds all three candidate sources (latest, deploy-history, and search) for both tab modes. One line, both tabs, all sources.

Deep links (`?compare=<versionId>`) still resolve a specific bundle directly regardless of this filter, so previously shared comparison URLs keep working — only the *picker list* hides deleted bundles.

## Stacking

This is **stacked on `wolny/distracted-gould-87d85d`** (PR #2373), because `buildCompareBaseQuery()` is introduced there and the `native_packages` gating it depends on does not exist on `main`. **Merge #2373 first**, then this. (Base it against `main` once #2373 lands if you prefer a flat history.)

## Test plan

- [ ] On an app with soft-deleted bundles that have native packages, open a bundle's **Dependencies** tab → the deleted bundles no longer appear in "Compare with bundle" (list or search).
- [ ] Same for the **Manifest** tab compare dropdown.
- [ ] A live bundle still appears and compares correctly.
- [ ] A `?compare=<id>` deep link still resolves even if that id is now deleted.
