### PR TITLE
feat(api): skip incompatible-bundle email for metadata-strategy channels

### DIFF
--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -313,7 +313,9 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
         outcome: skippedForMetadata ? 'skipped_metadata' : 'sent',
         update_strategy: updateStrategy ?? 'unknown',
         app_id: appId,
-        ...(incompatibleChannel ? { channel: incompatibleChannel } : {}),
+        // Use channel_name, not `channel`: trackPosthogEvent overwrites a `channel`
+        // tag with payload.channel ('bundle', the event category).
+        ...(incompatibleChannel ? { channel_name: incompatibleChannel } : {}),
       },
     }))
 

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -8,11 +8,16 @@ import { BUNDLE_INCOMPATIBLE_EVENT, buildBundleCompatibilityBentoEvent } from '.
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareV2 } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
+import { trackPosthogEvent } from '../utils/posthog.ts'
 import { checkPermission } from '../utils/rbac.ts'
 import { broadcastCLIEvent } from '../utils/realtime_broadcast.ts'
 import { hasOrgRight, hasOrgRightApikey, supabaseWithAuth } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
+
+// PostHog event recording whether the org-member incompatibility email was sent
+// or skipped (and why). Powers the weekly sent-vs-skipped breakdown.
+const BUNDLE_INCOMPATIBLE_EMAIL_EVENT = 'Bundle Incompatible Email'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -270,55 +275,90 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   // org/app names + the freshly created version id for the payload.
   let bundleIncompatibleBentoEvent: BentoTrackingPayload | undefined
   // PostHog records every incompatible upload (tracking runs unconditionally
