### PR TITLE
fix(audit): suppress stats refresh noise

### DIFF
--- a/supabase/migrations/20260603113951_suppress_stats_refresh_audit_logs.sql
+++ b/supabase/migrations/20260603113951_suppress_stats_refresh_audit_logs.sql
@@ -1,0 +1,120 @@
+CREATE OR REPLACE FUNCTION "public"."audit_log_trigger"() RETURNS "trigger"
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_old_record JSONB;
+  v_new_record JSONB;
+  v_changed_fields TEXT[];
+  v_org_id UUID;
+  v_record_id TEXT;
+  v_user_id UUID;
+  v_key TEXT;
+  v_org_exists BOOLEAN;
+  v_stats_refresh_fields CONSTANT TEXT[] := ARRAY['stats_refresh_requested_at', 'stats_updated_at', 'updated_at'];
+BEGIN
+  -- Skip audit logging for org DELETE operations
+  -- When an org is deleted, we can't insert into audit_logs because the org_id
+  -- foreign key would reference a non-existent org
+  IF TG_TABLE_NAME = 'orgs' AND TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  -- Get current user from auth context or API key
+  -- Uses get_identity() WITH key_mode parameter to support both JWT auth and API key authentication
+  v_user_id := public.get_identity('{read,upload,write,all}'::public.key_mode[]);
+
+  -- Skip audit logging if no user is identified
+  -- We only want to log actions performed by authenticated users
+  IF v_user_id IS NULL THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  -- Convert records to JSONB based on operation type
+  IF TG_OP = 'DELETE' THEN
+    v_old_record := pg_catalog.to_jsonb(OLD);
+    v_new_record := NULL;
+  ELSIF TG_OP = 'INSERT' THEN
+    v_old_record := NULL;
+    v_new_record := pg_catalog.to_jsonb(NEW);
+  ELSE -- UPDATE
+    v_old_record := pg_catalog.to_jsonb(OLD);
+    v_new_record := pg_catalog.to_jsonb(NEW);
+
+    -- Calculate changed fields by comparing old and new values
+    FOR v_key IN SELECT pg_catalog.jsonb_object_keys(v_new_record)
+    LOOP
+      IF v_old_record->v_key IS DISTINCT FROM v_new_record->v_key THEN
+        v_changed_fields := pg_catalog.array_append(v_changed_fields, v_key);
+      END IF;
+    END LOOP;
+
+    -- Dashboard chart refreshes only touch stats refresh state. The apps table
+    -- also receives updated_at from its update trigger, so keep that out too.
+    IF TG_TABLE_NAME = ANY(ARRAY['apps', 'orgs'])
+      AND v_changed_fields && ARRAY['stats_refresh_requested_at', 'stats_updated_at']
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(v_changed_fields) AS changed_field(field_name)
+        WHERE changed_field.field_name <> ALL(v_stats_refresh_fields)
+      ) THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  -- Get org_id and record_id based on table being modified
+  CASE TG_TABLE_NAME
+    WHEN 'orgs' THEN
+      v_org_id := COALESCE(NEW.id, OLD.id);
+      v_record_id := COALESCE(NEW.id, OLD.id)::TEXT;
+    WHEN 'apps' THEN
+      v_org_id := COALESCE(NEW.owner_org, OLD.owner_org);
+      v_record_id := COALESCE(NEW.app_id, OLD.app_id)::TEXT;
+    WHEN 'channels' THEN
+      v_org_id := COALESCE(NEW.owner_org, OLD.owner_org);
+      v_record_id := COALESCE(NEW.id, OLD.id)::TEXT;
+    WHEN 'app_versions' THEN
+      v_org_id := COALESCE(NEW.owner_org, OLD.owner_org);
+      v_record_id := COALESCE(NEW.id, OLD.id)::TEXT;
+    WHEN 'org_users' THEN
+      v_org_id := COALESCE(NEW.org_id, OLD.org_id);
+      v_record_id := COALESCE(NEW.id, OLD.id)::TEXT;
+    ELSE
+      -- Fallback for any other table (shouldn't happen with current triggers)
+      v_org_id := NULL;
+      v_record_id := NULL;
+  END CASE;
+
+  -- Only insert if we have a valid org_id and the org still exists
+  -- This handles edge cases where related tables are deleted after the org
+  IF v_org_id IS NOT NULL THEN
+    -- Check if the org still exists (important for DELETE operations on child tables)
+    SELECT EXISTS(SELECT 1 FROM public.orgs WHERE id = v_org_id) INTO v_org_exists;
+
+    IF v_org_exists THEN
+      INSERT INTO "public"."audit_logs" (
+        table_name, record_id, operation, user_id, org_id,
+        old_record, new_record, changed_fields
+      ) VALUES (
+        TG_TABLE_NAME, v_record_id, TG_OP, v_user_id, v_org_id,
+        v_old_record, v_new_record, v_changed_fields
+      );
+    END IF;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+ALTER FUNCTION "public"."audit_log_trigger"() OWNER TO "postgres";
+
+DELETE FROM "public"."audit_logs"
+WHERE "operation" = 'UPDATE'
+  AND "table_name" = ANY(ARRAY['apps', 'orgs'])
+  AND "changed_fields" && ARRAY['stats_refresh_requested_at', 'stats_updated_at']
+  AND NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.unnest("changed_fields") AS changed_field(field_name)
+    WHERE changed_field.field_name <> ALL(ARRAY['stats_refresh_requested_at', 'stats_updated_at', 'updated_at'])
+  );

