### PR TITLE
docs: Capgo Builder contact-support / easy-help design (shelved)

### DIFF
--- a/docs/superpowers/specs/2026-06-03-builder-contact-support-design.html
+++ b/docs/superpowers/specs/2026-06-03-builder-contact-support-design.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Capgo Builder — Contact Support &amp; Easy Help (Design)</title>
+<style>
+  :root{
+    --bg:#0b0e14; --panel:#141925; --panel2:#1b2233; --line:#2a3349;
+    --ink:#e6ebf5; --muted:#94a3b8; --dim:#64748b;
+    --blue:#4f8cff; --green:#34d399; --amber:#fbbf24; --pink:#f472b6; --purple:#a78bfa; --red:#fb7185;
+    --mono:'SF Mono',ui-monospace,'JetBrains Mono',Menlo,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:radial-gradient(1200px 700px at 70% -10%,#16203a 0%,var(--bg) 55%);
+       color:var(--ink);font:15px/1.65 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;padding:48px 24px 90px}
+  .wrap{max-width:1040px;margin:0 auto}
+  h1{font-size:30px;margin:0 0 4px;letter-spacing:-.5px}
+  .meta{color:var(--dim);font-family:var(--mono);font-size:12.5px;margin:0 0 4px}
+  .status{display:inline-block;font-family:var(--mono);font-size:11px;padding:3px 10px;border-radius:20px;border:1px solid #2a3f33;background:#0f2920;color:var(--green);margin:8px 0 30px}
+  h2{font-size:13px;text-transform:uppercase;letter-spacing:1.5px;color:var(--blue);margin:42px 0 14px;border-bottom:1px solid var(--line);padding-bottom:8px}
+  h3{font-size:15px;margin:22px 0 8px;color:var(--ink)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:18px 22px;margin-bottom:14px}
+  .goal{background:linear-gradient(135deg,#1a2336,#141b2b);border-left:3px solid var(--blue)}
+  code{font-family:var(--mono);font-size:.87em;background:#0e1421;border:1px solid var(--line);padding:1.5px 6px;border-radius:5px;color:#cbd5e1}
+  pre{font-family:var(--mono);font-size:12.5px;line-height:1.55;background:#0e1421;border:1px solid var(--line);border-radius:12px;padding:16px 18px;overflow-x:auto;color:#aeb9cc}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:6px 0}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--dim);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.8px}
+  ul,ol{margin:8px 0 0;padding-left:20px}
+  li{margin:5px 0}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;margin:2px 4px 2px 0;border:1px solid var(--line)}
+  .t-green{color:var(--green);background:#0f2920} .t-blue{color:var(--blue);background:#13203a}
+  .t-amber{color:var(--amber);background:#2a230f} .t-pink{color:var(--pink);background:#2c1424}
+  .t-purple{color:var(--purple);background:#1f1a33} .t-red{color:var(--red);background:#2c1620}
+  .note{font-size:13px;color:var(--muted)}
+  .warn{border-left:3px solid var(--amber);background:#221d0d}
+  .warn b{color:var(--amber)}
+  .ok{border-left:3px solid var(--green);background:#0f1c19}
+  .ok b{color:var(--green)}
+  .menu{font-family:var(--mono);font-size:13px;background:#0e1421;border:1px solid var(--line);border-radius:10px;padding:12px 16px;line-height:2}
+  .first{color:var(--green);font-weight:700}
+  .toc{columns:2;gap:24px;font-size:13.5px}
+  @media(max-width:640px){.toc{columns:1}}
+  .toc a,a{color:var(--blue);text-decoration:none}
+  .hl{color:var(--amber);font-weight:600}
+  .good{color:var(--green);font-weight:600}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Capgo Builder — "Contact Support" &amp; Easy Help</h1>
+  <div class="meta">docs/superpowers/specs/2026-06-03-builder-contact-support-design.md · 2026-06-03</div>
+  <span class="status" style="background:#221d0d;border-color:#3a2f0d;color:#fbbf24">⏸ SHELVED — design complete, deemed too complex to build now (Martin). Preserved for reference.</span>
+  <div class="card warn" style="margin:0 0 24px"><b>Outcome:</b> Fully designed &amp; stress-tested (sizing, Cloudflare Email Service limits, gzip/truncation, telemetry, and integration with the <code>Cap-go/automations</code> email↔Discord bridge). The complexity concentrated in the bridge integration — making a programmatically-sent ticket behave correctly (avoiding the <code>ownedOutboundCopy</code> heuristic, the double-delivery race from multiple bridge-routed <code>@capgo.app</code> recipients, and two-party reply threading). The cleanest robust path (a dedicated <code>POST /builder-ticket</code> endpoint in the automations worker + team-in-Discord) was judged not worth the cost now. Preserved so the analysis isn't lost. No implementation plan was produced (§8 is the closest skeleton).</div>
+
+  <div class="card">
+    <div class="toc">
+      <a href="#goal">1 · Goal</a><br>
+      <a href="#triggers">2 · Triggers &amp; menu</a><br>
+      <a href="#arch">3 · Architecture &amp; data flow</a><br>
+      <a href="#email">4 · Email transport + addressing + limits</a><br>
+      <a href="#log">5 · Internal log + combined bundle</a><br>
+      <a href="#ux">6 · Support-flow UX</a><br>
+      <a href="#sec">7 · Security &amp; privacy</a><br>
+      <a href="#build">8 · Components to build</a><br>
+      <a href="#test">9 · Error handling &amp; testing</a><br>
+      <a href="#open">10 · Open items + resolved decisions</a>
+    </div>
+  </div>
+
+  <h2 id="goal">1 · Goal</h2>
+  <div class="card goal">
+    Make it frictionless for a builder user to get help when something goes wrong, via two clearly-separated paths:
+    <ul>
+      <li><b>📨 Ask Capgo support</b> — email the user's logs to the team; the user receives a clean copy and the team replies to that thread.</li>
+      <li><b>🤖 Ask AI for help</b> — the existing AI build-log analysis (only when a build log exists).</li>
+    </ul>
+    A rich <b>internal log</b> is captured invisibly during every builder run and sent <i>in full</i> when help is requested — replacing today's truncated 12-line support bundle.
+    <p class="note" style="margin-bottom:0">Scope: Capgo <b>builder</b> CLI flows only. Not the rest of the CLI; no standalone command.</p>
+  </div>
+
+  <h2 id="triggers">2 · Triggers &amp; menu</h2>
+  <div class="card">
+    <p>Unified help menu at three points. <b class="first">"Ask Capgo support" is always first.</b></p>
+    <table>
+      <tr><th>Trigger</th><th>Build log?</th><th>Menu options (in order)</th></tr>
+      <tr><td>Build failure</td><td>Yes (<code>jobId</code> + log)</td><td><span class="tag t-green">📨 Ask Capgo support</span><span class="tag t-purple">🤖 Ask AI</span><span class="tag t-blue">🔄 Try again</span><span class="tag t-red">❌ Exit</span></td></tr>
+      <tr><td>Onboarding error</td><td>No</td><td><span class="tag t-green">📨 Ask Capgo support</span><span class="tag t-blue">🔄 Try again / ↩️ Restart</span><span class="tag t-red">❌ Exit</span></td></tr>
+      <tr><td>Unhandled error (raw provider API error)</td><td>No</td><td><span class="tag t-green">📨 Ask Capgo support</span><span class="tag t-blue">🔄 Try again</span><span class="tag t-red">❌ Exit</span></td></tr>
+    </table>
+    <p class="note"><b>AI is offered only when a build log exists.</b> Onboarding/unhandled errors get support only.</p>
+    <h3>AI ↔ support: fork + escalation</h3>
+    <p style="margin:0">Independent choices. After AI returns its analysis and the user is still stuck, the AI result screen adds <span class="tag t-green">📨 Still stuck — send this to Capgo support</span> carrying the <b>same logs + the AI analysis</b> into the email (no re-gathering).</p>
+  </div>
+
+  <h2 id="arch">3 · Architecture &amp; data flow</h2>
+  <div class="card">
+    <p>Reuses the proven path the AI feature already uses (<code>CLI → ${apiHost}/build/* → builder worker</code>). Backend is a <b>thin proxy</b> owning identity + rate limiting; the <b>worker</b> sends. <b class="good">Compression (gzip -9) happens in the CLI</b>, so the worker is a near pass-through.</p>
+<pre>CLI (user machine)
+  builder run writes a hidden verbose internal log as it goes
+  on failure/error → unified help menu
+  user picks "Ask Capgo support"
+    • assemble ONE combined bundle (labeled sections):
+        DIAGNOSTICS / INTERNAL CLI LOG / BUILD LOG (fastlane)? / AI ANALYSIS? / USER MESSAGE?
+    • <span style="color:#34d399">redact secrets (CLI-only) + TELL the user we do it</span>
+    • <span style="color:#34d399">GZIP -9 + BASE64 in the CLI</span> (Node — no mem/CPU limits)
+    • "We'll send your request to Capgo &amp; email you a copy at &lt;email&gt;. Secrets removed."
+        Send  /  View logs first  /  Cancel
+        └ View logs first → Show path (copies to clipboard) / Open preview (combined bundle)
+    • on Send → POST { appId, jobId?, bundleB64, … }  → ${apiHost}/build/support  (capgkey)
+        │
+        ▼
+capgo-new backend  public/build/support.ts   (THIN PROXY, JSON only)
+    1. auth capgkey → resolve user → VERIFIED email
+    2. <span style="color:#fbbf24">RATE LIMIT here (1/60s + 10/day per user) — NOT in the worker</span>
+    3. To = resolved email; reject if client-sent email differs
+    4. forward JSON { bundleB64, verifiedEmail, appId, jobId? }
+        ▼
+capgo_builder worker  /support
+    1. <span style="color:#34d399">NO gzip, NO DO pull</span> — drop bundleB64 into the attachment
+    2. env.EMAIL.send(...)        ← Cloudflare Email Service binding
+         from: "Capgo Builder Support" &lt;capgo_builder_support@capgo.app&gt;
+         to:   &lt;verified user email&gt;            (the USER — clean, well-titled email)
+         cc:   michael@capgo.app                (internal, NON-routed → safe; NOT martin@)
+         bcc:  capgo_builder_support@capgo.app  (ONLY bridge-routed addr; invisible)
+         (martin@ excluded — it IS bridge-routed → would race; NO replyTo)
+         attachments: [{ content: bundleB64, filename: …log.gz, type: application/gzip }]
+        ▼
+Cap-go/automations bridge → ingests the BCC copy → R2 attachment → Discord [SUPPORT] thread
+    (team works in Discord, not email)
+    team replies → To = capgo_builder_support@ (routed → dropped as self-copy),
+    CC = buildReplyAllCc = user + michael@ (originalTo+originalCc) → both get every reply → no loop/race</pre>
+    <p class="note" style="margin-bottom:0"><b>Split:</b> CLI = capture + combined bundle + redact(+inform) + <b>gzip-9/base64</b> · backend = identity + verified email + <b>rate limit</b> + forwarding · worker = attach blob + send.</p>
+  </div>
+
+  <h2 id="email">4 · Email transport, addressing &amp; real limits</h2>
+  <div class="card">
+    <p>Use <b>Cloudflare Email Service</b> (transactional, onboarded for <code>capgo.app</code>) — <b>not</b> the legacy Email Routing binding. <b>Resend is not used.</b> <b class="good">Capgo is on a paid CF plan (confirmed)</b> — required to send to arbitrary recipients (the user).</p>
+    <h3>Addressing — user is the visible To; BCC triggers the bridge</h3>
+    <ul>
+      <li><b>From</b> = <code>"Capgo Builder Support" &lt;capgo_builder_support@capgo.app&gt;</code>.</li>
+      <li><b>To</b> = the <b>user</b> (verified server-side from the capgkey owner) — external, not bridge-routed. The user gets a normal, well-titled email addressed to them.</li>
+      <li><b>BCC</b> = <code>capgo_builder_support@capgo.app</code> — the <b>single bridge-routed recipient</b> and the only envelope address that reaches the bridge; stripped from headers → invisible. Routed via ForwardEmail alias → <code>support@usecapgo.com</code>.</li>
+      <li><b>CC</b> = internal addresses that are <b>NOT bridge-routed</b> (e.g. <code>michael@capgo.app</code>). A non-routed CC adds an inbox recipient without a second <i>routed</i> one, and the bridge includes it on replies (<code>buildReplyAllCc</code> reads <code>originalCc</code>). <b><code>martin@capgo.app</code> is excluded</b> — it <i>is</i> bridge-routed → would race. CC list in worker config; every entry <b>must be a verified non-routed mailbox</b>.</li>
+      <li><b>No Reply-To</b> (bridge ignores it); <code>support@</code> not used.</li>
+    </ul>
+    <div class="card warn" style="margin:6px 0 12px">
+      <b>Invariant:</b> exactly ONE bridge-routed recipient per email — the BCC'd <code>capgo_builder_support@</code>. <code>To</code>/<code>CC</code> may include non-routed addresses (the user; non-routed internal mailboxes like <code>michael@</code>), but <b>never a second bridge-routed address</b> (<code>support@</code>, <code>martin@</code>). <b>Safety hinges on CC'd addresses staying non-routed — verify <code>michael@</code> before shipping, never add a routed address to the CC config.</b> Rare edge: if the <i>builder user's own</i> email is a routed <code>@capgo.app</code> address, the <code>To</code> copy also routes in → detect and drop the BCC in that case, or accept the dedup fallback.
+    </div>
+    <h3>Why a single routed address — the double-delivery race</h3>
+    <p>Two bridge-routed recipients ⇒ the bridge receives the mail twice. Its Message-ID dedup (index.ts:605-621) is <code>get</code>-then-<code>put</code>, <b>non-atomic</b>, on eventually-consistent KV across separate worker invocations — so simultaneous double-delivery (e.g. a reply-all hitting two routed addresses) could slip through and double-post. One routed recipient (the BCC) makes the race impossible by construction.</p>
+    <h3>Verified bridge behavior — replies reach the user (<code>Cap-go/automations/email/index.ts</code>)</h3>
+    <ul>
+      <li>Bridge ingests the BCC'd copy (envelope-routed to <code>capgo_builder_support@</code>), parses <b>header</b> To/CC → <code>originalTo = [user]</code>, <code>originalSender = From</code>.</li>
+      <li>Team replies in Discord → <code>to: originalSender</code> (<code>capgo_builder_support@</code>, routed → dropped as self-copy via <code>x-bridge-source</code>) and <code>cc: buildReplyAllCc = originalTo + originalCc</code> = <b>the user + the non-routed CC (<code>michael@</code>)</b> (index.ts:185/1577/1660) → <b>both receive every reply</b> (those copies land in normal inboxes → no re-ingest).</li>
+      <li>If the user replies by email → addressed to <code>capgo_builder_support@</code> → routed → threaded into their existing Discord thread (In-Reply-To). Bidirectional; user only ever sees clean emails.</li>
+      <li><b>No loop / no race:</b> the only routed recipient on any message is <code>capgo_builder_support@</code>, and the bridge drops its own <code>x-bridge-source</code> copies.</li>
+    </ul>
+    <h3>Limits that actually matter <span class="note">(verified against Cloudflare docs)</span></h3>
+    <table>
+      <tr><th>Limit</th><th>Value</th><th>Implication</th></tr>
+      <tr><td><b>Total message size</b></td><td class="hl">5 MiB</td><td>Hard ceiling on the base64'd email</td></tr>
+      <tr><td>… for verified <b>destination</b> addrs only</td><td>25 MiB</td><td>Recipient verified in the CF account (not the sender). The user isn't one → 5 MiB tier. Moot (measured 28 KB).</td></tr>
+      <tr><td><b>Attachments</b></td><td class="hl">must be base64 (~+33%)</td><td>5 MiB budget is the <i>encoded</i> size</td></tr>
+      <tr><td>Worker memory</td><td class="good">128 MB / isolate</td><td><b>Not</b> a constraint — the "10 MB" is <i>script bundle</i> size</td></tr>
+      <tr><td>Email-binding CPU</td><td class="hl">~50 ms / request</td><td><b>Why we don't gzip in the worker</b></td></tr>
+      <tr><td>Recipients (to+cc+bcc)</td><td>50</td><td>Fine (we use 2)</td></tr>
+    </table>
+    <div class="card ok" style="margin:10px 0">
+      <b>Sizing model — MEASURED:</b> a real GitHub build log (<code>logs_72018286007.zip</code>) = 123 KB raw → <b class="good">28 KB gzip(-9)+base64</b> = ~<b>4.4×</b> shrink, <b>188× under</b> the 5 MiB ceiling; the ~4.5 MiB encoded budget holds <b>~20 MiB raw</b>. <b>gzip level 9</b>, run in the <b>CLI</b>.
+    </div>
+    <h3>Config &amp; sender</h3>
+<pre>// builder worker wrangler.jsonc (prod + preprod)
+"send_email": [
+  { "name": "EMAIL", "remote": true,
+    "allowed_sender_addresses": ["capgo_builder_support@capgo.app"] }
+]</pre>
+    <p class="note">Sender setup: the <code>capgo.app</code> domain onboarding (SPF/DKIM) <i>is</i> the sender verification — any <code>@capgo.app</code> address sends immediately.</p>
+  </div>
+
+  <h2 id="log">5 · Internal log + combined bundle</h2>
+  <div class="card">
+    <p>Today only ~12 in-memory lines exist. Add a full, hidden, on-disk log per builder run.</p>
+    <ul>
+      <li><b>Module:</b> <code>cli/src/support/internal-log.ts</code> (new).</li>
+      <li><b>File:</b> <code>~/.capgo-credentials/support/internal-&lt;appId&gt;-&lt;ts&gt;.log</code>, <b>append-as-you-go</b> — survives crashes &amp; unhandled errors.</li>
+      <li><b>Captures:</b> all log levels incl. <code>debug</code>; every external API request+response (method, URL, status, body — <b>including raw provider API errors: Apple App Store Connect AND Google Play, plus Gradle/CocoaPods/signing</b>); every shell command (<code>cap add ios/android</code>, <code>pod install</code>, Gradle, …) with stdout/stderr; diagnostics (OS/arch, Node, CLI version, package manager, Capgo/Capacitor versions, appId, platform, channel, step).</li>
+      <li><b>Secret redaction on write — CLI-only</b> (capgkey/API keys, tokens, Apple/Google keys &amp; signing secrets). <b>No server-side re-scrub.</b> The support flow <b>tells the user</b> secrets are removed (§6).</li>
+      <li><b>Visibility:</b> never shown in normal runs; surfaced only on help request.</li>
+    </ul>
+    <h3>The combined bundle</h3>
+    <p style="margin:0">On <b>Ask Capgo support</b>, internal log + build log are <b>combined into one bundle file</b> with labeled sections (<code>DIAGNOSTICS / INTERNAL CLI LOG / BUILD LOG (fastlane) / AI ANALYSIS / USER MESSAGE</code>). One file = one attachment, one preview, one gzip. Built by <b>extending the existing <code>writeOnboardingSupportBundle</code></b>, then gzipped(-9)+base64'd in the CLI.</p>
+  </div>
+
+  <h2 id="ux">6 · Support-flow UX (CLI)</h2>
+  <div class="card">
+    <div class="menu">
+1. pick <span class="first">📨 Ask Capgo support</span><br>
+2. assemble <b>combined</b> bundle locally + redact secrets<br>
+3. "We'll send your request to the Capgo team and email you a copy at <b>&lt;email&gt;</b> —<br>
+&nbsp;&nbsp;&nbsp;&nbsp;they'll reply in that thread. <span style="color:var(--green)">Secrets are automatically removed.</span>"<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:var(--blue)">Send</span> · <span style="color:var(--blue)">View logs first</span> · <span style="color:var(--dim)">Cancel</span><br>
+4. View logs first → <b>Show path</b> (write file, <b>copy to clipboard</b>, "Copied: &lt;path&gt;") / <b>Open preview</b> (combined bundle)<br>
+5. Send → gzip-9+base64 → POST → <span style="color:var(--green)">"Sent — the team will reply to &lt;email&gt;."</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fail → <span style="color:var(--amber)">"Couldn't reach support. Logs at &lt;path&gt; — email support@capgo.app."</span>
+    </div>
+    <p class="note" style="margin-bottom:0">User-facing email: addressed <b>To: the user</b> (CC'd to non-routed internal addrs like <code>michael@</code>); the Discord bridge is triggered by an invisible BCC. Preview is <b>never shown by default</b> — only via "View logs first".</p>
+  </div>
+
+  <h2 id="sec">7 · Security &amp; privacy</h2>
+  <div class="card">
+    <ul>
+      <li><b>Recipient anti-spoofing:</b> the user's <code>To</code> email is derived <b>server-side</b> from the capgkey owner; reject if client-sent email differs. The routed <code>BCC</code> and any internal <code>CC</code> (<b>non-routed only</b>, e.g. <code>michael@</code>) are worker config; <b>never CC a bridge-routed address</b> (<code>support@</code>, <code>martin@</code>) → would race.</li>
+      <li><b>Secret redaction — CLI-only &amp; disclosed:</b> applied in the CLI on write; no server-side re-scrub; the flow <b>tells the user</b> secrets are removed.</li>
+      <li><b>Sender lock:</b> worker <code>send_email</code> restricted via <code>allowed_sender_addresses</code>.</li>
+      <li><b>Rate limiting — capgo-new backend, NOT the worker:</b> <span class="hl">1 request / 60 s + 10 / day per user</span>, enforced in <code>public/build/support.ts</code> using the resolved capgkey owner.</li>
+      <li><b>Size cap (encoded) — minimal guard, no R2 now:</b> real logs ~28 KB (188× under 5 MiB), so it almost never fires — but it turns a rare hard failure (<code>E_CONTENT_TOO_LARGE</code>) into graceful degradation. Iterative but cheap (CLI, no 50 ms limit): gzip-9+base64 once → if ≤ 4.5 MiB <b>send, no loop</b>; else keep diagnostics header, estimate raw budget from measured ratio, cut to the <b>tail</b>, refine with <b>linear ~200 KB steps</b> (capped ~8), + a "truncated" notice. Emit <code>support_truncated</code> telemetry → the trigger to reconsider R2.</li>
+    </ul>
+  </div>
+
+  <h2 id="build">8 · Components to build / change</h2>
+  <div class="card">
+    <h3>CLI <code>cli/src</code></h3>
+    <ul>
+      <li><code>support/internal-log.ts</code> — verbose logger + CLI-only redaction; wire into builder/onboarding + API/shell sites (capture raw Apple <b>and</b> Google errors).</li>
+      <li><b>Extend <code>writeOnboardingSupportBundle</code></b> → combined labeled bundle.</li>
+      <li><code>support/contact-support.ts</code> — assemble, gzip-9+base64, encoded-size guard, preview/path/clipboard UX (incl. "secrets removed" disclosure), POST, success/failure.</li>
+      <li>Update failure menus in <code>build/onboarding/ui/steps/ios-shared.tsx</code> &amp; <code>init/command.ts</code> (support-first); add AI escalation option.</li>
+      <li><b>Telemetry → PostHog</b> via existing <code>sendEvent()</code> (same as <code>ai/telemetry.ts</code>). Events: <code>CLI Builder Support Requested / Sent / Failed / Truncated</code> + <code>Escalated from AI</code>. Tags = closed-enum + metadata only (<code>app_id, platform, job_id?, trigger, has_build_log, has_ai_analysis, result, error_status?, truncated, raw_bytes, encoded_bytes</code>). <b>Never</b> send log content or the user's description. Respect <code>CAPGO_DISABLE_TELEMETRY</code> / <code>CAPGO_DISABLE_POSTHOG</code>.</li>
+    </ul>
+    <h3>capgo-new backend <code>public/build</code></h3>
+    <ul>
+      <li><code>support.ts</code> — mirror <code>ai_analyze.ts</code>: auth → verified email → <b>rate limit (1/60s + 10/day)</b> → reject mismatch → validate size → proxy JSON.</li>
+      <li>Register route in <code>public/build/index.ts</code>.</li>
+    </ul>
+    <h3>capgo_builder worker</h3>
+    <ul>
+      <li><code>/support</code> route — drop <code>bundleB64</code> into attachment; compose <code>env.EMAIL.send</code> with <b>To = user, BCC = capgo_builder_support@</b>. No gzip in worker.</li>
+      <li><code>wrangler.jsonc</code> — add <code>send_email</code> binding (prod + preprod, <code>remote: true</code>, sender allowlist).</li>
+    </ul>
+    <h3>Ops / DNS / account (one-time)</h3>
+    <ul>
+      <li><code>capgo.app</code> onboarded/verified in Email Service (SPF + DKIM) — done.</li>
+      <li class="good">Capgo on a <b>paid Cloudflare plan</b> — confirmed.</li>
+      <li><b>Route <code>capgo_builder_support@capgo.app</code> into the bridge</b> (ForwardEmail alias → <code>support@usecapgo.com</code>) — used only as BCC. <b>A CC is allowed only for NON-routed internal mailboxes</b> (e.g. <code>michael@</code>); <b>never CC a bridge-routed address</b> (<code>support@</code>, <code>martin@</code>) or the race returns. <b>Verify each CC address's routing before adding it</b> (and if routing rules change). Discord forum stays the team's primary view (optional role @mention).</li>
+    </ul>
+  </div>
+
+  <h2 id="test">9 · Error handling &amp; testing</h2>
+  <div class="card">
+    <ul>
+      <li><b>CLI:</b> network/backend failure → local-file fallback + instructions; clipboard failure non-fatal; encoded-size guard + truncation.</li>
+      <li><b>Backend:</b> auth failure, email mismatch, <b>rate-limit (429)</b>, oversize (<code>413</code>) → distinct errors.</li>
+      <li><b>Worker:</b> catch Email Service errors by <code>code</code> (<code>E_CONTENT_TOO_LARGE</code>, <code>E_RATE_LIMIT_EXCEEDED</code>, <code>E_DAILY_LIMIT_EXCEEDED</code>, <code>E_SENDER_DOMAIN_NOT_AVAILABLE</code>) → surface to CLI fallback.</li>
+      <li><b>Tests:</b> unit (redaction, combined-bundle assembly, gzip-9+base64 + truncation, menu logic, clipboard) · integration (auth + rate-limit 429 + email-verify + proxy + 413) · mocked Email Service send incl. <code>E_CONTENT_TOO_LARGE</code>; verify To=user + BCC addressing.</li>
+    </ul>
+  </div>
+
+  <h2 id="open">10 · Open items + resolved decisions</h2>
+  <div class="card">
+    <h3>Open</h3>
+    <ol>
+      <li>Final menu/label + email subject/body wording (provisional).</li>
+      <li>Confirm preprod Email Service onboarding for <code>capgo.app</code>.</li>
+      <li>Optional: Discord <b>role @mention</b> when the bridge opens a builder ticket (small automations change; replaces the rejected email-CC idea that would have raced).</li>
+    </ol>
+    <h3>Resolved decisions</h3>
+    <ul>
+      <li>Transport: Cloudflare Email Service (not Resend); <b>paid plan confirmed</b>.</li>
+      <li>Compression: <b>gzip level 9</b> in the CLI; worker is base64 pass-through.</li>
+      <li>Oversize: minimal CLI estimate+linear truncation guard; <b>no R2 now</b>; <code>support_truncated</code> telemetry as the trigger to reconsider.</li>
+      <li><b>Addressing (verified against bridge code):</b> <b>To = user</b> (clean inbox), <b>BCC = <code>capgo_builder_support@capgo.app</code></b> = the single bridge-routed recipient that opens the thread (invisible). <b>CC = non-routed internal addrs only</b> (e.g. <code>michael@</code>) — safe, and included on replies via <code>buildReplyAllCc</code>; <b><code>martin@</code> excluded</b> (bridge-routed → would race). No Reply-To; <code>support@</code> not used. User + <code>michael@</code> get every reply; single routed recipient + <code>x-bridge-source</code> drop ⇒ no loop, no race. Hinges on CC'd addrs staying non-routed.</li>
+      <li>Logs: <b>combined</b> into one labeled bundle by <b>extending <code>writeOnboardingSupportBundle</code></b>.</li>
+      <li>Redaction: <b>CLI-only</b>, disclosed to the user.</li>
+      <li>Rate limiting: <b>1/60s + 10/day per user</b>, at the <b>capgo-new backend</b>.</li>
+      <li>Provider errors captured for <b>both</b> Apple and Google.</li>
+    </ul>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-06-03-builder-contact-support-design.md
+++ b/docs/superpowers/specs/2026-06-03-builder-contact-support-design.md
@@ -1,0 +1,268 @@
+# Capgo Builder — "Contact Support" & Easy Help Design
+
+**Date:** 2026-06-03
+**Status:** ⏸️ **Shelved — design complete, deemed too complex to build now (decision: Martin).** Preserved for future reference.
+
+> **Outcome:** The feature was fully designed and stress-tested (sizing, Cloudflare Email Service limits, gzip/truncation, telemetry, and — most of all — integration with the `Cap-go/automations` email↔Discord bridge). The bridge integration is where the complexity concentrated: making a programmatically-sent ticket behave correctly through the bridge (avoiding the `ownedOutboundCopy` heuristic, the double-delivery race from multiple bridge-routed `@capgo.app` recipients, and reply threading for both the user and an internal recipient) kept surfacing edge cases. The cleanest robust path (a dedicated `POST /builder-ticket` endpoint in the automations worker, with the team working the ticket in Discord) was judged not worth the cost right now. This document captures the full analysis so the work isn't lost if the feature is revived. An implementation plan was intentionally **not** produced (§8 "Components to build" is the closest plan skeleton).
+**Scope:** Capgo **builder** CLI flows only (build init, builder onboarding, and unhandled errors surfaced during these flows). Not the rest of the CLI; no standalone command.
+
+---
+
+## 1. Goal
+
+Make it frictionless for a builder user to get help when something goes wrong, via two clearly-separated paths:
+
+1. **Ask Capgo support** — send the user's logs to the Capgo team by email, CC the user, so the team can reply and the user receives it.
+2. **Ask AI for help** — the existing AI build-log analysis (only meaningful when a build log exists).
+
+A rich **internal log** is captured invisibly during every builder run and sent *in full* when help is requested — replacing today's truncated 12-line support bundle.
+
+---
+
+## 2. Triggers & menu
+
+The unified help menu appears at three points, all within builder flows. **"Ask Capgo support" is always the first option.**
+
+| Trigger | Has build log? | Menu options (in order) |
+|---|---|---|
+| Build failure | Yes (`jobId` + captured build log) | `📨 Ask Capgo support` · `🤖 Ask AI for help` · `🔄 Try again` · `❌ Exit` |
+| Onboarding error (e.g. iOS/Android dependency sync fails) | No | `📨 Ask Capgo support` · `🔄 Try again` / `↩️ Restart onboarding` · `❌ Exit` |
+| Unhandled / unexpected error (raw provider API error shown to user) | No | `📨 Ask Capgo support` · `🔄 Try again` · `❌ Exit` |
+
+**AI is offered only when a build log exists** (build failures). For onboarding/unhandled errors AI is omitted entirely — only Capgo support.
+
+### AI ↔ support relationship: fork + escalation
+
+- AI and support are independent choices at the menu.
+- After AI returns its analysis and the user is still stuck, the AI result screen gains an extra option:
+  `📨 Still stuck — send this to Capgo support`
+  which carries the **same logs PLUS the AI analysis** into the support email (no re-gathering).
+
+---
+
+## 3. Architecture & data flow
+
+Reuses the exact proven path the AI feature already uses (`CLI → ${apiHost}/build/* → builder worker`). The capgo-new backend is a **thin proxy** that owns identity + rate limiting; the **capgo_builder worker** does the send. **Compression happens in the CLI** (see §4), so the worker is a near pass-through.
+
+```
+CLI (user machine)
+  builder run writes a hidden verbose internal log as it goes
+  on failure/error → unified help menu
+  user picks "Ask Capgo support"
+    • CLI assembles ONE combined bundle locally (labeled sections):
+        === DIAGNOSTICS ===   (versions, OS, appId, platform, step)
+        === INTERNAL CLI LOG ===
+        === BUILD LOG (fastlane) ===   (if a build ran)
+        === AI ANALYSIS ===            (if AI was run / escalation)
+        === USER MESSAGE ===           (optional)
+    • CLI redacts secrets (CLI-only) and TELLS the user it does so
+    • CLI GZIPS (level 9) + BASE64-ENCODES the bundle (Node, no mem/CPU limits)
+    • shows: "We'll email Capgo support and CC you (<email>), attaching your logs.
+              Secrets are automatically removed."   Options: Send / View logs first / Cancel
+        └ View logs first → Show path (copies path to clipboard, confirms)
+                          / Open preview   (the combined bundle, raw local file)
+    • on Send → POST { appId, jobId?, bundleB64, aiAnalysis?, description? }
+                to ${apiHost}/build/support   (header: capgkey)
+        │
+        ▼
+capgo-new backend  supabase/functions/_backend/public/build/support.ts  (THIN PROXY)
+    1. authenticate capgkey → resolve user → user's VERIFIED email
+    2. RATE LIMIT here (1/60s + 10/day per user) — NOT in the builder worker
+    3. CC email = resolved email; if client supplied an email and it differs → reject
+    4. forward JSON { bundleB64, verifiedEmail, appId, jobId? } to builder worker
+        │  (same proxy shape as public/build/ai_analyze.ts — JSON only, no binary)
+        ▼
+capgo_builder worker  /support
+    1. NO gzip / NO BUILD_LOGS DO pull — just place bundleB64 into the attachment
+    2. env.EMAIL.send(...)   ← Cloudflare Email Service binding
+         from: "Capgo Builder Support" <capgo_builder_support@capgo.app>
+         to:   <verified user email>              (the USER — clean, well-titled email)
+         cc:   michael@capgo.app                  (internal, NON-routed → safe; NOT martin@)
+         bcc:  capgo_builder_support@capgo.app    (ONLY bridge-routed addr; invisible)
+         (martin@ excluded — it IS bridge-routed → would race; NO replyTo)
+         attachments: [{ content: bundleB64, filename: support-<appId>-<ts>.log.gz,
+                         type: "application/gzip", disposition: "attachment" }]
+        │  (only the BCC reaches the bridge → exactly one delivery → one thread, no race)
+        ▼
+Cap-go/automations bridge (email.capgo.app)
+    ingests the BCC copy → stores attachment in R2 → opens Discord [SUPPORT] thread
+    (team works in Discord, not email)
+    team replies in Discord → To = capgo_builder_support@ (routed → dropped as self-copy),
+    CC = buildReplyAllCc = user + michael@ (originalTo+originalCc) → both get every reply → no loop/race
+```
+
+**Responsibility split**
+- *CLI* = capture, assemble (combined bundle), redact (+inform user), **gzip -9 + base64**.
+- *capgo-new backend* = identity + verified email + **rate limiting** + forwarding (thin, JSON only).
+- *capgo_builder worker* = attach the pre-encoded blob + `env.EMAIL.send(...)` (near pass-through).
+
+---
+
+## 4. Email transport — Cloudflare Email Service (and its real limits)
+
+We use **Cloudflare Email Service** (the transactional product, onboarded for `capgo.app` with SPF/DKIM) — **not** the legacy Email Routing `send_email` binding (verified-destinations only). **Resend is not used.** **Capgo is on a paid Cloudflare plan** (confirmed), which is required to send to arbitrary recipients (CC the user).
+
+`env.EMAIL.send({ from, to, cc, replyTo, subject, text, attachments, headers? })` supports arbitrary recipients (max 50), CC/BCC, replyTo, attachments, and custom headers.
+
+### Addressing & the dedicated builder support address
+
+**The user is the visible `To`; the bridge is triggered via a `BCC` to the single routed address.** The user gets a clean, well-titled email; the bridge still opens the Discord thread; and **no message ever has more than one bridge-routed recipient.**
+- **From** = `"Capgo Builder Support" <capgo_builder_support@capgo.app>`.
+- **To** = the **user** (verified server-side from the capgkey owner) — an external address, not bridge-routed.
+- **BCC** = `capgo_builder_support@capgo.app` — the **single bridge-routed recipient** and the only envelope address that reaches the bridge. BCC is stripped from headers → invisible to the user. Routed via ForwardEmail.net alias `→ support@usecapgo.com`.
+- **CC** = internal addresses that are **NOT bridge-routed** (e.g. `michael@capgo.app`). A non-routed CC is safe — it adds an inbox recipient without adding a second *routed* recipient — and the bridge includes it on replies (`buildReplyAllCc` reads `originalCc`), so it stays on the thread. **`martin@capgo.app` is excluded** because it **is** bridge-routed → CC'ing it would create the double-delivery race. Keep the CC list in worker config; **every entry must be a verified non-routed mailbox.**
+- **`support@capgo.app` not used; no `Reply-To`** (bridge ignores it).
+
+**Invariant: exactly ONE bridge-routed recipient per email — the BCC'd `capgo_builder_support@`.** `To`/`CC` may include non-routed addresses (the user; non-routed internal mailboxes like `michael@`), but **never a second bridge-routed address** (`support@`, `martin@`, …). **This safety hinges on the CC'd addresses staying non-routed — verify `michael@`'s routing before shipping, and never add a routed address to the CC config.** Rare edge: if the *builder user's own* email is a routed `@capgo.app` address, the `To` copy also routes in → detect and drop the BCC in that case (the single remaining routed copy still creates the thread), or accept the dedup as fallback.
+
+### Why a single routed address — the double-delivery race
+Two bridge-routed recipients ⇒ the bridge receives the mail twice. Its Message-ID dedup (index.ts:605-621) is **`get`-then-`put`, non-atomic, on eventually-consistent KV across separate worker invocations** — so simultaneous double-delivery (e.g. a reply-all hitting two routed addresses) could slip through and double-post. One routed recipient (the BCC) makes the race impossible by construction.
+
+### Verified bridge behavior — replies reach the user (`Cap-go/automations/email/index.ts`)
+- The bridge ingests the BCC'd copy (envelope-routed to `capgo_builder_support@`) and parses the **header** To/CC → `originalTo = [user]`, `originalSender = From = capgo_builder_support@`.
+- Team replies in Discord → `to: originalSender` (`capgo_builder_support@`, routed → dropped as a self-copy via `x-bridge-source`) and `cc: buildReplyAllCc = originalTo + originalCc` = **the user + the non-routed internal CC** (`michael@`) (index.ts:185, 1577, 1660). So **the user (and `michael@`) receive every reply.** Those reply copies land in normal inboxes (non-routed) → no re-ingest, no race.
+- If the user replies to the email, it's addressed to `capgo_builder_support@` → routed → threaded into their existing Discord thread (In-Reply-To). Bidirectional, and the user only ever sees clean emails.
+- **No loop / no race:** the only routed recipient on any message is `capgo_builder_support@`, and the bridge drops its own `x-bridge-source` copies.
+
+### Platform limits that actually matter (verified against Cloudflare docs)
+
+| Limit | Value | Implication |
+|---|---|---|
+| **Total message size** | **5 MiB** (incl. attachments) | Hard ceiling on the base64'd email |
+| Total message size (verified **destination** addresses only) | 25 MiB | "Verified address" = a recipient verified in the CF account (clicks a link), NOT the sender. An arbitrary CC'd user is not one → we are on the **5 MiB** tier. Not needed anyway (measured 28 KB). |
+| **Attachments** | **must be base64** (~33% inflation) | The 5 MiB budget is the *encoded* size |
+| Recipients (to+cc+bcc) | 50 | Fine (we use 2) |
+| Header size | 16 KB | Fine |
+| Worker **memory** | **128 MB** per isolate | NOT a constraint (the "10 MB" is *script bundle* size, unrelated) |
+| Email Service Workers-binding **CPU** | **~50 ms/request** | **Why we do NOT gzip in the worker** |
+| Worker request body | 100 MB (Free/Pro) | Fine for ≤ a few-MB upload |
+
+### Sizing model (measured, not guessed)
+
+- **Measured on a real GitHub build log** (`logs_72018286007.zip`): 123 KB raw → **28 KB gzipped(-9)+base64** = ~**4.4× effective** shrink. (GitHub logs carry per-line timestamps + ANSI codes, so they compress less than typical text — do not assume 10–20×.) That attachment is **188× smaller** than the 5 MiB ceiling.
+- At that real ratio, the ~4.5 MiB encoded budget holds **~20 MiB of raw log**. The user only sees the "Run fastlane build" step (a subset of the 123 KB) plus the small CLI-side internal log; a failing build would need to be ~100× larger than the measured one to approach the limit. The encoded-size guard (§7) covers the tail.
+- **Compression: gzip level 9** (max), done in the **CLI** (Node, no memory/CPU limits). The worker only base64-passes a ~1 MB blob, so it touches neither the 128 MB memory limit nor the ~50 ms binding-CPU limit.
+
+### Configuration & sender
+
+- `wrangler.jsonc` (builder worker, prod + preprod):
+  ```jsonc
+  "send_email": [
+    { "name": "EMAIL", "remote": true, "allowed_sender_addresses": ["capgo_builder_support@capgo.app"] }
+  ]
+  ```
+- **Sender setup:** the `capgo.app` domain onboarding (SPF/DKIM/MX) already done *is* the sender verification — any `@capgo.app` address then sends immediately, so `capgo_builder_support@capgo.app` works as-is.
+
+### Reply-To — resolved (not used)
+The bridge ignores `Reply-To` entirely (verified above), so we don't set it. The user is a **CC** recipient on replies (always receives them), never the primary `To` — unavoidable, since we can't send *as* the user, and acceptable.
+
+---
+
+## 5. The internal log (hidden verbose logger)
+
+Today the CLI keeps only the last ~12 lines in memory. This adds a full, hidden, on-disk log per builder run.
+
+- **Module:** `cli/src/support/internal-log.ts` (new).
+- **File:** `~/.capgo-credentials/support/internal-<appId>-<timestamp>.log`, **append-as-you-go** (flushed per write) so it survives crashes and unhandled errors.
+- **Captures:**
+  - every log entry at all levels, including `debug` (not just the TUI-visible tones);
+  - every external API request + response: method, URL, status, and body — **including raw provider/platform API errors** (Apple App Store Connect **and** Google Play, plus Gradle/CocoaPods/signing failures) that get surfaced to the user;
+  - every shell command executed (`cap add ios`/`cap add android`, `pod install`, Gradle, build steps, …) with stdout/stderr;
+  - diagnostics: OS + arch, Node version, CLI version, package manager, installed Capgo/Capacitor/CapAwesome versions, appId, platform, channel, current onboarding step.
+- **Secret redaction on write (CLI-only):** `capgkey`/API keys, bearer tokens, Apple/Google API keys & signing secrets, and similar — redacted before bytes hit disk. **There is no server-side re-scrub** (CLI-only). Because masking is opaque otherwise, **the support flow explicitly tells the user that secrets are removed** (§6).
+- **Visibility:** never shown during normal runs. Surfaced only when the user requests help (preview/path option) or sent to support.
+
+### The combined bundle
+When the user picks **Ask Capgo support**, the internal log and the build log are **combined into one bundle file** with labeled sections (`DIAGNOSTICS` / `INTERNAL CLI LOG` / `BUILD LOG (fastlane)` / `AI ANALYSIS` / `USER MESSAGE`). One file = one attachment, one preview, one thing to gzip.
+- **Always:** diagnostics + internal log.
+- **Build failures:** + the captured build log (`/tmp/capgo-builds/{jobId}.log`).
+- **AI escalation:** + the AI analysis text.
+
+This is built by **extending the existing `writeOnboardingSupportBundle`** (not a new assembler) to take the additional sections and emit the combined file; the file is then gzipped(-9)+base64'd in the CLI before upload.
+
+---
+
+## 6. Support-flow UX (CLI)
+
+1. User picks `📨 Ask Capgo support`.
+2. CLI assembles the **combined** bundle file locally (reusing `~/.capgo-credentials/support/`) and redacts secrets.
+3. CLI explains, shows the user's email, **and states that secrets are removed**:
+   > We'll send your request to the Capgo team and email you a copy at **<email>** — they'll reply right in that email thread. Your build/onboarding logs are attached, with **secrets (API keys, tokens, signing credentials) automatically removed**.
+
+   (Mechanically: the email is addressed **To: the user**, with the Discord bridge triggered via an invisible BCC — see §4. The user is the only visible recipient.)
+   Options: `Send` · `View logs first` · `Cancel`.
+4. **View logs first** → sub-menu:
+   - `Show path` → writes the bundle locally, **copies the path to the clipboard**, prints `Copied to clipboard: <path>`.
+   - `Open preview` → opens/pages the combined bundle file contents.
+   Then returns to `Send` / `Cancel`.
+5. **Send** → spinner → gzip(-9)+base64 → POST to `${apiHost}/build/support`.
+   - **Success:** `Sent — the Capgo team will reply to <email>. (Logs saved at <path>.)`
+   - **Failure (network/backend):** fallback — `Couldn't reach support. Your logs are saved at <path>. Please email them to support@capgo.app.`
+6. **Cancel** → back to the help menu.
+
+Preview is **never shown by default** — only via the explicit "View logs first" option.
+
+---
+
+## 7. Security & privacy
+
+- **Recipient anti-spoofing:** the user's `To` email is derived **server-side** from the capgkey owner; if the client sends an email that doesn't match the resolved owner, the backend rejects the request. The routed `BCC` (`capgo_builder_support@`) and any internal `CC` (**non-routed only**, e.g. `michael@`) are worker config, never client-supplied. **Never CC a bridge-routed address** (`support@`, `martin@`) — that causes the double-delivery race.
+- **Secret redaction (CLI-only, and disclosed):** applied in the CLI on write (§5); there is **no** server-side re-scrub. The support flow **tells the user** secrets are removed, so the masking is meaningful and transparent.
+- **Sender lock:** worker `send_email` binding restricted via `allowed_sender_addresses`.
+- **Rate limiting (capgo-new backend, NOT the builder worker):** **1 request per 60 s per user, plus 10 per day per user**, enforced in `public/build/support.ts` using the resolved capgkey owner. The per-minute limit stops accidental double-sends/bursts; the daily cap stops a script that respects the minute limit. Reuse existing backend rate-limit patterns.
+- **Size cap (on the *encoded* payload) — minimal safety guard, not gold-plating.** Decision: **no R2 now.** Real logs measure ~28 KB encoded (~188× under the 5 MiB ceiling), so the guard will almost never fire — but it converts a rare *hard failure* (`E_CONTENT_TOO_LARGE` → whole request fails on the user's worst day) into graceful degradation, so it's cheap insurance, not dead code. Fitting is iterative (gzip size isn't predictable from raw size) but **bounded and cheap** — it runs in the **CLI (Node), which has no 50 ms CPU limit**, so re-gzipping a few times costs milliseconds. Algorithm: (1) gzip(-9)+base64 once — if ≤ 4.5 MiB, **send, no loop** (the ~always case); (2) if over, keep the small diagnostics header untouched, then use the *measured* ratio from pass 1 to estimate a raw-body budget (`target_encoded × (raw/encoded) × 0.9`) and cut the body to its **tail** at that budget on line boundaries — lands close in one step; (3) refine with **linear fixed-size steps** (trim ~200 KB raw per pass — *not* exponential halving, so we never over-cut), re-checking each pass; (4) cap at ~8 iterations. Prepend an "older lines truncated (N lines omitted)" notice. No middle-dropping. Emit a **`support_truncated`** telemetry event whenever it fires — if telemetry ever shows real truncations, *that* is when an R2 fallback (attach-if-fits-else-upload-link, reusing the builder worker's existing R2 bucket + the CLI's existing TUS upload) becomes justified. Not before (YAGNI).
+
+---
+
+## 8. Components to build / change
+
+### CLI (`cli/src`)
+- `support/internal-log.ts` — new persistent verbose logger + CLI-only secret redaction.
+- Wire the logger into builder/onboarding command paths and the API/shell call sites (capture raw Apple **and** Google provider errors).
+- **Extend `writeOnboardingSupportBundle`** (in `onboarding-support.ts`) to emit the combined, labeled bundle (diagnostics + internal log + build log + AI analysis + optional user message).
+- `support/contact-support.ts` (or similar) — assemble (via the extended bundler), gzip(-9)+base64, encoded-size guard/truncation, preview/path/clipboard UX (incl. the "secrets removed" disclosure), POST to backend, success/failure handling.
+- Update the failure menus in `build/onboarding/ui/steps/ios-shared.tsx` and `init/command.ts` to the unified menu (support-first), and add the AI-result escalation option.
+- **Telemetry → PostHog.** Reuse the existing `sendEvent()` path (`cli/src/utils.ts`) that already forwards CLI events to PostHog via the backend — the same mechanism behind `ai/telemetry.ts`'s `CLI AI Build Analysis Choice/Result` events. New events: `CLI Builder Support Requested` / `Sent` / `Failed` / `Truncated`, plus `CLI Builder Support Escalated from AI`. Tags = **closed-enum + metadata only**: `app_id`, `platform`, `job_id?`, `trigger` (`build_failure|onboarding_error|unhandled_error`), `has_build_log`, `has_ai_analysis`, `result`, `error_status?`, `truncated` (bool), `raw_bytes`, `encoded_bytes`. **Privacy boundary (mirrors AI telemetry): never send log content or the user's free-text description.** Respect existing opt-outs `CAPGO_DISABLE_TELEMETRY` / `CAPGO_DISABLE_POSTHOG`. Distinct from `cli/src/posthog.ts` (direct `unhandled_error` exception capture) — they coexist; the unhandled-error trigger may emit both.
+
+### capgo-new backend (`supabase/functions/_backend/public/build`)
+- `support.ts` — new endpoint mirroring `ai_analyze.ts`: auth capgkey → resolve user + verified email → **rate limit (1/60s + 10/day per user)** → reject email mismatch → validate payload size → proxy JSON to builder worker.
+- Register route in `public/build/index.ts`.
+
+### capgo_builder worker (`capgo_builder_new`)
+- `/support` route handler — place `bundleB64` into the attachment, compose + `env.EMAIL.send(...)`, return result. No gzip in the worker.
+- `wrangler.jsonc` — add `send_email` binding (prod + preprod, `remote: true`, sender allowlist).
+
+### Ops / DNS / account (one-time)
+- `capgo.app` onboarded/verified in Cloudflare Email Service (SPF + DKIM) — done.
+- **Capgo is on a paid Cloudflare plan** — confirmed (required for arbitrary recipients / CC the user).
+- **Route `capgo_builder_support@capgo.app` into the bridge** (ForwardEmail.net alias → `support@usecapgo.com`) — the single ingestion address, used only as **BCC**. **A `CC` is allowed only for NON-routed internal mailboxes** (e.g. `michael@`, which does not route to the bridge); **never CC a bridge-routed address** (`support@`, `martin@`) or the double-delivery race returns. **Verify each CC address's routing status before adding it to config** (and re-verify if routing rules change). Discord forum remains the team's primary view (optional role @mention in the bridge).
+
+---
+
+## 9. Error handling & testing
+
+- **CLI:** network/backend failure → local-file fallback with copy-paste instructions; clipboard failure is non-fatal (still prints path); encoded-size guard with truncation.
+- **Backend:** auth failure, email mismatch, **rate-limit (429)**, oversize (`413`) → clear, distinct errors.
+- **Worker:** catch Email Service `send` errors by `code` (`E_CONTENT_TOO_LARGE`, `E_RATE_LIMIT_EXCEEDED`, `E_DAILY_LIMIT_EXCEEDED`, `E_SENDER_DOMAIN_NOT_AVAILABLE`, …) → surface to backend → CLI fallback.
+- **Tests:**
+  - Unit: redaction correctness, combined-bundle assembly (extended `writeOnboardingSupportBundle`), gzip(-9)+base64 + encoded-size truncation, menu logic (AI shown iff build log), clipboard/path helper.
+  - Integration: `/build/support` auth + rate-limit (429) + email-verify + proxy behavior; oversize/413 path.
+  - Mocked Cloudflare Email Service `send` for the worker `/support` handler (incl. `E_CONTENT_TOO_LARGE`).
+
+---
+
+## 10. Open items (resolve during implementation)
+
+1. Final menu/label wording (current wording is provisional).
+2. Confirm preprod Email Service onboarding state for `capgo.app`.
+3. Optional: a Discord **role @mention** when the bridge opens a builder ticket, if the team wants a stronger ping than the forum (small automations change; replaces the rejected internal-email-CC idea, which would have caused the double-delivery race).
+
+### Resolved decisions
+- Transport: Cloudflare Email Service (not Resend); paid plan confirmed.
+- Compression: **gzip level 9**, in the CLI; worker is base64 pass-through.
+- Oversize handling: minimal CLI-side estimate+linear truncation guard; **no R2 now**; `support_truncated` telemetry as the trigger to reconsider.
+- Addressing (verified against the bridge code): **To = the user** (clean inbox), **BCC = `capgo_builder_support@capgo.app`** = the single bridge-routed recipient that triggers the Discord thread (invisible). From = `"Capgo Builder Support" <capgo_builder_support@>`. **CC = non-routed internal addresses only** (e.g. `michael@`, which doesn't route to the bridge) — safe, and included on replies via `buildReplyAllCc`; **`martin@` excluded** (it's bridge-routed → would race). `support@` not used; no Reply-To. The user (and `michael@`) receive every reply via `buildReplyAllCc`; single routed recipient + `x-bridge-source` drop ⇒ no loop, no race. Hinges on CC'd addresses staying non-routed.
+- Logs: **combined** into one labeled bundle by **extending `writeOnboardingSupportBundle`**.
+- Redaction: **CLI-only**, disclosed to the user.
+- Rate limiting: **1/60s + 10/day per user**, at the **capgo-new backend**.
+- Provider errors captured for **both** Apple and Google.


### PR DESCRIPTION
## What this is

A complete design exploration for an **in-CLI "get help" flow** in the Capgo builder: a unified failure menu offering **📨 Ask Capgo support** and **🤖 Ask AI for help**, backed by a rich hidden internal log that's captured during every builder run and sent in full when help is requested.

Docs only — no code. Two files under `docs/superpowers/specs/`:
- `2026-06-03-builder-contact-support-design.md` — the spec
- `2026-06-03-builder-contact-support-design.html` — standalone visual render

## Status: ⏸️ Shelved (too complex to build now — Martin)

The feature was designed and stress-tested end-to-end (sizing measured on a real build log, Cloudflare Email Service limits verified, gzip/truncation, redaction, rate limiting, PostHog telemetry). The complexity concentrated in **integrating with the `Cap-go/automations` email↔Discord bridge** — making a programmatically-sent ticket behave correctly kept surfacing edge cases (the `ownedOutboundCopy` heuristic, a double-delivery race from multiple bridge-routed `@capgo.app` recipients, and reply threading for both the user and an internal recipient). The cleanest robust path (a dedicated `POST /builder-ticket` endpoint in the automations worker, team working in Discord) was judged not worth the cost right now.

Merging this **preserves the analysis** so it isn't lost if the feature is revived. An implementation plan was intentionally not produced; §8 ("Components to build") is the closest skeleton.

## Key design decisions captured
- Transport: **Cloudflare Email Service** (not Resend); gzip-9 + base64 in the CLI; worker is a near pass-through.
- Sizing: measured ~28 KB encoded on a real GitHub build log (188× under the 5 MiB ceiling).
- Logs: one combined bundle (diagnostics + internal log + build log + AI analysis) via an extended `writeOnboardingSupportBundle`.
- Privacy: CLI-only secret redaction, **disclosed to the user**.
- Backend: thin proxy endpoint mirroring `ai_analyze`, with rate limiting (1/60s + 10/day per user).
- The unresolved hard part: bridge addressing / reply routing (see the "Outcome" note at the top of the spec).

## Test plan
- [ ] N/A — documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specification for planned "Contact Support" and "Easy Help" features in Capgo Builder CLI, detailing the proposed architecture, data flow, email integration, security considerations, and error handling (specification marked as shelved).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->