### PR TITLE
feat(cli): add channel_name tag to compatibility events for PostHog

### DIFF
--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -227,7 +227,10 @@ async function verifyCompatibility(supabase: SupabaseType, pm: pmType, options: 
     tags: {
       result: compatibilitySummary.result,
       incompatible_count: compatibilitySummary.incompatibleCount,
+      // `channel` is overwritten by the event category ('bundle') in PostHog, so
+      // also send channel_name to keep the app channel queryable.
       channel,
+      channel_name: channel,
       ...(compatibilitySummary.reasons.length > 0 ? { reasons: compatibilitySummary.reasons.join(',') } : {}),
       ...(compatibilitySkipReason ? { skip_reason: compatibilitySkipReason } : {}),
     },
@@ -1367,7 +1370,10 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
       orgId,
       tags: {
         source: 'upload',
+        // `channel` is overwritten by the event category ('bundle') in PostHog
+        // (the backend still reads tags.channel); channel_name keeps it queryable.
         channel,
+        channel_name: channel,
         channel_overwritten: channelVersionSet,
         version_new_name: bundle,
         ...(compatibility.versionOldId ? { version_old_id: compatibility.versionOldId } : {}),


### PR DESCRIPTION
## Summary (AI generated)

- Add a `channel_name` tag to the `Bundle Upload Compatibility Checked` and `Bundle Incompatible` CLI events so the **app channel is queryable in PostHog**.
- Keep the existing `channel` tag — the backend reads `tags.channel` for the incompatible-email gate (added in #2381), so it must stay.

## Motivation (AI generated)

`trackPosthogEvent` builds the event properties as `{ ...tags, channel: payload.channel }`, where `payload.channel` is the event *category* (`'bundle'`). That spread order means a `channel` tag is always overwritten by `'bundle'`, so the app channel these events put in `tags.channel` was never queryable in PostHog (it always showed `bundle`). Sending it under a non-colliding `channel_name` key fixes that — consistent with the `channel_name` tag the backend `Bundle Incompatible Email` decision event already uses (#2381).

## Business Impact (AI generated)

Enables per-channel breakdowns of compatibility / incompatible-upload analytics in PostHog (e.g. which channels see the most incompatible uploads), which wasn't possible while the channel was clobbered.

## Test Plan (AI generated)

- [ ] `Bundle Upload Compatibility Checked` and `Bundle Incompatible` PostHog events carry `channel_name` = the app channel (e.g. `production`).
- [ ] The `channel` tag is still present (backend incompatible-email gate, which reads `tags.channel`, is unaffected).
- [ ] `bun run cli:typecheck` and `oxlint` pass.

Verified locally: CLI `tsgo` typecheck clean, `oxlint` 0/0 on the changed file.

Note: the standalone `Bundle Compatibility Checked` (command) event records no channel at all today (not clobbered, just absent) — left out of scope. Happy to add `channel_name` there too for uniform per-channel breakdowns if wanted.

Generated with AI
