### PR TITLE
fix(cli/apple-api): sanitize App ID name to satisfy Apple's alphanumeric+spaces rule

### DIFF
--- a/cli/src/build/onboarding/apple-api.ts
+++ b/cli/src/build/onboarding/apple-api.ts
@@ -312,7 +312,19 @@ export async function ensureBundleId(
     return { bundleIdResourceId: searchBody.data[0].id }
   }
 
-  // Register new
+  // Register new. Apple's `attributes.identifier` field accepts the
+  // reverse-DNS bundle id verbatim (dots, hyphens), but the human-readable
+  // `attributes.name` field rejects anything non-alphanumeric — including
+  // the dots that are mandatory in every real bundle id. The error reads:
+  //   'Capgo app.capgo.plugin.TutorialBuild1' is not a valid name for an
+  //   app id. Please choose a name containing only alphanumeric characters
+  //   and spaces. (ENTITY_ERROR.ATTRIBUTE.INVALID)
+  // So we sanitize by replacing every non-alphanumeric run with a single
+  // space and trimming. "app.capgo.plugin.TutorialBuild1" becomes
+  // "app capgo plugin TutorialBuild1" → final name "Capgo app capgo
+  // plugin TutorialBuild1", which Apple accepts. The identifier we send
+  // stays the original — the name is purely a portal display label.
+  const sanitizedName = identifier.replace(/[^a-zA-Z0-9]+/g, ' ').trim()
   const createBody = await ascFetch('/bundleIds', token, {
     method: 'POST',
     body: JSON.stringify({
@@ -320,7 +332,7 @@ export async function ensureBundleId(
         type: 'bundleIds',
         attributes: {
           identifier,
-          name: `Capgo ${identifier}`,
+          name: `Capgo ${sanitizedName}`,
           platform: 'IOS',
         },
       },


### PR DESCRIPTION
## Summary

- `ensureBundleId` sent `name="Capgo <identifier>"` verbatim to Apple's `/bundleIds` endpoint, but Apple's `attributes.name` field rejects anything that isn't alphanumeric or a space — every bundle id with the typical dot-separated components hit a 409:

  ```
  ENTITY_ERROR.ATTRIBUTE.INVALID — 'Capgo app.capgo.plugin.TutorialBuild1' is not a valid name for an app id. Please choose a name containing only alphanumeric characters and spaces.
  ```
- Sanitize the `name` (only) by replacing every non-alphanumeric run with a single space and trimming. `app.capgo.plugin.TutorialBuild1` becomes `app capgo plugin TutorialBuild1` so the final name reads `Capgo app capgo plugin TutorialBuild1` — Apple accepts that. The `identifier` we send is the original; the name is purely a portal-side display label.
- Cherry-pick from the long-running #2308 branch so this 1-line fix can ship independently of the rest of that work.

## Test plan

- [ ] Run `capgo build init` against any iOS project whose bundle id contains a dot (i.e. all real projects). Confirm the cert-creation step no longer 409s on the "not a valid name" message.
- [ ] After the new App ID is created, confirm it shows up in https://developer.apple.com/account/resources/identifiers/list with the sanitized human-readable name (e.g. `Capgo app capgo plugin TutorialBuild1`) and the original dotted identifier (`app.capgo.plugin.TutorialBuild1`).
- [ ] `bun run typecheck`, `bun run lint`, `bun run test:apple-api-import-helpers`, `bun run build` all green (verified locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple bundle ID registration to properly handle special characters in display names, ensuring compliance with Apple's validation requirements while preserving the underlying bundle identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->