### PR TITLE
fix(db): allow API key org status RPCs

### DIFF
--- a/supabase/migrations/20260601101710_allow_apikey_org_status_rpcs.sql
+++ b/supabase/migrations/20260601101710_allow_apikey_org_status_rpcs.sql
@@ -1,0 +1,13 @@
+-- The CLI uses the Supabase anon key and authenticates Capgo access with the
+-- capgkey request header. These status RPCs already perform org-scoped read
+-- checks via request_has_org_read_access(), so anon needs EXECUTE permission for
+-- valid API-key callers to receive trial warning context.
+REVOKE ALL ON FUNCTION "public"."is_paying_org"("orgid" "uuid") FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."is_paying_org"("orgid" "uuid") TO "anon";
+GRANT EXECUTE ON FUNCTION "public"."is_paying_org"("orgid" "uuid") TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."is_paying_org"("orgid" "uuid") TO "service_role";
+
+REVOKE ALL ON FUNCTION "public"."is_trial_org"("orgid" "uuid") FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."is_trial_org"("orgid" "uuid") TO "anon";
+GRANT EXECUTE ON FUNCTION "public"."is_trial_org"("orgid" "uuid") TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."is_trial_org"("orgid" "uuid") TO "service_role";

--- a/supabase/tests/46_test_org_status_rpcs.sql
+++ b/supabase/tests/46_test_org_status_rpcs.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(12);
+SELECT plan(18);
 
 -- Member of admin org can read billing/trial RPCs
 SELECT tests.authenticate_as('test_admin');
@@ -37,7 +37,11 @@ SELECT
     );
 
 -- Non-member should be denied by org authorization checks
-SELECT tests.authenticate_as('test_user');
+SELECT tests.create_supabase_user(
+    'org_status_non_member',
+    'org_status_non_member@test.local'
+);
+SELECT tests.authenticate_as('org_status_non_member');
 
 SELECT
     is(
@@ -63,8 +67,16 @@ SELECT
         'is_paying_and_good_plan_org_action - non-member org user gets false'
     );
 
--- Anonymous user should not have execute permission
+-- Anonymous API-key callers should be able to execute these RPCs, but the
+-- function bodies still gate the result through request_has_org_read_access().
 SELECT tests.clear_authentication();
+DO $$
+BEGIN
+    PERFORM set_config('request.jwt.claims', '{}', true);
+    PERFORM set_config('request.jwt.claim.sub', '', true);
+    PERFORM set_config('request.jwt.claim.role', 'anon', true);
+    PERFORM set_config('request.headers', '{}', true);
+END $$;
 
 SELECT
     is(
@@ -73,8 +85,8 @@ SELECT
             'public.is_paying_org(uuid)'::regprocedure,
             'EXECUTE'
         ),
-        false,
-        'is_paying_org - anonymous execute is blocked'
+        true,
+        'is_paying_org - anonymous execute is allowed for API-key CLI callers'
     );
 
 SELECT
@@ -84,8 +96,79 @@ SELECT
             'public.is_trial_org(uuid)'::regprocedure,
             'EXECUTE'
         ),
+        true,
+        'is_trial_org - anonymous execute is allowed for API-key CLI callers'
+    );
+
+DO $$
+BEGIN
+    PERFORM set_config('request.headers', '{"capgkey": "ae6e7458-c46d-4c00-aa3b-153b0b8520ea"}', true);
+END $$;
+
+SELECT
+    is(
+        is_paying_org('046a36ac-e03c-4590-9257-bd6c9dba9ee8'),
+        (
+            SELECT EXISTS (
+                SELECT 1
+                FROM public.stripe_info
+                WHERE customer_id = 'cus_Q38uE91NP8Ufqc'
+                    AND status = 'succeeded'
+            )
+        ),
+        'is_paying_org - anonymous API-key caller can read its own org paying state'
+    );
+
+SELECT
+    is(
+        public.is_trial_org('046a36ac-e03c-4590-9257-bd6c9dba9ee8'),
+        (
+            SELECT COALESCE(
+                GREATEST((trial_at::date - CURRENT_DATE), 0),
+                0
+            )::integer
+            FROM public.stripe_info
+            WHERE customer_id = 'cus_Q38uE91NP8Ufqc'
+        ),
+        'is_trial_org - anonymous API-key caller can read its own org trial days'
+    );
+
+DO $$
+BEGIN
+    PERFORM set_config('request.headers', '{"capgkey": "invalid-key"}', true);
+END $$;
+
+SELECT
+    is(
+        is_paying_org('046a36ac-e03c-4590-9257-bd6c9dba9ee8'),
         false,
-        'is_trial_org - anonymous execute is blocked'
+        'is_paying_org - anonymous invalid API key gets false'
+    );
+
+SELECT
+    is(
+        public.is_trial_org('046a36ac-e03c-4590-9257-bd6c9dba9ee8'),
+        0,
+        'is_trial_org - anonymous invalid API key gets 0'
+    );
+
+DO $$
+BEGIN
+    PERFORM set_config('request.headers', '{}', true);
+END $$;
+
+SELECT
+    is(
+        is_paying_org('046a36ac-e03c-4590-9257-bd6c9dba9ee8'),
+        false,
+        'is_paying_org - anonymous caller without API key gets false'
+    );
+
+SELECT
+    is(
+        public.is_trial_org('046a36ac-e03c-4590-9257-bd6c9dba9ee8'),
+        0,
+        'is_trial_org - anonymous caller without API key gets 0'
     );
 
 SELECT
@@ -100,6 +183,12 @@ SELECT
 
 -- service role keeps backend-style access
 SELECT tests.authenticate_as_service_role();
+DO $$
+BEGIN
+    PERFORM set_config('request.jwt.claim.role', 'service_role', true);
+    PERFORM set_config('request.jwt.claim.sub', '', true);
+    PERFORM set_config('request.headers', '{}', true);
+END $$;
 
 SELECT
     is(


### PR DESCRIPTION
## Summary (AI generated)

- Grant `anon` execute permission for `is_paying_org(uuid)` and `is_trial_org(uuid)` so CLI API-key requests can reach their existing authorization checks.
- Add regression coverage for valid API-key callers, invalid API keys, missing API keys, authenticated users, and service-role access.

## Motivation (AI generated)

CLI upload and channel commands authenticate Supabase RPC requests with the anon key plus the `capgkey` request header. The previous function grants blocked anon execution before `request_has_org_read_access()` could validate the API key, producing high-volume non-fatal `401` telemetry and suppressing trial-warning context.

## Business Impact (AI generated)

This restores trial/paying status context for CLI API-key users without broadening data access for invalid keys. It should reduce noisy unauthorized Supabase telemetry and make trial messaging visible again during CLI workflows.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun scripts/supabase-worktree.ts test db supabase/tests/00-supabase_test_helpers.sql supabase/tests/49_test_apikey_oracle_rpc_permissions.sql supabase/tests/46_test_org_status_rpcs.sql`
- [x] `git diff --check`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated organization status function permissions to enable broader API authentication patterns
  * Expanded test coverage to validate access control for organization-scoped operations across different authentication methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->