### PR TITLE
docs: CLI web login (device flow) — design spec, mockup & diagrams

### DIFF
--- a/docs/superpowers/specs/2026-06-03-cli-device-login-design.md
+++ b/docs/superpowers/specs/2026-06-03-cli-device-login-design.md
@@ -1,0 +1,278 @@
+# CLI Web Login (OAuth Device-Flow-Shaped API Key Delivery) — Design Spec
+
+**Date:** 2026-06-03
+**Status:** Draft for review · **Lifecycle: V4** (atomic create at authorize, hashed, transient one-time delivery)
+**Branch:** worktree-cli-oauth-device-flow
+**Mockup:** [authorize page](./assets/2026-06-03-cli-device-login-authorize-mockup.html) ·
+**Diagrams:** [flow](./assets/2026-06-03-cli-device-login-flow-diagram.html) ·
+[architecture](./assets/2026-06-03-cli-device-login-architecture.html) ·
+**This spec (HTML):** [spec page](./assets/2026-06-03-cli-device-login-spec.html)
+
+## Problem
+
+The Capgo CLI can only authenticate by the user manually obtaining an API key and
+pasting/passing it (`capgo login <key>`). There is no "click to log in from the
+browser" path. We want a flow that *feels* like OAuth — open a page, pick scope,
+authorize — but delivers a **Capgo API key** rather than an OAuth token.
+
+## Goal
+
+`capgo login` (no key) opens the browser, the user selects org/app RBAC roles and
+authorizes, a **new** API key is minted and delivered back to the CLI over HTTPS.
+Implemented as an **OAuth 2.0 Device Authorization Grant (RFC 8628) *shape*** — not a
+real OAuth token server.
+
+## Non-goals
+
+- No OAuth access/refresh tokens, no token endpoint, no scopes machinery, no client
+  registration. We borrow only the device-flow choreography.
+- We do **not** reuse existing API keys; every login mints a fresh key.
+- Manual `capgo login <key>` is retained as a fallback.
+- No Cloudflare Access / `workers-oauth-provider` adoption (wrong output + no device
+  grant + heavyweight).
+- **apikey v2 / RBAC only.** There is no `read/upload/write/all` `mode` — permission is
+  the **RBAC `role_name`** per binding (`post.ts` never writes `mode`).
+
+## Why device flow (not loopback redirect)
+
+Device flow keeps the key in TLS only (never in a localhost URL or browser history),
+needs no local port, doesn't depend on tightening browser localhost policies, and is a
+**recognizable, defensible** standard for security review. Cost: a few thin edge
+endpoints + one short-lived table.
+
+## Key lifecycle: V4 — create atomically at authorize, hashed, deliver once
+
+**The key is created at authorize-time** (while the user's JWT is present), stored
+**hashed** (`key = NULL`, only `key_hash`), and the **plaintext is held transiently** on
+the session row for the CLI to fetch exactly once, then burned. After delivery, only the
+hash remains anywhere.
+
+Why V4 (vs deferring creation to poll, "V3"): deferring would mean storing the *intent*
+(the bindings) and building the key later. A bug in that stored scope could mint a key
+with the **wrong scope** within the user's rights — which the RBAC check cannot catch
+(it only catches *escalation* beyond the user's rights). V4 creates the key atomically
+under the JWT, so nothing scope-bearing is stored between steps; the only transient
+state is the **opaque secret string**. A bug there can at worst yield a **dud key that
+fails login** — never a wrong-scope key. V4 also surfaces any creation error in the
+browser (user present), not on a later headless poll.
+
+- **Authorize** (browser, JWT): validate the user's RBAC and **create the key now** via
+  the shared creation function (hashed). Store `apikey_id` + an **encrypted, transient
+  `delivery_key`** (the plaintext, burn-on-read) on the session; set `status=authorized`.
+- **Poll** (CLI, `device_code`): on the first `authorized` poll, decrypt and return
+  `delivery_key` **once**, then **null it and burn the session**.
+- **Final at-rest state:** identical to a hashed dashboard key — only `key_hash` persists.
+
+### Security guards
+
+- **Creation always happens under the user's JWT** (at authorize). There is **no
+  key creation in the unauthenticated poll** — the poll only *delivers* an
+  already-created secret. This removes any "backend creates a key without the user's
+  authenticated context" risk by construction.
+- The shared creation function still performs the explicit RBAC check
+  (`org.update_user_roles` per org) intrinsically — escalation cannot occur regardless of
+  caller.
+- `delivery_key` is **encrypted at rest** (Worker secret) + short TTL + burn-on-read, so
+  a DB snapshot during the brief in-transit window is useless. It is the *only* plaintext
+  copy (the apikey row is hashed) and carries **no scope semantics**.
+
+## Architecture
+
+```
+ CLI                          Backend (CF Workers / Hono)              Browser (Vue page, logged in → JWT)
+  |  POST /cli-auth/start  ----------> create session ----.                    |
+  |  <-- device_code, user_code, URIs                      |                   |
+  |  print user_code, open verification_uri_complete  -------------------->  /cli-login?code=user_code
+  |                                                        |       show phrase + RBAC role picker
+  |                                          POST /cli-auth/authorize  <-- (JWT)
+  |                                          RBAC-check + CREATE key now (hashed),
+  |                                          store apikey_id + encrypted delivery_key,
+  |                                          mark authorized
+  |  POST /cli-auth/poll {device_code} (loop) -> status; when authorized:      |
+  |  <-- api_key (decrypt + return once), delivery_key nulled, session burned  |
+  |  save to ~/.capgo / ./.capgo                                               |
+```
+
+### 1. CLI command (`cli/src/login.ts`, helpers in a new `cli/src/loginWeb.ts`)
+
+- `capgo login` with no key → run the web device flow **in interactive terminals**. In
+  **non-interactive / CI** environments (no TTY, or `CI` set) it does **not** open a
+  browser — it requires an explicit key (positional `<key>` / `--apikey`) or the
+  `CAPGO_TOKEN` env var, failing with clear guidance otherwise. Flags: `--web` (force
+  web), `--local`/positional `<key>` keeps the manual path.
+- `POST /cli-auth/start` with `{ client_version, device_name }`. Receives
+  `{ device_code, user_code, verification_uri, verification_uri_complete, interval, expires_in }`.
+- Print the `user_code` ("Confirm your browser shows: enjoy-enough-outwit-win-river")
+  and open `verification_uri_complete` via the existing `open` dependency. Under
+  SSH/no-browser, print the URL to open manually.
+- Poll `POST /cli-auth/poll { device_code }`. Honor RFC 8628 responses:
+  `authorization_pending`, `slow_down`, `access_denied`, `expired_token` (abort + offer
+  manual `capgo login <key>`).
+- On `authorized`, receive the plaintext key **once**; save with the existing
+  `~/.capgo` / `./.capgo` writer (0o600, gitignore handling unchanged).
+- Handle Ctrl-C / timeout cleanly. No local server is opened.
+
+### 2. Backend (Hono, under `supabase/functions/_backend/`)
+
+Routes live under `public/cli-auth/*` (same group as the existing `apikey` endpoint).
+
+- **`POST /cli-auth/start`** — minimal/no auth. Generates `device_code` (32 random
+  bytes, base64url) and `user_code`, stores a session row (storing only the **hash** of
+  `device_code`), returns the device-flow payload. Rate-limited per IP. The `device_code`
+  is the per-session **bearer secret** the CLI reuses to authenticate every `/poll`.
+- **`GET /cli-auth/session?user_code=...`** — JWT-authed (the page). Returns only
+  **display** info: `device_name`, `client_version`, `created_at`, `status`. Never
+  returns `device_code` or `delivery_key`.
+- **`POST /cli-auth/authorize`** — JWT-authed (the page). Body
+  `{ user_code, name, bindings, expires_at, hashed }` (v2 RBAC: permission is the
+  `role_name` per binding; there is no `mode`). Verifies the session is `pending` and
+  unexpired, runs the full RBAC check under the JWT, **creates the key now** (hashed) via
+  the shared creation function, stores `apikey_id` + **encrypted `delivery_key`**, sets
+  `status=authorized`. Requires `org.update_user_roles` on every org in the bindings —
+  i.e. **only org admins** can authorize a CLI key for that org. Strictly rate-limited.
+- **`POST /cli-auth/poll`** — **authenticated by the `device_code` bearer secret**
+  (sent as `Authorization: Bearer <device_code>`, not a user JWT); the backend hashes it
+  and matches `device_code_hash` with a constant-time compare. Returns `{ status }`. On
+  the first `authorized` poll, decrypts and
+  returns `{ api_key }` **once**, nulls `delivery_key`, sets `status=consumed`, and burns
+  the session. Rate-limited; returns `slow_down` if polled faster than `interval`. **Does
+  not create keys** — delivery only.
+
+### 3. Frontend page (`src/pages/cli-login.vue` + `/cli-login/success`)
+
+- Requires an authenticated session (existing `auth` middleware); if not logged in, the
+  normal login runs first and returns here.
+- Reads `user_code` from the query (`verification_uri_complete` prefills it) or an input
+  field; calls `GET /cli-auth/session` to show device info + the verification phrase
+  prominently for the eyeball match.
+- Reuses the **org+role and app+role selectors** (`selectedOrgRole`, `pendingAppBindings`)
+  from `ApiKeys.vue` (extract a shared component/composable where practical) + expiration
+  honoring org policy.
+- "Authorize & send to CLI" → `POST /cli-auth/authorize` (creates the key); on success
+  shows "Return to your terminal". Any creation error shows here, in the browser.
+  "Cancel" marks the session denied.
+- Visual language matches `login.vue`. See mockup.
+
+## Data model: `cli_login_sessions`
+
+| column | type | notes |
+|---|---|---|
+| `id` | uuid pk | |
+| `device_code_hash` | text | SHA-256 of `device_code`; poll matches by hashing input |
+| `user_code` | text | 5 EFF-short words, hyphenated; unique among **active** sessions |
+| `device_name` | text | reported by CLI |
+| `client_version` | text | reported by CLI |
+| `status` | enum | `pending` / `authorized` / `consumed` / `denied` / `expired` |
+| `user_id` | uuid null | set on authorize (the approver) |
+| `apikey_id` | uuid null | the key created at authorize (hashed) |
+| `delivery_key` | text null | **encrypted JSON envelope** `{ name, key }` (apikey display name + plaintext); transient, nulled/burned on first poll |
+| `delivery_key_name` | text null | name/version of the KEK used to encrypt `delivery_key` (enables KEK rotation) |
+| `created_at` | timestamptz | |
+| `expires_at` | timestamptz | `created_at + 10 min` (session TTL) |
+| `authorized_at` | timestamptz null | |
+| `last_poll_at` | timestamptz null | for `slow_down` enforcement |
+
+- Stores **no scope/intent**. The key (hashed) and its bindings are real `apikeys` /
+  `role_bindings` rows created at authorize; the session holds only the device_code hash
+  and the encrypted one-time `delivery_key`.
+- Not client-accessible via RLS; reached only through edge functions.
+- Scheduled cleanup deletes expired/consumed rows (mirror `cleanup_expired_apikeys`).
+
+## `user_code` & `device_code` generation
+
+- `device_code`: 32 bytes, base64url. **Only its SHA-256 hash is stored.** The real
+  high-entropy poll secret / "state" anchor.
+- `user_code`: **EFF short wordlist** (1296 words), **5 words** hyphenated (~51 bits),
+  regenerated on collision against active sessions. Server-generated and stored (the
+  Stripe/GitHub model). It is a short-lived, rate-limited *handle*, not the secret — so
+  ~51 bits + rate-limit + 10-min TTL is ample (GitHub uses ~35 bits).
+
+## `delivery_key` encryption (AES-256-GCM, versioned KEK)
+
+- **Algorithm:** AES-256-GCM via WebCrypto `crypto.subtle` (codebase idiom; native on
+  Workers). Per-row random 12-byte IV; **AAD = session id** so a ciphertext can't be
+  swapped between rows. Stored `delivery_key` = base64(`iv ‖ ciphertext ‖ tag`).
+- **KEK storage:** a 256-bit key in a **Cloudflare Worker secret**, read via
+  `getEnv(c, 'CLI_DELIVERY_KEK_<version>')` (never committed; dev/test via the existing
+  gitignored vars). Generate with `openssl rand -base64 32`.
+- **Versioning (not hardcoded):** one pointer env `CLI_DELIVERY_KEK_CURRENT` selects the
+  version to encrypt new rows with; the row stores `delivery_key_name`, and decryption is
+  **data-driven** by that stored name. No version literal in logic.
+- **Rotation runbook (zero-downtime, free given 10-min TTL):** (1) `wrangler secret put
+  CLI_DELIVERY_KEK_v2`; (2) set `CLI_DELIVERY_KEK_CURRENT=v2` + deploy; (3) wait ~10 min
+  (old rows expire/burn); (4) delete `CLI_DELIVERY_KEK_v1`. In-flight v1 rows still
+  decrypt via their stored name during overlap.
+- **Simpler alt:** a single un-versioned KEK; rotation = swap the secret, accepting a
+  ≤10-min "please re-login" blip. (Versioned is the chosen default.)
+
+## Security checklist (the review-defensible story)
+
+- `device_code` high-entropy (256-bit), stored hashed; poll matches by hash.
+- `device_code` is the poll **bearer secret**: presented as `Authorization: Bearer`,
+  compared constant-time, never logged, accepted only on `/poll` (single-purpose). The
+  public `user_code` cannot be used to poll — only the secret `device_code` can.
+- `user_code` ~51 bits + unique-among-active + 10-min TTL + **strict rate limit** on
+  `authorize`/`poll` — mitigates the device-flow guess→planted-key attack.
+- **Key created only under the user's JWT** (authorize). The poll never creates — it only
+  delivers. No unauthenticated key creation exists.
+- **No scope-bearing state stored between steps** — eliminates the wrong-scope bug class.
+- **No privilege escalation**: shared creation function enforces `org.update_user_roles`
+  per org intrinsically. Service-role insert without the explicit check is banned.
+- **Hashed at rest**: `apikeys.key = NULL`, only `key_hash`. Not viewable in the dashboard.
+- **`delivery_key`**: encrypted JSON envelope `{ name, key }` at rest, short TTL,
+  burn-on-read; only plaintext copy, opaque (no scope meaning). `delivery_key_name`
+  records the KEK name/version so the KEK can be **rotated** (short-lived rows decrypt
+  via their stored name).
+- **Single-use**: session burned on first successful poll.
+- HTTPS-only + HSTS (existing CF posture). Optional CLI cert-pinning deferred.
+- Page states "authorizing the Capgo CLI on *this device*" and shows the phrase.
+- MITM: identical threat surface to every existing CLI call (key already rides HTTPS).
+- Note: V4 creates the credential at authorize rather than at the poll/token step, a
+  small, deliberate deviation from strict RFC 8628 chosen to remove the wrong-scope
+  surface; still device-flow-shaped (browser authorizes, CLI polls for delivery).
+
+## Reuse
+
+- **Shared key-creation function**: factor the core of
+  `supabase/functions/_backend/public/apikey/post.ts` (validation + RBAC check + key
+  generation + binding creation) into one function taking an explicit `actingUserId`,
+  with the RBAC gate **inside** it. Called by both the public endpoint (JWT) and
+  `/cli-auth/authorize`. No duplicated/forked security logic. v2/RBAC only —
+  permission is carried by `role_name` per binding, not a `mode`.
+- **Scope/permission UI**: reuse `ApiKeys.vue` org+role / app+role selectors; extract a
+  shared component/composable if it falls out cleanly.
+
+## Error / timeout handling
+
+- CLI: `pending` keep polling; `slow_down` widen interval; `expired_token` → message +
+  manual-paste fallback; `access_denied` → abort; network error → bounded backoff retry.
+- Page: invalid/expired/used `user_code` → clear error states; **creation errors surface
+  here at authorize** (user present); cancel → `denied`.
+- Fallback `capgo login <key>` always available.
+
+## Testing plan
+
+- **Unit**: `user_code` generator (format + collision regen), `device_code` hashing,
+  `delivery_key` encrypt/decrypt + burn, shared creation RBAC gate (acting-user cannot
+  exceed rights), CLI RFC 8628 poll state machine.
+- **Integration**: start → authorize (key created, hashed) → poll (delivered once) happy
+  path; expired session; denied; double-poll burns; rate-limit triggers `slow_down`;
+  wrong `device_code` rejected; **escalation attempt** (bindings for an org the user
+  isn't admin of → authorize rejected).
+- **Frontend**: page renders phrase + RBAC role pickers; authorize calls endpoint;
+  unauth redirect-then-return.
+- Target ≥80% coverage on new modules.
+
+## Open decisions (resolve in plan)
+
+1. ~~Key-at-rest / when to create~~ **Resolved (V4)**: create atomically at authorize,
+   store hashed, deliver via encrypted transient `delivery_key`, burn on poll.
+2. ~~Web default~~ **Resolved**: web flow is the default in interactive terminals;
+   non-interactive/CI requires an explicit key (`--apikey`/positional or `CAPGO_TOKEN`)
+   and never opens a browser.
+3. ~~Route mount~~ **Resolved**: routes live under `public/cli-auth/*` (alongside `apikey`).
+4. ~~delivery_key encryption~~ **Resolved**: AES-256-GCM (WebCrypto) over the JSON
+   envelope `{ name, key }`; 256-bit KEK in a Worker secret; `CLI_DELIVERY_KEK_CURRENT`
+   pointer + per-row `delivery_key_name` for data-driven, zero-downtime rotation. See the
+   `delivery_key` encryption section.
+5. CLI certificate pinning — now or follow-up.

--- a/docs/superpowers/specs/assets/2026-06-03-cli-device-login-architecture.html
+++ b/docs/superpowers/specs/assets/2026-06-03-cli-device-login-architecture.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en" class="capgolight">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Capgo CLI Web Login — Architecture</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Prompt:wght@500;600;700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{--primary:#515271;--secondary:#119eff;--accent:#1FB2A5;--ink:#1e293b;}
+  body{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;color:#1e293b;}
+  .font-prompt{font-family:"Prompt",sans-serif;}
+  .font-mono{font-family:"JetBrains Mono",ui-monospace,monospace;}
+  .card{border-radius:1.25rem;border:1px solid rgba(226,232,240,.8);background:#fff;box-shadow:0 24px 60px -40px rgba(15,23,42,.4);}
+  .chip{background:linear-gradient(135deg,#244366 0%,#0c6eb8 100%);}
+  .actor-cli{background:#eef5ff;color:#0c6eb8;border:1px solid rgba(17,158,255,.3);}
+  .actor-be{background:#eef0f7;color:#515271;border:1px solid rgba(81,82,113,.3);}
+  .actor-web{background:#e8f7f4;color:#0e8a7e;border:1px solid rgba(31,178,165,.35);}
+  .stepnum{background:linear-gradient(135deg,#244366 0%,#0c6eb8 100%);}
+  .rail{background:linear-gradient(180deg,#119eff 0%,#6876e1 100%);}
+</style>
+</head>
+<body style="background:linear-gradient(180deg,#f8fafc 0%,#eef4ff 60%,#f8fafc 100%);">
+
+<div class="mx-auto max-w-4xl px-5 py-12">
+
+  <!-- header -->
+  <header class="flex items-center gap-3">
+    <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl chip text-white font-prompt text-xl font-bold shadow-lg">C</span>
+    <div>
+      <p class="text-[0.72rem] font-bold tracking-[0.24em] text-slate-500 uppercase">Capgo · Engineering</p>
+      <h1 class="text-2xl font-semibold text-slate-950 sm:text-3xl">CLI Web Login — Architecture Overview</h1>
+    </div>
+  </header>
+  <p class="mt-3 text-sm text-slate-500">Proposal · 3 June 2026 · how a developer logs the Capgo CLI in from the browser</p>
+
+  <!-- TL;DR -->
+  <section class="card mt-8 p-6">
+    <h2 class="text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">In one sentence</h2>
+    <p class="mt-3 text-lg leading-8 text-slate-700">
+      A developer runs <span class="font-mono text-[0.95em] text-slate-900">capgo&nbsp;login</span>, a browser opens to a Capgo page where they pick which
+      <strong>organisation, app and permissions</strong> to grant, click <strong>Authorize</strong>, and a brand-new API key is
+      created and delivered straight back to their terminal — <strong>no copy-pasting keys by hand</strong>.
+    </p>
+    <div class="mt-5 grid gap-3 sm:grid-cols-3">
+      <div class="rounded-xl bg-slate-50 p-4"><p class="text-2xl font-semibold text-slate-900">~2</p><p class="text-sm text-slate-500">new backend endpoints</p></div>
+      <div class="rounded-xl bg-slate-50 p-4"><p class="text-2xl font-semibold text-slate-900">1</p><p class="text-sm text-slate-500">new web page</p></div>
+      <div class="rounded-xl bg-slate-50 p-4"><p class="text-2xl font-semibold text-slate-900">0</p><p class="text-sm text-slate-500">changes to how keys/permissions work</p></div>
+    </div>
+  </section>
+
+  <!-- problem / solution -->
+  <section class="mt-6 grid gap-4 sm:grid-cols-2">
+    <div class="card p-6">
+      <h2 class="text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">The problem today</h2>
+      <p class="mt-3 text-sm leading-7 text-slate-600">
+        The only way to log the CLI in is to manually find an API key in the dashboard and paste it.
+        There is no "log in with your browser" button. It's clunky and error-prone, and nudges people
+        toward reusing long-lived keys.
+      </p>
+    </div>
+    <div class="card p-6">
+      <h2 class="text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">The approach</h2>
+      <p class="mt-3 text-sm leading-7 text-slate-600">
+        We reuse the proven login choreography that <strong>GitHub, Stripe and Tailscale</strong> CLIs use —
+        the OAuth <em>Device Flow</em> — but it hands back a normal Capgo API key. It's a recognised,
+        auditable industry standard, not a bespoke design.
+      </p>
+    </div>
+  </section>
+
+  <!-- flow -->
+  <section class="card mt-6 p-6">
+    <h2 class="text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">How it works, step by step</h2>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs font-semibold">
+      <span class="rounded-full px-3 py-1 actor-cli">● CLI (developer's terminal)</span>
+      <span class="rounded-full px-3 py-1 actor-be">● Capgo backend</span>
+      <span class="rounded-full px-3 py-1 actor-web">● Browser page</span>
+    </div>
+
+    <ol class="mt-6 space-y-5">
+      <li class="relative flex gap-4">
+        <span class="stepnum flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white">1</span>
+        <div>
+          <p class="font-semibold text-slate-800">Developer runs <span class="font-mono text-[0.9em]">capgo login</span> <span class="ml-1 rounded px-1.5 py-0.5 text-[0.7rem] actor-cli">CLI</span></p>
+          <p class="mt-1 text-sm leading-6 text-slate-600">The CLI asks the backend to start a login session and receives a short confirmation phrase, e.g. <span class="font-mono text-slate-900">enjoy-enough-outwit-win</span>.</p>
+        </div>
+      </li>
+      <li class="relative flex gap-4">
+        <span class="stepnum flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white">2</span>
+        <div>
+          <p class="font-semibold text-slate-800">Browser opens to the authorize page <span class="ml-1 rounded px-1.5 py-0.5 text-[0.7rem] actor-web">Browser</span></p>
+          <p class="mt-1 text-sm leading-6 text-slate-600">The page shows the <strong>same phrase</strong>, so the developer can confirm they are on the genuine page for <em>their</em> terminal. They pick the organisation, app and permission level.</p>
+        </div>
+      </li>
+      <li class="relative flex gap-4">
+        <span class="stepnum flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white">3</span>
+        <div>
+          <p class="font-semibold text-slate-800">Developer clicks "Authorize" <span class="ml-1 rounded px-1.5 py-0.5 text-[0.7rem] actor-web">Browser</span> → <span class="rounded px-1.5 py-0.5 text-[0.7rem] actor-be">backend</span></p>
+          <p class="mt-1 text-sm leading-6 text-slate-600">The backend checks the user is allowed and <strong>creates the key right away</strong> (stored only as a hash, so it is never visible in the dashboard), keeping a one-time copy to hand to the terminal.</p>
+        </div>
+      </li>
+      <li class="relative flex gap-4">
+        <span class="stepnum flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white">4</span>
+        <div>
+          <p class="font-semibold text-slate-800">CLI receives the key over HTTPS <span class="ml-1 rounded px-1.5 py-0.5 text-[0.7rem] actor-cli">CLI</span></p>
+          <p class="mt-1 text-sm leading-6 text-slate-600">The terminal has been quietly checking with the backend; once approved it collects the <strong>one-time key</strong>, saves it locally, the temporary copy is burned, and only the hash remains on the server. Done.</p>
+        </div>
+      </li>
+    </ol>
+  </section>
+
+  <!-- security -->
+  <section class="card mt-6 p-6">
+    <h2 class="text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">Why it's safe</h2>
+    <div class="mt-4 grid gap-4 sm:grid-cols-2">
+      <div class="flex gap-3">
+        <span class="text-lg">🔒</span>
+        <p class="text-sm leading-6 text-slate-600"><strong>Key never travels in a link or browser history.</strong> It only moves over the same encrypted channel the CLI already uses for every command.</p>
+      </div>
+      <div class="flex gap-3">
+        <span class="text-lg">👁️</span>
+        <p class="text-sm leading-6 text-slate-600"><strong>Visual confirmation.</strong> The matching word-phrase in the terminal and the browser proves the developer is authorising their own session.</p>
+      </div>
+      <div class="flex gap-3">
+        <span class="text-lg">⏱️</span>
+        <p class="text-sm leading-6 text-slate-600"><strong>Short-lived &amp; single-use.</strong> A login session expires in ~10 minutes, is rate-limited against guessing, and the key can only be collected once.</p>
+      </div>
+      <div class="flex gap-3">
+        <span class="text-lg">✅</span>
+        <p class="text-sm leading-6 text-slate-600"><strong>Same permissions model.</strong> Authorising reuses our existing role/permission checks — it introduces no new way to grant access.</p>
+      </div>
+    </div>
+    <p class="mt-5 rounded-xl bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+      <strong class="text-slate-800">For security review:</strong> this is the OAuth 2.0 Device Authorization Grant (RFC&nbsp;8628) — the
+      same recognised flow used by the GitHub, Stripe and Tailscale CLIs — which makes it far easier to audit and defend
+      than a custom-built scheme.
+    </p>
+  </section>
+
+  <!-- why this design -->
+  <section class="card mt-6 p-6">
+    <h2 class="text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">Why this design over the alternative</h2>
+    <div class="mt-4 overflow-hidden rounded-xl border border-slate-200">
+      <table class="w-full text-sm">
+        <thead class="bg-slate-50 text-left text-slate-500">
+          <tr><th class="px-4 py-2.5 font-semibold">&nbsp;</th><th class="px-4 py-2.5 font-semibold">Device flow (chosen)</th><th class="px-4 py-2.5 font-semibold">Local-server redirect</th></tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 text-slate-700">
+          <tr><td class="px-4 py-2.5 font-medium text-slate-500">Key exposure</td><td class="px-4 py-2.5">Encrypted channel only</td><td class="px-4 py-2.5">Briefly in browser history</td></tr>
+          <tr><td class="px-4 py-2.5 font-medium text-slate-500">Reliability</td><td class="px-4 py-2.5">No local network port needed</td><td class="px-4 py-2.5">Depends on browser rules that keep tightening</td></tr>
+          <tr><td class="px-4 py-2.5 font-medium text-slate-500">Security review</td><td class="px-4 py-2.5">Recognised standard</td><td class="px-4 py-2.5">Bespoke surface to defend</td></tr>
+          <tr><td class="px-4 py-2.5 font-medium text-slate-500">Build cost</td><td class="px-4 py-2.5">~2 small endpoints + 1 page</td><td class="px-4 py-2.5">No backend, but trickier client</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <footer class="mt-8 text-center text-xs text-slate-400">
+    Capgo · CLI Web Login proposal · accompanying mockup of the authorize screen available separately
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/superpowers/specs/assets/2026-06-03-cli-device-login-authorize-mockup.html
+++ b/docs/superpowers/specs/assets/2026-06-03-cli-device-login-authorize-mockup.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en" class="capgolight">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Authorize Capgo CLI — mockup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Prompt:wght@500;600;700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet" />
+  <style>
+    :root{
+      --primary:#515271; --secondary:#119eff; --accent:#1FB2A5;
+      --azure-500:#119eff; --pumpkin:#ff7211;
+      --base-100:#ffffff; --base-200:#f8fafc; --base-300:#f1f5f9; --base-content:#1e293b;
+      --success:#36d399; --error:#f87272;
+    }
+    body{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;}
+    .font-prompt{font-family:"Prompt",sans-serif;}
+    .font-mono{font-family:"JetBrains Mono",ui-monospace,monospace;}
+    .auth-card{
+      border-radius:1.75rem; border:1px solid rgba(226,232,240,.75);
+      background:linear-gradient(180deg,rgba(255,255,255,.94) 0%,rgba(255,255,255,.84) 100%);
+      box-shadow:0 34px 80px -42px rgba(15,23,42,.5); backdrop-filter:blur(18px);
+    }
+    .btn-primary-capgo{
+      background:linear-gradient(135deg,rgba(36,67,102,1) 0%,rgba(12,110,184,1) 100%);
+      box-shadow:0 20px 38px -26px rgba(17,158,255,.85); color:#fff; transition:.2s;
+    }
+    .btn-primary-capgo:hover{transform:translateY(-2px);filter:brightness(1.05);}
+    .btn-secondary-capgo{
+      border:1px solid rgba(148,163,184,.55); background:rgba(255,255,255,.92); color:#334155; transition:.2s;
+    }
+    .btn-secondary-capgo:hover{border-color:rgba(17,158,255,.45);background:rgba(241,245,249,.95);}
+    .seg[aria-checked="true"]{
+      border-color:var(--secondary); background:rgba(17,158,255,.08);
+      box-shadow:0 0 0 1px var(--secondary) inset;
+    }
+    .seg[aria-checked="true"] .seg-dot{background:var(--secondary);border-color:var(--secondary);box-shadow:0 0 0 3px #fff inset;}
+  </style>
+</head>
+<body class="relative min-h-dvh w-full overflow-y-auto"
+  style="background:linear-gradient(180deg,rgba(248,250,252,.98) 0%,rgba(238,244,255,.9) 55%,rgba(248,250,252,.98) 100%);">
+
+  <div class="pointer-events-none absolute inset-0 hidden overflow-hidden lg:block" aria-hidden="true">
+    <div class="absolute top-[8%] -left-32 h-[22rem] w-[22rem] rounded-full opacity-55 blur-[52px]" style="background:rgba(17,158,255,.22)"></div>
+    <div class="absolute right-[-7rem] bottom-[8%] h-[18rem] w-[18rem] rounded-full opacity-55 blur-[52px]" style="background:rgba(104,118,225,.18)"></div>
+    <div class="absolute inset-0 opacity-40"
+      style="background-image:linear-gradient(rgba(148,163,184,.12) 1px,transparent 1px),linear-gradient(90deg,rgba(148,163,184,.12) 1px,transparent 1px);background-size:3rem 3rem;-webkit-mask-image:radial-gradient(circle at center,black 40%,transparent 82%);mask-image:radial-gradient(circle at center,black 40%,transparent 82%);"></div>
+  </div>
+
+  <div class="relative mx-auto flex min-h-dvh w-full max-w-xl flex-col justify-center px-4 py-10 sm:px-6">
+
+    <div class="mb-5 flex items-center gap-3">
+      <span class="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200/80 bg-white/80 shadow-sm">
+        <span class="font-prompt text-lg font-bold" style="color:var(--primary)">C</span>
+      </span>
+      <div class="min-w-0">
+        <p class="text-[0.7rem] font-semibold tracking-[0.22em] text-slate-500 uppercase">Capgo Console</p>
+        <p class="mt-0.5 truncate text-sm font-medium text-slate-600"><span class="font-prompt">Capgo</span> CLI authorization</p>
+      </div>
+    </div>
+
+    <div class="auth-card p-7">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p class="text-[0.72rem] font-bold tracking-[0.22em] text-slate-500 uppercase">Authorize device</p>
+          <h2 class="mt-2 text-2xl font-semibold leading-tight text-slate-950">Authorize the Capgo CLI</h2>
+          <p class="mt-2 text-sm leading-6 text-slate-500">
+            A CLI on this machine is requesting a new API key. Review the scope, then authorize.
+          </p>
+        </div>
+        <span class="self-start shrink-0 rounded-full border border-slate-300/90 bg-slate-50/95 px-3 py-1.5 text-[0.72rem] font-semibold text-slate-600">device&nbsp;flow</span>
+      </div>
+
+      <div class="mt-6 rounded-2xl border border-slate-200/80 bg-white/70 p-4">
+        <div class="flex items-center gap-2">
+          <svg class="h-4 w-4" style="color:var(--secondary)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="9"/></svg>
+          <p class="text-[0.72rem] font-bold tracking-[0.18em] text-slate-500 uppercase">Confirm this matches your terminal</p>
+        </div>
+        <div class="mt-3 flex items-center justify-center rounded-xl border border-dashed border-slate-300 py-3" style="background:var(--base-200)">
+          <span class="font-mono text-xl font-bold tracking-wide" style="color:var(--primary)">enjoy-enough-outwit-win</span>
+        </div>
+        <p class="mt-2 text-center text-xs text-slate-400">If the words differ, do not authorize — close this page.</p>
+      </div>
+
+      <div class="mt-4 flex items-center gap-3 rounded-xl bg-slate-50/80 px-4 py-3">
+        <svg class="h-5 w-5 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+        <div class="min-w-0 text-sm">
+          <p class="font-medium text-slate-700">MacBook-Pro · zsh</p>
+          <p class="text-slate-400">capgo-cli v6.2.0 · requested just now</p>
+        </div>
+      </div>
+
+      <div class="mt-6 space-y-5">
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-slate-700">Token name</label>
+          <input type="text" value="CLI – MacBook-Pro"
+            class="w-full rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-[var(--secondary)] focus:ring-2 focus:ring-[rgba(17,158,255,.25)]" />
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label class="mb-1.5 block text-sm font-medium text-slate-700">Organization</label>
+            <div class="relative">
+              <select class="w-full appearance-none rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-[var(--secondary)] focus:ring-2 focus:ring-[rgba(17,158,255,.25)]">
+                <option>Acme Inc.</option><option>Personal</option>
+              </select>
+              <svg class="pointer-events-none absolute right-3 top-3 h-4 w-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+            </div>
+          </div>
+          <div>
+            <label class="mb-1.5 block text-sm font-medium text-slate-700">App scope</label>
+            <div class="relative">
+              <select class="w-full appearance-none rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-[var(--secondary)] focus:ring-2 focus:ring-[rgba(17,158,255,.25)]">
+                <option>All apps in this org</option><option>com.acme.app</option><option>com.acme.staging</option>
+              </select>
+              <svg class="pointer-events-none absolute right-3 top-3 h-4 w-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-slate-700">Role for this key</label>
+          <div class="relative">
+            <select class="w-full appearance-none rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-[var(--secondary)] focus:ring-2 focus:ring-[rgba(17,158,255,.25)]">
+              <option>Member — read &amp; upload bundles</option>
+              <option>Admin — full organisation access</option>
+            </select>
+            <svg class="pointer-events-none absolute right-3 top-3 h-4 w-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </div>
+          <p class="mt-2 text-xs text-slate-400">v2 keys grant access by <strong>RBAC role</strong> (no read/upload/write/all mode). App-specific roles can be set per app above.</p>
+        </div>
+
+        <div class="flex items-center justify-between rounded-xl bg-slate-50/80 px-4 py-3">
+          <div class="text-sm">
+            <p class="font-medium text-slate-700">Expiration</p>
+            <p class="text-slate-400">Org policy: max 90 days</p>
+          </div>
+          <div class="relative">
+            <select class="appearance-none rounded-lg border border-slate-300 bg-white px-3 py-1.5 pr-8 text-sm text-slate-800 outline-none focus:border-[var(--secondary)]">
+              <option>90 days</option><option>30 days</option><option>7 days</option>
+            </select>
+            <svg class="pointer-events-none absolute right-2.5 top-2 h-4 w-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-7 flex flex-col gap-3 sm:flex-row-reverse">
+        <button class="btn-primary-capgo inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3.5 text-base font-semibold">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12l5 5L20 7"/></svg>
+          Authorize &amp; send to CLI
+        </button>
+        <button class="btn-secondary-capgo inline-flex w-full items-center justify-center rounded-xl px-4 py-3.5 text-base font-semibold">Cancel</button>
+      </div>
+
+      <div class="mt-5 flex items-start gap-2 border-t border-slate-200/70 pt-4">
+        <svg class="mt-0.5 h-4 w-4 shrink-0 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+        <p class="text-xs leading-5 text-slate-400">
+          You are authorizing the Capgo CLI on <span class="font-medium text-slate-500">this device</span>. The new key is delivered over an encrypted channel and shown to the CLI only once. Authorizing creates a fresh key — it never exposes your existing keys.
+        </p>
+      </div>
+    </div>
+
+    <p class="mt-4 text-center text-xs text-slate-400">Capgo · console.capgo.app</p>
+  </div>
+
+  <script>
+    document.querySelectorAll('[role="radio"]').forEach(el=>{
+      el.addEventListener('click',()=>{
+        el.closest('[role="radiogroup"]').querySelectorAll('[role="radio"]').forEach(r=>r.setAttribute('aria-checked','false'));
+        el.setAttribute('aria-checked','true');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/superpowers/specs/assets/2026-06-03-cli-device-login-flow-diagram.html
+++ b/docs/superpowers/specs/assets/2026-06-03-cli-device-login-flow-diagram.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Capgo CLI Web Login — Flow Diagram</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Prompt:wght@500;600;700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<style>
+  :root{--primary:#515271;--secondary:#119eff;--accent:#1FB2A5;}
+  body{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;color:#1e293b;}
+  .font-prompt{font-family:"Prompt",sans-serif;}
+  .chip{background:linear-gradient(135deg,#244366 0%,#0c6eb8 100%);}
+  .card{border-radius:1.25rem;border:1px solid rgba(226,232,240,.8);background:#fff;box-shadow:0 24px 60px -40px rgba(15,23,42,.4);}
+  .mermaid{display:flex;justify-content:center;}
+  .legend-cli{background:#eef5ff;color:#0c6eb8;border:1px solid rgba(17,158,255,.3);}
+  .legend-be{background:#eef0f7;color:#515271;border:1px solid rgba(81,82,113,.3);}
+  .legend-web{background:#e8f7f4;color:#0e8a7e;border:1px solid rgba(31,178,165,.35);}
+</style>
+</head>
+<body style="background:linear-gradient(180deg,#f8fafc 0%,#eef4ff 60%,#f8fafc 100%);">
+<div class="mx-auto max-w-5xl px-5 py-12">
+
+  <header class="flex items-center gap-3">
+    <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl chip text-white font-prompt text-xl font-bold shadow-lg">C</span>
+    <div>
+      <p class="text-[0.72rem] font-bold tracking-[0.24em] text-slate-500 uppercase">Capgo · Engineering</p>
+      <h1 class="text-2xl font-semibold text-slate-950 sm:text-3xl">CLI Web Login — Flow Diagram</h1>
+    </div>
+  </header>
+  <p class="mt-3 text-sm text-slate-500">OAuth Device Flow shape · who talks to whom, and in what order</p>
+
+  <div class="mt-5 flex flex-wrap gap-2 text-xs font-semibold">
+    <span class="rounded-full px-3 py-1 legend-cli">● CLI (developer's terminal — not logged in)</span>
+    <span class="rounded-full px-3 py-1 legend-be">● Capgo backend</span>
+    <span class="rounded-full px-3 py-1 legend-web">● Browser (developer IS logged in → has JWT)</span>
+  </div>
+
+  <!-- Sequence diagram -->
+  <section class="card mt-6 p-6">
+    <h2 class="mb-4 text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">Sequence — start to finish</h2>
+    <pre class="mermaid">
+sequenceDiagram
+    autonumber
+    actor Dev as Developer
+    participant CLI as CLI (terminal)
+    participant BE as Capgo Backend
+    participant Web as Browser (logged in)
+
+    Dev->>CLI: runs `capgo login`
+    CLI->>BE: POST /cli-auth/start (device name)
+    BE-->>CLI: device_code (secret) + user_code<br/>"enjoy-enough-outwit-win" + verify URL
+    CLI-->>Dev: prints the phrase to confirm
+    CLI->>Web: opens the verify URL
+
+    rect rgb(238,245,255)
+    note over CLI,BE: CLI quietly polls in the background
+    loop every few seconds
+        CLI->>BE: POST /cli-auth/poll (device_code)
+        BE-->>CLI: "authorization_pending"
+    end
+    end
+
+    Web->>BE: GET /cli-auth/session  [JWT]
+    BE-->>Web: device info + the same phrase
+    Dev->>Web: confirms phrase matches,<br/>picks org / app / permission
+    Web->>BE: POST /cli-auth/authorize  [JWT]
+    BE->>BE: check permission + create key NOW (hashed),<br/>stash one-time encrypted secret
+    BE-->>Web: success → "return to your terminal"
+
+    CLI->>BE: POST /cli-auth/poll (device_code)
+    BE-->>CLI: "authorized" + api_key (delivered once)<br/>secret burned, session destroyed
+    CLI->>CLI: save key to ~/.capgo
+    CLI-->>Dev: "Logged in!"
+    </pre>
+  </section>
+
+  <!-- Simple block view -->
+  <section class="card mt-6 p-6">
+    <h2 class="mb-4 text-sm font-bold tracking-[0.18em] text-slate-500 uppercase">At a glance — the two credentials</h2>
+    <pre class="mermaid">
+flowchart LR
+    Dev([Developer]) -->|runs capgo login| CLI[CLI · terminal]
+    CLI <-->|device_code secret<br/>start + poll| BE[(Capgo Backend)]
+    CLI -->|opens browser| Web[Browser page]
+    Web <-->|JWT session<br/>session + authorize| BE
+    BE -->|mint NEW key| Key{{New API key}}
+    Key -.delivered once over HTTPS.-> CLI
+    classDef cli fill:#eef5ff,stroke:#119eff,color:#0c6eb8;
+    classDef be fill:#eef0f7,stroke:#515271,color:#515271;
+    classDef web fill:#e8f7f4,stroke:#1FB2A5,color:#0e8a7e;
+    classDef key fill:#fff4e8,stroke:#ff7211,color:#b8480a;
+    class CLI cli; class BE be; class Web web; class Key key;
+    </pre>
+    <p class="mt-4 rounded-xl bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+      The <strong>CLI</strong> talks to the backend with a one-time <em>device_code</em> secret (it isn't logged in).
+      The <strong>browser</strong> talks to the backend with the developer's <em>JWT</em> (their existing dashboard login).
+      The backend is the bridge: the logged-in browser authorises, and the key flows back to the waiting terminal.
+    </p>
+  </section>
+
+  <footer class="mt-8 text-center text-xs text-slate-400">Capgo · CLI Web Login proposal</footer>
+</div>
+
+<script>
+  mermaid.initialize({
+    startOnLoad:true,
+    theme:'base',
+    themeVariables:{
+      primaryColor:'#eef0f7', primaryBorderColor:'#515271', primaryTextColor:'#1e293b',
+      lineColor:'#94a3b8', actorBkg:'#eef5ff', actorBorder:'#119eff', actorTextColor:'#0c6eb8',
+      signalColor:'#475569', signalTextColor:'#334155', noteBkgColor:'#e8f7f4', noteBorderColor:'#1FB2A5',
+      fontFamily:'ui-sans-serif, system-ui, sans-serif'
+    },
+    securityLevel:'loose'
+  });
+</script>
+</body>
+</html>

--- a/docs/superpowers/specs/assets/2026-06-03-cli-device-login-spec.html
+++ b/docs/superpowers/specs/assets/2026-06-03-cli-device-login-spec.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="en" class="capgolight">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Capgo CLI Web Login — Spec (V4)</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Prompt:wght@500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{--primary:#515271;--secondary:#119eff;--accent:#1FB2A5;--pumpkin:#ff7211;}
+  body{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;color:#1e293b;}
+  .font-prompt{font-family:"Prompt",sans-serif;}
+  .font-mono,code,pre{font-family:"JetBrains Mono",ui-monospace,monospace;}
+  .chip{background:linear-gradient(135deg,#244366 0%,#0c6eb8 100%);}
+  .card{border-radius:1.1rem;border:1px solid rgba(226,232,240,.85);background:#fff;box-shadow:0 20px 50px -38px rgba(15,23,42,.38);}
+  h2{scroll-margin-top:5rem;}
+  code:not(pre code){background:#eef2f7;color:#334155;border-radius:.35rem;padding:.05rem .35rem;font-size:.86em;}
+  pre{background:#0f172a;color:#e2e8f0;border-radius:.75rem;padding:1rem 1.1rem;overflow:auto;font-size:.78rem;line-height:1.45;}
+  table{width:100%;border-collapse:collapse;font-size:.86rem;}
+  th{background:#f1f5f9;text-align:left;color:#475569;font-weight:600;padding:.5rem .7rem;}
+  td{border-top:1px solid #eef2f7;padding:.5rem .7rem;color:#334155;vertical-align:top;}
+  .tag{font-size:.7rem;font-weight:700;letter-spacing:.04em;border-radius:9999px;padding:.15rem .6rem;}
+  .ok{background:#e8f7f0;color:#0e8a5f;}
+  .warn{background:#fff4e8;color:#b8480a;}
+  .toc a{color:#0c6eb8;text-decoration:none;}
+  .toc a:hover{text-decoration:underline;}
+  ul.dash{list-style:none;padding-left:0;}
+  ul.dash li{position:relative;padding-left:1.1rem;margin:.35rem 0;line-height:1.55;}
+  ul.dash li::before{content:"";position:absolute;left:0;top:.62em;width:.45rem;height:.45rem;border-radius:9999px;background:var(--secondary);}
+</style>
+</head>
+<body style="background:linear-gradient(180deg,#f8fafc 0%,#eef4ff 55%,#f8fafc 100%);">
+<div class="mx-auto max-w-3xl px-5 py-12">
+
+  <header class="flex items-center gap-3">
+    <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl chip text-white font-prompt text-xl font-bold shadow-lg">C</span>
+    <div>
+      <p class="text-[0.72rem] font-bold tracking-[0.24em] text-slate-500 uppercase">Capgo · Design Spec</p>
+      <h1 class="text-2xl font-semibold text-slate-950 sm:text-3xl">CLI Web Login — Device Flow</h1>
+    </div>
+  </header>
+  <div class="mt-3 flex flex-wrap items-center gap-2 text-sm text-slate-500">
+    <span class="tag ok">Lifecycle V4</span>
+    <span class="tag warn">Draft for review</span>
+    <span>· 3 June 2026 · apikey v2 / RBAC only</span>
+  </div>
+
+  <nav class="card toc mt-6 p-5 text-sm">
+    <p class="mb-2 font-bold tracking-[0.14em] text-slate-500 uppercase text-[0.7rem]">Contents</p>
+    <ol class="grid gap-1 sm:grid-cols-2 list-decimal pl-5 text-slate-600">
+      <li><a href="#problem">Problem &amp; goal</a></li>
+      <li><a href="#lifecycle">Key lifecycle (V4)</a></li>
+      <li><a href="#arch">Architecture &amp; components</a></li>
+      <li><a href="#data">Data model</a></li>
+      <li><a href="#codes">user_code / device_code</a></li>
+      <li><a href="#security">Security checklist</a></li>
+      <li><a href="#reuse">Reuse &amp; testing</a></li>
+      <li><a href="#open">Open decisions</a></li>
+    </ol>
+  </nav>
+
+  <section id="problem" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Problem &amp; goal</h2>
+    <p class="mt-3 text-sm leading-7 text-slate-600">Today the CLI only authenticates by manually pasting an API key — there is no "log in from the browser" path. <strong>Goal:</strong> <code>capgo login</code> opens the browser, the user picks org/app <strong>RBAC roles</strong> and authorizes, and a fresh API key is delivered back to the terminal over HTTPS. It uses the shape of the OAuth 2.0 Device Authorization Grant (RFC&nbsp;8628) but hands back a normal Capgo API key — not an OAuth token.</p>
+    <p class="mt-3 text-sm leading-7 text-slate-600"><strong>Non-goals:</strong> no OAuth token server, no refresh tokens, no reuse of existing keys (always mint fresh), manual <code>capgo login &lt;key&gt;</code> kept as fallback. <strong>apikey v2 / RBAC only</strong> — permission is the <code>role_name</code> per binding; there is no <code>read/upload/write/all</code> mode.</p>
+  </section>
+
+  <section id="lifecycle" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Key lifecycle — V4 (create at authorize, hashed, deliver once)</h2>
+    <p class="mt-3 text-sm leading-7 text-slate-600">The key is <strong>created at authorize-time</strong> (under the user's JWT), stored <strong>hashed</strong> (<code>key = NULL</code>, only <code>key_hash</code>), and the plaintext is held <strong>transiently</strong> on the session for the CLI to fetch once, then burned. After delivery, only the hash remains — so the key is <strong>not viewable in the dashboard</strong>.</p>
+    <div class="mt-4 grid gap-3 sm:grid-cols-3">
+      <div class="rounded-xl bg-slate-50 p-4"><p class="font-semibold text-slate-800">① Authorize</p><p class="mt-1 text-xs leading-5 text-slate-500">JWT present. RBAC-check, create key now (hashed), store <code>apikey_id</code> + encrypted one-time <code>delivery_key</code>.</p></div>
+      <div class="rounded-xl bg-slate-50 p-4"><p class="font-semibold text-slate-800">② Poll</p><p class="mt-1 text-xs leading-5 text-slate-500">CLI polls with <code>device_code</code>; backend returns the plaintext once, then nulls it and burns the session.</p></div>
+      <div class="rounded-xl bg-slate-50 p-4"><p class="font-semibold text-slate-800">③ Rest</p><p class="mt-1 text-xs leading-5 text-slate-500">Only <code>key_hash</code> persists — identical to a hashed dashboard key.</p></div>
+    </div>
+    <p class="mt-4 rounded-xl bg-[#eef5ff] p-4 text-sm leading-6 text-slate-700"><strong>Why V4 over deferring creation to the poll (“V3”):</strong> deferring would store the <em>intent</em> (bindings) and build the key later — a bug in that stored scope could mint a <strong>wrong-scope</strong> key within the user's rights, which the RBAC check can't catch (it only blocks <em>escalation</em>). V4 creates atomically under the JWT, so nothing scope-bearing is stored between steps; the only transient state is the <strong>opaque secret string</strong>, whose worst-case bug is a <strong>dud key that fails login</strong> — never wrong scope. Creation errors also surface in the browser, not on a headless poll.</p>
+    <p class="mt-3 text-sm font-semibold text-slate-700">Security guards</p>
+    <ul class="dash text-sm text-slate-600">
+      <li><strong>Creation only under the JWT</strong> (authorize). The poll never creates — it only delivers. No unauthenticated key creation exists.</li>
+      <li>Shared creation function enforces <code>org.update_user_roles</code> per org <strong>intrinsically</strong> — escalation impossible regardless of caller. Service-role insert without the check is banned.</li>
+      <li><code>delivery_key</code> is <strong>encrypted at rest</strong> (Worker secret) + short TTL + burn-on-read; the only plaintext copy, and <strong>opaque</strong> (no scope meaning).</li>
+    </ul>
+  </section>
+
+  <section id="arch" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Architecture &amp; components</h2>
+    <pre class="mt-3">CLI                        Backend (CF Workers / Hono)       Browser (logged in → JWT)
+ | POST /cli-auth/start  -----> create session ---.                  |
+ | &lt;-- device_code, user_code, URIs               |                  |
+ | print user_code, open verify URL ----------------------------->  /cli-login?code=user_code
+ |                                                 |   show phrase + RBAC role picker
+ |                              POST /cli-auth/authorize  &lt;-- (JWT)
+ |                              RBAC-check + CREATE key now (hashed),
+ |                              store apikey_id + encrypted delivery_key
+ | POST /cli-auth/poll {device_code} (loop) -> status; when authorized:
+ | &lt;-- api_key (decrypt + return once), delivery_key nulled, session burned
+ | save to ~/.capgo</pre>
+
+    <p class="mt-4 text-sm font-semibold text-slate-700">CLI (<code>cli/src/login.ts</code> + new <code>loginWeb.ts</code>)</p>
+    <ul class="dash text-sm text-slate-600">
+      <li><code>capgo login</code> (no key) runs the web flow <strong>in interactive terminals</strong>. In <strong>CI / non-interactive</strong> (no TTY or <code>CI</code> set) it never opens a browser — it requires an explicit key (positional / <code>--apikey</code>) or <code>CAPGO_TOKEN</code>. <code>--web</code> forces web; <code>capgo login &lt;key&gt;</code> stays as manual fallback.</li>
+      <li>Calls <code>/cli-auth/start</code>, prints the <code>user_code</code>, opens <code>verification_uri_complete</code> (existing <code>open</code> dep), then polls honoring RFC 8628 (<code>authorization_pending</code> / <code>slow_down</code> / <code>access_denied</code> / <code>expired_token</code>). No local server.</li>
+      <li>On <code>authorized</code>, saves the key once via the existing <code>~/.capgo</code> / <code>./.capgo</code> writer (0o600).</li>
+    </ul>
+
+    <p class="mt-4 text-sm font-semibold text-slate-700">Backend endpoints (Hono, under <code>supabase/functions/_backend/public/cli-auth/*</code>)</p>
+    <ul class="dash text-sm text-slate-600">
+      <li><code>POST /cli-auth/start</code> — minimal auth; generates <code>device_code</code> (32 bytes) + <code>user_code</code>, stores the session (only the <em>hash</em> of <code>device_code</code>), returns the device-flow payload. Rate-limited per IP.</li>
+      <li><code>GET /cli-auth/session?user_code=…</code> — JWT-authed; returns display info only (device name, version, status). Never returns <code>device_code</code> or <code>delivery_key</code>.</li>
+      <li><code>POST /cli-auth/authorize</code> — JWT-authed. Body <code>{ user_code, name, bindings, expires_at, hashed }</code>. RBAC-check under JWT, <strong>create the key now (hashed)</strong> via the shared function, store <code>apikey_id</code> + encrypted <code>delivery_key</code>, mark authorized. Requires <code>org.update_user_roles</code> on every org — <strong>only org admins</strong> can authorize for that org.</li>
+      <li><code>POST /cli-auth/poll</code> — <strong>authenticated by the <code>device_code</code> bearer secret</strong> (<code>Authorization: Bearer</code>, not a JWT); backend hashes it and matches <code>device_code_hash</code> (constant-time). On first <code>authorized</code> poll returns the plaintext once, nulls <code>delivery_key</code>, burns the session. <strong>Never creates keys.</strong></li>
+    </ul>
+
+    <p class="mt-4 text-sm font-semibold text-slate-700">Frontend (<code>src/pages/cli-login.vue</code> + success)</p>
+    <ul class="dash text-sm text-slate-600">
+      <li>Auth-gated page; shows the verification phrase for the eyeball match + device info.</li>
+      <li>Reuses <code>ApiKeys.vue</code> <strong>org+role / app+role</strong> selectors (<code>selectedOrgRole</code>, <code>pendingAppBindings</code>) + expiration.</li>
+      <li>Authorize → <code>/cli-auth/authorize</code>; success shows "return to your terminal"; creation errors surface here. Styled like <code>login.vue</code>.</li>
+    </ul>
+  </section>
+
+  <section id="data" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Data model — <code>cli_login_sessions</code></h2>
+    <div class="mt-3 overflow-hidden rounded-xl border border-slate-200">
+      <table>
+        <thead><tr><th>column</th><th>type</th><th>notes</th></tr></thead>
+        <tbody>
+          <tr><td><code>id</code></td><td>uuid pk</td><td></td></tr>
+          <tr><td><code>device_code_hash</code></td><td>text</td><td>SHA-256 of <code>device_code</code>; poll matches by hashing input</td></tr>
+          <tr><td><code>user_code</code></td><td>text</td><td>5 EFF-short words, hyphenated; unique among active sessions</td></tr>
+          <tr><td><code>device_name</code> / <code>client_version</code></td><td>text</td><td>reported by CLI</td></tr>
+          <tr><td><code>status</code></td><td>enum</td><td>pending / authorized / consumed / denied / expired</td></tr>
+          <tr><td><code>user_id</code></td><td>uuid null</td><td>set on authorize (the approver)</td></tr>
+          <tr><td><code>apikey_id</code></td><td>uuid null</td><td>the key created at authorize (hashed)</td></tr>
+          <tr><td><code>delivery_key</code></td><td>text null</td><td><strong>encrypted JSON envelope</strong> <code>{ name, key }</code>; transient, nulled/burned on first poll</td></tr>
+          <tr><td><code>delivery_key_name</code></td><td>text null</td><td>KEK name/version used to encrypt <code>delivery_key</code> (enables rotation)</td></tr>
+          <tr><td><code>expires_at</code></td><td>timestamptz</td><td><code>created_at + 10 min</code> (session TTL)</td></tr>
+          <tr><td><code>last_poll_at</code></td><td>timestamptz null</td><td>for <code>slow_down</code> enforcement</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="mt-3 text-sm leading-6 text-slate-600">Stores <strong>no scope/intent</strong> — the key (hashed) and its bindings are real <code>apikeys</code> / <code>role_bindings</code> rows created at authorize. The session holds only the device-code hash and the encrypted one-time <code>delivery_key</code>. Not client-accessible (no RLS path); reached only via edge functions; scheduled cleanup of expired/consumed rows.</p>
+  </section>
+
+  <section id="codes" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900"><code>user_code</code> &amp; <code>device_code</code></h2>
+    <ul class="dash mt-2 text-sm text-slate-600">
+      <li><strong><code>device_code</code></strong> — 32 bytes, base64url. Only its SHA-256 hash is stored. The real high-entropy poll secret ("state" anchor).</li>
+      <li><strong><code>user_code</code></strong> — EFF short wordlist (1296 words), <strong>5 words</strong> hyphenated (~51 bits), server-generated &amp; stored (Stripe/GitHub model), unique among active sessions. A short-lived, rate-limited <em>handle</em> — not the secret — so ~51 bits + rate-limit + 10-min TTL is ample (GitHub uses ~35 bits). The <strong>two tokens have separated roles</strong>: <code>user_code</code> is the public browser handle; <code>device_code</code> is the secret that authenticates the poll, so knowing <code>user_code</code> alone can't poll.</li>
+    </ul>
+  </section>
+
+  <section id="security" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Security checklist</h2>
+    <ul class="dash mt-2 text-sm text-slate-600">
+      <li><code>device_code</code> 256-bit, stored hashed; poll matches by hash.</li>
+      <li><code>user_code</code> ~51 bits + unique-among-active + 10-min TTL + strict rate limit on authorize/poll — mitigates guess→planted-key.</li>
+      <li>Key created <strong>only under the user's JWT</strong> (authorize); poll only delivers. No unauthenticated creation.</li>
+      <li><strong>No scope-bearing state between steps</strong> → eliminates the wrong-scope bug class.</li>
+      <li>No privilege escalation: shared function enforces <code>org.update_user_roles</code> per org intrinsically; service-role insert without the check is banned.</li>
+      <li>Hashed at rest (<code>apikeys.key = NULL</code>); not viewable in dashboard. <code>delivery_key</code> = encrypted JSON envelope <code>{name,key}</code>, short-TTL, burn-on-read, opaque; <code>delivery_key_name</code> records the KEK version for rotation.</li>
+      <li>Single-use session burn; HTTPS-only + HSTS; optional CLI cert-pinning deferred.</li>
+      <li><em>Note:</em> V4 creates the credential at authorize rather than the poll/token step — a deliberate deviation from strict RFC 8628 to remove the wrong-scope surface; still device-flow-shaped.</li>
+    </ul>
+  </section>
+
+  <section id="reuse" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Reuse &amp; testing</h2>
+    <ul class="dash mt-2 text-sm text-slate-600">
+      <li><strong>Shared creation function</strong>: factor the core of <code>apikey/post.ts</code> (validation + RBAC + key gen + bindings) into one fn taking an explicit <code>actingUserId</code>, RBAC gate <em>inside</em>. Called by the public endpoint and <code>/cli-auth/authorize</code>. v2/RBAC only.</li>
+      <li><strong>UI</strong>: reuse <code>ApiKeys.vue</code> org+role / app+role selectors.</li>
+      <li><strong>Tests</strong>: unit (user_code gen, device_code hash, delivery_key encrypt/burn, RBAC gate, CLI poll state machine); integration (happy path, expired, denied, double-poll burns, rate-limit slow_down, wrong device_code, <strong>escalation attempt rejected</strong>); frontend (phrase + role pickers, unauth redirect). Target ≥80% on new modules.</li>
+    </ul>
+  </section>
+
+  <section id="open" class="card mt-6 p-6">
+    <h2 class="text-lg font-semibold text-slate-900">Open decisions</h2>
+    <ol class="mt-2 list-decimal pl-5 text-sm leading-7 text-slate-600">
+      <li><span class="line-through">Key-at-rest / when to create</span> — <strong>Resolved (V4)</strong>: create at authorize, hashed, deliver via encrypted transient <code>delivery_key</code>.</li>
+      <li><span class="line-through">Web default</span> — <strong>Resolved</strong>: default in interactive terminals; CI/non-interactive requires an explicit key (<code>--apikey</code> / <code>CAPGO_TOKEN</code>), never opens a browser.</li>
+      <li><span class="line-through">Route mount</span> — <strong>Resolved</strong>: under <code>public/cli-auth/*</code> (alongside <code>apikey</code>).</li>
+      <li><span class="line-through">delivery_key encryption</span> — <strong>Resolved (envelope)</strong>: encrypted JSON <code>{name,key}</code> + <code>delivery_key_name</code> KEK version for rotation. (Worker secret vs KMS = impl detail.)</li>
+      <li>CLI certificate pinning — now or follow-up.</li>
+    </ol>
+  </section>
+
+  <footer class="mt-8 text-center text-xs text-slate-400">Capgo · CLI Web Login · design spec V4 · branch worktree-cli-oauth-device-flow</footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What

Captures the **design docs** for a proposed *CLI web login* flow — logging the Capgo CLI in from the browser (OAuth Device-Flow shape) so users authorize and receive an API key without manually pasting one.

**Status: design only / on hold.** Per discussion this feature is **not being implemented right now**; this PR exists to preserve the design exploration, decisions, and mockups for the record so we can pick it up later. **Docs-only — no code changes.**

## Contents (`docs/superpowers/specs/`)

- `2026-06-03-cli-device-login-design.md` — the design spec (V4 lifecycle).
- `assets/2026-06-03-cli-device-login-spec.html` — the spec rendered as a shareable page.
- `assets/2026-06-03-cli-device-login-authorize-mockup.html` — mockup of the in-app "Authorize CLI" page (Capgo design system).
- `assets/2026-06-03-cli-device-login-flow-diagram.html` — sequence + block flow diagrams.
- `assets/2026-06-03-cli-device-login-architecture.html` — non-technical architecture explainer.

## Design summary (for reviewers)

- **Device flow (RFC 8628 shape)**, not a real OAuth token server — it delivers a normal Capgo API key. apikey **v2 / RBAC only** (permission = `role_name` per binding; no `mode`).
- **V4 key lifecycle:** the key is created **at authorize-time under the user's JWT** (reusing the existing `apikey` creation path, so RBAC is enforced and there's no privilege escalation), stored **hashed**; the plaintext is held in an **AES-256-GCM encrypted, burn-on-read** `delivery_key` that the CLI fetches once via polling, then the session is destroyed.
- Two tokens: `device_code` (256-bit secret, poll bearer auth) and `user_code` (5-word eyeball-match handle).
- New `cli_login_sessions` table + endpoints under `public/cli-auth/*`; CLI runs the flow only in interactive terminals (CI falls back to a manual key).

## Test plan

N/A — documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design specifications and architecture documentation for a new CLI web-based login flow, enabling users to authenticate through browser authorization instead of manual API key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->