### PR TITLE
fix(cli): only email org admins when an incompatible bundle goes live

### DIFF
--- a/cli/src/bundle/compatibility.ts
+++ b/cli/src/bundle/compatibility.ts
@@ -129,45 +129,6 @@ export async function checkCompatibilityInternal(
     }
   }
 
-  // Surface incompatible results from the explicit `capgo bundle compatibility`
-  // command to Bento via the backend. The silent internal callers (sdk.ts,
-  // releaseType.ts) are intentionally excluded. The command uploads nothing, so
-  // only the channel's current (old) version is reported — version_new is empty.
-  if (hasIncompatible && !silent) {
-    // Best-effort telemetry: the org/version lookups are awaited, so a network
-    // or auth failure must be swallowed here — it must never break the command.
-    try {
-      const [channelResult, appResult] = await Promise.all([
-        supabase.from('channels').select('version ( id, name )').eq('name', channel).eq('app_id', resolvedAppId).maybeSingle(),
-        supabase.from('apps').select('owner_org').eq('app_id', resolvedAppId).maybeSingle(),
-      ])
-      const oldVersion = (channelResult.data?.version ?? undefined) as unknown as { id?: number | string, name?: string } | undefined
-      // The command re-queries the channel separately, so version_old can come
-      // back unresolved (race with a channel repoint, or a transient failure).
-      // version_old is required for this signal — skip the event entirely rather
-      // than emit one missing the version it is about.
-      if (oldVersion?.id != null) {
-        void trackEvent({
-          channel: 'bundle',
-          event: 'Bundle Incompatible',
-          icon: '🚫',
-          apikey: enrichedOptions.apikey,
-          appId: resolvedAppId,
-          orgId: appResult.data?.owner_org ?? undefined,
-          tags: {
-            source: 'command',
-            channel,
-            version_old_id: String(oldVersion.id),
-            ...(oldVersion.name ? { version_old_name: oldVersion.name } : {}),
-          },
-        })
-      }
-    }
-    catch {
-      // telemetry must never break a command
-    }
-  }
-
   return {
     finalCompatibility: compatibility.finalCompatibility,
     hasIncompatible,

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -714,7 +714,7 @@ async function setVersionInChannel(
   appid: string,
   localConfig: localConfigType,
   selfAssign?: boolean,
-) {
+): Promise<boolean> {
   const { data: versionId } = await supabase
     .rpc('get_app_versions', { apikey, name_version: bundle, appid })
     .single()
@@ -743,10 +743,11 @@ async function setVersionInChannel(
 
     if (displayBundleUrl)
       log.info(`Bundle url: ${bundleUrl}`)
+    return true
   }
-  else {
-    log.warn('The upload key is not allowed to set the version in the channel')
-  }
+
+  log.warn('The upload key is not allowed to set the version in the channel')
+  return false
 }
 
 export async function getDefaultUploadChannel(appId: string, supabase: SupabaseType, hostWeb: string) {
@@ -1305,10 +1306,11 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
     log.warn('Cannot delete linked bundle on upload as a upload organization member')
   }
 
+  let channelVersionSet = false
   if (hasOrganizationPerm(permissions, OrganizationPerm.write)) {
     if (options.verbose)
       log.info(`[Verbose] Setting bundle ${bundle} to channel ${channel}...`)
-    await setVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, channel, userId, orgId, appid, localConfig, options.selfAssign)
+    channelVersionSet = await setVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, channel, userId, orgId, appid, localConfig, options.selfAssign)
     if (options.verbose)
       log.info(`[Verbose] Channel updated successfully`)
 
@@ -1352,10 +1354,9 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
     notifyConsole: true,
   }).catch(() => {})
 
