### PR TITLE
fix(files): restore bandwidth tracking

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -421,7 +421,9 @@ async function getHandler(c: Context): Promise<Response> {
   if (response != null) {
     response = ensureNoTransformResponse(response)
     cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache hit' })
-    await saveBandwidthUsage(c, getTransferredBytesFromResponse(response))
+    if (c.req.raw.method !== 'HEAD') {
+      await saveBandwidthUsage(c, getTransferredBytesFromResponse(response))
+    }
     // Best-effort restore: if file is cached but missing in R2, write it back.
     await backgroundTask(c, async () => {
       try {

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -300,17 +300,33 @@ function getTransferredBytesFromResponse(response: Response): number | null {
   return null
 }
 
+function isPositiveFiniteNumber(value: number | null | undefined): value is number {
+  return value != null && Number.isFinite(value) && value > 0
+}
+
+function getAppIdFromAttachmentPath(r2Path: string | null | undefined): string | undefined {
+  if (!r2Path)
+    return undefined
+
+  const pathParts = r2Path.split('/')
+  const appsIndex = pathParts.indexOf('apps')
+  if (appsIndex === -1)
+    return undefined
+
+  return pathParts[appsIndex + 1]
+}
+
 async function saveBandwidthUsage(c: Context, fileSize: number | null | undefined) {
   cloudlog({ requestId: c.get('requestId'), message: 'saveBandwidthUsage', fileSize })
-  if (!fileSize || fileSize <= 0)
+  if (!isPositiveFiniteNumber(fileSize))
     return Promise.resolve()
 
   cloudlog({ requestId: c.get('requestId'), message: 'getHandler files track bandwidth', fileSize })
-  const r2Path = new URL(c.req.url).pathname.split(`/files/read/${ATTACHMENT_PREFIX}/`)[1]
-  const app_id = r2Path?.split('/')[3]
+  const r2Path = c.get('fileId') || getRawAttachmentRouteId(c)
+  const app_id = getAppIdFromAttachmentPath(r2Path)
   const device_id = c.req.query('device_id')
   if (app_id && device_id) {
-    await createStatsBandwidth(c, device_id, app_id, fileSize ?? 0)
+    await createStatsBandwidth(c, device_id, app_id, fileSize)
   }
   else {
     cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cannot track bandwidth no app_id or device_id', r2Path, app_id, device_id })
@@ -405,6 +421,7 @@ async function getHandler(c: Context): Promise<Response> {
   if (response != null) {
     response = ensureNoTransformResponse(response)
     cloudlog({ requestId: c.get('requestId'), message: 'getHandler files cache hit' })
+    await saveBandwidthUsage(c, getTransferredBytesFromResponse(response))
     // Best-effort restore: if file is cached but missing in R2, write it back.
     await backgroundTask(c, async () => {
       try {
@@ -525,7 +542,7 @@ function rangeHeader(objLen: number, r2Range: R2Range): string {
   return `bytes ${startIndexInclusive}-${endIndexInclusive}/${objLen}`
 }
 
-function calculateBytesTransferred(objLen: number, r2Range: R2Range | undefined): number {
+export function calculateBytesTransferred(objLen: number, r2Range: R2Range | undefined): number {
   if (!r2Range)
     return objLen
   let startIndexInclusive = 0
@@ -536,10 +553,11 @@ function calculateBytesTransferred(objLen: number, r2Range: R2Range | undefined)
   if ('length' in r2Range && r2Range.length != null) {
     endIndexInclusive = startIndexInclusive + r2Range.length - 1
   }
-  if ('suffix' in r2Range) {
+  if ('suffix' in r2Range && r2Range.suffix != null) {
     startIndexInclusive = objLen - r2Range.suffix
   }
-  return endIndexInclusive - startIndexInclusive + 1
+  const bytesTransferred = endIndexInclusive - startIndexInclusive + 1
+  return isPositiveFiniteNumber(bytesTransferred) ? bytesTransferred : objLen
 }
 
 function optionsHandler(c: Context) {

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -492,6 +492,7 @@ async function getHandler(c: Context): Promise<Response> {
   const bytesTransferred = calculateBytesTransferred(object.size, object.range)
   await saveBandwidthUsage(c, bytesTransferred)
   const headers = objectHeaders(object)
+  headers.set('content-length', bytesTransferred.toString())
   if (object.range != null && c.req.header('range')) {
     cloudlog({ requestId: c.get('requestId'), message: 'getHandler files range request', range: rangeHeader(object.size, object.range) })
     headers.set('content-range', rangeHeader(object.size, object.range))
@@ -536,7 +537,7 @@ function rangeHeader(objLen: number, r2Range: R2Range): string {
   if ('length' in r2Range && r2Range.length != null) {
     endIndexInclusive = startIndexInclusive + r2Range.length - 1
   }
-  if ('suffix' in r2Range) {
+  if ('suffix' in r2Range && r2Range.suffix != null) {
     startIndexInclusive = objLen - r2Range.suffix
   }
   return `bytes ${startIndexInclusive}-${endIndexInclusive}/${objLen}`

--- a/tests/files-bandwidth.unit.test.ts
+++ b/tests/files-bandwidth.unit.test.ts
@@ -98,6 +98,32 @@ describe('files bandwidth tracking', () => {
     )
   })
 
+  it('does not track bandwidth for cached HEAD reads', async () => {
+    globalThis.caches = {
+      default: {
+        match: async () => new Response(null, {
+          headers: {
+            'cache-control': 'public, max-age=3600',
+            'content-length': '3478395',
+          },
+        }),
+        put: async () => { },
+      },
+    } as any
+    const appGlobal = await createFilesApp('/files')
+
+    const response = await appGlobal.fetch(
+      new Request('http://localhost/files/read/attachments/orgs/test-org/apps/com.test.app/bundle.zip?device_id=device-1', {
+        method: 'HEAD',
+      }),
+      { ATTACHMENT_BUCKET: {} },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(200)
+    expect(createStatsBandwidthMock).not.toHaveBeenCalled()
+  })
+
   it('keeps range response headers finite when suffix is present but empty', async () => {
     retryGetMock.mockResolvedValue(createR2Object(3_478_395, { offset: 0, length: 100, suffix: undefined } as unknown as R2Range))
     const appGlobal = await createFilesApp('/files')

--- a/tests/files-bandwidth.unit.test.ts
+++ b/tests/files-bandwidth.unit.test.ts
@@ -89,11 +89,35 @@ describe('files bandwidth tracking', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(response.headers.get('content-length')).toBe('3478395')
     expect(createStatsBandwidthMock).toHaveBeenCalledWith(
       expect.anything(),
       'device-1',
       'com.test.app',
       3_478_395,
+    )
+  })
+
+  it('keeps range response headers finite when suffix is present but empty', async () => {
+    retryGetMock.mockResolvedValue(createR2Object(3_478_395, { offset: 0, length: 100, suffix: undefined } as unknown as R2Range))
+    const appGlobal = await createFilesApp('/files')
+
+    const response = await appGlobal.fetch(
+      new Request('http://localhost/files/read/attachments/orgs/test-org/apps/com.test.app/bundle.zip?device_id=device-1', {
+        headers: { range: 'bytes=0-99' },
+      }),
+      { ATTACHMENT_BUCKET: {} },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(206)
+    expect(response.headers.get('content-range')).toBe('bytes 0-99/3478395')
+    expect(response.headers.get('content-length')).toBe('100')
+    expect(createStatsBandwidthMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'device-1',
+      'com.test.app',
+      100,
     )
   })
 })

--- a/tests/files-bandwidth.unit.test.ts
+++ b/tests/files-bandwidth.unit.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const retryGetMock = vi.fn()
+const createStatsBandwidthMock = vi.fn()
+
+vi.mock('hono/adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('hono/adapter')>()
+  return {
+    ...actual,
+    getRuntimeKey: () => 'workerd',
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/discord.ts', () => ({
+  sendDiscordAlert500: () => Promise.resolve(),
+  sendDiscordAlert: () => Promise.resolve(),
+}))
+
+vi.mock('../supabase/functions/_backend/files/retry.ts', () => ({
+  DEFAULT_RETRY_PARAMS: {},
+  RetryBucket: class RetryBucketMock {
+    constructor() { }
+    get() {
+      return retryGetMock()
+    }
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/stats.ts', () => ({
+  createStatsBandwidth: createStatsBandwidthMock,
+}))
+
+function createR2Object(size: number, range?: R2Range): R2ObjectBody {
+  return {
+    body: new Response('bundle bytes').body,
+    checksums: {},
+    customMetadata: {},
+    etag: 'etag',
+    httpEtag: '"etag"',
+    httpMetadata: {},
+    key: 'orgs/test-org/apps/com.test.app/bundle.zip',
+    range,
+    size,
+    uploaded: new Date(),
+    version: 'version',
+    writeHttpMetadata(headers: Headers) {
+      headers.set('content-type', 'application/zip')
+    },
+  } as R2ObjectBody
+}
+
+async function createFilesApp(routePrefix: string) {
+  const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+  const { createAllCatch, createHono } = await import('../supabase/functions/_backend/utils/hono.ts')
+  const { version } = await import('../supabase/functions/_backend/utils/version.ts')
+
+  const appGlobal = createHono('files', version)
+  appGlobal.route(routePrefix, files)
+  createAllCatch(appGlobal, 'files')
+  return appGlobal
+}
+
+describe('files bandwidth tracking', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    globalThis.caches = {
+      default: {
+        match: async () => null,
+        put: async () => { },
+      },
+    } as any
+  })
+
+  it('calculates full object bytes when Cloudflare returns an empty range shape', async () => {
+    const { calculateBytesTransferred } = await import('../supabase/functions/_backend/files/files.ts')
+
+    expect(calculateBytesTransferred(3_478_395, { suffix: undefined } as unknown as R2Range)).toBe(3_478_395)
+  })
+
+  it('tracks bandwidth for file-worker reads with the calculated object size', async () => {
+    retryGetMock.mockResolvedValue(createR2Object(3_478_395, { suffix: undefined } as unknown as R2Range))
+    const appGlobal = await createFilesApp('/files')
+
+    const response = await appGlobal.fetch(
+      new Request('http://localhost/files/read/attachments/orgs/test-org/apps/com.test.app/bundle.zip?device_id=device-1'),
+      { ATTACHMENT_BUCKET: {} },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(200)
+    expect(createStatsBandwidthMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'device-1',
+      'com.test.app',
+      3_478_395,
+    )
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Restore file-worker bandwidth tracking when Cloudflare returns an R2 range object with empty range fields.
- Avoid dropping valid downloads when byte calculation produces an invalid value; fall back to the R2 object size.
- Track cache-hit downloads when the cached response exposes a transferable byte count.
- Add a regression test for the `suffix: undefined` range shape that caused prod bandwidth writes to stop.

## Motivation (AI generated)

Prod bandwidth processing stopped because file downloads were still served successfully, but the file worker calculated transferred bytes as `NaN`. `saveBandwidthUsage()` treated that as non-billable and returned before calling `createStatsBandwidth()`, so `BANDWIDTH_USAGE.writeDataPoint()` never ran.

## Business Impact (AI generated)

Restores bandwidth usage reporting for customer downloads, which protects usage analytics, billing visibility, and plan-limit enforcement accuracy.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `bun run lint`
- [x] `bun run typecheck:backend`
- [x] `bunx oxlint tests/files-bandwidth.unit.test.ts`
- [x] `bunx vitest run tests/files-bandwidth.unit.test.ts`
- [x] `bunx vitest run tests/files-bandwidth.unit.test.ts tests/files-r2-error.test.ts`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- [ ] GitHub CI

## Screenshots (AI generated)

N/A. Backend-only file worker fix.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [x] My change does not require a documentation update.
- [x] My change has focused regression test coverage.
- [x] I have tested the affected code path locally.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bandwidth tracking now properly accounts for cached file downloads.
  * Improved bandwidth calculation validation to ensure accuracy.

* **Tests**
  * Added comprehensive test coverage for bandwidth tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->