### PR TITLE
[codex] manage API key channel permissions

### DIFF
--- a/playwright/e2e/apikeys.spec.ts
+++ b/playwright/e2e/apikeys.spec.ts
@@ -1,9 +1,17 @@
 import type { Locator, Page } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { getSupabaseClient, resetAndSeedAppData, resetAppData, USER_ID } from '../../tests/test-utils'
 import { expect, test } from '../support/commands'
 
 test.use({ screenshot: 'off', trace: 'off', video: 'off' })
 
-const DEMO_ORG_ID = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+const INHERITED_ORG_ID = randomUUID()
+const INHERITED_APP_ID = `com.apikeys.e2e.${randomUUID().replaceAll('-', '').slice(0, 12)}`
+const INHERITED_CUSTOMER_ID = `cus_apikeys_e2e_${randomUUID().replaceAll('-', '').slice(0, 12)}`
+
+function uniqueKeyName(prefix: string) {
+  return `${prefix} ${Date.now().toString(36)}`
+}
 
 async function openCreateKeyDialog(page: Page) {
   await page.click('[data-test="create-key"]')
@@ -47,23 +55,9 @@ async function createInheritedOrgAdminApiKey(page: Page, keyName: string) {
   const dialog = await openCreateKeyDialog(page)
   await dialog.locator('input[type="text"]').fill(keyName)
 
-  await dialog.locator('[data-test="create-key-org-dropdown"]').click()
-  const orgCheckboxes = dialog.locator('[data-test="create-key-org-checkbox"]:not(:disabled)')
-  const orgCount = await orgCheckboxes.count()
-  for (let index = 0; index < orgCount; index++) {
-    const checkbox = orgCheckboxes.nth(index)
-    const orgId = await checkbox.getAttribute('data-org-id')
-    if (orgId === DEMO_ORG_ID) {
-      await checkbox.check()
-    }
-    else if (await checkbox.isChecked()) {
-      await checkbox.uncheck()
-    }
-  }
-  await page.mouse.click(5, 5)
-
   const orgAdminRole = dialog.locator('[data-test="create-key-org-role-org_admin"]')
-  await orgAdminRole.click()
+  await expect(orgAdminRole).toBeVisible()
+  await orgAdminRole.check({ force: true })
   await expect(orgAdminRole).toBeChecked()
 
   await page.getByRole('button', { name: 'Create' }).click()
@@ -79,6 +73,12 @@ async function expectChannelPermissionOverridePersists(page: Page, keyRow: Locat
 
   const appSelect = page.locator('[data-test="apikey-channel-permissions-app-select"]')
   await expect(appSelect).toContainText(expectedAppText)
+  const targetAppOption = appSelect.locator('option', { hasText: expectedAppText }).first()
+  await expect(targetAppOption).toBeAttached()
+  const targetAppUuid = await targetAppOption.getAttribute('value')
+  expect(targetAppUuid).toBeTruthy()
+  await appSelect.selectOption(targetAppUuid!)
+  await expect(appSelect).toHaveValue(targetAppUuid!)
 
   const promoteSelect = panel.locator('[data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"]').first()
   await expect(promoteSelect).toBeVisible()
@@ -90,16 +90,47 @@ async function expectChannelPermissionOverridePersists(page: Page, keyRow: Locat
   await expect(promoteSelect).toBeEnabled()
 
   await page.getByRole('button', { name: 'Close', exact: true }).click()
+  await expect(panel).not.toBeVisible()
   await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
+  await expect(panel).toBeVisible()
+  await appSelect.selectOption(targetAppUuid!)
+  await expect(appSelect).toHaveValue(targetAppUuid!)
   const reopenedPromoteSelect = page
     .locator(`[data-test="channel-permissions-panel"] [data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"][data-channel-id="${channelId}"]`)
     .first()
+  await expect(reopenedPromoteSelect).toBeVisible()
   await expect(reopenedPromoteSelect).toHaveValue('deny')
   await page.getByRole('button', { name: 'Close', exact: true }).click()
 }
 
 test.describe('API Key Management', () => {
+  test.beforeAll(async () => {
+    await resetAndSeedAppData(INHERITED_APP_ID, {
+      orgId: INHERITED_ORG_ID,
+      userId: USER_ID,
+      stripeCustomerId: INHERITED_CUSTOMER_ID,
+    })
+    const supabase = getSupabaseClient()
+    const { error } = await supabase.rpc('rbac_enable_for_org', {
+      p_org_id: INHERITED_ORG_ID,
+      p_granted_by: USER_ID,
+    })
+    expect(error).toBeNull()
+  })
+
+  test.afterAll(async () => {
+    await resetAppData(INHERITED_APP_ID)
+    const supabase = getSupabaseClient()
+    await supabase.from('role_bindings').delete().eq('org_id', INHERITED_ORG_ID)
+    await supabase.from('org_users').delete().eq('org_id', INHERITED_ORG_ID)
+    await supabase.from('orgs').delete().eq('id', INHERITED_ORG_ID)
+    await supabase.from('stripe_info').delete().eq('customer_id', INHERITED_CUSTOMER_ID)
+  })
+
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript((orgId) => {
+      localStorage.setItem('capgo_current_org_id', orgId)
+    }, INHERITED_ORG_ID)
     // Login first
     await page.login('test@capgo.app', 'testtest')
     // Go to API keys page
@@ -107,7 +138,7 @@ test.describe('API Key Management', () => {
   })
 
   test('should create new API key', async ({ page }) => {
-    const keyName = `Playwright Read ${Date.now()}`
+    const keyName = uniqueKeyName('Read')
 
     await createRbacApiKey(page, keyName)
   })
@@ -148,21 +179,21 @@ test.describe('API Key Management', () => {
   })
 
   test('should manage channel permission overrides for app-scoped API keys', async ({ page }) => {
-    const keyName = `Playwright Channel ${Date.now()}`
+    const keyName = uniqueKeyName('Channel')
     const keyRow = await createDemoAppApiKey(page, keyName)
 
     await expectChannelPermissionOverridePersists(page, keyRow, 'Demo app')
   })
 
   test('should manage inherited org-admin channel permissions for API keys', async ({ page }) => {
-    const keyName = `Playwright Inherited Channel ${Date.now()}`
+    const keyName = uniqueKeyName('Inherited')
     const keyRow = await createInheritedOrgAdminApiKey(page, keyName)
 
-    await expectChannelPermissionOverridePersists(page, keyRow, 'Demo app · App Admin')
+    await expectChannelPermissionOverridePersists(page, keyRow, 'Seeded App · App Admin')
   })
 
   test('should delete API key', async ({ page }) => {
-    const keyName = `Playwright Delete ${Date.now()}`
+    const keyName = uniqueKeyName('Delete')
 
     await createRbacApiKey(page, keyName)
 

--- a/playwright/e2e/apikeys.spec.ts
+++ b/playwright/e2e/apikeys.spec.ts
@@ -20,6 +20,27 @@ async function createRbacApiKey(page: Page, keyName: string) {
   await expect(page.locator('tr', { hasText: keyName })).toContainText('Member')
 }
 
+async function createDemoAppApiKey(page: Page, keyName: string) {
+  const dialog = await openCreateKeyDialog(page)
+  await dialog.locator('input[type="text"]').fill(keyName)
+
+  await dialog.locator('[data-test="create-key-add-app"]').click()
+  const demoAppOption = dialog.locator('label', { hasText: 'com.demo.app' }).first()
+  await expect(demoAppOption).toBeVisible()
+  await demoAppOption.locator('[data-test="create-key-app-checkbox"]').check()
+
+  const selectedApp = dialog.locator('[data-test="create-key-selected-app"]', { hasText: 'Demo app' }).first()
+  await expect(selectedApp).toBeVisible()
+  await selectedApp.locator('[data-test="create-key-app-role-select"]').selectOption('app_developer')
+  await page.mouse.click(5, 5)
+  await expect(dialog.locator('.fixed.inset-0.z-10')).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Create' }).click()
+  await expect(page.getByText('Added new API key successfully').first()).toBeVisible()
+  await expect(page.locator('tr', { hasText: keyName })).toHaveCount(1)
+  return page.locator('tr', { hasText: keyName })
+}
+
 test.describe('API Key Management', () => {
   test.beforeEach(async ({ page }) => {
     // Login first
@@ -67,6 +88,35 @@ test.describe('API Key Management', () => {
 
     await page.mouse.click(5, 5)
     await page.getByRole('button', { name: 'Cancel' }).click()
+  })
+
+  test('should manage channel permission overrides for app-scoped API keys', async ({ page }) => {
+    const keyName = `Playwright Channel ${Date.now()}`
+    const keyRow = await createDemoAppApiKey(page, keyName)
+
+    await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
+    const panel = page.locator('[data-test="channel-permissions-panel"]')
+    await expect(panel).toBeVisible()
+
+    const appSelect = page.locator('[data-test="apikey-channel-permissions-app-select"]')
+    await expect(appSelect).toContainText('Demo app')
+
+    const promoteSelect = panel.locator('[data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"]').first()
+    await expect(promoteSelect).toBeVisible()
+    const channelId = Number(await promoteSelect.getAttribute('data-channel-id'))
+    expect(channelId).toBeGreaterThan(0)
+
+    await promoteSelect.selectOption('deny')
+    await expect(promoteSelect).toHaveValue('deny')
+    await expect(promoteSelect).toBeEnabled()
+
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
+    const reopenedPromoteSelect = page
+      .locator(`[data-test="channel-permissions-panel"] [data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"][data-channel-id="${channelId}"]`)
+      .first()
+    await expect(reopenedPromoteSelect).toHaveValue('deny')
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
   })
 
   test('should delete API key', async ({ page }) => {

--- a/playwright/e2e/apikeys.spec.ts
+++ b/playwright/e2e/apikeys.spec.ts
@@ -1,7 +1,9 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 import { expect, test } from '../support/commands'
 
 test.use({ screenshot: 'off', trace: 'off', video: 'off' })
+
+const DEMO_ORG_ID = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
 
 async function openCreateKeyDialog(page: Page) {
   await page.click('[data-test="create-key"]')
@@ -39,6 +41,61 @@ async function createDemoAppApiKey(page: Page, keyName: string) {
   await expect(page.getByText('Added new API key successfully').first()).toBeVisible()
   await expect(page.locator('tr', { hasText: keyName })).toHaveCount(1)
   return page.locator('tr', { hasText: keyName })
+}
+
+async function createInheritedOrgAdminApiKey(page: Page, keyName: string) {
+  const dialog = await openCreateKeyDialog(page)
+  await dialog.locator('input[type="text"]').fill(keyName)
+
+  await dialog.locator('[data-test="create-key-org-dropdown"]').click()
+  const orgCheckboxes = dialog.locator('[data-test="create-key-org-checkbox"]:not(:disabled)')
+  const orgCount = await orgCheckboxes.count()
+  for (let index = 0; index < orgCount; index++) {
+    const checkbox = orgCheckboxes.nth(index)
+    const orgId = await checkbox.getAttribute('data-org-id')
+    if (orgId === DEMO_ORG_ID) {
+      await checkbox.check()
+    }
+    else if (await checkbox.isChecked()) {
+      await checkbox.uncheck()
+    }
+  }
+  await page.mouse.click(5, 5)
+
+  const orgAdminRole = dialog.locator('[data-test="create-key-org-role-org_admin"]')
+  await orgAdminRole.click()
+  await expect(orgAdminRole).toBeChecked()
+
+  await page.getByRole('button', { name: 'Create' }).click()
+  await expect(page.getByText('Added new API key successfully').first()).toBeVisible()
+  await expect(page.locator('tr', { hasText: keyName })).toHaveCount(1)
+  return page.locator('tr', { hasText: keyName })
+}
+
+async function expectChannelPermissionOverridePersists(page: Page, keyRow: Locator, expectedAppText: string) {
+  await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
+  const panel = page.locator('[data-test="channel-permissions-panel"]')
+  await expect(panel).toBeVisible()
+
+  const appSelect = page.locator('[data-test="apikey-channel-permissions-app-select"]')
+  await expect(appSelect).toContainText(expectedAppText)
+
+  const promoteSelect = panel.locator('[data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"]').first()
+  await expect(promoteSelect).toBeVisible()
+  const channelId = Number(await promoteSelect.getAttribute('data-channel-id'))
+  expect(channelId).toBeGreaterThan(0)
+
+  await promoteSelect.selectOption('deny')
+  await expect(promoteSelect).toHaveValue('deny')
+  await expect(promoteSelect).toBeEnabled()
+
+  await page.getByRole('button', { name: 'Close', exact: true }).click()
+  await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
+  const reopenedPromoteSelect = page
+    .locator(`[data-test="channel-permissions-panel"] [data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"][data-channel-id="${channelId}"]`)
+    .first()
+  await expect(reopenedPromoteSelect).toHaveValue('deny')
+  await page.getByRole('button', { name: 'Close', exact: true }).click()
 }
 
 test.describe('API Key Management', () => {
@@ -94,29 +151,14 @@ test.describe('API Key Management', () => {
     const keyName = `Playwright Channel ${Date.now()}`
     const keyRow = await createDemoAppApiKey(page, keyName)
 
-    await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
-    const panel = page.locator('[data-test="channel-permissions-panel"]')
-    await expect(panel).toBeVisible()
+    await expectChannelPermissionOverridePersists(page, keyRow, 'Demo app')
+  })
 
-    const appSelect = page.locator('[data-test="apikey-channel-permissions-app-select"]')
-    await expect(appSelect).toContainText('Demo app')
+  test('should manage inherited org-admin channel permissions for API keys', async ({ page }) => {
+    const keyName = `Playwright Inherited Channel ${Date.now()}`
+    const keyRow = await createInheritedOrgAdminApiKey(page, keyName)
 
-    const promoteSelect = panel.locator('[data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"]').first()
-    await expect(promoteSelect).toBeVisible()
-    const channelId = Number(await promoteSelect.getAttribute('data-channel-id'))
-    expect(channelId).toBeGreaterThan(0)
-
-    await promoteSelect.selectOption('deny')
-    await expect(promoteSelect).toHaveValue('deny')
-    await expect(promoteSelect).toBeEnabled()
-
-    await page.getByRole('button', { name: 'Close', exact: true }).click()
-    await keyRow.locator('[data-test^="manage-key-channel-permissions-"]').click()
-    const reopenedPromoteSelect = page
-      .locator(`[data-test="channel-permissions-panel"] [data-test="channel-permission-select"][data-permission-key="channel.promote_bundle"][data-channel-id="${channelId}"]`)
-      .first()
-    await expect(reopenedPromoteSelect).toHaveValue('deny')
-    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await expectChannelPermissionOverridePersists(page, keyRow, 'Demo app · App Admin')
   })
 
   test('should delete API key', async ({ page }) => {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -37,6 +37,7 @@ declare module 'vue' {
     BundleUploadsCard: typeof import('./components/dashboard/BundleUploadsCard.vue')['default']
     BundleUploadsChart: typeof import('./components/dashboard/BundleUploadsChart.vue')['default']
     ChannelHistoryTable: typeof import('./components/tables/ChannelHistoryTable.vue')['default']
+    ChannelPermissionOverridesPanel: typeof import('./components/permissions/ChannelPermissionOverridesPanel.vue')['default']
     ChannelTable: typeof import('./components/tables/ChannelTable.vue')['default']
     ChartCard: typeof import('./components/dashboard/ChartCard.vue')['default']
     CreditsCta: typeof import('./components/CreditsCta.vue')['default']

--- a/src/components/permissions/ChannelPermissionOverridesPanel.vue
+++ b/src/components/permissions/ChannelPermissionOverridesPanel.vue
@@ -1,0 +1,338 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { toast } from 'vue-sonner'
+import { useSupabase } from '~/services/supabase'
+import { getRbacRoleI18nKey } from '~/stores/organization'
+
+type PrincipalType = 'user' | 'group' | 'apikey'
+type ChannelPermissionKey = 'channel.read' | 'channel.read_history' | 'channel.promote_bundle'
+
+interface ChannelSummary {
+  id: number
+  name: string
+}
+
+const props = withDefaults(defineProps<{
+  appId: string
+  principalType: PrincipalType
+  principalId: string
+  principalName: string
+  roleName: string
+  editable?: boolean
+}>(), {
+  editable: true,
+})
+
+const { t } = useI18n()
+const supabase = useSupabase()
+const channelOverrides = ref<Record<string, boolean>>({})
+const channelOverridesLoading = ref(false)
+const channelOverridesSearch = ref('')
+const channelOverridesSaving = ref<Record<string, boolean>>({})
+const channels = ref<ChannelSummary[]>([])
+
+const channelPermissionOptions = computed(() => [
+  { key: 'channel.read' as ChannelPermissionKey, label: t('channel-permission-read') },
+  { key: 'channel.read_history' as ChannelPermissionKey, label: t('channel-permission-history') },
+  { key: 'channel.promote_bundle' as ChannelPermissionKey, label: t('channel-permission-associate') },
+])
+
+const roleDefaultChannelPermissions: Record<string, Record<ChannelPermissionKey, boolean>> = {
+  app_admin: {
+    'channel.read': true,
+    'channel.read_history': true,
+    'channel.promote_bundle': true,
+  },
+  app_developer: {
+    'channel.read': true,
+    'channel.read_history': true,
+    'channel.promote_bundle': true,
+  },
+  app_uploader: {
+    'channel.read': true,
+    'channel.read_history': true,
+    'channel.promote_bundle': true,
+  },
+  app_reader: {
+    'channel.read': false,
+    'channel.read_history': false,
+    'channel.promote_bundle': false,
+  },
+}
+
+const filteredChannels = computed(() => {
+  if (!channelOverridesSearch.value)
+    return channels.value
+  const searchLower = channelOverridesSearch.value.toLowerCase()
+  return channels.value.filter(channel => channel.name.toLowerCase().includes(searchLower))
+})
+
+function getRoleDisplayName(roleName: string): string {
+  const i18nKey = getRbacRoleI18nKey(roleName)
+  return i18nKey ? t(i18nKey) : roleName.replaceAll('_', ' ')
+}
+
+function getOverrideKey(channelId: number, permission: ChannelPermissionKey) {
+  return `${channelId}:${permission}`
+}
+
+function hasOverride(channelId: number, permission: ChannelPermissionKey) {
+  const key = getOverrideKey(channelId, permission)
+  return Object.prototype.hasOwnProperty.call(channelOverrides.value, key)
+}
+
+function getOverrideValue(channelId: number, permission: ChannelPermissionKey) {
+  const key = getOverrideKey(channelId, permission)
+  if (!hasOverride(channelId, permission))
+    return undefined
+  return channelOverrides.value[key]
+}
+
+function getDefaultPermission(roleName: string, permission: ChannelPermissionKey) {
+  return roleDefaultChannelPermissions[roleName]?.[permission] ?? false
+}
+
+function getSelectValue(channelId: number, permission: ChannelPermissionKey): 'default' | 'allow' | 'deny' {
+  const override = getOverrideValue(channelId, permission)
+  if (override === undefined)
+    return 'default'
+  return override ? 'allow' : 'deny'
+}
+
+function getDefaultLabel(roleName: string, permission: ChannelPermissionKey) {
+  return getDefaultPermission(roleName, permission)
+    ? t('channel-permissions-default-allow')
+    : t('channel-permissions-default-deny')
+}
+
+function isSavingOverride(channelId: number, permission: ChannelPermissionKey) {
+  const key = getOverrideKey(channelId, permission)
+  return !!channelOverridesSaving.value[key]
+}
+
+async function loadChannelPermissions() {
+  if (!props.appId || !props.principalId) {
+    channels.value = []
+    channelOverrides.value = {}
+    return
+  }
+
+  channelOverridesLoading.value = true
+  try {
+    const { data: channelData, error: channelError } = await supabase
+      .from('channels')
+      .select('id, name')
+      .eq('app_id', props.appId)
+      .order('name', { ascending: true })
+
+    if (channelError)
+      throw channelError
+
+    channels.value = (channelData as ChannelSummary[]) || []
+
+    if (channels.value.length === 0) {
+      channelOverrides.value = {}
+      return
+    }
+
+    const channelIds = channels.value.map(channel => channel.id)
+    const { data: overrides, error: overridesError } = await supabase
+      .from('channel_permission_overrides' as any)
+      .select('channel_id, permission_key, is_allowed')
+      .eq('principal_type', props.principalType)
+      .eq('principal_id', props.principalId)
+      .in('channel_id', channelIds)
+
+    if (overridesError)
+      throw overridesError
+
+    const nextOverrides: Record<string, boolean> = {}
+    for (const override of (overrides as any[] || [])) {
+      const key = getOverrideKey(override.channel_id, override.permission_key)
+      nextOverrides[key] = override.is_allowed
+    }
+    channelOverrides.value = nextOverrides
+  }
+  catch (error) {
+    console.error('Error loading channel permissions:', error)
+    toast.error(t('error-loading-channel-permissions'))
+  }
+  finally {
+    channelOverridesLoading.value = false
+  }
+}
+
+async function updateChannelPermission(channelId: number, permission: ChannelPermissionKey, value: 'default' | 'allow' | 'deny') {
+  if (!props.editable || !props.principalId)
+    return
+
+  const key = getOverrideKey(channelId, permission)
+  if (channelOverridesSaving.value[key])
+    return
+
+  const defaultAllowed = getDefaultPermission(props.roleName, permission)
+  const previousOverrides = { ...channelOverrides.value }
+
+  channelOverridesSaving.value = { ...channelOverridesSaving.value, [key]: true }
+
+  let nextOverride: boolean | null = null
+  if (value === 'default') {
+    nextOverride = null
+  }
+  else {
+    const isAllowed = value === 'allow'
+    nextOverride = isAllowed === defaultAllowed ? null : isAllowed
+  }
+
+  if (nextOverride === null) {
+    const updated = { ...channelOverrides.value }
+    delete updated[key]
+    channelOverrides.value = updated
+  }
+  else {
+    channelOverrides.value = { ...channelOverrides.value, [key]: nextOverride }
+  }
+
+  try {
+    if (nextOverride === null) {
+      const { error } = await supabase
+        .from('channel_permission_overrides' as any)
+        .delete()
+        .eq('principal_type', props.principalType)
+        .eq('principal_id', props.principalId)
+        .eq('channel_id', channelId)
+        .eq('permission_key', permission)
+
+      if (error)
+        throw error
+    }
+    else {
+      const { error } = await supabase
+        .from('channel_permission_overrides' as any)
+        .upsert({
+          principal_type: props.principalType,
+          principal_id: props.principalId,
+          channel_id: channelId,
+          permission_key: permission,
+          is_allowed: nextOverride,
+        }, { onConflict: 'principal_type,principal_id,channel_id,permission_key' })
+
+      if (error)
+        throw error
+    }
+  }
+  catch (error) {
+    console.error('Error saving channel permission override:', error)
+    channelOverrides.value = previousOverrides
+    toast.error(t('error-saving-channel-permissions'))
+  }
+  finally {
+    const updatedSaving = { ...channelOverridesSaving.value }
+    delete updatedSaving[key]
+    channelOverridesSaving.value = updatedSaving
+  }
+}
+
+watch(
+  () => [props.appId, props.principalType, props.principalId] as const,
+  () => {
+    channelOverridesSearch.value = ''
+    channelOverrides.value = {}
+    channels.value = []
+    loadChannelPermissions()
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div class="space-y-4" data-test="channel-permissions-panel">
+    <div class="space-y-1">
+      <div class="text-xs font-semibold tracking-wide text-gray-400 uppercase">
+        {{ t('channel-permissions-principal') }}
+      </div>
+      <div class="text-base text-gray-900 dark:text-gray-100">
+        {{ principalName || '-' }}
+      </div>
+      <div class="text-xs text-gray-500">
+        {{ t('channel-permissions-role') }}: {{ getRoleDisplayName(roleName) }}
+      </div>
+    </div>
+
+    <div>
+      <input
+        v-model="channelOverridesSearch"
+        type="text"
+        class="w-full d-input d-input-bordered"
+        :placeholder="t('search-channels')"
+        data-test="channel-permissions-search"
+      >
+    </div>
+
+    <div v-if="channelOverridesLoading" class="py-6 text-sm text-gray-500">
+      {{ t('loading') }}...
+    </div>
+
+    <div v-else-if="filteredChannels.length === 0" class="py-6 text-sm text-gray-500">
+      {{ t('channel-permissions-empty') }}
+    </div>
+
+    <div v-else class="overflow-x-auto border border-slate-200 dark:border-slate-700 rounded-lg">
+      <table class="min-w-full text-sm">
+        <thead class="bg-slate-50 dark:bg-slate-900/40">
+          <tr>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">
+              {{ t('channels') }}
+            </th>
+            <th
+              v-for="perm in channelPermissionOptions"
+              :key="perm.key"
+              class="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200"
+            >
+              {{ perm.label }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="channel in filteredChannels"
+            :key="channel.id"
+            class="border-t border-slate-200 dark:border-slate-700"
+            data-test="channel-permissions-row"
+            :data-channel-id="channel.id"
+          >
+            <td class="px-3 py-2 text-gray-900 dark:text-gray-100">
+              {{ channel.name }}
+            </td>
+            <td
+              v-for="perm in channelPermissionOptions"
+              :key="perm.key"
+              class="px-3 py-2"
+            >
+              <select
+                class="w-full d-select d-select-sm d-select-bordered"
+                :value="getSelectValue(channel.id, perm.key)"
+                :disabled="!editable || isSavingOverride(channel.id, perm.key)"
+                data-test="channel-permission-select"
+                :data-channel-id="channel.id"
+                :data-permission-key="perm.key"
+                @change="updateChannelPermission(channel.id, perm.key, ($event.target as HTMLSelectElement).value as 'default' | 'allow' | 'deny')"
+              >
+                <option value="default">
+                  {{ getDefaultLabel(roleName, perm.key) }}
+                </option>
+                <option value="allow">
+                  {{ t('channel-permissions-allow') }}
+                </option>
+                <option value="deny">
+                  {{ t('channel-permissions-deny') }}
+                </option>
+              </select>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/components/permissions/ChannelPermissionOverridesPanel.vue
+++ b/src/components/permissions/ChannelPermissionOverridesPanel.vue
@@ -13,6 +13,12 @@ interface ChannelSummary {
   name: string
 }
 
+interface ChannelPermissionOverrideSummary {
+  channel_id: number
+  permission_key: ChannelPermissionKey
+  is_allowed: boolean
+}
+
 const props = withDefaults(defineProps<{
   appId: string
   principalType: PrincipalType
@@ -30,6 +36,7 @@ const channelOverrides = ref<Record<string, boolean>>({})
 const channelOverridesLoading = ref(false)
 const channelOverridesSearch = ref('')
 const channelOverridesSaving = ref<Record<string, boolean>>({})
+const loadRequestId = ref(0)
 const channels = ref<ChannelSummary[]>([])
 
 const channelPermissionOptions = computed(() => [
@@ -39,6 +46,16 @@ const channelPermissionOptions = computed(() => [
 ])
 
 const roleDefaultChannelPermissions: Record<string, Record<ChannelPermissionKey, boolean>> = {
+  org_super_admin: {
+    'channel.read': true,
+    'channel.read_history': true,
+    'channel.promote_bundle': true,
+  },
+  org_admin: {
+    'channel.read': true,
+    'channel.read_history': true,
+    'channel.promote_bundle': true,
+  },
   app_admin: {
     'channel.read': true,
     'channel.read_history': true,
@@ -112,9 +129,12 @@ function isSavingOverride(channelId: number, permission: ChannelPermissionKey) {
 }
 
 async function loadChannelPermissions() {
+  const currentRequestId = ++loadRequestId.value
+
   if (!props.appId || !props.principalId) {
     channels.value = []
     channelOverrides.value = {}
+    channelOverridesLoading.value = false
     return
   }
 
@@ -125,6 +145,9 @@ async function loadChannelPermissions() {
       .select('id, name')
       .eq('app_id', props.appId)
       .order('name', { ascending: true })
+
+    if (currentRequestId !== loadRequestId.value)
+      return
 
     if (channelError)
       throw channelError
@@ -138,17 +161,20 @@ async function loadChannelPermissions() {
 
     const channelIds = channels.value.map(channel => channel.id)
     const { data: overrides, error: overridesError } = await supabase
-      .from('channel_permission_overrides' as any)
+      .from('channel_permission_overrides')
       .select('channel_id, permission_key, is_allowed')
       .eq('principal_type', props.principalType)
       .eq('principal_id', props.principalId)
       .in('channel_id', channelIds)
 
+    if (currentRequestId !== loadRequestId.value)
+      return
+
     if (overridesError)
       throw overridesError
 
     const nextOverrides: Record<string, boolean> = {}
-    for (const override of (overrides as any[] || [])) {
+    for (const override of (overrides || []) as ChannelPermissionOverrideSummary[]) {
       const key = getOverrideKey(override.channel_id, override.permission_key)
       nextOverrides[key] = override.is_allowed
     }
@@ -159,7 +185,8 @@ async function loadChannelPermissions() {
     toast.error(t('error-loading-channel-permissions'))
   }
   finally {
-    channelOverridesLoading.value = false
+    if (currentRequestId === loadRequestId.value)
+      channelOverridesLoading.value = false
   }
 }
 
@@ -197,7 +224,7 @@ async function updateChannelPermission(channelId: number, permission: ChannelPer
   try {
     if (nextOverride === null) {
       const { error } = await supabase
-        .from('channel_permission_overrides' as any)
+        .from('channel_permission_overrides')
         .delete()
         .eq('principal_type', props.principalType)
         .eq('principal_id', props.principalId)
@@ -209,7 +236,7 @@ async function updateChannelPermission(channelId: number, permission: ChannelPer
     }
     else {
       const { error } = await supabase
-        .from('channel_permission_overrides' as any)
+        .from('channel_permission_overrides')
         .upsert({
           principal_type: props.principalType,
           principal_id: props.principalId,
@@ -240,7 +267,7 @@ watch(
     channelOverridesSearch.value = ''
     channelOverrides.value = {}
     channels.value = []
-    loadChannelPermissions()
+    void loadChannelPermissions()
   },
   { immediate: true },
 )

--- a/src/components/tables/AccessTable.vue
+++ b/src/components/tables/AccessTable.vue
@@ -8,6 +8,7 @@ import { toast } from 'vue-sonner'
 import IconShield from '~icons/heroicons/shield-check'
 import IconTrash from '~icons/heroicons/trash'
 import IconWrench from '~icons/heroicons/wrench'
+import ChannelPermissionOverridesPanel from '~/components/permissions/ChannelPermissionOverridesPanel.vue'
 import { formatDate } from '~/services/date'
 import { checkPermissions } from '~/services/permissions'
 import { useSupabase } from '~/services/supabase'
@@ -19,7 +20,7 @@ const props = defineProps<{
 
 interface RoleBinding {
   id: string
-  principal_type: string
+  principal_type: 'user' | 'group'
   principal_id: string
   role_id: string
   role_name: string
@@ -40,13 +41,6 @@ interface RoleBinding {
 
 type Element = RoleBinding
 
-type ChannelPermissionKey = 'channel.read' | 'channel.read_history' | 'channel.promote_bundle'
-
-interface ChannelSummary {
-  id: number
-  name: string
-}
-
 const { t } = useI18n()
 const dialogStore = useDialogV2Store()
 const supabase = useSupabase()
@@ -59,12 +53,7 @@ const isLoading = ref(true)
 const currentPage = ref(1)
 const canUpdateUserRoles = ref(false)
 const selectedRole = ref('')
-const channelOverrides = ref<Record<string, boolean>>({})
-const channelOverridesLoading = ref(false)
-const channelOverridesSearch = ref('')
-const channelOverridesSaving = ref<Record<string, boolean>>({})
 const selectedPrincipal = ref<Element | null>(null)
-const channels = ref<ChannelSummary[]>([])
 
 // Define app role options
 const appRoleOptions = computed(() => [
@@ -72,73 +61,6 @@ const appRoleOptions = computed(() => [
   { label: t('role-app-uploader'), value: 'app_uploader' },
   { label: t('role-app-reader'), value: 'app_reader' },
 ])
-
-const channelPermissionOptions = computed(() => [
-  { key: 'channel.read' as ChannelPermissionKey, label: t('channel-permission-read') },
-  { key: 'channel.read_history' as ChannelPermissionKey, label: t('channel-permission-history') },
-  { key: 'channel.promote_bundle' as ChannelPermissionKey, label: t('channel-permission-associate') },
-])
-
-const roleDefaultChannelPermissions: Record<string, Record<ChannelPermissionKey, boolean>> = {
-  app_admin: {
-    'channel.read': true,
-    'channel.read_history': true,
-    'channel.promote_bundle': true,
-  },
-  app_developer: {
-    'channel.read': true,
-    'channel.read_history': true,
-    'channel.promote_bundle': true,
-  },
-  app_uploader: {
-    'channel.read': true,
-    'channel.read_history': true,
-    'channel.promote_bundle': true,
-  },
-  app_reader: {
-    'channel.read': false,
-    'channel.read_history': false,
-    'channel.promote_bundle': false,
-  },
-}
-
-function getOverrideKey(channelId: number, permission: ChannelPermissionKey) {
-  return `${channelId}:${permission}`
-}
-
-function hasOverride(channelId: number, permission: ChannelPermissionKey) {
-  const key = getOverrideKey(channelId, permission)
-  return Object.prototype.hasOwnProperty.call(channelOverrides.value, key)
-}
-
-function getOverrideValue(channelId: number, permission: ChannelPermissionKey) {
-  const key = getOverrideKey(channelId, permission)
-  if (!hasOverride(channelId, permission))
-    return undefined
-  return channelOverrides.value[key]
-}
-
-function getDefaultPermission(roleName: string, permission: ChannelPermissionKey) {
-  return roleDefaultChannelPermissions[roleName]?.[permission] ?? false
-}
-
-function getSelectValue(channelId: number, permission: ChannelPermissionKey): 'default' | 'allow' | 'deny' {
-  const override = getOverrideValue(channelId, permission)
-  if (override === undefined)
-    return 'default'
-  return override ? 'allow' : 'deny'
-}
-
-function getDefaultLabel(roleName: string, permission: ChannelPermissionKey) {
-  return getDefaultPermission(roleName, permission)
-    ? t('channel-permissions-default-allow')
-    : t('channel-permissions-default-deny')
-}
-
-function isSavingOverride(channelId: number, permission: ChannelPermissionKey) {
-  const key = getOverrideKey(channelId, permission)
-  return !!channelOverridesSaving.value[key]
-}
 
 async function loadAppInfo() {
   try {
@@ -190,70 +112,11 @@ async function fetchData() {
   }
 }
 
-const filteredChannels = computed(() => {
-  if (!channelOverridesSearch.value)
-    return channels.value
-  const searchLower = channelOverridesSearch.value.toLowerCase()
-  return channels.value.filter(channel => channel.name.toLowerCase().includes(searchLower))
-})
-
-async function loadChannelPermissions() {
-  if (!selectedPrincipal.value)
-    return
-
-  channelOverridesLoading.value = true
-  try {
-    const { data: channelData, error: channelError } = await supabase
-      .from('channels')
-      .select('id, name')
-      .eq('app_id', props.appId)
-      .order('name', { ascending: true })
-
-    if (channelError)
-      throw channelError
-
-    channels.value = (channelData as ChannelSummary[]) || []
-
-    if (channels.value.length === 0) {
-      channelOverrides.value = {}
-      return
-    }
-
-    const channelIds = channels.value.map(channel => channel.id)
-    const { data: overrides, error: overridesError } = await supabase
-      .from('channel_permission_overrides' as any)
-      .select('channel_id, permission_key, is_allowed')
-      .eq('principal_type', selectedPrincipal.value.principal_type)
-      .eq('principal_id', selectedPrincipal.value.principal_id)
-      .in('channel_id', channelIds)
-
-    if (overridesError)
-      throw overridesError
-
-    const nextOverrides: Record<string, boolean> = {}
-    for (const override of (overrides as any[] || [])) {
-      const key = getOverrideKey(override.channel_id, override.permission_key)
-      nextOverrides[key] = override.is_allowed
-    }
-    channelOverrides.value = nextOverrides
-  }
-  catch (error) {
-    console.error('Error loading channel permissions:', error)
-    toast.error(t('error-loading-channel-permissions'))
-  }
-  finally {
-    channelOverridesLoading.value = false
-  }
-}
-
 async function openChannelPermissions(element: Element) {
   if (!canUpdateUserRoles.value)
     return
 
   selectedPrincipal.value = element
-  channelOverridesSearch.value = ''
-  channelOverrides.value = {}
-  channels.value = []
 
   dialogStore.openDialog({
     id: 'channel-permissions',
@@ -267,80 +130,6 @@ async function openChannelPermissions(element: Element) {
       },
     ],
   })
-
-  await loadChannelPermissions()
-}
-
-async function updateChannelPermission(channelId: number, permission: ChannelPermissionKey, value: 'default' | 'allow' | 'deny') {
-  if (!selectedPrincipal.value || !canUpdateUserRoles.value)
-    return
-
-  const key = getOverrideKey(channelId, permission)
-  if (channelOverridesSaving.value[key])
-    return
-
-  const roleName = selectedPrincipal.value.role_name
-  const defaultAllowed = getDefaultPermission(roleName, permission)
-  const previousOverrides = { ...channelOverrides.value }
-
-  channelOverridesSaving.value = { ...channelOverridesSaving.value, [key]: true }
-
-  let nextOverride: boolean | null = null
-  if (value === 'default') {
-    nextOverride = null
-  }
-  else {
-    const isAllowed = value === 'allow'
-    nextOverride = isAllowed === defaultAllowed ? null : isAllowed
-  }
-
-  if (nextOverride === null) {
-    const updated = { ...channelOverrides.value }
-    delete updated[key]
-    channelOverrides.value = updated
-  }
-  else {
-    channelOverrides.value = { ...channelOverrides.value, [key]: nextOverride }
-  }
-
-  try {
-    if (nextOverride === null) {
-      const { error } = await supabase
-        .from('channel_permission_overrides' as any)
-        .delete()
-        .eq('principal_type', selectedPrincipal.value.principal_type)
-        .eq('principal_id', selectedPrincipal.value.principal_id)
-        .eq('channel_id', channelId)
-        .eq('permission_key', permission)
-
-      if (error)
-        throw error
-    }
-    else {
-      const { error } = await supabase
-        .from('channel_permission_overrides' as any)
-        .upsert({
-          principal_type: selectedPrincipal.value.principal_type,
-          principal_id: selectedPrincipal.value.principal_id,
-          channel_id: channelId,
-          permission_key: permission,
-          is_allowed: nextOverride,
-        }, { onConflict: 'principal_type,principal_id,channel_id,permission_key' })
-
-      if (error)
-        throw error
-    }
-  }
-  catch (error) {
-    console.error('Error saving channel permission override:', error)
-    channelOverrides.value = previousOverrides
-    toast.error(t('error-saving-channel-permissions'))
-  }
-  finally {
-    const updatedSaving = { ...channelOverridesSaving.value }
-    delete updatedSaving[key]
-    channelOverridesSaving.value = updatedSaving
-  }
 }
 
 async function showRoleModal(element: Element): Promise<string | undefined> {
@@ -616,87 +405,13 @@ watch(dynamicColumns, (newCols) => {
     defer
     to="#dialog-v2-content"
   >
-    <div class="space-y-4">
-      <div class="space-y-1">
-        <div class="text-xs font-semibold tracking-wide text-gray-400 uppercase">
-          {{ t('channel-permissions-principal') }}
-        </div>
-        <div class="text-base text-gray-900 dark:text-gray-100">
-          {{ selectedPrincipal?.principal_name || '-' }}
-        </div>
-        <div class="text-xs text-gray-500">
-          {{ t('channel-permissions-role') }}: {{ selectedPrincipal ? getRoleDisplayName(selectedPrincipal.role_name) : '-' }}
-        </div>
-      </div>
-
-      <div>
-        <input
-          v-model="channelOverridesSearch"
-          type="text"
-          class="w-full d-input d-input-bordered"
-          :placeholder="t('search-channels')"
-        >
-      </div>
-
-      <div v-if="channelOverridesLoading" class="py-6 text-sm text-gray-500">
-        {{ t('loading') }}...
-      </div>
-
-      <div v-else-if="filteredChannels.length === 0" class="py-6 text-sm text-gray-500">
-        {{ t('channel-permissions-empty') }}
-      </div>
-
-      <div v-else class="overflow-x-auto border border-slate-200 dark:border-slate-700 rounded-lg">
-        <table class="min-w-full text-sm">
-          <thead class="bg-slate-50 dark:bg-slate-900/40">
-            <tr>
-              <th class="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">
-                {{ t('channels') }}
-              </th>
-              <th
-                v-for="perm in channelPermissionOptions"
-                :key="perm.key"
-                class="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200"
-              >
-                {{ perm.label }}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="channel in filteredChannels"
-              :key="channel.id"
-              class="border-t border-slate-200 dark:border-slate-700"
-            >
-              <td class="px-3 py-2 text-gray-900 dark:text-gray-100">
-                {{ channel.name }}
-              </td>
-              <td
-                v-for="perm in channelPermissionOptions"
-                :key="perm.key"
-                class="px-3 py-2"
-              >
-                <select
-                  class="w-full d-select d-select-sm d-select-bordered"
-                  :value="getSelectValue(channel.id, perm.key)"
-                  :disabled="isSavingOverride(channel.id, perm.key)"
-                  @change="updateChannelPermission(channel.id, perm.key, ($event.target as HTMLSelectElement).value as 'default' | 'allow' | 'deny')"
-                >
-                  <option value="default">
-                    {{ getDefaultLabel(selectedPrincipal?.role_name || 'app_reader', perm.key) }}
-                  </option>
-                  <option value="allow">
-                    {{ t('channel-permissions-allow') }}
-                  </option>
-                  <option value="deny">
-                    {{ t('channel-permissions-deny') }}
-                  </option>
-                </select>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <ChannelPermissionOverridesPanel
+      v-if="selectedPrincipal"
+      :app-id="props.appId"
+      :principal-type="selectedPrincipal.principal_type"
+      :principal-id="selectedPrincipal.principal_id"
+      :principal-name="selectedPrincipal.principal_name || '-'"
+      :role-name="selectedPrincipal.role_name"
+    />
   </Teleport>
 </template>

--- a/src/pages/ApiKeys.vue
+++ b/src/pages/ApiKeys.vue
@@ -12,8 +12,10 @@ import IconArrowPath from '~icons/heroicons/arrow-path'
 import IconCalendar from '~icons/heroicons/calendar'
 import IconClipboard from '~icons/heroicons/clipboard-document'
 import IconPencil from '~icons/heroicons/pencil'
+import IconShield from '~icons/heroicons/shield-check'
 import IconTrash from '~icons/heroicons/trash'
 import IconXMark from '~icons/heroicons/x-mark'
+import ChannelPermissionOverridesPanel from '~/components/permissions/ChannelPermissionOverridesPanel.vue'
 import {
   confirmApiKeyDeletion,
   confirmApiKeyRegeneration,
@@ -40,7 +42,7 @@ interface Role {
 
 interface RoleBindingRow {
   id: string
-  principal_type: string
+  principal_type: 'apikey'
   principal_id: string
   scope_type: string
   org_id: string | null
@@ -61,6 +63,15 @@ interface ScopePickerState {
   x: number
   y: number
   width: number
+}
+
+interface ApiKeyAppAccessOption {
+  appUuid: string
+  publicAppId: string
+  appName: string
+  orgId: string
+  orgName: string
+  roleName: string
 }
 
 const { t } = useI18n()
@@ -103,6 +114,10 @@ const manageableOrgIds = ref(new Set<string>())
 const pendingAppBindings = ref<Record<string, string>>({})
 const showOrgDropdown = ref(false)
 const showAppDropdown = ref(false)
+const selectedApiKeyForChannelPermissions = ref<Database['public']['Tables']['apikeys']['Row'] | null>(null)
+const channelPermissionAppOptions = ref<ApiKeyAppAccessOption[]>([])
+const selectedChannelPermissionAppUuid = ref('')
+const channelPermissionAppsLoading = ref(false)
 
 // Available apps for selection (populated when showing app dialog)
 const availableApps = ref<{ id: string, app_id: string, name: string | null, owner_org: string }[]>([])
@@ -680,6 +695,9 @@ function ensureSelectedOrgRoleAllowed() {
 }
 
 const selectedAppIds = computed(() => Object.keys(pendingAppBindings.value))
+const selectedChannelPermissionApp = computed(() =>
+  channelPermissionAppOptions.value.find(app => app.appUuid === selectedChannelPermissionAppUuid.value),
+)
 
 columns.value = [
   {
@@ -756,6 +774,13 @@ columns.value = [
         icon: IconClipboard,
         title: t('copy'),
         onClick: (key: Database['public']['Tables']['apikeys']['Row']) => copyKey(key),
+      },
+      {
+        icon: IconShield,
+        title: t('channel-permissions-title'),
+        visible: (key: Database['public']['Tables']['apikeys']['Row']) => hasChannelPermissionApps(key),
+        onClick: (key: Database['public']['Tables']['apikeys']['Row']) => openApiKeyChannelPermissions(key),
+        testId: (key: Database['public']['Tables']['apikeys']['Row']) => `manage-key-channel-permissions-${key.id}`,
       },
       {
         icon: IconPencil,
@@ -852,7 +877,7 @@ async function fetchAllBindings() {
 
   allBindings.value = ((data || []) as any[]).map(row => ({
     id: row.id,
-    principal_type: row.principal_type,
+    principal_type: 'apikey',
     principal_id: row.principal_id,
     scope_type: row.scope_type,
     org_id: row.org_id,
@@ -1211,6 +1236,115 @@ function getAppNameById(appId: string) {
 function getAppOrgNameById(appId: string) {
   const app = availableApps.value.find(a => a.id === appId)
   return app?.owner_org ? getOrgNameById(app.owner_org) : ''
+}
+
+function getApiKeyAdminOrgIds(key: Database['public']['Tables']['apikeys']['Row']) {
+  return getBindingsForKey(key)
+    .filter(binding => binding.scope_type === 'org' && !!binding.org_id && rolesWithInheritedAppAccess.has(binding.role_name))
+    .map(binding => binding.org_id!)
+}
+
+function hasChannelPermissionApps(key: Database['public']['Tables']['apikeys']['Row']) {
+  if (!key.rbac_id)
+    return false
+
+  const bindings = getBindingsForKey(key)
+  return bindings.some(binding => binding.scope_type === 'app' && !!binding.app_id)
+    || bindings.some(binding => binding.scope_type === 'org' && !!binding.org_id && rolesWithInheritedAppAccess.has(binding.role_name))
+}
+
+async function loadApiKeyChannelPermissionApps(key: Database['public']['Tables']['apikeys']['Row']) {
+  channelPermissionAppsLoading.value = true
+  channelPermissionAppOptions.value = []
+  selectedChannelPermissionAppUuid.value = ''
+
+  try {
+    const bindings = getBindingsForKey(key)
+    const directAppRoleById = new Map<string, string>()
+    for (const binding of bindings) {
+      if (binding.scope_type === 'app' && binding.app_id && binding.role_name)
+        directAppRoleById.set(binding.app_id, binding.role_name)
+    }
+
+    const adminOrgIds = Array.from(new Set(getApiKeyAdminOrgIds(key)))
+    const appRows: { id: string, app_id: string, name: string | null, owner_org: string }[] = []
+
+    const directAppIds = Array.from(directAppRoleById.keys())
+    if (directAppIds.length > 0) {
+      const { data, error } = await supabase
+        .from('apps')
+        .select('id, app_id, name, owner_org')
+        .in('id', directAppIds)
+
+      if (error)
+        throw error
+      appRows.push(...((data || []) as { id: string, app_id: string, name: string | null, owner_org: string }[]))
+    }
+
+    if (adminOrgIds.length > 0) {
+      const { data, error } = await supabase
+        .from('apps')
+        .select('id, app_id, name, owner_org')
+        .in('owner_org', adminOrgIds)
+
+      if (error)
+        throw error
+      appRows.push(...((data || []) as { id: string, app_id: string, name: string | null, owner_org: string }[]))
+    }
+
+    const uniqueAppsById = new Map<string, { id: string, app_id: string, name: string | null, owner_org: string }>()
+    for (const app of appRows) {
+      if (app.id)
+        uniqueAppsById.set(app.id, app)
+    }
+
+    const options = Array.from(uniqueAppsById.values()).map((app): ApiKeyAppAccessOption => {
+      const displayName = app.name || app.app_id
+      return {
+        appUuid: app.id,
+        publicAppId: app.app_id,
+        appName: displayName,
+        orgId: app.owner_org,
+        orgName: getOrgNameById(app.owner_org),
+        roleName: directAppRoleById.get(app.id) ?? 'app_admin',
+      }
+    }).sort((a, b) => a.appName.localeCompare(b.appName))
+
+    cacheAppNames(Array.from(uniqueAppsById.values()))
+    channelPermissionAppOptions.value = options
+    selectedChannelPermissionAppUuid.value = options[0]?.appUuid ?? ''
+  }
+  catch (error) {
+    console.error('Error loading API key channel permission apps:', error)
+    toast.error(t('error-loading-channel-permissions'))
+  }
+  finally {
+    channelPermissionAppsLoading.value = false
+  }
+}
+
+async function openApiKeyChannelPermissions(key: Database['public']['Tables']['apikeys']['Row']) {
+  if (!key.rbac_id)
+    return
+
+  selectedApiKeyForChannelPermissions.value = key
+  channelPermissionAppOptions.value = []
+  selectedChannelPermissionAppUuid.value = ''
+
+  dialogStore.openDialog({
+    id: 'apikey-channel-permissions',
+    title: t('channel-permissions-title'),
+    description: t('channel-permissions-description'),
+    size: 'xl',
+    buttons: [
+      {
+        text: t('close'),
+        role: 'cancel',
+      },
+    ],
+  })
+
+  await loadApiKeyChannelPermissionApps(key)
 }
 
 async function getUserFacingErrorMessage(error: unknown, fallbackMessage: string) {
@@ -1664,6 +1798,46 @@ getKeys()
               </template>
             </VueDatePicker>
           </div>
+        </div>
+      </Teleport>
+
+      <!-- Teleport Content for API Key Channel Permissions -->
+      <Teleport v-if="dialogStore.showDialog && dialogStore.dialogOptions?.id === 'apikey-channel-permissions'" defer to="#dialog-v2-content">
+        <div class="space-y-4">
+          <div v-if="channelPermissionAppsLoading" class="py-6 text-sm text-gray-500">
+            {{ t('loading') }}...
+          </div>
+          <div v-else-if="channelPermissionAppOptions.length === 0" class="py-6 text-sm text-gray-500">
+            {{ t('app-access-none') }}
+          </div>
+          <template v-else-if="selectedApiKeyForChannelPermissions?.rbac_id && selectedChannelPermissionApp">
+            <div>
+              <label class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+                {{ t('app') }}
+              </label>
+              <select
+                v-model="selectedChannelPermissionAppUuid"
+                class="w-full d-select d-select-bordered"
+                data-test="apikey-channel-permissions-app-select"
+              >
+                <option
+                  v-for="app in channelPermissionAppOptions"
+                  :key="app.appUuid"
+                  :value="app.appUuid"
+                >
+                  {{ app.appName }} · {{ getRoleDisplayName(app.roleName) }} · {{ app.orgName }}
+                </option>
+              </select>
+            </div>
+
+            <ChannelPermissionOverridesPanel
+              :app-id="selectedChannelPermissionApp.publicAppId"
+              principal-type="apikey"
+              :principal-id="selectedApiKeyForChannelPermissions.rbac_id"
+              :principal-name="selectedApiKeyForChannelPermissions.name || hideString(selectedApiKeyForChannelPermissions.key)"
+              :role-name="selectedChannelPermissionApp.roleName"
+            />
+          </template>
         </div>
       </Teleport>
 

--- a/src/route-map.d.ts
+++ b/src/route-map.d.ts
@@ -20,9 +20,9 @@ import type {
 
 declare module 'vue-router' {
   interface TypesConfig {
-    ParamParsers:
-      | never
+    _ParamParsers: {}
     RouteNamedMap: import('vue-router/auto-routes').RouteNamedMap
+    _RouteFileInfoMap: import('vue-router/auto-routes')._RouteFileInfoMap
   }
 }
 
@@ -553,11 +553,15 @@ declare module 'vue-router/auto-routes' {
         | '/[...all]'
       views:
         | never
+      pathParamNames:
+        | 'all'
     }
     'src/pages/accountDisabled.vue': {
       routes:
         | '/accountDisabled'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/admin/dashboard/index.vue': {
@@ -565,11 +569,15 @@ declare module 'vue-router/auto-routes' {
         | '/admin/dashboard/'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/admin/dashboard/credits.vue': {
       routes:
         | '/admin/dashboard/credits'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/admin/dashboard/debug.vue': {
@@ -577,11 +585,15 @@ declare module 'vue-router/auto-routes' {
         | '/admin/dashboard/debug'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/admin/dashboard/organizations.vue': {
       routes:
         | '/admin/dashboard/organizations'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/admin/dashboard/plugins.vue': {
@@ -589,11 +601,15 @@ declare module 'vue-router/auto-routes' {
         | '/admin/dashboard/plugins'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/admin/dashboard/replication.vue': {
       routes:
         | '/admin/dashboard/replication'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/admin/dashboard/revenue.vue': {
@@ -601,11 +617,15 @@ declare module 'vue-router/auto-routes' {
         | '/admin/dashboard/revenue'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/admin/dashboard/updates.vue': {
       routes:
         | '/admin/dashboard/updates'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/admin/dashboard/users.vue': {
@@ -613,11 +633,15 @@ declare module 'vue-router/auto-routes' {
         | '/admin/dashboard/users'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/ApiKeys.vue': {
       routes:
         | '/ApiKeys'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/app/[app].vue': {
@@ -625,137 +649,196 @@ declare module 'vue-router/auto-routes' {
         | '/app/[app]'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].access.vue': {
       routes:
         | '/app/[app].access'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].builds.vue': {
       routes:
         | '/app/[app].builds'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].bundle.[bundle].vue': {
       routes:
         | '/app/[app].bundle.[bundle]'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'bundle'
     }
     'src/pages/app/[app].bundle.[bundle].dependencies.vue': {
       routes:
         | '/app/[app].bundle.[bundle].dependencies'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'bundle'
     }
     'src/pages/app/[app].bundle.[bundle].history.vue': {
       routes:
         | '/app/[app].bundle.[bundle].history'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'bundle'
     }
     'src/pages/app/[app].bundle.[bundle].manifest.vue': {
       routes:
         | '/app/[app].bundle.[bundle].manifest'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'bundle'
     }
     'src/pages/app/[app].bundle.[bundle].preview.vue': {
       routes:
         | '/app/[app].bundle.[bundle].preview'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'bundle'
     }
     'src/pages/app/[app].bundles.vue': {
       routes:
         | '/app/[app].bundles'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].bundles.new.vue': {
       routes:
         | '/app/[app].bundles.new'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].channel.[channel].vue': {
       routes:
         | '/app/[app].channel.[channel]'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'channel'
     }
     'src/pages/app/[app].channel.[channel].devices.vue': {
       routes:
         | '/app/[app].channel.[channel].devices'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'channel'
     }
     'src/pages/app/[app].channel.[channel].history.vue': {
       routes:
         | '/app/[app].channel.[channel].history'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'channel'
     }
     'src/pages/app/[app].channel.[channel].preview.vue': {
       routes:
         | '/app/[app].channel.[channel].preview'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'channel'
     }
     'src/pages/app/[app].channel.[channel].statistics.vue': {
       routes:
         | '/app/[app].channel.[channel].statistics'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'channel'
     }
     'src/pages/app/[app].channels.vue': {
       routes:
         | '/app/[app].channels'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].device.[device].vue': {
       routes:
         | '/app/[app].device.[device]'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'device'
     }
     'src/pages/app/[app].device.[device].deployments.vue': {
       routes:
         | '/app/[app].device.[device].deployments'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'device'
     }
     'src/pages/app/[app].device.[device].logs.vue': {
       routes:
         | '/app/[app].device.[device].logs'
       views:
         | never
+      pathParamNames:
+        | 'app'
+        | 'device'
     }
     'src/pages/app/[app].devices.vue': {
       routes:
         | '/app/[app].devices'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].info.vue': {
       routes:
         | '/app/[app].info'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/[app].logs.vue': {
       routes:
         | '/app/[app].logs'
       views:
         | never
+      pathParamNames:
+        | 'app'
     }
     'src/pages/app/modules.vue': {
       routes:
         | '/app/modules'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/app/modules_test.vue': {
@@ -763,11 +846,15 @@ declare module 'vue-router/auto-routes' {
         | '/app/modules_test'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/app/new.vue': {
       routes:
         | '/app/new'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/apps.vue': {
@@ -775,11 +862,15 @@ declare module 'vue-router/auto-routes' {
         | '/apps'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/confirm-signup.vue': {
       routes:
         | '/confirm-signup'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/dashboard.vue': {
@@ -787,11 +878,15 @@ declare module 'vue-router/auto-routes' {
         | '/dashboard'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/delete_account.vue': {
       routes:
         | '/delete_account'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/demo_dialog.vue': {
@@ -799,11 +894,15 @@ declare module 'vue-router/auto-routes' {
         | '/demo_dialog'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/forgot_password.vue': {
       routes:
         | '/forgot_password'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/invitation.vue': {
@@ -811,17 +910,23 @@ declare module 'vue-router/auto-routes' {
         | '/invitation'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/log-as/[userId].vue': {
       routes:
         | '/log-as/[userId]'
       views:
         | never
+      pathParamNames:
+        | 'userId'
     }
     'src/pages/login.vue': {
       routes:
         | '/login'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/onboarding/invitation.vue': {
@@ -829,11 +934,15 @@ declare module 'vue-router/auto-routes' {
         | '/onboarding/invitation'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/onboarding/organization.vue': {
       routes:
         | '/onboarding/organization'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/onboarding/set_password.vue': {
@@ -841,11 +950,15 @@ declare module 'vue-router/auto-routes' {
         | '/onboarding/set_password'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/register.vue': {
       routes:
         | '/register'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/resend_email.vue': {
@@ -853,11 +966,15 @@ declare module 'vue-router/auto-routes' {
         | '/resend_email'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/scan.vue': {
       routes:
         | '/scan'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/account/index.vue': {
@@ -865,11 +982,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/account/'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/account/ChangePassword.vue': {
       routes:
         | '/settings/account/ChangePassword'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/account/ManageTwoFactor.vue': {
@@ -877,11 +998,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/account/ManageTwoFactor'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/account/Notifications.vue': {
       routes:
         | '/settings/account/Notifications'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/index.vue': {
@@ -889,11 +1014,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/organization/ApiKeys.vue': {
       routes:
         | '/settings/organization/ApiKeys'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/ApiKeys.[id].vue': {
@@ -901,11 +1030,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/ApiKeys.[id]'
       views:
         | never
+      pathParamNames:
+        | 'id'
     }
     'src/pages/settings/organization/Security.vue': {
       routes:
         | '/settings/organization/Security'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/AuditLogs.vue': {
@@ -913,11 +1046,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/AuditLogs'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/organization/Credits.vue': {
       routes:
         | '/settings/organization/Credits'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/DeleteOrgDialog.vue': {
@@ -925,11 +1062,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/DeleteOrgDialog'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/organization/Groups.vue': {
       routes:
         | '/settings/organization/Groups'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/Groups.[id].vue': {
@@ -937,11 +1078,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/Groups.[id]'
       views:
         | never
+      pathParamNames:
+        | 'id'
     }
     'src/pages/settings/organization/Members.vue': {
       routes:
         | '/settings/organization/Members'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/Notifications.vue': {
@@ -949,11 +1094,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/Notifications'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/organization/Plans.vue': {
       routes:
         | '/settings/organization/Plans'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/settings/organization/Usage.vue': {
@@ -961,11 +1110,15 @@ declare module 'vue-router/auto-routes' {
         | '/settings/organization/Usage'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/settings/organization/Webhooks.vue': {
       routes:
         | '/settings/organization/Webhooks'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/sso-callback.vue': {
@@ -973,11 +1126,15 @@ declare module 'vue-router/auto-routes' {
         | '/sso-callback'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/Webhooks.vue': {
       routes:
         | '/Webhooks'
       views:
+        | never
+      pathParamNames:
         | never
     }
   }

--- a/tests/rbac-permissions.test.ts
+++ b/tests/rbac-permissions.test.ts
@@ -891,6 +891,111 @@ describe('rbac permission system', () => {
         expect(deniedError).toBeTruthy()
         expect((deniedError as Error).message).toContain('PERMISSION_DENIED_CHANNEL_PROMOTE_BUNDLE')
       })
+
+      it('should apply channel permission overrides to API key principals', async () => {
+        const testId = randomUUID()
+        const orgId = randomUUID()
+        const appUuid = randomUUID()
+        const appId = `com.rbac.apikey.channel-override.${testId}`
+        const apiKey = `apikey-channel-override-${testId}`
+
+        await query(`
+          INSERT INTO public.orgs (id, name, management_email, created_by, use_new_rbac)
+          VALUES ($1::uuid, $2, $3, $4::uuid, true)
+        `, [orgId, `RBAC API Key Channel Override ${testId}`, `rbac-apikey-channel-${testId}@capgo.app`, USER_ID])
+
+        await query(`
+          INSERT INTO public.apps (id, app_id, name, icon_url, owner_org)
+          VALUES ($1::uuid, $2, $3, $4, $5::uuid)
+        `, [appUuid, appId, `RBAC API Key Channel Override App ${testId}`, 'rbac-apikey-channel-icon', orgId])
+
+        const version = await query(`
+          INSERT INTO public.app_versions (app_id, name, owner_org, user_id, storage_provider)
+          VALUES ($1, $2, $3::uuid, $4::uuid, 'r2-direct')
+          RETURNING id
+        `, [appId, `1.0.0-apikey-channel-${testId}`, orgId, USER_ID])
+
+        const channel = await query(`
+          INSERT INTO public.channels (name, app_id, version, created_by, owner_org)
+          VALUES ($1, $2, $3::bigint, $4::uuid, $5::uuid)
+          RETURNING id
+        `, [`production-${testId}`, appId, version.rows[0].id, USER_ID, orgId])
+
+        const apiKeyResult = await query(`
+          INSERT INTO public.apikeys (user_id, key, name)
+          VALUES ($1::uuid, $2, $3)
+          RETURNING rbac_id
+        `, [USER_ID, apiKey, `API Key Channel Override ${testId}`])
+        const apiKeyRbacId = apiKeyResult.rows[0]?.rbac_id
+        expect(apiKeyRbacId).toBeTruthy()
+
+        await query(`
+          INSERT INTO public.role_bindings (
+            principal_type,
+            principal_id,
+            role_id,
+            scope_type,
+            org_id,
+            app_id,
+            granted_by,
+            is_direct
+          )
+          SELECT
+            public.rbac_principal_apikey(),
+            $1::uuid,
+            r.id,
+            public.rbac_scope_app(),
+            $2::uuid,
+            $3::uuid,
+            $4::uuid,
+            true
+          FROM public.roles r
+          WHERE r.name = public.rbac_role_app_developer()
+        `, [apiKeyRbacId, orgId, appUuid, USER_ID])
+
+        const allowedBeforeOverride = await query(`
+          SELECT public.rbac_check_permission_direct(
+            public.rbac_perm_channel_promote_bundle(),
+            $1::uuid,
+            $2::uuid,
+            $3,
+            $4::bigint,
+            $5
+          ) AS allowed
+        `, [USER_ID, orgId, appId, channel.rows[0].id, apiKey])
+
+        expect(allowedBeforeOverride.rows[0].allowed).toBe(true)
+
+        await query(`
+          INSERT INTO public.channel_permission_overrides (
+            principal_type,
+            principal_id,
+            channel_id,
+            permission_key,
+            is_allowed
+          )
+          VALUES (
+            public.rbac_principal_apikey(),
+            $1::uuid,
+            $2::bigint,
+            public.rbac_perm_channel_promote_bundle(),
+            false
+          )
+        `, [apiKeyRbacId, channel.rows[0].id])
+
+        const allowedAfterOverride = await query(`
+          SELECT public.rbac_check_permission_direct(
+            public.rbac_perm_channel_promote_bundle(),
+            $1::uuid,
+            $2::uuid,
+            $3,
+            $4::bigint,
+            $5
+          ) AS allowed
+        `, [USER_ID, orgId, appId, channel.rows[0].id, apiKey])
+
+        expect(allowedAfterOverride.rows[0].allowed).toBe(false)
+      })
     })
 
     describe('RBAC compatibility flag', () => {

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -429,7 +429,7 @@ describe('[POST] /stats', () => {
     }
   })
 
-  it.concurrent('filters legacy download_fail before saved stats and logs', async () => {
+  testIt('filters legacy download_fail before saved stats and logs', async () => {
     const cases = [
       { pluginVersion: '7.16.9', shouldRecord: false, createVersion: true },
       { pluginVersion: '7.16.9', shouldRecord: false, createVersion: false },
@@ -439,13 +439,14 @@ describe('[POST] /stats', () => {
       { pluginVersion: 'not-a-version', shouldRecord: false, createVersion: true },
     ]
 
-    for (const testCase of cases) {
+    for (const [caseIndex, testCase] of cases.entries()) {
       const uuid = randomUUID().toLowerCase()
+      const caseId = randomUUID().slice(0, 8)
       const baseData = getBaseData(APP_NAME_STATS) as StatsPayload
       baseData.device_id = uuid
       baseData.action = 'download_fail'
       baseData.plugin_version = testCase.pluginVersion
-      baseData.version_build = `1.0.0-download-fail-${testCase.pluginVersion.replace(/\./g, '-')}-${testCase.createVersion ? 'existing' : 'missing'}`
+      baseData.version_build = `1.0.0-download-fail-${caseIndex}-${caseId}-${testCase.pluginVersion.replace(/\./g, '-')}-${testCase.createVersion ? 'existing' : 'missing'}`
       const versionName = testCase.createVersion
         ? (await createAppVersions(baseData.version_build, APP_NAME_STATS)).name
         : baseData.version_build


### PR DESCRIPTION
## Summary (AI generated)

- Extracted the channel permission override table into a reusable component.
- Reused the component for existing user/group app access and for API-key app access.
- Added an API-key page action to manage per-channel overrides for keys with direct app access or inherited app-admin access from org admin roles.
- Added backend RBAC coverage and Playwright persistence coverage for API-key channel overrides.

## Motivation (AI generated)

API keys currently expose app-level role assignment but not the per-channel override flow that users and groups have. The backend already supports `channel_permission_overrides` for API-key principals, so the UI should let API keys behave like user rights for app role plus channel-level exceptions.

## Business Impact (AI generated)

This gives teams finer control over deployment automation keys without granting broader app permissions than needed. It reduces operational risk for customers using API keys in CI/CD and keeps API-key management aligned with the existing RBAC model.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run supabase:with-env -- bunx vitest run tests/rbac-permissions.test.ts`
- [x] Targeted Playwright scenario for API-key channel permission override persistence
- [x] GitHub CI `Run Playwright tests`
- [x] GitHub CI `Run tests`

## Screenshots (AI generated)

Screenshot captured in the Codex thread after opening the API-key channel permissions dialog locally.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint`.
- [x] My change does not require a change to the documentation.
- [x] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage per-API-key channel permission overrides from API keys—select app context, set allow/deny per channel, and see settings persist when reopening the permissions panel.
* **Tests**
  * Added end-to-end and RBAC tests validating override persistence across UI reopen and correct permission enforcement for API key principals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->