-  // Surface incompatible uploads to Bento via the backend (it resolves
-  // version_new_id + org/app names and gates delivery via the
-  // bundle_incompatible preference). Fires only once the version exists and the
-  // channel has been set, and only when the bundle was actually incompatible.
+  // Record every incompatible upload in PostHog (`Bundle Incompatible`). The
+  // channel_overwritten flag lets the backend gate the org-member email to
+  // uploads that actually went live (i.e. overwrote the channel's version).
   if (compatibility?.result === 'incompatible') {
     void trackEvent({
       channel: 'bundle',
@@ -1367,6 +1368,7 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
       tags: {
         source: 'upload',
         channel,
+        channel_overwritten: channelVersionSet,
         version_new_name: bundle,
         ...(compatibility.versionOldId ? { version_old_id: compatibility.versionOldId } : {}),
         ...(compatibility.versionOldName ? { version_old_name: compatibility.versionOldName } : {}),

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -269,12 +269,15 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   // lifecycle automation can react. Mirrors the builder block above; resolves
   // org/app names + the freshly created version id for the payload.
   let bundleIncompatibleBentoEvent: BentoTrackingPayload | undefined
-  if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT) {
+  // PostHog records every incompatible upload (tracking runs unconditionally
+  // below). Skip the org/app/version lookups + email unless the incompatible
+  // bundle actually went live — i.e. the upload overwrote the channel's version.
+  // (buildBundleCompatibilityBentoEvent re-checks channelOverwritten too, so the
+  // gate stays unit-tested even though we short-circuit the DB work here.)
+  const channelOverwritten = trackedBody.tags?.channel_overwritten === true
+    || trackedBody.tags?.channel_overwritten === 'true'
+  if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT && channelOverwritten) {
     const tags = trackedBody.tags ?? {}
-    // PostHog records every incompatible upload (tracking runs unconditionally
-    // below). The helper only returns a payload — i.e. emails org admins — when
-    // the incompatible bundle actually went live (channel_overwritten).
-    const channelOverwritten = tags.channel_overwritten === true || tags.channel_overwritten === 'true'
     const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
       ? tags.version_new_name
       : undefined

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -269,13 +269,12 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   // lifecycle automation can react. Mirrors the builder block above; resolves
   // org/app names + the freshly created version id for the payload.
   let bundleIncompatibleBentoEvent: BentoTrackingPayload | undefined
-  // PostHog records every incompatible upload (tracking runs unconditionally
-  // below). Only email org admins when the incompatible bundle actually went
-  // live — i.e. the upload overwrote the channel's version (channel_overwritten).
-  const incompatibleChannelOverwritten = trackedBody.tags?.channel_overwritten === true
-    || trackedBody.tags?.channel_overwritten === 'true'
-  if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT && incompatibleChannelOverwritten) {
+  if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT) {
     const tags = trackedBody.tags ?? {}
+    // PostHog records every incompatible upload (tracking runs unconditionally
+    // below). The helper only returns a payload — i.e. emails org admins — when
+    // the incompatible bundle actually went live (channel_overwritten).
+    const channelOverwritten = tags.channel_overwritten === true || tags.channel_overwritten === 'true'
     const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
       ? tags.version_new_name
       : undefined
@@ -307,6 +306,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
         event: trackedBody.event,
         orgId: onboardingOrgId,
         appId,
+        channelOverwritten,
         channel: typeof tags.channel === 'string' ? tags.channel : undefined,
         source: typeof tags.source === 'string' ? tags.source : undefined,
         versionNewId,

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -269,7 +269,12 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   // lifecycle automation can react. Mirrors the builder block above; resolves
   // org/app names + the freshly created version id for the payload.
   let bundleIncompatibleBentoEvent: BentoTrackingPayload | undefined
-  if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT) {
+  // PostHog records every incompatible upload (tracking runs unconditionally
+  // below). Only email org admins when the incompatible bundle actually went
+  // live — i.e. the upload overwrote the channel's version (channel_overwritten).
+  const incompatibleChannelOverwritten = trackedBody.tags?.channel_overwritten === true
+    || trackedBody.tags?.channel_overwritten === 'true'
+  if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT && incompatibleChannelOverwritten) {
     const tags = trackedBody.tags ?? {}
     const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
       ? tags.version_new_name

--- a/supabase/functions/_backend/utils/bundle_compatibility_recovery.ts
+++ b/supabase/functions/_backend/utils/bundle_compatibility_recovery.ts
@@ -1,16 +1,14 @@
 import type { BentoTrackingPayload } from './tracking.ts'
 
 /**
- * The CLI emits a `Bundle Incompatible` tracking event whenever a bundle's
- * native dependencies don't match the version currently live on the target
- * channel. It fires from two flows:
- * - `bundle upload` (after the new version is created), and
- * - the standalone `capgo bundle compatibility` command.
- *
- * We turn that into a Bento signal event so a lifecycle automation can react
- * (e.g. nudge the org toward a native rebuild / Capgo Builder). Delivery and
- * email gating are handled by `sendNotifToOrgMembers` via the dedicated
- * `bundle_incompatible` preference key. Mirrors `buildBuilderOnboardingBentoEvent`.
+ * The CLI emits a `Bundle Incompatible` tracking event when a `bundle upload`'s
+ * native dependencies don't match the version currently live on the channel.
+ * PostHog records every such upload; this helper builds the Bento payload only
+ * when the incompatible bundle actually went live — i.e. the upload overwrote
+ * the channel's version (`channelOverwritten`) — so org admins are emailed only
+ * when it can affect users. Delivery + email gating run through
+ * `sendNotifToOrgMembers` via the dedicated `bundle_incompatible` preference key.
+ * Mirrors `buildBuilderOnboardingBentoEvent`.
  */
 export const BUNDLE_INCOMPATIBLE_EVENT = 'Bundle Incompatible'
 
@@ -19,17 +17,20 @@ export interface BundleCompatibilityBentoInput {
   event: string
   orgId: string | undefined
   appId: string | undefined
+  /**
+   * True only when the upload overwrote the channel's live version. The Bento
+   * email is built only in that case; PostHog still records every incompatible
+   * upload upstream.
+   */
+  channelOverwritten: boolean | undefined
   /** Channel the bundle was checked against. */
   channel: string | undefined
-  /** Which flow detected the incompatibility: 'upload' | 'command'. */
+  /** Which flow emitted the event (currently always 'upload'). */
   source: string | undefined
-  /**
-   * New bundle being uploaded. Empty for the standalone command, which uploads
-   * nothing — only the upload flow has a freshly created version.
-   */
+  /** The freshly uploaded bundle (its id is resolved server-side). */
   versionNewId: string | undefined
   versionNewName: string | undefined
-  /** Version currently live on the channel that the bundle was compared against. */
+  /** Version that was live on the channel before this upload. */
   versionOldId: string | undefined
   versionOldName: string | undefined
   orgName: string | undefined
@@ -46,6 +47,11 @@ export function buildBundleCompatibilityBentoEvent(input: BundleCompatibilityBen
     return undefined
   if (!input.orgId || !input.appId)
     return undefined
+  // Email gate: only build a payload when the incompatible bundle actually went
+  // live (the upload overwrote the channel's version). PostHog still records the
+  // event upstream regardless of this.
+  if (!input.channelOverwritten)
+    return undefined
 
   const source = input.source ?? 'unknown'
   const channel = input.channel ?? ''
@@ -57,10 +63,8 @@ export function buildBundleCompatibilityBentoEvent(input: BundleCompatibilityBen
     // Dedicated key — independent from other bundle/OTA email preferences.
     preferenceKey: 'bundle_incompatible',
     // Permanent per app+channel+version claim (no reopening cron window): repeated
-    // incompatible uploads / `bundle compatibility` checks of the SAME version must
-    // not re-email org admins. A genuinely new version has a different uniqId and
-    // notifies on its own; the old version is the fallback for the command flow
-    // (which uploads no new bundle).
+    // incompatible uploads of the SAME version must not re-email org admins. A
+    // genuinely new version has a different uniqId and notifies on its own.
     once: true,
     uniqId: `bundle_incompatible:${input.appId}:${channel}:${versionNewName || versionOldName}`,
     data: {

--- a/tests/bundle-compatibility-recovery.unit.test.ts
+++ b/tests/bundle-compatibility-recovery.unit.test.ts
@@ -5,6 +5,7 @@ const base = {
   event: BUNDLE_INCOMPATIBLE_EVENT,
   orgId: 'org-1',
   appId: 'com.demo.app',
+  channelOverwritten: true,
   channel: 'production',
   source: 'upload',
   versionNewId: '101',
@@ -20,7 +21,7 @@ describe('buildBundleCompatibilityBentoEvent', () => {
     expect(BUNDLE_INCOMPATIBLE_EVENT).toBe('Bundle Incompatible')
   })
 
-  it.concurrent('builds a full payload for an incompatible upload', () => {
+  it.concurrent('builds a full payload for an incompatible upload that went live', () => {
     const r = buildBundleCompatibilityBentoEvent(base)
     expect(r).toBeDefined()
     expect(r!.event).toBe('bundle_incompatible')
@@ -29,7 +30,6 @@ describe('buildBundleCompatibilityBentoEvent', () => {
     // same incompatible version don't re-email org admins.
     expect(r!.once).toBe(true)
     expect(r!.cron).toBeUndefined()
-    // uniqId keys off the new version for uploads.
     expect(r!.uniqId).toBe('bundle_incompatible:com.demo.app:production:1.0.1')
     expect(r!.data).toMatchObject({
       org_id: 'org-1',
@@ -45,14 +45,23 @@ describe('buildBundleCompatibilityBentoEvent', () => {
     })
   })
 
-  it.concurrent('falls back to the old version in uniqId for the command flow (no new version)', () => {
-    const r = buildBundleCompatibilityBentoEvent({ ...base, source: 'command', versionNewId: undefined, versionNewName: undefined })
+  // Email gate: only an incompatible upload that overwrote the channel's live
+  // version produces a payload. PostHog still records every incompatible upload
+  // upstream — this only controls the org-member email.
+  it.concurrent('returns undefined when the channel was not overwritten', () => {
+    expect(buildBundleCompatibilityBentoEvent({ ...base, channelOverwritten: false })).toBeUndefined()
+  })
+
+  it.concurrent('returns undefined when channel_overwritten is missing', () => {
+    expect(buildBundleCompatibilityBentoEvent({ ...base, channelOverwritten: undefined })).toBeUndefined()
+  })
+
+  it.concurrent('falls back to the old version in uniqId when the new version is absent', () => {
+    const r = buildBundleCompatibilityBentoEvent({ ...base, versionNewId: undefined, versionNewName: undefined })
     expect(r).toBeDefined()
     expect(r!.uniqId).toBe('bundle_incompatible:com.demo.app:production:1.0.0')
-    expect(r!.data.source).toBe('command')
     expect(r!.data.version_new_id).toBe('')
     expect(r!.data.version_new_name).toBe('')
-    expect(r!.data.version_old_id).toBe('100')
     expect(r!.data.version_old_name).toBe('1.0.0')
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- Decouples the PostHog `Bundle Incompatible` event from the org-member email. The event still fires on **every incompatible upload** (now tagged `channel_overwritten`), but the Bento email only sends when the incompatible bundle **actually overwrote the channel's live version**.
- `setVersionInChannel` now returns whether it overwrote the channel; the upload passes that through as the `channel_overwritten` tag.
- `events.ts` gates the Bento payload on `channel_overwritten` — PostHog tracking stays unconditional (every incompatible upload is recorded; only the email is gated).
- The standalone `capgo bundle compatibility` command no longer emits `Bundle Incompatible` at all (its incompatibility is already tracked via `Bundle Compatibility Checked`, and the dev sees the full result in the terminal).

## Motivation (AI generated)

Follow-up to #2372. The email previously fired for any incompatible bundle — including the dry-run `capgo bundle compatibility` command and uploads that never went live (e.g. an upload-only member without `app.create_channel`). Those cases don't affect end users, so the email was noisy and misleading. We still want the broad PostHog signal for analytics, so the two concerns are now split: **track always, email only when it matters.**

## Business Impact (AI generated)

Org admins only get the "incompatible bundle is live" email when an incompatible OTA bundle actually became live on a channel and can affect users — keeping the alert trustworthy and actionable, and keeping any Bento automation enrollment clean. Analytics still capture every incompatible upload, now with a `channel_overwritten` dimension to split "went live" vs not.

## Test Plan (AI generated)

- [ ] Incompatible upload that overwrites the channel (write perms) → `Bundle Incompatible` in PostHog with `channel_overwritten=true`; org-member email sent (once per version).
- [ ] Incompatible upload that does NOT overwrite the channel (upload-only member / no `app.create_channel`) → `Bundle Incompatible` in PostHog with `channel_overwritten=false`; **no email**.
- [ ] `capgo bundle compatibility` with an incompatible result → no `Bundle Incompatible` event and no email; still recorded via `Bundle Compatibility Checked`.
- [ ] `bun run cli:typecheck`, `bun run typecheck:backend`, oxlint, and the helper unit test pass.

Verified locally: CLI + backend `tsgo` typecheck, `oxlint` (0 warnings / 0 errors on changed files), helper unit test 6/6.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics for incompatible bundle uploads now only emit when the upload actually overwrote the live channel; removed noisy/silent-case tracking.

* **Bug Fixes / Telemetry**
  * Tracking payloads now include a clear "channel overwritten" flag to accurately reflect whether the channel version was changed.

* **Tests**
  * Updated tests to cover the channel-overwritten gating and fallback/version behaviors.

* **Documentation**
  * Clarified event gating and payload semantics in comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->