### PR TITLE
fix(cli): disambiguate onboarding step durations

### DIFF
--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -225,6 +225,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
   const pendingTelemetryRef = useRef<Array<{
     step: AndroidOnboardingStep
     durationMs?: number
+    durationStep?: AndroidOnboardingStep
     errorCategory?: AndroidOnboardingErrorCategory
   }>>([])
   const pendingActionTelemetryRef = useRef<Array<{
@@ -321,7 +322,10 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
     const now = Date.now()
     // Initial step (previous.step === null) and same-step error re-entries have
     // no meaningful previous-step duration.
-    const durationMs = previous.step === null || previous.step === step
+    const durationStep = previous.step === null || previous.step === step
+      ? undefined
+      : previous.step
+    const durationMs = durationStep === undefined
       ? undefined
       : now - previous.startedAt
 
@@ -337,6 +341,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
     const eventPayload = {
       step,
       durationMs,
+      durationStep,
       errorCategory: carriesErrorCategory ? errorCategoryRef.current : undefined,
     }
 

--- a/cli/src/build/onboarding/telemetry.ts
+++ b/cli/src/build/onboarding/telemetry.ts
@@ -10,6 +10,8 @@ export interface TrackBuilderOnboardingStepInput {
   platform: Platform
   step: OnboardingStep | AndroidOnboardingStep
   durationMs?: number
+  /** Step whose elapsed time is represented by durationMs. */
+  durationStep?: OnboardingStep | AndroidOnboardingStep
   /** Raw caught error — mapped via the platform's category mapper. Use this OR errorCategory, not both. */
   error?: unknown
   /** Pre-computed category. Takes precedence over `error` if both are present. */
@@ -38,8 +40,11 @@ export async function trackBuilderOnboardingStep(input: TrackBuilderOnboardingSt
     app_id: input.appId,
   }
 
-  if (typeof input.durationMs === 'number' && Number.isFinite(input.durationMs))
+  if (typeof input.durationMs === 'number' && Number.isFinite(input.durationMs)) {
     tags.duration_ms = String(Math.round(input.durationMs))
+    if (input.durationStep)
+      tags.duration_step = input.durationStep
+  }
 
   if (input.errorCategory !== undefined) {
     tags.error_category = input.errorCategory

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -190,6 +190,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey, o
   const pendingTelemetryRef = useRef<Array<{
     step: OnboardingStep
     durationMs?: number
+    durationStep?: OnboardingStep
     errorCategory?: OnboardingErrorCategory
   }>>([])
   const [resolvedOrgId, setResolvedOrgId] = useState<string | null>(null)
@@ -414,13 +415,17 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey, o
     const now = Date.now()
     // Initial step (previous.step === null) and same-step error re-entries have
     // no meaningful previous-step duration.
-    const durationMs = previous.step === null || previous.step === step
+    const durationStep = previous.step === null || previous.step === step
+      ? undefined
+      : previous.step
+    const durationMs = durationStep === undefined
       ? undefined
       : now - previous.startedAt
 
     const eventPayload = {
       step,
       durationMs,
+      durationStep,
       errorCategory: step === 'error' ? errorCategoryRef.current : undefined,
     }
 

--- a/tests/builder-onboarding-telemetry.unit.test.ts
+++ b/tests/builder-onboarding-telemetry.unit.test.ts
@@ -21,6 +21,7 @@ describe('trackBuilderOnboardingStep', () => {
       appId: 'com.example.app',
       orgId: 'org-uuid-1',
       durationMs: 1234,
+      durationStep: 'welcome',
     })
 
     expect(sendEventMock).toHaveBeenCalledTimes(1)
@@ -38,6 +39,7 @@ describe('trackBuilderOnboardingStep', () => {
         platform: 'ios',
         app_id: 'com.example.app',
         duration_ms: '1234',
+        duration_step: 'welcome',
       },
     })
     expect(payload.tags.error_category).toBeUndefined()


### PR DESCRIPTION
## Summary (AI generated)

- Added a `duration_step` tag to Builder Onboarding Step telemetry when `duration_ms` is present.
- Updated iOS and Android onboarding step timing emitters to identify the previous step being measured.
- Covered the payload shape with the existing builder onboarding telemetry unit test.

## Motivation (AI generated)

PostHog timing analysis was misleading because `step` represented the step being entered, while `duration_ms` represented time spent in the previous step. That made dashboards attribute build-request time to `detecting-ci-secrets`. Keeping `step` unchanged preserves existing funnels, and `duration_step` gives timing queries the correct dimension.

## Business Impact (AI generated)

This improves onboarding analytics accuracy for Capgo Builder. More reliable step timing makes it easier to diagnose real onboarding friction instead of chasing false slow steps, which helps prioritize fixes that improve user activation.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/builder-onboarding-telemetry.unit.test.ts`
- [x] `bun run cli:lint`
- [x] `bun run cli:typecheck`
- [x] `bun run cli:build`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved telemetry tracking for Android onboarding step transitions, capturing additional step-level duration metrics alongside overall step timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->