### PR TITLE
fix(auth): share paid website cookie

### DIFF
--- a/src/services/websiteAuthCookie.ts
+++ b/src/services/websiteAuthCookie.ts
@@ -1,7 +1,6 @@
 import { getLocalConfig } from '~/services/supabase'
 
 const WEBSITE_PAID_USER_COOKIE_NAME = 'capgo_paid_user'
-const LEGACY_WEBSITE_AUTH_COOKIE_NAME = 'capgo_logged_in'
 const WEBSITE_PAID_USER_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
 
 interface WebsiteAuthOrganization {
@@ -9,18 +8,37 @@ interface WebsiteAuthOrganization {
   role?: string | null
 }
 
-function getWebsiteCookieDomain() {
-  try {
-    const { hostWeb } = getLocalConfig()
-    const hostname = new URL(hostWeb).hostname.replace(/^www\./, '')
-    if (!hostname || hostname === 'localhost' || /^[\d.]+$/.test(hostname))
-      return null
+function isCookieDomainUnsupported(hostname: string) {
+  return !hostname || hostname === 'localhost' || /^[\d.]+$/.test(hostname)
+}
 
-    return `.${hostname}`
+function hostnameFromUrl(url: string | undefined) {
+  if (!url)
+    return null
+
+  try {
+    return new URL(url).hostname
   }
   catch {
     return null
   }
+}
+
+function getWebsiteCookieDomain() {
+  const { host, hostWeb } = getLocalConfig()
+  const hostname = (
+    hostnameFromUrl(hostWeb)
+    ?? hostnameFromUrl(host)
+    ?? globalThis.location?.hostname
+    ?? ''
+  )
+    .replace(/^www\./, '')
+    .replace(/^console\./, '')
+
+  if (isCookieDomainUnsupported(hostname))
+    return null
+
+  return `.${hostname}`
 }
 
 function getCookieAttributes(maxAgeSeconds: number, domain?: string | null) {
@@ -55,7 +73,6 @@ export function clearWebsitePaidUserCookie() {
 
   const domain = getWebsiteCookieDomain()
   clearWebsiteCookie(WEBSITE_PAID_USER_COOKIE_NAME, domain)
-  clearWebsiteCookie(LEGACY_WEBSITE_AUTH_COOKIE_NAME, domain)
 }
 
 export function setWebsitePaidUserCookie(isPaidUser: boolean) {
@@ -69,7 +86,6 @@ export function setWebsitePaidUserCookie(isPaidUser: boolean) {
 
   const domain = getWebsiteCookieDomain()
   writeWebsiteCookie(WEBSITE_PAID_USER_COOKIE_NAME, '1', WEBSITE_PAID_USER_COOKIE_MAX_AGE_SECONDS, domain)
-  clearWebsiteCookie(LEGACY_WEBSITE_AUTH_COOKIE_NAME, domain)
 }
 
 export function syncWebsitePaidUserCookieFromOrganizations(organizations: WebsiteAuthOrganization[]) {

--- a/tests/website-auth-cookie.unit.test.ts
+++ b/tests/website-auth-cookie.unit.test.ts
@@ -1,14 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearWebsitePaidUserCookie, syncWebsitePaidUserCookieFromOrganizations } from '../src/services/websiteAuthCookie.ts'
 
+const localConfig = vi.hoisted(() => ({
+  value: {
+    host: 'https://console.capgo.app',
+    hostWeb: 'https://www.capgo.app' as string | undefined,
+  },
+}))
+
 vi.mock('~/services/supabase', () => ({
-  getLocalConfig: () => ({ hostWeb: 'https://www.capgo.app' }),
+  getLocalConfig: () => localConfig.value,
 }))
 
 describe('website paid user cookie', () => {
   let cookieWrites: string[]
 
   beforeEach(() => {
+    localConfig.value = {
+      host: 'https://console.capgo.app',
+      hostWeb: 'https://www.capgo.app',
+    }
     cookieWrites = []
     vi.stubGlobal('document', {
       get cookie() {
@@ -19,6 +30,7 @@ describe('website paid user cookie', () => {
       },
     })
     vi.stubGlobal('location', {
+      hostname: 'console.capgo.app',
       protocol: 'https:',
     })
   })
@@ -36,6 +48,19 @@ describe('website paid user cookie', () => {
     expect(cookieWrites).toContain('capgo_paid_user=1; Path=/; Max-Age=2592000; SameSite=Lax; Domain=.capgo.app; Secure')
   })
 
+  it('falls back to the console host when the landing URL is not configured', () => {
+    localConfig.value = {
+      host: 'https://console.capgo.app',
+      hostWeb: undefined,
+    }
+
+    syncWebsitePaidUserCookieFromOrganizations([
+      { paying: true, role: 'owner' },
+    ])
+
+    expect(cookieWrites).toContain('capgo_paid_user=1; Path=/; Max-Age=2592000; SameSite=Lax; Domain=.capgo.app; Secure')
+  })
+
   it('clears the cookie when paid access is only from an invite', () => {
     syncWebsitePaidUserCookieFromOrganizations([
       { paying: true, role: 'invite_read' },
@@ -45,10 +70,10 @@ describe('website paid user cookie', () => {
     expect(cookieWrites).toContain('capgo_paid_user=; Path=/; Max-Age=0; SameSite=Lax; Secure')
   })
 
-  it('also clears the previous logged-in cookie name', () => {
+  it('clears the paid user cookie', () => {
     clearWebsitePaidUserCookie()
 
-    expect(cookieWrites).toContain('capgo_logged_in=; Path=/; Max-Age=0; SameSite=Lax; Domain=.capgo.app; Secure')
-    expect(cookieWrites).toContain('capgo_logged_in=; Path=/; Max-Age=0; SameSite=Lax; Secure')
+    expect(cookieWrites).toContain('capgo_paid_user=; Path=/; Max-Age=0; SameSite=Lax; Domain=.capgo.app; Secure')
+    expect(cookieWrites).toContain('capgo_paid_user=; Path=/; Max-Age=0; SameSite=Lax; Secure')
   })
 })


### PR DESCRIPTION
## Summary

Fixes the paid-user website cookie so it is shared on the website domain even when `LANDING_URL` is not configured in the console build. Platform admins also receive the website Console CTA cookie even if they do not belong to a paid org.

## Motivation

After the paid-cookie header changes were merged, logged-in paid users could still miss the Console button on the website because the console could write `capgo_paid_user` as a host-only cookie on `console.capgo.app`. The website on `capgo.app` cannot read a host-only console cookie. Capgo platform admins should also always get the Console CTA.

## Business Impact

Paid users and Capgo platform admins now get the intended simplified website header and direct Console CTA after visiting the console. This reduces confusion for active customers and operators without changing access control or billing behavior.

## Test Plan

- [x] `bunx vitest run tests/website-auth-cookie.unit.test.ts tests/auth-sso-provisioning.unit.test.ts`
- [x] `bunx eslint src/modules/auth.ts src/stores/organization.ts src/services/websiteAuthCookie.ts tests/auth-sso-provisioning.unit.test.ts tests/website-auth-cookie.unit.test.ts`
- [x] `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## AI-Generated Content

This PR was generated with AI assistance and reviewed through local validation before submission.