-  // below). Skip the org/app/version lookups + email unless the incompatible
-  // bundle actually went live — i.e. the upload overwrote the channel's version.
-  // (buildBundleCompatibilityBentoEvent re-checks channelOverwritten too, so the
-  // gate stays unit-tested even though we short-circuit the DB work here.)
+  // below). The org-member email is only relevant when the incompatible bundle
+  // actually went live — i.e. the upload overwrote the channel's version — AND the
+  // channel doesn't gate delivery itself. On the metadata (`version_number`)
+  // strategy, `min_update_version` keeps the bundle off incompatible devices, so
+  // there's no breakage to warn about — we skip the email there. Either outcome is
+  // recorded in PostHog (sent vs skipped_metadata) for the weekly breakdown.
   const channelOverwritten = trackedBody.tags?.channel_overwritten === true
     || trackedBody.tags?.channel_overwritten === 'true'
   if (onboardingOrgId && appId && trackedBody.event === BUNDLE_INCOMPATIBLE_EVENT && channelOverwritten) {
     const tags = trackedBody.tags ?? {}
-    const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
-      ? tags.version_new_name
-      : undefined
-    const [orgResult, appResult] = await Promise.all([
-      supabase.from('orgs').select('id, name').eq('id', onboardingOrgId).single(),
-      supabase.from('apps').select('name').eq('app_id', appId).single(),
-    ])
-    if (orgResult.error || appResult.error) {
-      // Best-effort signal: never fail the CLI's request, and don't emit a Bento
-      // event with empty org/app context. Log and skip instead.
-      cloudlog({ requestId: c.get('requestId'), message: 'bundle incompatible bento lookup failed; skipping signal', org: orgResult.error, app: appResult.error })
+    const incompatibleChannel = typeof tags.channel === 'string' ? tags.channel : undefined
+
+    // Look up the channel's update strategy to decide whether the email is warranted.
+    let updateStrategy: string | null = null
+    if (incompatibleChannel) {
+      const { data: channelRow } = await supabase
+        .from('channels')
+        .select('disable_auto_update')
+        .eq('app_id', appId)
+        .eq('name', incompatibleChannel)
+        .maybeSingle()
+      updateStrategy = channelRow?.disable_auto_update ?? null
     }
-    else {
-      // The upload flow sends only version_new_name; resolve its id here (the
-      // version exists by the time this event is sent). The command flow uploads
-      // nothing, so versionNewName is absent and version_new_id stays empty.
-      let versionNewId: string | undefined
-      if (versionNewName) {
-        const { data: versionNewData } = await supabase
-          .from('app_versions')
-          .select('id')
-          .eq('app_id', appId)
-          .eq('name', versionNewName)
-          .maybeSingle()
-        versionNewId = toIdString(versionNewData?.id)
+    const skippedForMetadata = updateStrategy === 'version_number'
+
+    // Record the email decision in PostHog (sent vs skipped_metadata). Fire-and-
+    // forget; setPersonProperties:false so these transient decision tags don't get
+    // $set onto the acting user's person profile.
+    await backgroundTask(c, trackPosthogEvent(c, {
+      event: BUNDLE_INCOMPATIBLE_EMAIL_EVENT,
+      user_id: typeof trackedBody.user_id === 'string' ? trackedBody.user_id : undefined,
+      channel: 'bundle',
+      setPersonProperties: false,
+      groups: { organization: onboardingOrgId },
+      tags: {
+        outcome: skippedForMetadata ? 'skipped_metadata' : 'sent',
+        update_strategy: updateStrategy ?? 'unknown',
+        app_id: appId,
+        ...(incompatibleChannel ? { channel: incompatibleChannel } : {}),
+      },
+    }))
+
+    if (!skippedForMetadata) {
+      const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
+        ? tags.version_new_name
+        : undefined
+      const [orgResult, appResult] = await Promise.all([
+        supabase.from('orgs').select('id, name').eq('id', onboardingOrgId).single(),
+        supabase.from('apps').select('name').eq('app_id', appId).single(),
+      ])
+      if (orgResult.error || appResult.error) {
+        // Best-effort signal: never fail the CLI's request, and don't emit a Bento
+        // event with empty org/app context. Log and skip instead.
+        cloudlog({ requestId: c.get('requestId'), message: 'bundle incompatible bento lookup failed; skipping signal', org: orgResult.error, app: appResult.error })
       }
-      const versionOldId = toIdString(tags.version_old_id)
-      bundleIncompatibleBentoEvent = buildBundleCompatibilityBentoEvent({
-        event: trackedBody.event,
-        orgId: onboardingOrgId,
-        appId,
-        channelOverwritten,
-        channel: typeof tags.channel === 'string' ? tags.channel : undefined,
-        source: typeof tags.source === 'string' ? tags.source : undefined,
-        versionNewId,
-        versionNewName,
-        versionOldId,
-        versionOldName: typeof tags.version_old_name === 'string' ? tags.version_old_name : undefined,
-        orgName: orgResult.data?.name ?? undefined,
-        appName: appResult.data?.name ?? undefined,
-      })
+      else {
+        // The upload flow sends only version_new_name; resolve its id here (the
+        // version exists by the time this event is sent).
+        let versionNewId: string | undefined
+        if (versionNewName) {
+          const { data: versionNewData } = await supabase
+            .from('app_versions')
+            .select('id')
+            .eq('app_id', appId)
+            .eq('name', versionNewName)
+            .maybeSingle()
+          versionNewId = toIdString(versionNewData?.id)
+        }
+        const versionOldId = toIdString(tags.version_old_id)
+        bundleIncompatibleBentoEvent = buildBundleCompatibilityBentoEvent({
+          event: trackedBody.event,
+          orgId: onboardingOrgId,
+          appId,
+          channelOverwritten,
+          channel: incompatibleChannel,
+          source: typeof tags.source === 'string' ? tags.source : undefined,
+          versionNewId,
+          versionNewName,
+          versionOldId,
+          versionOldName: typeof tags.version_old_name === 'string' ? tags.version_old_name : undefined,
+          orgName: orgResult.data?.name ?? undefined,
+          appName: appResult.data?.name ?? undefined,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
## Summary (AI generated)

- Skip the org-member "incompatible bundle" email when the channel uses the **metadata (`version_number`) update strategy**. On that strategy `min_update_version` gates delivery, so the incompatible bundle never reaches incompatible devices — there's no breakage to warn about, and the email would be a false alarm.
- `private/events.ts` now looks up `channels.disable_auto_update` for the incompatible upload and only builds the Bento email payload when the strategy is **not** `version_number`.
- Either way, it emits a new **`Bundle Incompatible Email`** PostHog event tagged `outcome = sent | skipped_metadata` (plus `update_strategy`, `channel`, `app_id`, and the `organization` group), so we can track emails sent vs skipped-by-strategy. `setPersonProperties: false` keeps these transient decision tags off the acting user's person profile.
- PostHog tracking of the underlying incompatible upload (`Bundle Incompatible`) is unchanged — every incompatible upload is still recorded; only the email is gated.

## Motivation (AI generated)

Follow-up to the incompatible-bundle email work (#2372 / #2379). The email warns "your update could break your app for existing users," but on `version_number` channels the bundle is gated by `min_update_version`, so it can't reach incompatible devices and nothing breaks. Sending that warning there is wrong — and it lands on a small, mostly-paying audience (production today: ~20 paying / 2 trial apps on this strategy), exactly the worst recipients for a false alarm. The PostHog decision event gives visibility into how often we send vs skip.

## Business Impact (AI generated)

Avoids alarming (mostly paying) customers with a scary, inaccurate "your app could break" email when their own update strategy already prevents the breakage — protecting trust in Capgo's notifications. The `Bundle Incompatible Email` event enables monitoring of the send/skip split over time.

## Test Plan (AI generated)

- [ ] Incompatible upload that goes live on a `version_number` channel → **no** Bento email; PostHog `Bundle Incompatible Email` with `outcome=skipped_metadata`, `update_strategy=version_number`.
- [ ] Incompatible upload that goes live on a `none` (or semver) channel → Bento email sent (once per version); PostHog `Bundle Incompatible Email` with `outcome=sent`.
- [ ] Incompatible upload that did not overwrite the channel → no decision event, no email (unchanged).
- [ ] `Bundle Incompatible` (PostHog) still fires for every incompatible upload regardless of strategy.
- [ ] `bun run typecheck:backend` and oxlint pass.

Verified locally: backend `tsgo` typecheck clean, `oxlint` 0/0 on the changed file.

Generated with AI
