### PR TITLE
fix(cli): label Supabase function perf operations

### DIFF
--- a/cli/src/analytics/supabase-perf.ts
+++ b/cli/src/analytics/supabase-perf.ts
@@ -75,10 +75,11 @@ function safeRecord(info: SupabaseCallInfo): void {
 export const SLOW_THRESHOLD_MS = 5000
 
 /**
- * Parses a Supabase REST/RPC URL into a low-cardinality operation label.
+ * Parses a Supabase REST/RPC/Functions URL into a low-cardinality operation label.
  * Query strings are discarded so filter values never leak and cardinality
  * stays bounded. `/rest/v1/rpc/get_user_id` => `rpc:get_user_id`;
- * `/rest/v1/apps?...` => `GET apps`.
+ * `/rest/v1/apps?...` => `GET apps`;
+ * `/functions/v1/files/upload_link` => `POST functions:files/upload_link`.
  */
 export function deriveSupabaseOperation(url: string, method: string): string {
   let pathname: string
@@ -88,6 +89,13 @@ export function deriveSupabaseOperation(url: string, method: string): string {
   catch {
     pathname = url.split('?')[0]
   }
+  const functionsMarker = '/functions/v1/'
+  const functionsIdx = pathname.indexOf(functionsMarker)
+  if (functionsIdx >= 0) {
+    const functionRoute = pathname.slice(functionsIdx + functionsMarker.length).replace(/^\/+|\/+$/g, '')
+    return functionRoute ? `${method} functions:${functionRoute}` : `${method} functions`
+  }
+
   const marker = '/rest/v1/'
   const idx = pathname.indexOf(marker)
   const after = idx >= 0 ? pathname.slice(idx + marker.length) : pathname.replace(/^\//, '')

--- a/cli/test/test-supabase-perf.mjs
+++ b/cli/test/test-supabase-perf.mjs
@@ -22,6 +22,8 @@ try {
   assert.equal(deriveSupabaseOperation('https://db.co/rest/v1/rpc/get_user_id', 'POST'), 'rpc:get_user_id')
   assert.equal(deriveSupabaseOperation('https://db.co/rest/v1/apps?select=*&app_id=eq.com.x', 'GET'), 'GET apps')
   assert.equal(deriveSupabaseOperation('https://db.co/rest/v1/app_versions', 'POST'), 'POST app_versions')
+  assert.equal(deriveSupabaseOperation('https://db.co/functions/v1/files/upload_link', 'POST'), 'POST functions:files/upload_link')
+  assert.equal(deriveSupabaseOperation('https://db.co/functions/v1/private/delete_failed_version', 'DELETE'), 'DELETE functions:private/delete_failed_version')
   assert.equal(deriveSupabaseOperation('not a url', 'GET'), 'GET not a url')
 
   // 2. enable flag defaults off


### PR DESCRIPTION
## Summary (AI generated)

- Label Supabase Edge Function telemetry operations with the invoked function route instead of collapsing them to `POST functions` or `DELETE functions`.
- Add regression coverage for `files/upload_link` and `private/delete_failed_version` operation labels.

## Motivation (AI generated)

The Supabase p95 latency dashboard was too broad for Edge Function calls because all `/functions/v1/...` requests shared the same `METHOD functions` operation label. Keeping the function route makes slow CLI/backend paths visible without exposing query strings or request bodies.

## Business Impact (AI generated)

More granular CLI performance telemetry makes it easier to identify slow upload and cleanup paths, reducing investigation time for support and improving the ability to prioritize reliability work that affects users during releases.

## Test Plan (AI generated)

- [x] `bun run --cwd cli lint`
- [x] `bun run --cwd cli test:supabase-perf`
- [x] `bun run --cwd cli typecheck`

Generated with AI
