### PR TITLE
fix(stripe): send DataFast attribution metadata

### DIFF
--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -10,7 +10,7 @@ import AdminOnlyModal from '~/components/AdminOnlyModal.vue'
 import CreditsCta from '~/components/CreditsCta.vue'
 import { formatIncludedThenPrice } from '~/services/creditPricing'
 import { checkPermissions } from '~/services/permissions'
-import { openCheckout } from '~/services/stripe'
+import { getDatafastAttribution, openCheckout } from '~/services/stripe'
 import { getCreditUnitPricing, getCurrentPlanNameOrg, useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { sendEvent } from '~/services/tracking'
@@ -152,10 +152,6 @@ function isSafariBrowser() {
   return /Version\/[\d.]+/.test(ua) && /Safari\//.test(ua) && !/Chrome|CriOS|FxiOS|OPiOS|Edg|Chromium/.test(ua)
 }
 
-async function getStripeAttributionId() {
-  return (await cookieStore.get('datafast_visitor_id'))?.value
-}
-
 async function prefetchStripeCheckoutUrl(plan: Database['public']['Tables']['plans']['Row'], isYear: boolean) {
   if (!plan.stripe_id)
     return
@@ -166,7 +162,7 @@ async function prefetchStripeCheckoutUrl(plan: Database['public']['Tables']['pla
 
   const successUrl = `${window.location.href}?success=1`
   const cancelUrl = `${window.location.href}?cancel=1`
-  const attributionId = await getStripeAttributionId()
+  const datafastAttribution = await getDatafastAttribution()
   try {
     const resp = await supabase.functions.invoke('private/stripe_checkout', {
       body: JSON.stringify({
@@ -175,7 +171,9 @@ async function prefetchStripeCheckoutUrl(plan: Database['public']['Tables']['pla
         cancelUrl,
         recurrence: isYear ? 'year' : 'month',
         orgId: currentOrganization.value?.gid ?? '',
-        attributionId,
+        attributionId: datafastAttribution.visitorId,
+        datafastVisitorId: datafastAttribution.visitorId,
+        datafastSessionId: datafastAttribution.sessionId,
       }),
     })
 

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -78,9 +78,11 @@ export async function openPortal(orgId: string, t: ComposerTranslation) {
   return dialogStore.onDialogDismiss()
 }
 
-async function getAttributionId() {
-  // attribute is made via cookie of name datafast_visitor_id
-  return (await cookieStore.get('datafast_visitor_id'))?.value
+export async function getDatafastAttribution() {
+  return {
+    visitorId: (await cookieStore.get('datafast_visitor_id'))?.value,
+    sessionId: (await cookieStore.get('datafast_session_id'))?.value,
+  }
 }
 
 export async function openCheckout(priceId: string, successUrl: string, cancelUrl: string, isYear: boolean, orgId: string) {
@@ -89,7 +91,7 @@ export async function openCheckout(priceId: string, successUrl: string, cancelUr
   const session = await supabase.auth.getSession()
   if (!session)
     return
-  const attributionId = await getAttributionId()
+  const datafastAttribution = await getDatafastAttribution()
   try {
     const resp = await supabase.functions.invoke('private/stripe_checkout', {
       body: JSON.stringify({
@@ -98,7 +100,9 @@ export async function openCheckout(priceId: string, successUrl: string, cancelUr
         cancelUrl,
         recurrence: isYear ? 'year' : 'month',
         orgId,
-        attributionId,
+        attributionId: datafastAttribution.visitorId,
+        datafastVisitorId: datafastAttribution.visitorId,
+        datafastSessionId: datafastAttribution.sessionId,
       }),
     })
     if (!resp.error && resp.data?.url)
@@ -114,9 +118,15 @@ export async function startCreditTopUp(orgId: string, quantity = 100) {
   if (!orgId)
     return
   const supabase = useSupabase()
+  const datafastAttribution = await getDatafastAttribution()
   try {
     const { data, error } = await supabase.functions.invoke('private/credits/start-top-up', {
-      body: JSON.stringify({ orgId, quantity }),
+      body: JSON.stringify({
+        orgId,
+        quantity,
+        datafastVisitorId: datafastAttribution.visitorId,
+        datafastSessionId: datafastAttribution.sessionId,
+      }),
     })
     if (error || !data?.url) {
       console.error('Failed to start credit top-up', error ?? data)

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -78,10 +78,22 @@ export async function openPortal(orgId: string, t: ComposerTranslation) {
   return dialogStore.onDialogDismiss()
 }
 
+async function getCookieValue(name: string) {
+  if ('cookieStore' in globalThis && globalThis.cookieStore)
+    return (await globalThis.cookieStore.get(name))?.value
+
+  if (typeof document === 'undefined')
+    return undefined
+
+  const encodedName = `${encodeURIComponent(name)}=`
+  const cookie = document.cookie.split('; ').find(cookie => cookie.startsWith(encodedName))
+  return cookie ? decodeURIComponent(cookie.slice(encodedName.length)) : undefined
+}
+
 export async function getDatafastAttribution() {
   return {
-    visitorId: (await cookieStore.get('datafast_visitor_id'))?.value,
-    sessionId: (await cookieStore.get('datafast_session_id'))?.value,
+    visitorId: await getCookieValue('datafast_visitor_id'),
+    sessionId: await getCookieValue('datafast_session_id'),
   }
 }
 

--- a/supabase/functions/_backend/private/credits.ts
+++ b/supabase/functions/_backend/private/credits.ts
@@ -64,6 +64,8 @@ interface CostCalculationResponse {
 interface StartTopUpRequest {
   orgId: string
   quantity?: number
+  datafastVisitorId?: string
+  datafastSessionId?: string
 }
 
 interface CompleteTopUpRequest {
@@ -565,6 +567,10 @@ app.post('/start-top-up', middlewareAuth, async (c) => {
     successUrl,
     cancelUrl,
     body.orgId,
+    {
+      visitorId: body.datafastVisitorId,
+      sessionId: body.datafastSessionId,
+    },
   )
 
   return c.json({ url: checkout.url })

--- a/supabase/functions/_backend/private/stripe_checkout.ts
+++ b/supabase/functions/_backend/private/stripe_checkout.ts
@@ -12,6 +12,8 @@ interface CheckoutData {
   clientReferenceId?: string
   recurrence: 'month' | 'year'
   attributionId?: string
+  datafastVisitorId?: string
+  datafastSessionId?: string
   successUrl: string
   cancelUrl: string
   orgId: string
@@ -55,6 +57,9 @@ app.post('/', middlewareAuth, async (c) => {
     throw simpleError('not_authorize', 'Not authorize')
 
   cloudlog({ requestId: c.get('requestId'), message: 'user', org })
-  const checkout = await createCheckout(c, org.customer_id, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId)
+  const checkout = await createCheckout(c, org.customer_id, body.recurrence ?? 'month', body.priceId ?? 'price_1KkINoGH46eYKnWwwEi97h1B', body.successUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.cancelUrl ?? `${getEnv(c, 'WEBAPP_URL')}/app/usage`, body.clientReferenceId, body.attributionId, {
+    visitorId: body.datafastVisitorId,
+    sessionId: body.datafastSessionId,
+  })
   return c.json({ url: checkout.url })
 })

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -471,6 +471,11 @@ export interface CreditCheckoutDetails {
   itemsSummary: CreditCheckoutItemSummary[]
 }
 
+export interface DatafastAttribution {
+  visitorId?: string | null
+  sessionId?: string | null
+}
+
 export interface StripeData {
   data: Database['public']['Tables']['stripe_info']['Insert']
   isUpgrade: boolean
@@ -498,14 +503,24 @@ export function parsePriceIds(c: Context, prices: Stripe.SubscriptionItem[]): { 
   return { priceId, productId }
 }
 
-export async function createCheckout(c: Context, customerId: string, recurrence: string, planId: string, successUrl: string, cancelUrl: string, clientReferenceId?: string, attributionId?: string) {
+function getDatafastAttributionMetadata(attribution?: DatafastAttribution): Record<string, string> {
+  return {
+    ...(attribution?.visitorId ? { datafast_visitor_id: attribution.visitorId } : {}),
+    ...(attribution?.sessionId ? { datafast_session_id: attribution.sessionId } : {}),
+  }
+}
+
+export async function createCheckout(c: Context, customerId: string, recurrence: string, planId: string, successUrl: string, cancelUrl: string, clientReferenceId?: string, attributionId?: string, datafastAttribution?: DatafastAttribution) {
   if (!isStripeConfigured(c))
     return { url: '' }
   const prices = await getPriceIds(c, planId, recurrence)
   cloudlog({ requestId: c.get('requestId'), message: 'prices', prices })
   if (!prices.priceId)
     return Promise.reject(new Error('Cannot find price'))
-  const metadata = attributionId ? { attribution_id: attributionId } : undefined
+  const metadata = {
+    ...(attributionId ? { attribution_id: attributionId } : {}),
+    ...getDatafastAttributionMetadata(datafastAttribution),
+  }
   const allowedSuccessUrl = getAllowedRedirectUrl(c, successUrl, 'success_url')
   const allowedCancelUrl = getAllowedRedirectUrl(c, cancelUrl, 'cancel_url')
   const session = await getStripe(c).checkout.sessions.create({
@@ -517,7 +532,7 @@ export async function createCheckout(c: Context, customerId: string, recurrence:
     cancel_url: allowedCancelUrl,
     automatic_tax: { enabled: true },
     client_reference_id: clientReferenceId,
-    metadata,
+    metadata: Object.keys(metadata).length ? metadata : undefined,
     customer_update: {
       address: 'auto',
       name: 'auto',
@@ -566,6 +581,7 @@ export async function createOneTimeCheckout(
   successUrl: string,
   cancelUrl: string,
   clientReferenceId?: string,
+  datafastAttribution?: DatafastAttribution,
 ) {
   if (!isStripeConfigured(c))
     return { url: '' }
@@ -611,6 +627,7 @@ export async function createOneTimeCheckout(
       productId,
       orgId: clientReferenceId ?? '',
       intendedQuantity: String(quantity),
+      ...getDatafastAttributionMetadata(datafastAttribution),
     },
   })
   return { url: session.url }

--- a/tests/stripe-redirects.unit.test.ts
+++ b/tests/stripe-redirects.unit.test.ts
@@ -132,6 +132,12 @@ describe('stripe redirect URL allowlist', () => {
       'plan_test',
       '/app/success',
       '/app/cancel',
+      'org_123',
+      'legacy_visitor_123',
+      {
+        visitorId: 'visitor_123',
+        sessionId: 'session_123',
+      },
     )
 
     expect(result.url).toBe('https://pay.capgo.test/p/pay')
@@ -139,6 +145,12 @@ describe('stripe redirect URL allowlist', () => {
       allow_promotion_codes: true,
       success_url: 'https://capgo.test/app/success?success=true',
       cancel_url: 'https://capgo.test/app/cancel',
+      client_reference_id: 'org_123',
+      metadata: {
+        attribution_id: 'legacy_visitor_123',
+        datafast_visitor_id: 'visitor_123',
+        datafast_session_id: 'session_123',
+      },
     }))
   })
 
@@ -304,6 +316,10 @@ describe('stripe redirect URL allowlist', () => {
       '/app/success',
       '/app/cancel',
       'org_123',
+      {
+        visitorId: 'visitor_456',
+        sessionId: 'session_456',
+      },
     )
 
     expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
@@ -313,6 +329,8 @@ describe('stripe redirect URL allowlist', () => {
         }),
       ],
       metadata: expect.objectContaining({
+        datafast_visitor_id: 'visitor_456',
+        datafast_session_id: 'session_456',
         intendedQuantity: '5',
         orgId: 'org_123',
       }),


### PR DESCRIPTION
## Summary

AI-generated content: This PR adds DataFast Stripe Checkout attribution metadata to subscription and credit top-up checkout sessions.

- Sends `datafast_visitor_id` and `datafast_session_id` from frontend DataFast cookies to backend checkout endpoints.
- Writes the exact DataFast metadata keys onto Stripe subscription and one-time Checkout sessions.
- Keeps the existing legacy `attribution_id` metadata for subscription checkout compatibility.
- Adds Stripe checkout unit coverage for subscription and credit top-up metadata.

## Motivation

AI-generated content: DataFast revenue attribution requires Stripe Checkout sessions to include DataFast visitor and session identifiers in Checkout metadata, as documented in the Stripe Checkout API integration guide.

## Business Impact

AI-generated content: This should allow Capgo paid subscriptions and credit purchases to attribute revenue back to DataFast sessions, improving channel and campaign revenue reporting without changing checkout behavior for users.

## Test Plan

AI-generated content:

- [x] `bun lint`
- [x] `bunx vitest run tests/stripe-redirects.unit.test.ts`
- [x] `bun run typecheck:backend`
- [x] `bun run typecheck:frontend`
- [x] Commit hook full typecheck (`bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced customer attribution tracking in checkout and subscription management flows, enabling improved identification of customer acquisition sources.
  * Added support for visitor and session identifier tracking to provide more comprehensive customer journey insights during plan upgrades and credit purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->