### PR TITLE
fix(frontend): resolve TS2589 in apps table row mapping

### DIFF
--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -134,10 +134,11 @@ async function getMyApps() {
     const rows = data ?? []
     totalApps.value = rows[0]?.total_count ?? 0
 
-    apps.value = rows.map(app => ({
-      ...appWithImmediateIcon(app),
-      last_upload_at: app.last_upload_at ?? null,
-    }))
+    // appWithImmediateIcon spreads the whole RPC row, so last_upload_at is carried
+    // through as-is. Avoid re-building the object inline (e.g. { ...appWithImmediateIcon(app),
+    // last_upload_at } ) here: spreading into the AppRowWithIconState intersection makes
+    // vue-tsc hit TS2589 (excessively deep type instantiation).
+    apps.value = rows.map(appWithImmediateIcon)
     if (rows.length)
       loadAppIcons(rows, currentRun)
   }


### PR DESCRIPTION
## Summary

The apps page failed `typecheck:frontend` (`vue-tsc`) with:

`src/pages/apps.vue(137,18): error TS2589: Type instantiation is excessively deep and possibly infinite.`

### Root cause

#2378 changed the row mapping to rebuild each row inline:

```ts
apps.value = rows.map(app => ({
  ...appWithImmediateIcon(app),
  last_upload_at: app.last_upload_at ?? null,
}))
```

`rows` comes from the `get_org_apps_with_last_upload` RPC, whose row type includes `transfer_history: Json[] | null`, and `Json` is recursively defined. Spreading the helper's result into a fresh object literal and checking it against the `AppRowWithIconState` intersection forced TypeScript to instantiate that recursive type too deeply, tripping TS2589.

### Fix

```ts
apps.value = rows.map(appWithImmediateIcon)
```

Behavior is identical:
- `appWithImmediateIcon` spreads the whole RPC row, so `last_upload_at` is still carried through at runtime.
- `?? null` was a no-op — `last_upload_at` is already `string | null`.
- The `<AppTable>` prop type is unchanged because `apps` is explicitly typed `AppRowWithIconState[]`.

A comment was added so the inline spread is not reintroduced.

## Test plan

- [x] `vue-tsc --project tsconfig.frontend.json --noEmit` → 0 errors (was 1: TS2589)
- [x] `oxlint src/pages/apps.vue` → clean
- [x] `eslint src/pages/apps.vue` → clean
- [ ] Apps table still renders the "Last upload" column with per-app timestamps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where app upload timestamps were not being preserved correctly during data processing. Previously, this information would be unnecessarily reset to null, but is now properly maintained and displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->