### PR TITLE
[codex] Scope worker deployments by changed code

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,8 +12,36 @@ on:
 permissions: {}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: Resolve deploy scope
+    permissions:
+      contents: read
+    outputs:
+      api: ${{ steps.scope.outputs.api }}
+      files: ${{ steps.scope.outputs.files }}
+      plugins: ${{ steps.scope.outputs.plugins }}
+      supabase: ${{ steps.scope.outputs.supabase }}
+      translation: ${{ steps.scope.outputs.translation }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Resolve deploy scope
+        id: scope
+        run: bun scripts/deploy-scope.ts "${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+
   # Tests already passed before tag was created, so just build and deploy
   supabase_deploy:
+    needs: changes
+    if: ${{ needs.changes.outputs.supabase == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Build code and deploy to Supabase
@@ -74,7 +102,8 @@ jobs:
         run: supabase functions deploy
 
   deploy_webapp:
-    needs: supabase_deploy
+    needs: [changes, supabase_deploy]
+    if: ${{ always() && needs.changes.result == 'success' && (needs.supabase_deploy.result == 'success' || needs.supabase_deploy.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -144,7 +173,8 @@ jobs:
           prerelease: ${{ contains(github.ref, '-alpha.') }}
 
   deploy_api:
-    needs: supabase_deploy
+    needs: [changes, supabase_deploy]
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.api == 'true' && (needs.supabase_deploy.result == 'success' || needs.supabase_deploy.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -173,7 +203,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy_translation_worker:
-    needs: deploy_api
+    needs: [changes, deploy_api]
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.translation == 'true' && (needs.deploy_api.result == 'success' || needs.deploy_api.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -202,7 +233,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy_files:
-    needs: supabase_deploy
+    needs: [changes, supabase_deploy]
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.files == 'true' && (needs.supabase_deploy.result == 'success' || needs.supabase_deploy.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -231,7 +263,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy_plugin_regions:
-    needs: supabase_deploy
+    needs: [changes, supabase_deploy]
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.plugins == 'true' && (needs.supabase_deploy.result == 'success' || needs.supabase_deploy.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -36,7 +36,9 @@ jobs:
           bun-version: latest
       - name: Resolve deploy scope
         id: scope
-        run: bun scripts/deploy-scope.ts "${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: bun scripts/deploy-scope.ts "$REF_NAME" >> "$GITHUB_OUTPUT"
 
   # Tests already passed before tag was created, so just build and deploy
   supabase_deploy:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -203,8 +203,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy_translation_worker:
-    needs: [changes, deploy_api]
-    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.translation == 'true' && (needs.deploy_api.result == 'success' || needs.deploy_api.result == 'skipped') }}
+    needs: [changes, supabase_deploy, deploy_api]
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.translation == 'true' && (needs.supabase_deploy.result == 'success' || (needs.supabase_deploy.result == 'skipped' && needs.changes.outputs.supabase != 'true')) && (needs.deploy_api.result == 'success' || (needs.deploy_api.result == 'skipped' && needs.changes.outputs.api != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/scripts/deploy-scope.ts
+++ b/scripts/deploy-scope.ts
@@ -38,7 +38,7 @@ export const deployMatchers: Record<DeployTarget, RegExp[]> = {
     /^supabase\/functions\//,
     /^supabase\/migrations\//,
     /^messages\/en\.json$/,
-    /^shared\/preview-subdomain\.ts$/,
+    /^supabase\/functions\/shared\/preview-subdomain\.ts$/,
   ],
   api: [
     ...workerDependencyMatchers,
@@ -63,7 +63,7 @@ export const deployMatchers: Record<DeployTarget, RegExp[]> = {
     /^supabase\/functions\/_backend\/files\//,
     /^supabase\/functions\/_backend\/private\/(download_link|upload_link)\.ts$/,
     /^supabase\/functions\/_backend\/public\/ok\.ts$/,
-    /^shared\/preview-subdomain\.ts$/,
+    /^supabase\/functions\/shared\/preview-subdomain\.ts$/,
   ],
   plugins: [
     ...workerDependencyMatchers,

--- a/scripts/deploy-scope.ts
+++ b/scripts/deploy-scope.ts
@@ -45,6 +45,7 @@ export const deployMatchers: Record<DeployTarget, RegExp[]> = {
     ...backendDependencyMatchers,
     ...backendUtilityMatchers,
     /^cloudflare_workers\/api\//,
+    /^supabase\/functions\/_backend\/files\/util\.ts$/,
     /^supabase\/functions\/_backend\/private\//,
     /^supabase\/functions\/_backend\/public\//,
     /^supabase\/functions\/_backend\/triggers\//,
@@ -176,7 +177,7 @@ export function getPreviousCapgoTag(head: string, includePrereleaseTags: boolean
 }
 
 function getChangedFiles(base: string, head: string, run: GitRunner = runGit): string[] {
-  const files = run(['diff', '--name-only', '--diff-filter=ACMRT', `${base}..${head}`])
+  const files = run(['diff', '--name-only', '--diff-filter=ACMRTD', `${base}..${head}`])
   return files ? files.split('\n').filter(Boolean) : []
 }
 

--- a/scripts/deploy-scope.ts
+++ b/scripts/deploy-scope.ts
@@ -147,9 +147,23 @@ export function getComparableDeployHead(after: string, run: GitRunner = runGit):
   }
 }
 
-export function getPreviousCapgoTag(head: string, run: GitRunner = runGit): string | null {
+export function isAlphaDeployRef(after: string, run: GitRunner = runGit): boolean {
+  if (after.includes('-alpha')) {
+    return true
+  }
+
+  return run(['log', '-1', '--format=%s', after]).includes('-alpha')
+}
+
+export function getPreviousCapgoTag(head: string, includePrereleaseTags: boolean, run: GitRunner = runGit): string | null {
   try {
-    const tag = run(['describe', '--tags', '--match', 'capgo-[0-9]*', '--abbrev=0', head])
+    const args = ['describe', '--tags', '--match', 'capgo-[0-9]*']
+    if (!includePrereleaseTags) {
+      args.push('--exclude', 'capgo-*-alpha*')
+    }
+    args.push('--abbrev=0', head)
+
+    const tag = run(args)
     return tag || null
   }
   catch (error) {
@@ -167,8 +181,9 @@ function getChangedFiles(base: string, head: string, run: GitRunner = runGit): s
 }
 
 export function resolveDeployScopeFromGit(after = 'HEAD', run: GitRunner = runGit): DeployScopeResult {
+  const includePrereleaseTags = isAlphaDeployRef(after, run)
   const head = getComparableDeployHead(after, run)
-  const base = getPreviousCapgoTag(head, run)
+  const base = getPreviousCapgoTag(head, includePrereleaseTags, run)
 
   if (!base) {
     return {

--- a/scripts/deploy-scope.ts
+++ b/scripts/deploy-scope.ts
@@ -1,0 +1,204 @@
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+import { TextDecoder } from 'node:util'
+
+export type DeployTarget = 'supabase' | 'api' | 'translation' | 'files' | 'plugins'
+export type DeployScope = Record<DeployTarget, boolean>
+type GitRunner = (args: string[]) => string
+
+export interface DeployScopeResult {
+  base: string | null
+  files: string[]
+  head: string
+  scope: DeployScope
+}
+
+const deployTargets = ['supabase', 'api', 'translation', 'files', 'plugins'] as const satisfies readonly DeployTarget[]
+
+const workerDependencyMatchers = [
+  /^package\.json$/,
+  /^\.npmrc$/,
+  /^bunfig\.toml$/,
+  /^tsconfig\.json$/,
+  /^deno-env\.d\.ts$/,
+]
+
+const backendDependencyMatchers = [
+  /^supabase\/functions\/deno\.(json|lock)$/,
+]
+
+const backendUtilityMatchers = [
+  /^supabase\/functions\/_backend\/utils\//,
+]
+
+export const deployMatchers: Record<DeployTarget, RegExp[]> = {
+  supabase: [
+    ...backendDependencyMatchers,
+    /^supabase\/config\.toml$/,
+    /^supabase\/functions\//,
+    /^supabase\/migrations\//,
+    /^messages\/en\.json$/,
+    /^shared\/preview-subdomain\.ts$/,
+  ],
+  api: [
+    ...workerDependencyMatchers,
+    ...backendDependencyMatchers,
+    ...backendUtilityMatchers,
+    /^cloudflare_workers\/api\//,
+    /^supabase\/functions\/_backend\/private\//,
+    /^supabase\/functions\/_backend\/public\//,
+    /^supabase\/functions\/_backend\/triggers\//,
+    /^messages\/en\.json$/,
+  ],
+  translation: [
+    ...workerDependencyMatchers,
+    /^cloudflare_workers\/translation\//,
+    /^messages\/en\.json$/,
+  ],
+  files: [
+    ...workerDependencyMatchers,
+    ...backendDependencyMatchers,
+    ...backendUtilityMatchers,
+    /^cloudflare_workers\/files\//,
+    /^supabase\/functions\/_backend\/files\//,
+    /^supabase\/functions\/_backend\/private\/(download_link|upload_link)\.ts$/,
+    /^supabase\/functions\/_backend\/public\/ok\.ts$/,
+    /^shared\/preview-subdomain\.ts$/,
+  ],
+  plugins: [
+    ...workerDependencyMatchers,
+    ...backendDependencyMatchers,
+    ...backendUtilityMatchers,
+    /^cloudflare_workers\/plugin\//,
+    /^supabase\/functions\/_backend\/plugins\//,
+    /^supabase\/functions\/_backend\/private\/latency\.ts$/,
+    /^supabase\/functions\/_backend\/public\/ok\.ts$/,
+  ],
+}
+
+function runGit(args: string[]): string {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function stringifyGitErrorOutput(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value instanceof Uint8Array) {
+    return new TextDecoder().decode(value)
+  }
+
+  return ''
+}
+
+function getGitErrorText(error: unknown): string {
+  const parts = []
+
+  if (error instanceof Error) {
+    parts.push(error.message)
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const outputs = error as { stdout?: unknown, stderr?: unknown }
+    parts.push(stringifyGitErrorOutput(outputs.stdout))
+    parts.push(stringifyGitErrorOutput(outputs.stderr))
+  }
+
+  return parts.filter(Boolean).join('\n')
+}
+
+function isNoMatchingTagError(error: unknown): boolean {
+  return /no matching tag|no names found|no tags can describe|fatal: no tag/i.test(getGitErrorText(error))
+}
+
+function allTargets(value: boolean): DeployScope {
+  return deployTargets.reduce((scope, target) => {
+    scope[target] = value
+    return scope
+  }, {} as DeployScope)
+}
+
+export function matchesDeployTarget(target: DeployTarget, files: string[]): boolean {
+  return files.some(file => deployMatchers[target].some(pattern => pattern.test(file)))
+}
+
+export function resolveDeployScopeFromFiles(files: string[]): DeployScope {
+  return deployTargets.reduce((scope, target) => {
+    scope[target] = matchesDeployTarget(target, files)
+    return scope
+  }, {} as DeployScope)
+}
+
+export function getComparableDeployHead(after: string, run: GitRunner = runGit): string {
+  const subject = run(['log', '-1', '--format=%s', after])
+  if (!subject.startsWith('chore(release):')) {
+    return after
+  }
+
+  try {
+    return run(['rev-parse', `${after}^`])
+  }
+  catch {
+    return after
+  }
+}
+
+export function getPreviousCapgoTag(head: string, run: GitRunner = runGit): string | null {
+  try {
+    const tag = run(['describe', '--tags', '--match', 'capgo-[0-9]*', '--abbrev=0', head])
+    return tag || null
+  }
+  catch (error) {
+    if (!isNoMatchingTagError(error)) {
+      throw error
+    }
+
+    return null
+  }
+}
+
+function getChangedFiles(base: string, head: string, run: GitRunner = runGit): string[] {
+  const files = run(['diff', '--name-only', '--diff-filter=ACMRT', `${base}..${head}`])
+  return files ? files.split('\n').filter(Boolean) : []
+}
+
+export function resolveDeployScopeFromGit(after = 'HEAD', run: GitRunner = runGit): DeployScopeResult {
+  const head = getComparableDeployHead(after, run)
+  const base = getPreviousCapgoTag(head, run)
+
+  if (!base) {
+    return {
+      base: null,
+      files: [],
+      head,
+      scope: allTargets(true),
+    }
+  }
+
+  const files = getChangedFiles(base, head, run)
+  return {
+    base,
+    files,
+    head,
+    scope: resolveDeployScopeFromFiles(files),
+  }
+}
+
+if (import.meta.main) {
+  const result = resolveDeployScopeFromGit(process.argv[2] ?? 'HEAD')
+
+  console.error(`Deploy scope base: ${result.base ?? '<none>'}`)
+  console.error(`Deploy scope head: ${result.head}`)
+  console.error(`Deploy scope changed files: ${result.files.length}`)
+  for (const file of result.files) {
+    console.error(`- ${file}`)
+  }
+
+  for (const target of deployTargets) {
+    console.log(`${target}=${result.scope[target]}`)
+  }
+}

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -28,6 +28,7 @@ export const componentMatchers: Record<Component, RegExp[]> = {
   capgo: [
     ...sharedMatchers,
     /^\.github\/workflows\/build_and_deploy\.yml$/,
+    /^scripts\/deploy-scope\.ts$/,
     /^aliproxy\//,
     /^android\//,
     /^assets\//,

--- a/tests/deploy-scope.test.ts
+++ b/tests/deploy-scope.test.ts
@@ -58,6 +58,16 @@ describe('deploy scope matching', () => {
     })
   })
 
+  it.concurrent('deploys files worker when the shared preview subdomain helper changes', () => {
+    expect(resolveDeployScopeFromFiles(['supabase/functions/shared/preview-subdomain.ts'])).toEqual({
+      api: false,
+      files: true,
+      plugins: false,
+      supabase: true,
+      translation: false,
+    })
+  })
+
   it.concurrent('deploys package dependency changes to Cloudflare workers without forcing Supabase', () => {
     expect(resolveDeployScopeFromFiles(['package.json'])).toEqual({
       api: true,

--- a/tests/deploy-scope.test.ts
+++ b/tests/deploy-scope.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDeployScopeFromFiles, resolveDeployScopeFromGit } from '../scripts/deploy-scope.ts'
+
+const noBackendDeploys = {
+  api: false,
+  files: false,
+  plugins: false,
+  supabase: false,
+  translation: false,
+}
+
+describe('deploy scope matching', () => {
+  it.concurrent('does not deploy backend targets for frontend-only changes', () => {
+    expect(resolveDeployScopeFromFiles(['src/pages/index.vue'])).toEqual(noBackendDeploys)
+  })
+
+  it.concurrent('does not deploy backend targets for CLI-only lockfile changes', () => {
+    expect(resolveDeployScopeFromFiles(['bun.lock', 'cli/src/index.ts'])).toEqual(noBackendDeploys)
+  })
+
+  it.concurrent('deploys translation plus API surfaces when source messages change', () => {
+    expect(resolveDeployScopeFromFiles(['messages/en.json'])).toEqual({
+      api: true,
+      files: false,
+      plugins: false,
+      supabase: true,
+      translation: true,
+    })
+  })
+
+  it.concurrent('keeps plugin endpoint changes scoped to Supabase and plugin workers', () => {
+    expect(resolveDeployScopeFromFiles(['supabase/functions/_backend/plugins/updates.ts'])).toEqual({
+      api: false,
+      files: false,
+      plugins: true,
+      supabase: true,
+      translation: false,
+    })
+  })
+
+  it.concurrent('keeps public API changes scoped to Supabase and API workers', () => {
+    expect(resolveDeployScopeFromFiles(['supabase/functions/_backend/public/app/index.ts'])).toEqual({
+      api: true,
+      files: false,
+      plugins: false,
+      supabase: true,
+      translation: false,
+    })
+  })
+
+  it.concurrent('deploys shared Hono utilities to workers that import backend code', () => {
+    expect(resolveDeployScopeFromFiles(['supabase/functions/_backend/utils/hono.ts'])).toEqual({
+      api: true,
+      files: true,
+      plugins: true,
+      supabase: true,
+      translation: false,
+    })
+  })
+
+  it.concurrent('deploys package dependency changes to Cloudflare workers without forcing Supabase', () => {
+    expect(resolveDeployScopeFromFiles(['package.json'])).toEqual({
+      api: true,
+      files: true,
+      plugins: true,
+      supabase: false,
+      translation: true,
+    })
+  })
+
+  it.concurrent('ignores generated release commits when resolving changed code', () => {
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'log -1 --format=%s capgo-12.0.0': 'chore(release): 12.0.0',
+        'rev-parse capgo-12.0.0^': 'feature-head',
+        'describe --tags --match capgo-[0-9]* --abbrev=0 feature-head': 'capgo-11.0.0',
+        'diff --name-only --diff-filter=ACMRT capgo-11.0.0..feature-head': 'src/pages/index.vue',
+      }
+
+      if (key in responses) {
+        return responses[key]
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    expect(resolveDeployScopeFromGit('capgo-12.0.0', run)).toEqual({
+      base: 'capgo-11.0.0',
+      files: ['src/pages/index.vue'],
+      head: 'feature-head',
+      scope: noBackendDeploys,
+    })
+  })
+
+  it.concurrent('deploys all targets when no previous Capgo tag exists', () => {
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      if (key === 'log -1 --format=%s HEAD') {
+        return 'feat: first capgo release'
+      }
+      if (key === 'describe --tags --match capgo-[0-9]* --abbrev=0 HEAD') {
+        throw Object.assign(new Error('git describe failed'), {
+          stderr: 'fatal: No names found, cannot describe anything.',
+        })
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    expect(resolveDeployScopeFromGit('HEAD', run)).toEqual({
+      base: null,
+      files: [],
+      head: 'HEAD',
+      scope: {
+        api: true,
+        files: true,
+        plugins: true,
+        supabase: true,
+        translation: true,
+      },
+    })
+  })
+})

--- a/tests/deploy-scope.test.ts
+++ b/tests/deploy-scope.test.ts
@@ -74,7 +74,7 @@ describe('deploy scope matching', () => {
       const responses: Record<string, string> = {
         'log -1 --format=%s capgo-12.0.0': 'chore(release): 12.0.0',
         'rev-parse capgo-12.0.0^': 'feature-head',
-        'describe --tags --match capgo-[0-9]* --abbrev=0 feature-head': 'capgo-11.0.0',
+        'describe --tags --match capgo-[0-9]* --exclude capgo-*-alpha* --abbrev=0 feature-head': 'capgo-11.0.0',
         'diff --name-only --diff-filter=ACMRT capgo-11.0.0..feature-head': 'src/pages/index.vue',
       }
 
@@ -93,13 +93,75 @@ describe('deploy scope matching', () => {
     })
   })
 
+  it.concurrent('excludes alpha tags when resolving production deploy scope', () => {
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'log -1 --format=%s capgo-12.0.0': 'chore(release): 12.0.0',
+        'rev-parse capgo-12.0.0^': 'feature-head',
+        'describe --tags --match capgo-[0-9]* --exclude capgo-*-alpha* --abbrev=0 feature-head': 'capgo-11.0.0',
+        'diff --name-only --diff-filter=ACMRT capgo-11.0.0..feature-head': 'supabase/functions/_backend/plugins/updates.ts',
+      }
+
+      if (key in responses) {
+        return responses[key]
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    expect(resolveDeployScopeFromGit('capgo-12.0.0', run)).toEqual({
+      base: 'capgo-11.0.0',
+      files: ['supabase/functions/_backend/plugins/updates.ts'],
+      head: 'feature-head',
+      scope: {
+        api: false,
+        files: false,
+        plugins: true,
+        supabase: true,
+        translation: false,
+      },
+    })
+  })
+
+  it.concurrent('includes alpha tags when resolving alpha deploy scope', () => {
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'log -1 --format=%s capgo-12.0.0-alpha.1': 'chore(release): 12.0.0-alpha.1',
+        'rev-parse capgo-12.0.0-alpha.1^': 'feature-head',
+        'describe --tags --match capgo-[0-9]* --abbrev=0 feature-head': 'capgo-11.0.0-alpha.9',
+        'diff --name-only --diff-filter=ACMRT capgo-11.0.0-alpha.9..feature-head': 'cloudflare_workers/translation/index.ts',
+      }
+
+      if (key in responses) {
+        return responses[key]
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    expect(resolveDeployScopeFromGit('capgo-12.0.0-alpha.1', run)).toEqual({
+      base: 'capgo-11.0.0-alpha.9',
+      files: ['cloudflare_workers/translation/index.ts'],
+      head: 'feature-head',
+      scope: {
+        api: false,
+        files: false,
+        plugins: false,
+        supabase: false,
+        translation: true,
+      },
+    })
+  })
+
   it.concurrent('deploys all targets when no previous Capgo tag exists', () => {
     const run = (args: string[]) => {
       const key = args.join(' ')
       if (key === 'log -1 --format=%s HEAD') {
         return 'feat: first capgo release'
       }
-      if (key === 'describe --tags --match capgo-[0-9]* --abbrev=0 HEAD') {
+      if (key === 'describe --tags --match capgo-[0-9]* --exclude capgo-*-alpha* --abbrev=0 HEAD') {
         throw Object.assign(new Error('git describe failed'), {
           stderr: 'fatal: No names found, cannot describe anything.',
         })

--- a/tests/deploy-scope.test.ts
+++ b/tests/deploy-scope.test.ts
@@ -68,6 +68,16 @@ describe('deploy scope matching', () => {
     })
   })
 
+  it.concurrent('deploys API and files workers when the shared TUS file utility changes', () => {
+    expect(resolveDeployScopeFromFiles(['supabase/functions/_backend/files/util.ts'])).toEqual({
+      api: true,
+      files: true,
+      plugins: false,
+      supabase: true,
+      translation: false,
+    })
+  })
+
   it.concurrent('deploys package dependency changes to Cloudflare workers without forcing Supabase', () => {
     expect(resolveDeployScopeFromFiles(['package.json'])).toEqual({
       api: true,
@@ -85,7 +95,7 @@ describe('deploy scope matching', () => {
         'log -1 --format=%s capgo-12.0.0': 'chore(release): 12.0.0',
         'rev-parse capgo-12.0.0^': 'feature-head',
         'describe --tags --match capgo-[0-9]* --exclude capgo-*-alpha* --abbrev=0 feature-head': 'capgo-11.0.0',
-        'diff --name-only --diff-filter=ACMRT capgo-11.0.0..feature-head': 'src/pages/index.vue',
+        'diff --name-only --diff-filter=ACMRTD capgo-11.0.0..feature-head': 'src/pages/index.vue',
       }
 
       if (key in responses) {
@@ -110,7 +120,7 @@ describe('deploy scope matching', () => {
         'log -1 --format=%s capgo-12.0.0': 'chore(release): 12.0.0',
         'rev-parse capgo-12.0.0^': 'feature-head',
         'describe --tags --match capgo-[0-9]* --exclude capgo-*-alpha* --abbrev=0 feature-head': 'capgo-11.0.0',
-        'diff --name-only --diff-filter=ACMRT capgo-11.0.0..feature-head': 'supabase/functions/_backend/plugins/updates.ts',
+        'diff --name-only --diff-filter=ACMRTD capgo-11.0.0..feature-head': 'supabase/functions/_backend/plugins/updates.ts',
       }
 
       if (key in responses) {
@@ -141,7 +151,7 @@ describe('deploy scope matching', () => {
         'log -1 --format=%s capgo-12.0.0-alpha.1': 'chore(release): 12.0.0-alpha.1',
         'rev-parse capgo-12.0.0-alpha.1^': 'feature-head',
         'describe --tags --match capgo-[0-9]* --abbrev=0 feature-head': 'capgo-11.0.0-alpha.9',
-        'diff --name-only --diff-filter=ACMRT capgo-11.0.0-alpha.9..feature-head': 'cloudflare_workers/translation/index.ts',
+        'diff --name-only --diff-filter=ACMRTD capgo-11.0.0-alpha.9..feature-head': 'cloudflare_workers/translation/index.ts',
       }
 
       if (key in responses) {
@@ -190,6 +200,39 @@ describe('deploy scope matching', () => {
         plugins: true,
         supabase: true,
         translation: true,
+      },
+    })
+  })
+
+  it.concurrent.each([
+    ['supabase', 'supabase/config.toml'],
+    ['api', 'cloudflare_workers/api/index.ts'],
+    ['translation', 'cloudflare_workers/translation/index.ts'],
+    ['files', 'cloudflare_workers/files/index.ts'],
+    ['plugins', 'cloudflare_workers/plugin/index.ts'],
+  ] as const)('deploys %s when a matched file is deleted', (target, file) => {
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'log -1 --format=%s HEAD': 'feat: delete deployed code',
+        'describe --tags --match capgo-[0-9]* --exclude capgo-*-alpha* --abbrev=0 HEAD': 'capgo-11.0.0',
+        'diff --name-only --diff-filter=ACMRTD capgo-11.0.0..HEAD': file,
+      }
+
+      if (key in responses) {
+        return responses[key]
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    expect(resolveDeployScopeFromGit('HEAD', run)).toEqual({
+      base: 'capgo-11.0.0',
+      files: [file],
+      head: 'HEAD',
+      scope: {
+        ...noBackendDeploys,
+        [target]: true,
       },
     })
   })

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -16,7 +16,7 @@ describe('release scope matching', () => {
   })
 
   it.concurrent('treats capgo deploy workflow changes as capgo-only releases', () => {
-    const files = ['.github/workflows/build_and_deploy.yml']
+    const files = ['.github/workflows/build_and_deploy.yml', 'scripts/deploy-scope.ts']
 
     expect(matchesComponent('capgo', files)).toBe(true)
     expect(matchesComponent('cli', files)).toBe(false)


### PR DESCRIPTION
## Summary (AI generated)

- Added `scripts/deploy-scope.ts` to resolve Supabase/API/translation/files/plugin deploy targets from changed code since the previous Capgo tag.
- Updated `build_and_deploy.yml` so frontend-only releases keep deploying the web app but skip unchanged Supabase and Cloudflare backend workers.
- Added deploy-scope unit tests and made deploy-scope script changes count as Capgo release scope.

## Motivation (AI generated)

The tag deploy workflow ran every backend deploy job for every `capgo-*` release. That redeployed the translation worker, API worker, and plugin workers even when only frontend or CLI-adjacent files changed. The new scope job ignores generated release commits and deploys backend targets only when their source/config inputs changed.

## Business Impact (AI generated)

This reduces unnecessary Cloudflare and Supabase deployments, lowers production deploy noise, and avoids needless worker churn for frontend-only releases while preserving backend deploys when API/plugin/files/translation code actually changes.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/deploy-scope.test.ts tests/release-scope.test.ts`
- [x] `bunx eslint --no-ignore scripts/deploy-scope.ts tests/deploy-scope.test.ts tests/release-scope.test.ts`
- [x] `bun lint`
- [x] `bun run lint:backend`
- [x] `bun typecheck`
- [x] `bun scripts/deploy-scope.ts capgo-12.156.6` verified a CLI-only lockfile release resolves all backend deploy targets to `false`.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow with component-aware change detection that conditionally executes specific deployment targets based on modified components rather than deploying all targets unconditionally.
  * Added extensive test coverage for deployment scope detection logic to ensure accurate identification of affected components across various development scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->