### PR TITLE
feat(cli/build init): ask "continue or restart?" when Android progress exists

### DIFF
--- a/cli/src/build/onboarding/android/types.ts
+++ b/cli/src/build/onboarding/android/types.ts
@@ -2,6 +2,7 @@
 
 export type AndroidOnboardingStep
   = | 'welcome'
+    | 'resume-prompt'
     | 'credentials-exist'
     | 'backing-up'
     | 'no-platform'
@@ -193,6 +194,7 @@ export interface AndroidOnboardingProgress {
 
 export const ANDROID_STEP_PROGRESS: Record<AndroidOnboardingStep, number> = {
   'welcome': 0,
+  'resume-prompt': 2,
   'credentials-exist': 0,
   'backing-up': 0,
   'no-platform': 0,
@@ -274,6 +276,8 @@ export function getAndroidPhaseLabel(step: AndroidOnboardingStep): string {
     case 'backing-up':
     case 'no-platform':
       return ''
+    case 'resume-prompt':
+      return 'Resume or restart?'
     case 'keystore-method-select':
     case 'keystore-explainer':
     case 'keystore-existing-path':

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -994,7 +994,15 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
           const existing = await loadSavedCredentials(appId)
           if (cancelled)
             return
-          if (existing?.android && !initialProgress)
+          // NB: do NOT gate this on `!initialProgress`. The welcome step is
+          // only reached via the trivial-welcome resume case or the
+          // resume-prompt Restart handler — never during an actual resume
+          // (that routes resume-prompt → startStep directly). Gating on the
+          // stale, still-non-null `initialProgress` prop would send a Restart
+          // straight to keystore-method-select and silently overwrite existing
+          // saved credentials without offering the backup flow. Mirror iOS
+          // (cli/src/build/onboarding/ui/app.tsx) and check creds only.
+          if (existing?.android)
             setStep('credentials-exist')
           else
             setStep('keystore-method-select')

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -2300,10 +2300,20 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
           ? 'Import existing JSON'
           : serviceAccountMethod === 'generate' ? 'Create via Google' : null
         const keystoreReady = Boolean(completedSteps.keystoreReady)
+        const androidPackage = completedSteps.androidPackageChosen
+        // The service-account fork governs which downstream breadcrumbs make
+        // sense. On the import path the user never signs in with Google or
+        // picks a GCP project, so surfacing "Signed in with Google: No" there
+        // is misleading — only show the OAuth-path lines once the user is
+        // actually on (or has made progress along) that path. The import line
+        // likewise only shows on the import path. Before either is chosen we
+        // show neither, so a user who's about to auto-import isn't told they
+        // haven't done OAuth steps that don't apply to them.
+        const onImportPath = serviceAccountMethod === 'existing'
+        const onOAuthPath = serviceAccountMethod === 'generate' || hasAnyOAuthProgress(initialProgress)
         const signedIn = completedSteps.googleSignInComplete
         const playAccount = completedSteps.playAccountChosen
         const gcpProject = completedSteps.gcpProjectChosen
-        const androidPackage = completedSteps.androidPackageChosen
         const saProvisioned = completedSteps.serviceAccountProvisioned
         const resumeLabel = getAndroidPhaseLabel(startStep) || startStep
         return (
@@ -2315,11 +2325,24 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
               <Text>{`•  Keystore method: ${keystoreLabel}`}</Text>
               {saLabel && <Text>{`•  Service account method: ${saLabel}`}</Text>}
               <Text>{`•  Keystore ready: ${keystoreReady ? `Yes (${completedSteps.keystoreReady!.keystorePath})` : 'No'}`}</Text>
-              <Text>{`•  Signed in with Google: ${signedIn ? `Yes (${signedIn.email})` : 'No'}`}</Text>
-              <Text>{`•  Play Developer account: ${playAccount ? `Yes (${playAccount.displayName || playAccount.developerId})` : 'No'}`}</Text>
-              <Text>{`•  GCP project: ${gcpProject ? `Yes (${gcpProject.displayName})` : 'No'}`}</Text>
-              <Text>{`•  Android package: ${androidPackage ? `Yes (${androidPackage.packageName})` : 'No'}`}</Text>
-              <Text>{`•  Service account provisioned: ${saProvisioned ? `Yes (${saProvisioned.email})` : 'No'}`}</Text>
+              {onImportPath && (
+                <Text>{`•  Service account JSON: ${initialProgress.serviceAccountJsonPath ? `selected (${initialProgress.serviceAccountJsonPath})` : 'not selected yet'}`}</Text>
+              )}
+              {onOAuthPath && (
+                <Text>{`•  Signed in with Google: ${signedIn ? `Yes (${signedIn.email})` : 'No'}`}</Text>
+              )}
+              {onOAuthPath && (
+                <Text>{`•  Play Developer account: ${playAccount ? `Yes (${playAccount.displayName || playAccount.developerId})` : 'No'}`}</Text>
+              )}
+              {onOAuthPath && (
+                <Text>{`•  GCP project: ${gcpProject ? `Yes (${gcpProject.displayName})` : 'No'}`}</Text>
+              )}
+              {(onImportPath || onOAuthPath) && (
+                <Text>{`•  Android package: ${androidPackage ? `Yes (${androidPackage.packageName})` : 'No'}`}</Text>
+              )}
+              {onOAuthPath && (
+                <Text>{`•  Service account provisioned: ${saProvisioned ? `Yes (${saProvisioned.email})` : 'No'}`}</Text>
+              )}
               <Text dimColor>{`•  Resume target: ${resumeLabel}`}</Text>
             </Box>
             <Select
@@ -2332,6 +2355,11 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
                 if (selectFiredRef.current)
                   return
                 selectFiredRef.current = true
+                // Record which branch the user took. The funnel already shows
+                // the resume-prompt step + the next step (welcome on restart,
+                // the resume target on continue), but the explicit choice tag
+                // gives a clean continue-vs-restart split without inferring it.
+                trackAction('resume_prompt_decision', { choice: value })
                 if (value === 'continue') {
                   // Now that the user has committed to picking up where they
                   // left off, replay the breadcrumb log so they see the

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -217,7 +217,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
   const [step, setStep] = useState<AndroidOnboardingStep>(
     initialProgress !== null && startStep !== 'welcome'
       ? 'resume-prompt'
-      : startStep === 'welcome' ? 'welcome' : startStep,
+      : startStep,
   )
 
   // Telemetry: resolve org id once + emit per-step events

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -208,8 +208,16 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
   const { exit } = useApp()
   const startStep: AndroidOnboardingStep = getAndroidResumeStep(initialProgress)
 
+  // When there's saved progress AND the resume target isn't trivially 'welcome',
+  // land on the resume-prompt fork so the user can see what's saved and decide
+  // whether to continue or restart from scratch — instead of being silently
+  // teleported to the middle of the wizard with no chance to bail out cleanly.
+  // The trivial case (no progress, or resume target is welcome) keeps the
+  // existing zero-friction path.
   const [step, setStep] = useState<AndroidOnboardingStep>(
-    startStep === 'welcome' ? 'welcome' : startStep,
+    initialProgress !== null && startStep !== 'welcome'
+      ? 'resume-prompt'
+      : startStep === 'welcome' ? 'welcome' : startStep,
   )
 
   // Telemetry: resolve org id once + emit per-step events
@@ -743,7 +751,16 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
     [persist],
   )
 
-  useEffect(() => {
+  // Re-emit the breadcrumb entries the user "earned" before this session — the
+  // partial keystore inputs (path / alias / store + key password) and the
+  // completed-phase markers (sign-in, Play account, GCP project, package, SA).
+  // Wrapped in a useCallback so both the mount-time path AND the resume-prompt
+  // "Continue" handler can call it. We DON'T want this firing while the user is
+  // still on the resume-prompt screen — the side log would fill with stale
+  // entries BEFORE the user has chosen Continue vs Restart, and picking Restart
+  // would leave those entries dangling next to a fresh wizard. addLog's
+  // consecutive-dedupe protects against accidental double calls.
+  const hydrateCompletedLog = useCallback(() => {
     if (!initialProgress)
       return
     const { completedSteps } = initialProgress
@@ -802,7 +819,77 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
       addLog(`✔ Service account — ${completedSteps.serviceAccountProvisioned.email}`)
     if (completedSteps.playInviteProvisioned)
       addLog(`✔ Service account invited to Play Console`)
+  }, [initialProgress, addLog])
+
+  // Mount-time hydration. Suppressed when the initial step is the resume-prompt
+  // fork — that path defers hydration to the user's explicit Continue choice
+  // (see the resume-prompt onChange below). The trivial-progress paths
+  // (welcome / no progress) still hydrate here so any partial input the user
+  // had keeps its breadcrumb.
+  const skipMountHydrationRef = useRef(step === 'resume-prompt')
+  useEffect(() => {
+    if (skipMountHydrationRef.current)
+      return
+    hydrateCompletedLog()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  /**
+   * Reset everything for a fresh-start onboarding pass. Called from the
+   * resume-prompt restart handler (mount-time "start over" branch).
+   *
+   * Wipes the on-disk progress file AND every piece of in-memory state that
+   * could otherwise leak across into the next attempt (keystore inputs +
+   * outputs, the service-account fork choice and imported JSON path, OAuth
+   * tokens, the chosen Play account / GCP project / Android package, and the
+   * provisioning outputs). Does NOT addLog or setStep — the caller picks the
+   * user-facing message and the next step.
+   */
+  const resetForFreshStart = useCallback(async () => {
+    await deleteAndroidProgress(appId).catch(() => { /* best-effort */ })
+    // Phase 1 — keystore inputs + outputs
+    setKeystoreMethod(null)
+    setKeystorePathMode('choose')
+    setKeystoreExistingPath('')
+    setKeystoreAlias('')
+    setKeystoreStorePassword('')
+    setKeystoreKeyPassword('')
+    setKeystoreCommonName('')
+    setKeystoreReady(null)
+    setKeystoreBase64('')
+    setRandomPasswordGenerated(false)
+    setDetectedAliases([])
+    setKeyPasswordProbe(null)
+    keyPasswordProbeRef.current = false
+    // Phase 2 — service-account fork
+    setServiceAccountMethod(null)
+    setSaJsonPathMode('choose')
+    setServiceAccountJsonPath('')
+    setSaValidationResult(null)
+    // Phase 2b — Google sign-in / OAuth
+    setGoogleSignIn(null)
+    setAccessToken('')
+    setRefreshTokenState('')
+    setOauthClientId('')
+    setOauthStatusMessages([])
+    setShowOAuthLearnMore(false)
+    // Phase 3 — Play developer account
+    setPlayAccountChoice(null)
+    setPlayDevIdMode('actions')
+    // Phase 4 — GCP project
+    setGcpProjects([])
+    setGcpProjectChoice(null)
+    setNewProjectDisplayName('')
+    // Phase 4.5 — Android package
+    setAndroidPackageChoice(null)
+    setDetectedPackageIds([])
+    setPackageSelectMode('choose')
+    packageLoadedRef.current = false
+    // Phase 5 — provisioning outputs
+    setServiceAccountProvisioned(null)
+    setPlayInviteProvisioned(null)
+    setServiceAccountKeyBase64('')
+  }, [appId])
 
   const handleError = useCallback(
     (err: unknown, failedStep: AndroidOnboardingStep) => {
@@ -2180,6 +2267,81 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
         </Box>
       )}
 
+      {/* Resume-or-restart prompt — only reachable when initialProgress is
+          non-null AND getAndroidResumeStep didn't resolve to 'welcome'. The
+          initial step useState above wires this branch. */}
+      {step === 'resume-prompt' && initialProgress && (() => {
+        const { startedAt, keystoreMethod, serviceAccountMethod, completedSteps } = initialProgress
+        // Defensive date parse: legacy / corrupted progress files can carry an
+        // unparseable startedAt — show the raw string with a dim suffix instead
+        // of crashing the wizard.
+        let whenLabel: string
+        try {
+          const d = new Date(startedAt)
+          if (Number.isNaN(d.getTime()))
+            throw new Error('NaN')
+          whenLabel = d.toLocaleString()
+        }
+        catch {
+          whenLabel = `${startedAt} (could not parse)`
+        }
+        const keystoreLabel = keystoreMethod === 'existing'
+          ? 'Import existing keystore'
+          : keystoreMethod === 'generate' ? 'Generate new keystore' : 'Not chosen yet'
+        const saLabel = serviceAccountMethod === 'existing'
+          ? 'Import existing JSON'
+          : serviceAccountMethod === 'generate' ? 'Create via Google' : null
+        const keystoreReady = Boolean(completedSteps.keystoreReady)
+        const signedIn = completedSteps.googleSignInComplete
+        const playAccount = completedSteps.playAccountChosen
+        const gcpProject = completedSteps.gcpProjectChosen
+        const androidPackage = completedSteps.androidPackageChosen
+        const saProvisioned = completedSteps.serviceAccountProvisioned
+        const resumeLabel = getAndroidPhaseLabel(startStep) || startStep
+        return (
+          <Box flexDirection="column" marginTop={1} gap={1}>
+            <Text bold color="cyan">{`↩️  Found in-progress onboarding for ${appId}`}</Text>
+            <Text>Pick up where you left off, or start over from the welcome step.</Text>
+            <Box flexDirection="column">
+              <Text>{`•  Started: ${whenLabel}`}</Text>
+              <Text>{`•  Keystore method: ${keystoreLabel}`}</Text>
+              {saLabel && <Text>{`•  Service account method: ${saLabel}`}</Text>}
+              <Text>{`•  Keystore ready: ${keystoreReady ? `Yes (${completedSteps.keystoreReady!.keystorePath})` : 'No'}`}</Text>
+              <Text>{`•  Signed in with Google: ${signedIn ? `Yes (${signedIn.email})` : 'No'}`}</Text>
+              <Text>{`•  Play Developer account: ${playAccount ? `Yes (${playAccount.displayName || playAccount.developerId})` : 'No'}`}</Text>
+              <Text>{`•  GCP project: ${gcpProject ? `Yes (${gcpProject.displayName})` : 'No'}`}</Text>
+              <Text>{`•  Android package: ${androidPackage ? `Yes (${androidPackage.packageName})` : 'No'}`}</Text>
+              <Text>{`•  Service account provisioned: ${saProvisioned ? `Yes (${saProvisioned.email})` : 'No'}`}</Text>
+              <Text dimColor>{`•  Resume target: ${resumeLabel}`}</Text>
+            </Box>
+            <Select
+              options={[
+                { label: '▶️  Continue from where I left off', value: 'continue' },
+                { label: '🔄  Restart onboarding (wipe saved progress)', value: 'restart' },
+              ]}
+              onChange={async (value) => {
+                // @inkjs/ui re-fire guard — see selectFiredRef JSDoc.
+                if (selectFiredRef.current)
+                  return
+                selectFiredRef.current = true
+                if (value === 'continue') {
+                  // Now that the user has committed to picking up where they
+                  // left off, replay the breadcrumb log so they see the
+                  // in-progress state they're resuming into. Held back at
+                  // mount so the resume-prompt screen itself wasn't surrounded
+                  // by stale "✔ …" entries while they were still deciding.
+                  hydrateCompletedLog()
+                  setStep(startStep)
+                  return
+                }
+                await resetForFreshStart()
+                addLog('↩️  Restarted — fresh start', 'yellow')
+                setStep('welcome')
+              }}
+            />
+          </Box>
+        )
+      })()}
       {step === 'welcome' && <WelcomeStep />}
 
       {step === 'no-platform' && <NoPlatformStep androidDir={androidDir} dense={false} />}

--- a/cli/src/build/onboarding/telemetry.ts
+++ b/cli/src/build/onboarding/telemetry.ts
@@ -19,7 +19,11 @@ export interface TrackBuilderOnboardingStepInput {
 }
 
 export type BuilderOnboardingAction
-  = | 'android_sa_method_selected'
+  // Shared (both platforms): which branch the user picked on the resume-prompt
+  // fork — `continue` resumes saved progress, `restart` wipes it. Carries a
+  // `choice` tag with that value.
+  = | 'resume_prompt_decision'
+    | 'android_sa_method_selected'
     | 'android_sa_validation_recovery_selected'
     | 'android_sa_validation_result'
 

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -49,7 +49,8 @@ import { getBuildOnboardingRecoveryAdvice } from '../recovery.js'
 import { createCiSecretEntries, detectCiSecretTargets, getCiSecretRepoLabelAsync, getCiSecretTargetLabel, listExistingCiSecretKeysAsync, uploadCiSecretsAsync } from '../ci-secrets.js'
 import type { CiSecretEntry, CiSecretSetupAdvice, CiSecretTarget } from '../ci-secrets.js'
 import { defaultExportPath, exportCredentialsToEnv } from '../env-export.js'
-import { trackBuilderOnboardingStep } from '../telemetry.js'
+import type { BuilderOnboardingAction } from '../telemetry.js'
+import { trackBuilderOnboardingAction, trackBuilderOnboardingStep } from '../telemetry.js'
 import { writeWorkflowFile, WORKFLOW_PATH } from '../workflow-writer.js'
 import type { BuildScriptChoice, PackageManager } from '../workflow-generator.js'
 import type { BuildCredentials } from '../../../schemas/build.js'
@@ -286,6 +287,11 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
     durationStep?: OnboardingStep
     errorCategory?: OnboardingErrorCategory
   }>>([])
+  const pendingActionTelemetryRef = useRef<Array<{
+    step: OnboardingStep
+    action: BuilderOnboardingAction
+    tags?: Record<string, boolean | number | string>
+  }>>([])
   const [resolvedOrgId, setResolvedOrgId] = useState<string | null>(null)
   const resolvedApiKeyRef = useRef<string | null>(apikey ?? null)
   const orgIdResolvedRef = useRef(false)
@@ -500,6 +506,18 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
       }
       pendingTelemetryRef.current = []
     }
+    if (resolvedOrgId && pendingActionTelemetryRef.current.length > 0) {
+      for (const queued of pendingActionTelemetryRef.current) {
+        void trackBuilderOnboardingAction({
+          apikey: resolvedApiKeyRef.current,
+          appId,
+          orgId: resolvedOrgId,
+          platform: 'ios',
+          ...queued,
+        })
+      }
+      pendingActionTelemetryRef.current = []
+    }
 
     // (2) Now safely skip the duplicate-step path.
     if (isDuplicateStep)
@@ -539,6 +557,35 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
     }
   }, [step, appId, resolvedOrgId, error])
 
+  // Emit a named "Builder Onboarding Action" event (distinct from the per-step
+  // funnel). Mirrors the Android helper: fires immediately once the org id is
+  // resolved, otherwise buffers until the resolver lands (drained in the
+  // telemetry effect above). Never throws — telemetry must not break the wizard.
+  const trackAction = useCallback(
+    (
+      action: BuilderOnboardingAction,
+      tags?: Record<string, boolean | number | string>,
+      actionStep: OnboardingStep = step,
+    ): void => {
+      if (!resolvedApiKeyRef.current)
+        return
+
+      const payload = { step: actionStep, action, tags }
+      if (resolvedOrgId) {
+        void trackBuilderOnboardingAction({
+          apikey: resolvedApiKeyRef.current,
+          appId,
+          orgId: resolvedOrgId,
+          platform: 'ios',
+          ...payload,
+        })
+      }
+      else {
+        pendingActionTelemetryRef.current.push(payload)
+      }
+    },
+    [appId, resolvedOrgId, step],
+  )
   const [teamId, setTeamId] = useState(initialProgress?.completedSteps.certificateCreated?.teamId || '')
   const [certData, setCertData] = useState<CertificateData | null>(initialProgress?.completedSteps.certificateCreated || null)
   const [profileData, setProfileData] = useState<ProfileData | null>(initialProgress?.completedSteps.profileCreated || null)
@@ -2859,6 +2906,11 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
                 { label: '🔄  Restart onboarding (wipe saved progress)', value: 'restart' },
               ]}
               onChange={async (value) => {
+                // Record which branch the user took. The funnel already shows
+                // the resume-prompt step + the next step (welcome on restart,
+                // the resume target on continue), but the explicit choice tag
+                // gives a clean continue-vs-restart split without inferring it.
+                trackAction('resume_prompt_decision', { choice: value })
                 if (value === 'continue') {
                   // Now that the user has committed to picking up where
                   // they left off, replay the breadcrumb log so they see


### PR DESCRIPTION
## Summary

Ports the iOS **"Continue or restart onboarding?"** resume-prompt to the **Android** builder onboarding flow. When a prior in-progress onboarding is found for the app, the user now lands on a fork screen — they can **continue from where they left off** or **restart from scratch (wipe saved progress)** — instead of being silently teleported into the middle of the wizard.

This mirrors the iOS implementation (`cli/src/build/onboarding/ui/app.tsx`) 1:1, adapted to the Android phases (keystore → service account → Play account → GCP project → package → provisioning).

## Changes

**`cli/src/build/onboarding/android/types.ts`**
- Add `'resume-prompt'` to `AndroidOnboardingStep`
- Add `'resume-prompt': 2` to `ANDROID_STEP_PROGRESS`
- Add `case 'resume-prompt' → 'Resume or restart?'` in `getAndroidPhaseLabel`

**`cli/src/build/onboarding/android/ui/app.tsx`**
- **Initial step** lands on `resume-prompt` when `initialProgress` exists and the resume target isn't trivially `welcome` (the zero-friction path is preserved otherwise)
- **Deferred hydration**: the always-on mount breadcrumb effect is extracted into a `hydrateCompletedLog` callback + a `skipMountHydrationRef`-guarded mount effect, so breadcrumbs replay only after the user picks **Continue** — not while they're still deciding
- **`resetForFreshStart`**: wipes the on-disk progress file plus all in-memory phase state (keystore inputs/outputs, service-account fork + imported JSON path, OAuth tokens, Play account, GCP project, Android package, provisioning outputs) on **Restart**
- **Resume-prompt render**: breadcrumb of saved state (started time, keystore/SA method, keystore-ready, Google sign-in, Play account, GCP project, Android package, SA provisioned, resume target) + a Continue/Restart `Select`, using the existing `selectFiredRef` double-fire guard

## Test plan

- [x] `tsgo` typecheck — 0 errors in the edited files
- [x] `oxlint` — clean on both files
- [x] `test-android-onboarding-progress.mjs` — 11/11 pass (`getAndroidResumeStep`, which the new UI relies on, is unchanged)
- [ ] Manual: run `capgo build init --platform android`, quit mid-flow, re-run, and verify the resume-prompt appears with correct breadcrumb; confirm **Continue** resumes at the right step and **Restart** wipes progress and returns to the welcome step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android onboarding now shows a resume prompt when saved progress exists, letting users continue or restart the setup.
  * The resume UI summarizes saved progress and offers “Continue” (resumes where left off) or “Restart onboarding” (fully clears saved progress and starts fresh).
  * Progress labels updated to clearly indicate the resume decision, improving clarity during recovery from incomplete setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->