### PR TITLE
fix(cli): repair builder CTA and compatibility tables

### DIFF
--- a/cli/src/build/needed.ts
+++ b/cli/src/build/needed.ts
@@ -4,10 +4,10 @@ import type { Compatibility } from '../schemas/common'
 import type { Database } from '../types/supabase.types'
 import process, { env, stdout } from 'node:process'
 import { log } from '@clack/prompts'
-import { Table } from '@sauber/table'
 import { difference, parse } from '@std/semver'
 import { trackEvent } from '../analytics/track'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import { formatTable } from '../terminal-table'
 import {
   checkCompatibilityCloud,
   createSupabaseClient,
@@ -205,29 +205,27 @@ export function formatShortBuildNeeded(required: boolean): string {
 
 export function formatBuildNeededTable(finalCompatibility: Compatibility[], options: FormatOptions = {}): string {
   const color = options.color ?? shouldUseColor()
-  const table = new Table()
-  table.headers = ['Package', 'Current app', 'Local', 'Change', 'Native diff', 'Required']
-  table.theme = Table.roundTheme
-  table.rows = []
-
-  for (const entry of sortCompatibility(finalCompatibility)) {
+  const rows = sortCompatibility(finalCompatibility).map((entry) => {
     const change = getVersionChangeType(entry)
     const details = getCompatibilityDetails(entry)
     const required = !details.compatible
     const nativeDiff = getNativeDiffLabel(entry)
     const changeColor = colorForVersionChange(change)
 
-    table.rows.push([
+    return [
       entry.name,
       entry.remoteVersion || '-',
       entry.localVersion || '-',
       colorize(change, changeColor, color),
       nativeDiff === '-' ? nativeDiff : colorize(nativeDiff, 'red', color),
       required ? colorize('yes', 'red', color) : colorize('no', 'green', color),
-    ])
-  }
+    ]
+  })
 
-  return table.toString()
+  return formatTable({
+    headers: ['Package', 'Current app', 'Local', 'Change', 'Native diff', 'Required'],
+    rows,
+  })
 }
 
 export function formatVerboseBuildNeeded(

--- a/cli/src/bundle/builder-cta.ts
+++ b/cli/src/bundle/builder-cta.ts
@@ -126,9 +126,9 @@ async function runBuilderCta(params: MaybePromptBuilderCtaParams): Promise<Build
       message: question,
       initialValue: 'yes',
       options: [
-        { value: 'yes', label: 'yes' },
-        { value: 'no', label: 'no' },
-        { value: 'learn', label: 'learn what Capgo Builder is' },
+        { value: 'yes', label: '✅ Yes' },
+        { value: 'no', label: '❌ No' },
+        { value: 'learn', label: '📖 Learn what Capgo Builder is' },
       ],
     })
 

--- a/cli/src/bundle/builder-cta.ts
+++ b/cli/src/bundle/builder-cta.ts
@@ -1,4 +1,5 @@
-import { confirm as pConfirm, isCancel as pIsCancel, log } from '@clack/prompts'
+import { isCancel as pIsCancel, log, select as pSelect } from '@clack/prompts'
+import open from 'open'
 import { trackEvent } from '../analytics/track'
 
 export type BuilderCtaSurface = 'skip' | 'ci-ad' | 'prompt-onboarding' | 'prompt-build'
@@ -31,17 +32,6 @@ const LEARN_URL = 'https://capgo.app/native-build/'
 // Why a native build is needed — folded into the prompt and the CI ad.
 const REASON = 'This update includes native changes. An app store update may be required for these changes to take effect. Capgo Builder can help you build and publish the required native update.'
 
-/**
- * Render a clickable terminal hyperlink (OSC 8). Clicking it opens the URL in the
- * browser **without dismissing the active prompt**. Terminals that don't support
- * OSC 8 just render `text`.
- */
-function terminalLink(text: string, url: string): string {
-  const ESC = String.fromCharCode(27) // \x1B
-  const BEL = String.fromCharCode(7) // \x07
-  return `${ESC}]8;;${url}${BEL}${text}${ESC}]8;;${BEL}`
-}
-
 export function printBuilderCiAd(hasCredentials: boolean): void {
   const action = hasCredentials
     ? 'run a native build (npx @capgo/cli build request --platform <ios|android>)'
@@ -49,8 +39,21 @@ export function printBuilderCiAd(hasCredentials: boolean): void {
   log.warn(`${REASON} To ${action} — learn more: ${LEARN_URL} · docs: ${DOCS_URL}`)
 }
 
-/** Confirm-prompt seam (`@clack/prompts` `confirm` satisfies it); injectable for tests. */
-export type BuilderConfirm = (opts: { message: string, initialValue?: boolean }) => Promise<boolean | symbol>
+export type BuilderCtaChoice = 'yes' | 'no' | 'learn'
+
+interface BuilderSelectOption {
+  value: BuilderCtaChoice
+  label: string
+}
+
+interface BuilderSelectOptions {
+  message: string
+  options: BuilderSelectOption[]
+  initialValue?: BuilderCtaChoice
+}
+
+/** Select-prompt seam (`@clack/prompts` `select` satisfies it); injectable for tests. */
+export type BuilderSelect = (opts: BuilderSelectOptions) => Promise<BuilderCtaChoice | symbol>
 
 export interface MaybePromptBuilderCtaParams {
   incompatible: boolean
@@ -61,8 +64,10 @@ export interface MaybePromptBuilderCtaParams {
   orgId: string
   apikey: string
   incompatibleCount: number
-  /** Injectable for tests; defaults to the `@clack/prompts` confirm prompt. */
-  confirm?: BuilderConfirm
+  /** Injectable for tests; defaults to the `@clack/prompts` select prompt. */
+  select?: BuilderSelect
+  /** Injectable for tests; defaults to opening the learn page in the browser. */
+  openUrl?: (url: string) => Promise<unknown>
 }
 
 /**
@@ -110,25 +115,45 @@ async function runBuilderCta(params: MaybePromptBuilderCtaParams): Promise<Build
   // Message 1: the context, printed above the prompt so the question stays short.
   log.info(REASON)
 
-  // Message 2: the short yes/no question, plus a clickable "learn more" hyperlink
-  // that opens in the browser without dismissing this prompt.
-  const confirm = params.confirm ?? pConfirm
+  const select = params.select ?? ((opts: BuilderSelectOptions) => pSelect<BuilderCtaChoice>(opts))
+  const openUrl = params.openUrl ?? open
   const question = mode === 'build'
     ? 'Start a native build with Capgo Builder now?'
     : 'Would you like to configure Capgo Builder now?'
-  const accepted = await confirm({
-    message: `${question}\n${terminalLink('Learn what Capgo Builder is', LEARN_URL)}`,
-    initialValue: true,
-  })
-  if (pIsCancel(accepted))
+
+  while (true) {
+    const choice = await select({
+      message: question,
+      initialValue: 'yes',
+      options: [
+        { value: 'yes', label: 'yes' },
+        { value: 'no', label: 'no' },
+        { value: 'learn', label: 'learn what Capgo Builder is' },
+      ],
+    })
+
+    if (pIsCancel(choice))
+      return 'continue'
+
+    if (choice === 'learn') {
+      void trackEvent({ channel: 'bundle', event: 'Builder CTA Learn Selected', icon: '📖', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })
+      log.info(`Learn more: ${LEARN_URL}`)
+      try {
+        await openUrl(LEARN_URL)
+      }
+      catch {
+        log.warn(`Could not open your browser automatically. Visit: ${LEARN_URL}`)
+      }
+      continue
+    }
+
+    if (choice === 'yes') {
+      void trackEvent({ channel: 'bundle', event: 'Builder CTA Accepted', icon: '✅', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })
+      return mode === 'build' ? 'launch-build' : 'launch-onboarding'
+    }
+
+    // Declined → just continue the OTA upload (no follow-up prompt).
+    void trackEvent({ channel: 'bundle', event: 'Builder CTA Declined', icon: '🚫', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })
     return 'continue'
-
-  if (accepted === true) {
-    void trackEvent({ channel: 'bundle', event: 'Builder CTA Accepted', icon: '✅', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })
-    return mode === 'build' ? 'launch-build' : 'launch-onboarding'
   }
-
-  // Declined → just continue the OTA upload (no follow-up prompt).
-  void trackEvent({ channel: 'bundle', event: 'Builder CTA Declined', icon: '🚫', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })
-  return 'continue'
 }

--- a/cli/src/bundle/builder-cta.ts
+++ b/cli/src/bundle/builder-cta.ts
@@ -3,7 +3,7 @@ import open from 'open'
 import { trackEvent } from '../analytics/track'
 
 export type BuilderCtaSurface = 'skip' | 'ci-ad' | 'prompt-onboarding' | 'prompt-build'
-export type BuilderCtaAction = 'continue' | 'launch-onboarding' | 'launch-build'
+export type BuilderCtaAction = 'continue' | 'abort' | 'launch-onboarding' | 'launch-build'
 
 export interface BuilderCtaContext {
   incompatible: boolean
@@ -133,7 +133,7 @@ async function runBuilderCta(params: MaybePromptBuilderCtaParams): Promise<Build
     })
 
     if (pIsCancel(choice))
-      return 'continue'
+      return 'abort'
 
     if (choice === 'learn') {
       void trackEvent({ channel: 'bundle', event: 'Builder CTA Learn Selected', icon: '📖', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })

--- a/cli/src/bundle/builder-cta.ts
+++ b/cli/src/bundle/builder-cta.ts
@@ -137,7 +137,6 @@ async function runBuilderCta(params: MaybePromptBuilderCtaParams): Promise<Build
 
     if (choice === 'learn') {
       void trackEvent({ channel: 'bundle', event: 'Builder CTA Learn Selected', icon: '📖', apikey: params.apikey, appId: params.appId, orgId: params.orgId, tags: { mode } })
-      log.info(`Learn more: ${LEARN_URL}`)
       try {
         await openUrl(LEARN_URL)
       }

--- a/cli/src/bundle/compatibility.ts
+++ b/cli/src/bundle/compatibility.ts
@@ -1,9 +1,9 @@
 import type { BundleCompatibilityOptions } from '../schemas/bundle'
 import type { Compatibility } from '../utils'
 import { intro, log } from '@clack/prompts'
-import { Table } from '@sauber/table'
 import { trackEvent } from '../analytics/track'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import { formatTable } from '../terminal-table'
 import {
   checkCompatibilityCloud,
   createSupabaseClient,
@@ -94,29 +94,24 @@ export async function checkCompatibilityInternal(
   })
 
   if (!silent) {
-    const table = new Table()
-    table.headers = ['Package', 'Local', 'Remote', 'Status', 'Details']
-    table.theme = Table.roundTheme
-    table.rows = []
-
     const yesSymbol = enrichedOptions.text ? 'OK' : '✅'
     const noSymbol = enrichedOptions.text ? 'FAIL' : '❌'
-
-    for (const entry of compatibility.finalCompatibility) {
-      const { name, localVersion, remoteVersion } = entry
+    const rows = compatibility.finalCompatibility.map((entry) => {
       const details = getCompatibilityDetails(entry)
-      const statusSymbol = details.compatible ? yesSymbol : noSymbol
-      table.rows.push([
-        name,
-        localVersion || '-',
-        remoteVersion || '-',
-        statusSymbol,
+      return [
+        entry.name,
+        entry.localVersion || '-',
+        entry.remoteVersion || '-',
+        details.compatible ? yesSymbol : noSymbol,
         details.message,
-      ])
-    }
+      ]
+    })
 
     log.success('Compatibility Check Results')
-    log.info(table.toString())
+    log.info(formatTable({
+      headers: ['Package', 'Local', 'Remote', 'Status', 'Details'],
+      rows,
+    }))
 
     // Summary
     if (hasIncompatible) {

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -9,7 +9,6 @@ import { existsSync, readFileSync } from 'node:fs'
 import { cwd } from 'node:process'
 import { S3Client } from '@bradenmacdonald/s3-lite-client'
 import { intro, log, outro, confirm as pConfirm, isCancel as pIsCancel, select as pSelect, spinner as spinnerC } from '@clack/prompts'
-import { Table } from '@sauber/table'
 import { greaterOrEqual, parse } from '@std/semver'
 // Native fetch is available in Node.js >= 18
 import pack from '../../package.json'
@@ -22,6 +21,7 @@ import { getChecksum } from '../checksum'
 import { getRepoStarStatus, isRepoStarredInSession, starRepository } from '../github'
 import { confirmWithRememberedChoice } from '../promptPreferences'
 import { showReplicationProgress } from '../replicationProgress'
+import { formatTable } from '../terminal-table'
 import { usesAlwaysDirectUpdate } from '../updaterConfig'
 import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasCliPermission, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
@@ -55,25 +55,21 @@ async function persistVersionData(
  * Display a compatibility table for the given packages
  */
 function displayCompatibilityTable(packages: Compatibility[]) {
-  const table = new Table()
-  table.headers = ['Package', 'Local', 'Remote', 'Status', 'Details']
-  table.theme = Table.roundTheme
-  table.rows = []
-
-  for (const entry of packages) {
-    const { name, localVersion, remoteVersion } = entry
+  const rows = packages.map((entry) => {
     const details = getCompatibilityDetails(entry)
-    const statusSymbol = details.compatible ? '✅' : '❌'
-    table.rows.push([
-      name,
-      localVersion || '-',
-      remoteVersion || '-',
-      statusSymbol,
+    return [
+      entry.name,
+      entry.localVersion || '-',
+      entry.remoteVersion || '-',
+      details.compatible ? '✅' : '❌',
       details.message,
-    ])
-  }
+    ]
+  })
 
-  log.info(table.toString())
+  log.info(formatTable({
+    headers: ['Package', 'Local', 'Remote', 'Status', 'Details'],
+    rows,
+  }))
 }
 
 async function getBundle(config: CapacitorConfig, options: OptionsUpload) {

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -36,6 +36,8 @@ type localConfigType = Awaited<ReturnType<typeof getLocalConfig>>
 
 export type { UploadBundleResult }
 
+const UPLOAD_CANCELLED_BY_USER = 'Upload cancelled by user'
+
 function uploadFail(message: string): never {
   log.error(message)
   throw new Error(message)
@@ -909,6 +911,9 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   if (incompatible && !silent) {
     const hasCredentials = (await loadSavedCredentials(appid)) !== null
     const builderAction = await maybePromptBuilderCta({ incompatible, interactive, hasCredentials, appId: appid, orgId, apikey, incompatibleCount })
+    if (builderAction === 'abort')
+      throw new Error(UPLOAD_CANCELLED_BY_USER)
+
     if (builderAction !== 'continue') {
       // Skip the OTA upload and hand the launch back to the CLI entry point, which
       // runs the Ink-based build commands. Doing it here would pull `ink` into the
@@ -1513,6 +1518,9 @@ export async function uploadBundle(appid: string, options: OptionsUpload) {
     // Show simple message by default, full error details only with --verbose
     const simpleMessage = error instanceof Error ? error.message : String(error)
     const verboseMessage = formatError(error)
+
+    if (simpleMessage === UPLOAD_CANCELLED_BY_USER)
+      throw error instanceof Error ? error : new Error(String(error))
 
     if (options.verbose) {
       log.error(`uploadBundle failed:${verboseMessage}`)

--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -2,8 +2,8 @@ import type { OptionsSetChannel } from '../schemas/channel'
 import type { Database } from '../types/supabase.types'
 import type { Compatibility } from '../utils'
 import { intro, log, outro } from '@clack/prompts'
-import { Table } from '@sauber/table'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
+import { formatTable } from '../terminal-table'
 import {
   checkCompatibilityNativePackages,
   checkPlanValid,
@@ -25,25 +25,21 @@ import {
  * Display a compatibility table for the given packages
  */
 function displayCompatibilityTable(packages: Compatibility[]) {
-  const table = new Table()
-  table.headers = ['Package', 'Local', 'Remote', 'Status', 'Details']
-  table.theme = Table.roundTheme
-  table.rows = []
-
-  for (const entry of packages) {
-    const { name, localVersion, remoteVersion } = entry
+  const rows = packages.map((entry) => {
     const details = getCompatibilityDetails(entry)
-    const statusSymbol = details.compatible ? '✅' : '❌'
-    table.rows.push([
-      name,
-      localVersion || '-',
-      remoteVersion || '-',
-      statusSymbol,
+    return [
+      entry.name,
+      entry.localVersion || '-',
+      entry.remoteVersion || '-',
+      details.compatible ? '✅' : '❌',
       details.message,
-    ])
-  }
+    ]
+  })
 
-  log.info(table.toString())
+  log.info(formatTable({
+    headers: ['Package', 'Local', 'Remote', 'Status', 'Details'],
+    rows,
+  }))
 }
 
 export type { OptionsSetChannel } from '../schemas/channel'

--- a/cli/src/terminal-table.ts
+++ b/cli/src/terminal-table.ts
@@ -1,0 +1,108 @@
+const ESC = '\\u001B'
+const BEL = '\\u0007'
+const ANSI_PATTERN = new RegExp(`${ESC}(?:\\[[0-?]*[ -/]*[@-~]|\\][^${BEL}]*(?:${BEL}|${ESC}\\\\)|[@-Z\\\\-_])`, 'g')
+const MARK_PATTERN = /\p{Mark}/u
+
+export type TableCell = string | number | boolean | null | undefined
+
+export interface FormatTableOptions {
+  headers?: TableCell[]
+  rows: TableCell[][]
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, '')
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x1100
+    && (
+      codePoint <= 0x115F
+      || codePoint === 0x2329
+      || codePoint === 0x232A
+      || (codePoint >= 0x2600 && codePoint <= 0x27BF)
+      || (codePoint >= 0x2E80 && codePoint <= 0xA4CF && codePoint !== 0x303F)
+      || (codePoint >= 0xAC00 && codePoint <= 0xD7A3)
+      || (codePoint >= 0xF900 && codePoint <= 0xFAFF)
+      || (codePoint >= 0xFE10 && codePoint <= 0xFE19)
+      || (codePoint >= 0xFE30 && codePoint <= 0xFE6F)
+      || (codePoint >= 0xFF00 && codePoint <= 0xFF60)
+      || (codePoint >= 0xFFE0 && codePoint <= 0xFFE6)
+      || (codePoint >= 0x1F000 && codePoint <= 0x1FAFF)
+    )
+  )
+}
+
+export function visibleWidth(value: string): number {
+  let width = 0
+
+  for (const char of stripAnsi(value)) {
+    const codePoint = char.codePointAt(0)
+    if (!codePoint)
+      continue
+
+    if (codePoint <= 0x1F || (codePoint >= 0x7F && codePoint <= 0x9F))
+      continue
+    if (codePoint === 0x200D || (codePoint >= 0xFE00 && codePoint <= 0xFE0F) || MARK_PATTERN.test(char))
+      continue
+
+    width += isWideCodePoint(codePoint) ? 2 : 1
+  }
+
+  return width
+}
+
+function cellToString(cell: TableCell): string {
+  if (cell == null)
+    return ''
+
+  return String(cell)
+}
+
+function padEndVisible(value: string, width: number): string {
+  const padding = width - visibleWidth(value)
+  return padding > 0 ? `${value}${' '.repeat(padding)}` : value
+}
+
+function bold(value: string): string {
+  return `\x1B[1m${value}\x1B[0m`
+}
+
+export function formatTable({ headers = [], rows }: FormatTableOptions): string {
+  const normalizedHeaders = headers.map(cellToString)
+  const normalizedRows = rows.map(row => row.map(cellToString))
+  const content = [
+    ...(normalizedHeaders.length ? [normalizedHeaders] : []),
+    ...normalizedRows,
+  ]
+
+  if (!content.length)
+    return ''
+
+  const columnCount = Math.max(...content.map(row => row.length))
+  const widths = Array.from({ length: columnCount }, (_, index) =>
+    Math.max(...content.map(row => visibleWidth(row[index] ?? ''))),
+  )
+
+  const renderLine = (left: string, middle: string, right: string) =>
+    `${left}${widths.map(width => '─'.repeat(width)).join(middle)}${right}`
+
+  const renderRow = (row: string[], header = false) =>
+    `│ ${widths.map((width, index) => {
+      const value = row[index] ?? ''
+      return padEndVisible(header ? bold(value) : value, width)
+    }).join(' │ ')} │`
+
+  return [
+    renderLine('╭─', '─┬─', '─╮'),
+    ...(normalizedHeaders.length
+      ? [
+          renderRow(normalizedHeaders, true),
+          ...(normalizedRows.length ? [renderLine('├─', '─┼─', '─┤')] : []),
+        ]
+      : []),
+    ...normalizedRows.map(row => renderRow(row)),
+    renderLine('╰─', '─┴─', '─╯'),
+  ].join('\n')
+}

--- a/cli/test/test-build-needed.mjs
+++ b/cli/test/test-build-needed.mjs
@@ -13,6 +13,7 @@ const {
   isBuildNeeded,
   selectDefaultChannelName,
 } = await import('../src/build/needed.ts')
+const { formatTable, visibleWidth } = await import('../src/terminal-table.ts')
 
 let failures = 0
 
@@ -142,6 +143,19 @@ await test('formats verbose table with version-change color coding', () => {
   assert.match(output, /\x1B\[31mmajor\x1B\[0m/)
   assert.match(output, /\x1B\[33mminor\x1B\[0m/)
   assert.match(output, /\x1B\[32mpatch\x1B\[0m/)
+})
+
+await test('formats table borders around emoji and ansi cells', () => {
+  const output = formatTable({
+    headers: ['Package', 'Status', 'Details'],
+    rows: [
+      ['@capacitor/android', '❌', 'version changed: 8.1.0 → 0.1.0'],
+      ['@capacitor/ios', '✅', '\x1B[32mCompatible\x1B[0m'],
+    ],
+  })
+
+  const lineWidths = output.split('\n').map(line => visibleWidth(line))
+  assert.deepEqual([...new Set(lineWidths)], [lineWidths[0]])
 })
 
 if (failures > 0) {

--- a/tests/builder-cta.unit.test.ts
+++ b/tests/builder-cta.unit.test.ts
@@ -36,35 +36,50 @@ describe('decideBuilderCtaSurface', () => {
 
 describe('maybePromptBuilderCta', () => {
   it.concurrent('returns continue when compatible', async () => {
-    const confirm = vi.fn()
-    expect(await maybePromptBuilderCta({ ...baseParams, incompatible: false, confirm })).toBe('continue')
-    expect(confirm).not.toHaveBeenCalled()
+    const select = vi.fn()
+    expect(await maybePromptBuilderCta({ ...baseParams, incompatible: false, select })).toBe('continue')
+    expect(select).not.toHaveBeenCalled()
   })
 
-  it.concurrent('launches onboarding on accept (no credentials) with a single prompt + learn link', async () => {
-    const confirm = vi.fn().mockResolvedValue(true)
-    expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: false, confirm })).toBe('launch-onboarding')
-    expect(confirm).toHaveBeenCalledTimes(1)
-    const msg = confirm.mock.calls[0][0].message as string
+  it.concurrent('launches onboarding on yes (no credentials) with a selector and learn option', async () => {
+    const select = vi.fn().mockResolvedValue('yes')
+    expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: false, select })).toBe('launch-onboarding')
+    expect(select).toHaveBeenCalledTimes(1)
+    const msg = select.mock.calls[0][0].message as string
     expect(msg).toContain('Would you like to configure Capgo Builder now?')
-    expect(msg).toContain('https://capgo.app/native-build/')
+    expect(select.mock.calls[0][0].options).toEqual([
+      { value: 'yes', label: 'yes' },
+      { value: 'no', label: 'no' },
+      { value: 'learn', label: 'learn what Capgo Builder is' },
+    ])
   })
 
   it.concurrent('launches build on accept (credentials present) with the build question', async () => {
-    const confirm = vi.fn().mockResolvedValue(true)
-    expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: true, confirm })).toBe('launch-build')
-    expect(confirm.mock.calls[0][0].message as string).toContain('Start a native build with Capgo Builder now?')
+    const select = vi.fn().mockResolvedValue('yes')
+    expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: true, select })).toBe('launch-build')
+    expect(select.mock.calls[0][0].message as string).toContain('Start a native build with Capgo Builder now?')
   })
 
-  it.concurrent('continues on decline without a second prompt', async () => {
-    const confirm = vi.fn().mockResolvedValue(false)
-    expect(await maybePromptBuilderCta({ ...baseParams, confirm })).toBe('continue')
-    expect(confirm).toHaveBeenCalledTimes(1)
+  it.concurrent('continues on no without a second prompt', async () => {
+    const select = vi.fn().mockResolvedValue('no')
+    expect(await maybePromptBuilderCta({ ...baseParams, select })).toBe('continue')
+    expect(select).toHaveBeenCalledTimes(1)
+  })
+
+  it.concurrent('opens the learn page and asks again', async () => {
+    const select = vi.fn()
+      .mockResolvedValueOnce('learn')
+      .mockResolvedValueOnce('no')
+    const openUrl = vi.fn().mockResolvedValue(undefined)
+
+    expect(await maybePromptBuilderCta({ ...baseParams, select, openUrl })).toBe('continue')
+    expect(openUrl).toHaveBeenCalledWith('https://capgo.app/native-build/')
+    expect(select).toHaveBeenCalledTimes(2)
   })
 
   it.concurrent('shows the CI ad and continues when non-interactive', async () => {
-    const confirm = vi.fn()
-    expect(await maybePromptBuilderCta({ ...baseParams, interactive: false, confirm })).toBe('continue')
-    expect(confirm).not.toHaveBeenCalled()
+    const select = vi.fn()
+    expect(await maybePromptBuilderCta({ ...baseParams, interactive: false, select })).toBe('continue')
+    expect(select).not.toHaveBeenCalled()
   })
 })

--- a/tests/builder-cta.unit.test.ts
+++ b/tests/builder-cta.unit.test.ts
@@ -92,9 +92,9 @@ describe('maybePromptBuilderCta', () => {
     const msg = select.mock.calls[0][0].message as string
     expect(msg).toContain('Would you like to configure Capgo Builder now?')
     expect(select.mock.calls[0][0].options).toEqual([
-      { value: 'yes', label: 'yes' },
-      { value: 'no', label: 'no' },
-      { value: 'learn', label: 'learn what Capgo Builder is' },
+      { value: 'yes', label: '✅ Yes' },
+      { value: 'no', label: '❌ No' },
+      { value: 'learn', label: '📖 Learn what Capgo Builder is' },
     ])
   })
 

--- a/tests/builder-cta.unit.test.ts
+++ b/tests/builder-cta.unit.test.ts
@@ -110,11 +110,11 @@ describe('maybePromptBuilderCta', () => {
     expect(select).toHaveBeenCalledTimes(1)
   })
 
-  it('continues when the selector is cancelled', async () => {
+  it('aborts when the selector is cancelled', async () => {
     const cancelChoice = await getClackCancelSymbol()
     const select = vi.fn().mockResolvedValue(cancelChoice)
 
-    expect(await maybePromptBuilderCta({ ...baseParams, select })).toBe('continue')
+    expect(await maybePromptBuilderCta({ ...baseParams, select })).toBe('abort')
     expect(select).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/builder-cta.unit.test.ts
+++ b/tests/builder-cta.unit.test.ts
@@ -1,7 +1,8 @@
+import { PassThrough, Writable } from 'node:stream'
 import { describe, expect, it, vi } from 'vitest'
 
 // trackEvent is fire-and-forget (void) and never asserted, so a shared module
-// mock is safe under concurrent execution. Everything else (confirm,
+// mock is safe under concurrent execution. Everything else (select, openUrl,
 // hasCredentials) is passed per-test, so there is no shared mutable state.
 vi.mock('../cli/src/analytics/track.ts', () => ({ trackEvent: vi.fn() }))
 
@@ -16,6 +17,49 @@ const baseParams = {
   orgId: 'org1',
   apikey: 'k',
   incompatibleCount: 2,
+}
+
+const learnUrl = 'https://capgo.app/native-build/'
+
+interface CliClackPrompts {
+  isCancel: (value: unknown) => boolean
+  log: {
+    warn: (message: string) => void
+  }
+  select: <Value>(opts: {
+    message: string
+    options: { value: Value, label: string }[]
+    signal: AbortSignal
+    input: PassThrough
+    output: Writable
+  }) => Promise<Value | symbol>
+}
+
+let cliClackPrompts: Promise<CliClackPrompts> | undefined
+
+function getCliClackPrompts(): Promise<CliClackPrompts> {
+  cliClackPrompts ??= import(new URL('../cli/node_modules/@clack/prompts', import.meta.url).href) as Promise<CliClackPrompts>
+  return cliClackPrompts
+}
+
+async function getClackCancelSymbol(): Promise<symbol> {
+  const { isCancel, select } = await getCliClackPrompts()
+  const input = new PassThrough()
+  const output = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    },
+  })
+
+  const choice = await select({
+    message: 'Cancel fixture',
+    options: [{ value: 'yes', label: 'yes' }],
+    signal: AbortSignal.abort(),
+    input,
+    output,
+  })
+  expect(isCancel(choice)).toBe(true)
+  return choice as symbol
 }
 
 describe('decideBuilderCtaSurface', () => {
@@ -35,13 +79,13 @@ describe('decideBuilderCtaSurface', () => {
 })
 
 describe('maybePromptBuilderCta', () => {
-  it.concurrent('returns continue when compatible', async () => {
+  it('returns continue when compatible', async () => {
     const select = vi.fn()
     expect(await maybePromptBuilderCta({ ...baseParams, incompatible: false, select })).toBe('continue')
     expect(select).not.toHaveBeenCalled()
   })
 
-  it.concurrent('launches onboarding on yes (no credentials) with a selector and learn option', async () => {
+  it('launches onboarding on yes (no credentials) with a selector and learn option', async () => {
     const select = vi.fn().mockResolvedValue('yes')
     expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: false, select })).toBe('launch-onboarding')
     expect(select).toHaveBeenCalledTimes(1)
@@ -54,30 +98,68 @@ describe('maybePromptBuilderCta', () => {
     ])
   })
 
-  it.concurrent('launches build on accept (credentials present) with the build question', async () => {
+  it('launches build on accept (credentials present) with the build question', async () => {
     const select = vi.fn().mockResolvedValue('yes')
     expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: true, select })).toBe('launch-build')
     expect(select.mock.calls[0][0].message as string).toContain('Start a native build with Capgo Builder now?')
   })
 
-  it.concurrent('continues on no without a second prompt', async () => {
+  it('continues on no without a second prompt', async () => {
     const select = vi.fn().mockResolvedValue('no')
     expect(await maybePromptBuilderCta({ ...baseParams, select })).toBe('continue')
     expect(select).toHaveBeenCalledTimes(1)
   })
 
-  it.concurrent('opens the learn page and asks again', async () => {
+  it('continues when the selector is cancelled', async () => {
+    const cancelChoice = await getClackCancelSymbol()
+    const select = vi.fn().mockResolvedValue(cancelChoice)
+
+    expect(await maybePromptBuilderCta({ ...baseParams, select })).toBe('continue')
+    expect(select).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the learn page and asks again', async () => {
     const select = vi.fn()
       .mockResolvedValueOnce('learn')
       .mockResolvedValueOnce('no')
     const openUrl = vi.fn().mockResolvedValue(undefined)
 
     expect(await maybePromptBuilderCta({ ...baseParams, select, openUrl })).toBe('continue')
-    expect(openUrl).toHaveBeenCalledWith('https://capgo.app/native-build/')
+    expect(openUrl).toHaveBeenCalledWith(learnUrl)
     expect(select).toHaveBeenCalledTimes(2)
   })
 
-  it.concurrent('shows the CI ad and continues when non-interactive', async () => {
+  it('opens the learn page before launching a build on yes', async () => {
+    const select = vi.fn()
+      .mockResolvedValueOnce('learn')
+      .mockResolvedValueOnce('yes')
+    const openUrl = vi.fn().mockResolvedValue(undefined)
+
+    expect(await maybePromptBuilderCta({ ...baseParams, hasCredentials: true, select, openUrl })).toBe('launch-build')
+    expect(openUrl).toHaveBeenCalledWith(learnUrl)
+    expect(select).toHaveBeenCalledTimes(2)
+  })
+
+  it('warns and asks again when opening the learn page fails', async () => {
+    const select = vi.fn()
+      .mockResolvedValueOnce('learn')
+      .mockResolvedValueOnce('yes')
+    const openUrl = vi.fn().mockRejectedValue(new Error('browser unavailable'))
+    const { log } = await getCliClackPrompts()
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => {})
+
+    try {
+      expect(await maybePromptBuilderCta({ ...baseParams, select, openUrl })).toBe('launch-onboarding')
+      expect(openUrl).toHaveBeenCalledWith(learnUrl)
+      expect(warn).toHaveBeenCalledWith(`Could not open your browser automatically. Visit: ${learnUrl}`)
+      expect(select).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('shows the CI ad and continues when non-interactive', async () => {
     const select = vi.fn()
     expect(await maybePromptBuilderCta({ ...baseParams, interactive: false, select })).toBe('continue')
     expect(select).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary (AI generated)

- Replaced the Capgo Builder CTA confirm prompt with a three-option selector: yes, no, and learn what Capgo Builder is.
- Changed the learn path to open the Builder page in the browser and then return to the selector.
- Added a width-aware CLI table formatter and used it for compatibility/build-needed tables so emoji and ANSI styling keep borders aligned.

## Motivation (AI generated)

The Builder CTA prompt rendered the learn option as broken prompt text/link behavior instead of as a selectable action. Compatibility tables also misaligned when status cells used emoji because the previous table renderer measured displayed width incorrectly.

## Business Impact (AI generated)

This improves CLI onboarding for Capgo Builder and avoids confusing, broken terminal output during native compatibility checks. Cleaner Builder discovery and compatibility output should reduce friction for users who need native builds after OTA-incompatible changes.

## Test Plan (AI generated)

- [x] `bun test tests/builder-cta.unit.test.ts`
- [x] `bun run test:build-needed`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:mcp`
- [x] `bun run test:bundle`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Builder setup prompt now uses a selectable "yes / no / learn" flow that can open native-build docs and re-prompts after "learn".

* **Improvements**
  * Replaced legacy table rendering with a terminal-friendly table formatter for consistent alignment, Unicode/emoji-aware sizing, and cleaner output.
  * CTA behavior simplified for clearer interactive prompts and consistent non-interactive messaging.

* **Tests**
  * Added/updated tests for table rendering (emoji/ANSI) and the new select-driven CTA flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->