### PR TITLE
fix(frontend): lock page scroll behind subscription-required overlay

### DIFF
--- a/src/layouts/app.vue
+++ b/src/layouts/app.vue
@@ -170,8 +170,8 @@ function handleSecondaryTab(key: string) {
     />
     <main class="relative flex flex-1 w-full min-h-0 mt-0 overflow-hidden bg-blue-50 dark:bg-slate-800/40">
       <div
-        class="flex-1 w-full min-h-0 mx-auto overflow-y-auto"
-        :class="{ 'blur-sm pointer-events-none select-none': showPaymentOverlay }"
+        class="flex-1 w-full min-h-0 mx-auto"
+        :class="showPaymentOverlay ? 'overflow-hidden blur-sm pointer-events-none select-none' : 'overflow-y-auto'"
       >
         <RouterView class="w-full" />
       </div>

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -86,7 +86,10 @@ displayStore.defaultBack = '/apps'
 <template>
   <div>
     <div class="overflow-hidden pb-4 h-full">
-      <div class="relative overflow-y-auto px-4 pt-2 mx-auto mb-8 w-full h-full sm:px-6 md:pt-8 lg:px-8 max-w-9xl max-h-fit">
+      <div
+        class="relative px-4 pt-2 mx-auto mb-8 w-full h-full sm:px-6 md:pt-8 lg:px-8 max-w-9xl max-h-fit"
+        :class="shouldBlurContent ? 'overflow-hidden' : 'overflow-y-auto'"
+      >
         <!-- Only show FailedCard for security access issues (2FA/password) -->
         <FailedCard v-if="lacksSecurityAccess" />
 

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -15,6 +15,8 @@ const supabase = useSupabase()
 const { t } = useI18n()
 const displayStore = useDisplayStore()
 const apps = ref<Database['public']['Tables']['apps']['Row'][]>([])
+// Scroll container ref - used to reset scroll when a blocking overlay activates
+const scrollContainer = ref<HTMLElement | null>(null)
 
 const { currentOrganization } = storeToRefs(organizationStore)
 
@@ -41,6 +43,17 @@ const paymentFailed = computed(() => {
 
 // Should blur the content (either no apps OR payment failed)
 const shouldBlurContent = computed(() => hasNoApps.value || paymentFailed.value)
+
+// Locking the scroll container with `overflow-hidden` preserves its current
+// scrollTop. If the user had already scrolled (e.g. before the overlay resolved,
+// or after switching to a failed org), the absolutely-positioned overlay would
+// stay anchored to the top of the scroll content and end up above the viewport,
+// out of reach. Reset the scroll position when the overlay activates so it stays
+// centered in view.
+watch(shouldBlurContent, (blur) => {
+  if (blur && scrollContainer.value)
+    scrollContainer.value.scrollTop = 0
+}, { flush: 'post' })
 
 async function getMyApps() {
   await organizationStore.awaitInitialLoad()
@@ -87,6 +100,7 @@ displayStore.defaultBack = '/apps'
   <div>
     <div class="overflow-hidden pb-4 h-full">
       <div
+        ref="scrollContainer"
         class="relative px-4 pt-2 mx-auto mb-8 w-full h-full sm:px-6 md:pt-8 lg:px-8 max-w-9xl max-h-fit"
         :class="shouldBlurContent ? 'overflow-hidden' : 'overflow-y-auto'"
       >


### PR DESCRIPTION
## Problem

On the **Dashboard** (and any app page) shown to an organization whose subscription is inactive/expired, the **subscription-required** blocking overlay appears over blurred demo content — but the page could still be **scrolled**. On the dashboard this was especially broken: scrolling moved the modal itself out of view.

## Root cause

The blocking overlays (`PaymentRequiredModal`, and the dashboard empty-state overlay) are rendered as `position: absolute; inset: 0` inside an `overflow-y-auto` scroll container:

- `src/pages/dashboard.vue` — the modal lives **inside** the `overflow-y-auto` container, alongside the (blurred) `Usage` demo content, which is taller than the viewport. Because the container stays scrollable, the user can scroll the blurred content and the absolutely-positioned modal scrolls off-screen with it.
- `src/layouts/app.vue` — the modal is a pinned sibling (so it doesn't scroll away), but the blurred content behind it could still be scrolled.

Nothing locked scrolling while a blocking overlay was active.

## Fix

When a blocking overlay is active, switch the scroll container from `overflow-y-auto` to `overflow-hidden`:

- `dashboard.vue`: gated on `shouldBlurContent` (covers both the payment-failed and empty-state overlays).
- `app.vue`: gated on `showPaymentOverlay`.

This locks scrolling exactly when the overlay is shown, so the blurred content can't be scrolled and the modal stays pinned and centered. Normal (non-overlay) behaviour is unchanged — the container keeps `overflow-y-auto`.

## Verification

- Reproduced the exact computed-CSS structure (nested `overflow` containers, `max-h-fit`, `absolute inset-0` overlay, tall content) in a browser and drove a real (trusted) wheel event:
  - **Before** (`overflow-y-auto`): wheel scrolls the container, modal moves `-1200px` off-screen.
  - **After** (`overflow-hidden`): wheel does not scroll, modal stays pinned and fully visible.
- `bunx eslint` on both files: clean.
- `bun typecheck`: no errors in the changed files.

## Test plan

- [ ] As an org with an inactive/expired subscription, open `/dashboard` and confirm the page cannot be scrolled and the "subscription required" modal stays centered.
- [ ] Open an app page (non-`/info`) for an unpaid org and confirm the blurred content behind the modal cannot be scrolled.
- [ ] As a paid org, confirm the dashboard and app pages scroll normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay and blur states now consistently disable scrolling and block interactions with underlying content when active.
  * Dashboard scroll position is reset when overlays/blur activate to prevent misalignment or visual drift when toggling overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->