--- a/tests/chart-refresh-rpc.test.ts
+++ b/tests/chart-refresh-rpc.test.ts
@@ -43,6 +43,24 @@ async function countCronStatAppMessages(appId: string): Promise<number> {
   return rows[0]?.count ?? 0
 }
 
+async function countStatsRefreshAuditLogs(): Promise<number> {
+  const rows = await executeSQL(
+    `SELECT COUNT(*)::integer AS count
+     FROM public.audit_logs
+     WHERE org_id = $1::uuid
+       AND operation = 'UPDATE'
+       AND table_name IN ('apps', 'orgs')
+       AND changed_fields && ARRAY['stats_refresh_requested_at', 'stats_updated_at']::text[]
+       AND NOT EXISTS (
+         SELECT 1
+         FROM pg_catalog.unnest(changed_fields) AS changed_field(field_name)
+         WHERE changed_field.field_name <> ALL(ARRAY['stats_refresh_requested_at', 'stats_updated_at', 'updated_at']::text[])
+       )`,
+    [orgId],
+  )
+  return rows[0]?.count ?? 0
+}
+
 async function getAppRefreshState(appId: string) {
   const { data, error } = await getSupabaseClient()
     .from('apps')
@@ -125,6 +143,7 @@ describe('chart refresh RPCs', () => {
       stats_refresh_requested_at: null,
       stats_updated_at: null,
     }).in('app_id', [staleAppId, freshAppId]).throwOnError()
+    await getSupabaseClient().from('audit_logs').delete().eq('org_id', orgId).throwOnError()
   })
 
   afterAll(async () => {
@@ -181,6 +200,7 @@ describe('chart refresh RPCs', () => {
     expect(firstResponse?.queued_count).toBe(1)
     expect(firstResponse?.skipped_count).toBe(0)
     expect(await countCronStatAppMessages(staleAppId)).toBe(1)
+    expect(await countStatsRefreshAuditLogs()).toBe(0)
 
     const { data: secondResponse, error: secondError } = await authorizedClient.rpc('request_app_chart_refresh', {
       app_id: staleAppId,
@@ -232,6 +252,7 @@ describe('chart refresh RPCs', () => {
     expect(freshState?.stats_refresh_requested_at).toBeNull()
     expect(await countCronStatAppMessages(staleAppId)).toBe(1)
     expect(await countCronStatAppMessages(freshAppId)).toBe(0)
+    expect(await countStatsRefreshAuditLogs()).toBe(0)
   })
 
   it('request_org_chart_refresh preserves the current org request marker when no apps are queued', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Suppress audit log entries when dashboard chart refreshes only update stats refresh metadata on apps/orgs.
- Delete existing audit log rows whose changed fields are limited to stats refresh metadata and automatic updated_at noise.
- Add chart refresh regression assertions that no stats refresh audit spam is created.

## Motivation (AI generated)

Dashboard visits can auto-request chart refreshes, which updates stats_refresh_requested_at and fills the audit log with non-user-facing operational noise. Audit logs should stay focused on meaningful user or API changes.

## Business Impact (AI generated)

Cleaner audit logs make organization activity easier to review, reduce customer confusion, and avoid storage/query noise from repeated dashboard visits.

## Test Plan (AI generated)

- [x] bun run lint
- [x] bun run lint:backend
- [x] bun run supabase:with-env -- bunx vitest run tests/chart-refresh-rpc.test.ts
- [x] bun run supabase:with-env -- bunx vitest run tests/audit-logs.test.ts
- [x] commit hook typechecks: bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit logs no longer record changes from automatic stats refresh operations on apps and organizations, keeping audit trails cleaner and focused on meaningful user-initiated changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capgo/pull/2398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->