### PR TITLE
fix(auth): grant website cookie to platform admins

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -7,7 +7,7 @@ import { isSsoUser, provisionSsoUser } from '~/services/ssoProvisioning'
 import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getLocalConfig, useSupabase } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
-import { clearWebsitePaidUserCookie } from '~/services/websiteAuthCookie'
+import { clearWebsitePaidUserCookie, setWebsitePaidUserCookie } from '~/services/websiteAuthCookie'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 import { hasPendingInviteSkip } from '~/utils/pendingInviteSkip'
@@ -292,6 +292,8 @@ async function guard(
     if (organizationsLoaded && isAdminRoute) {
       try {
         main.isAdmin = await isPlatformAdmin()
+        if (main.isAdmin)
+          setWebsitePaidUserCookie(true)
       }
       catch (error) {
         console.error('Failed to resolve platform admin status:', error)
@@ -317,6 +319,8 @@ async function guard(
     try {
       // isPlatformAdmin() is the only frontend admin-rights source.
       main.isAdmin = await isPlatformAdmin()
+      if (main.isAdmin)
+        setWebsitePaidUserCookie(true)
     }
     catch (error) {
       console.error('Failed to resolve platform admin status:', error)
@@ -386,6 +390,8 @@ async function guard(
       try {
         // Re-check via the single approved frontend path for admin-rights.
         main.isAdmin = await isPlatformAdmin()
+        if (main.isAdmin)
+          setWebsitePaidUserCookie(true)
       }
       catch (error) {
         console.error('Failed to resolve platform admin status:', error)

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -4,8 +4,8 @@ import type { Database } from '~/types/supabase.types'
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import { createSignedImageUrl, getImmediateImageUrl, resolveImagePath } from '~/services/storage'
-import { stripeEnabled, useSupabase } from '~/services/supabase'
-import { clearWebsitePaidUserCookie, syncWebsitePaidUserCookieFromOrganizations } from '~/services/websiteAuthCookie'
+import { isPlatformAdmin, stripeEnabled, useSupabase } from '~/services/supabase'
+import { clearWebsitePaidUserCookie, setWebsitePaidUserCookie, syncWebsitePaidUserCookieFromOrganizations } from '~/services/websiteAuthCookie'
 import { createDeferredPromise } from '../utils/promise'
 import { useDashboardAppsStore } from './dashboardApps'
 import { useDisplayStore } from './display'
@@ -499,6 +499,15 @@ export const useOrganizationStore = defineStore('organization', () => {
     })
 
     syncWebsitePaidUserCookieFromOrganizations(mappedData)
+    isPlatformAdmin()
+      .then((isAdmin) => {
+        main.isAdmin = isAdmin
+        if (isAdmin)
+          setWebsitePaidUserCookie(true)
+      })
+      .catch((error) => {
+        console.error('Failed to resolve platform admin status:', error)
+      })
     _organizations.value = new Map(mappedData.map(item => [item.gid, item as Organization]))
     loadOrganizationLogos(mappedData, logoLoadRun)
 

--- a/tests/auth-sso-provisioning.unit.test.ts
+++ b/tests/auth-sso-provisioning.unit.test.ts
@@ -90,6 +90,7 @@ function createTestContext() {
   const mockCreateSignedImageUrl = vi.fn(async (value: string) => value)
   const mockGetPlans = vi.fn(async () => [])
   const mockIsPlatformAdmin = vi.fn(async () => false)
+  const mockSetWebsitePaidUserCookie = vi.fn()
   const mockFetch = vi.fn<(...args: unknown[]) => Promise<MockFetchResponse>>(async () => ({
     ok: true,
     json: async () => ({ success: true }),
@@ -109,6 +110,7 @@ function createTestContext() {
     mockRpc,
     mockSendEvent,
     mockSetUser,
+    mockSetWebsitePaidUserCookie,
     mockGetSession,
     mockSignOut,
     organizationStore,
@@ -150,6 +152,11 @@ vi.mock('~/services/storage', () => ({
 
 vi.mock('~/services/tracking', () => ({
   sendEvent: (...args: unknown[]) => getContext().mockSendEvent(...args),
+}))
+
+vi.mock('~/services/websiteAuthCookie', () => ({
+  clearWebsitePaidUserCookie: vi.fn(),
+  setWebsitePaidUserCookie: (isPaidUser: boolean) => getContext().mockSetWebsitePaidUserCookie(isPaidUser),
 }))
 
 vi.mock('~/services/supabase', () => ({
@@ -346,6 +353,25 @@ describe('auth guard SSO provisioning', () => {
       expect(next).not.toHaveBeenCalledWith(expect.objectContaining({
         path: '/accountDisabled',
       }))
+    })
+  })
+
+  it.concurrent('sets the website paid user cookie for platform admins after login', async () => {
+    await withTestContext(async (context) => {
+      context.mockIsPlatformAdmin.mockResolvedValue(true)
+
+      const guard = await getGuard()
+      const next = vi.fn()
+
+      await guard(
+        { path: '/dashboard', fullPath: '/dashboard', meta: { middleware: 'auth' }, query: {} },
+        { path: '/login', fullPath: '/login', meta: {}, query: {} },
+        next,
+      )
+
+      expect(context.mockSetWebsitePaidUserCookie).toHaveBeenCalledWith(true)
+      expect(context.mainStore.isAdmin).toBe(true)
+      expect(next).toHaveBeenCalledWith()
     })
   })
 

--- a/tests/organization-store-delete.unit.test.ts
+++ b/tests/organization-store-delete.unit.test.ts
@@ -18,6 +18,7 @@ const mockFrom = vi.fn((table: string) => {
   }
 })
 const mockRpc = vi.fn()
+const mockIsPlatformAdmin = vi.fn(async () => false)
 const mockCreateSignedImageUrl = vi.fn()
 const mockResolveImagePath = vi.fn((raw?: string | null) => ({
   normalized: raw?.trim().replace(/^\/+/, '').replace(/^images\//, '') ?? '',
@@ -27,10 +28,12 @@ const mockUpdateDashboard = vi.fn()
 const mainStore = {
   auth: { id: 'auth-user-123' } as { id: string } | undefined,
   user: { id: 'user-123' } as { id: string } | undefined,
+  isAdmin: false,
   updateDashboard: mockUpdateDashboard,
 }
 
 vi.mock('~/services/supabase', () => ({
+  isPlatformAdmin: mockIsPlatformAdmin,
   stripeEnabled: ref(true),
   useSupabase: () => ({
     auth: {
@@ -79,6 +82,7 @@ describe('organization store deleteOrganization', () => {
     setActivePinia(createPinia())
     mainStore.auth = { id: 'auth-user-123' }
     mainStore.user = { id: 'user-123' }
+    mainStore.isAdmin = false
     mockEq.mockResolvedValue({ data: null, error: null })
     mockIn.mockResolvedValue({ data: [], error: null })
     vi.stubGlobal('localStorage', {
@@ -187,19 +191,19 @@ describe('organization store refreshOrganizationLogos', () => {
     mockCreateSignedImageUrl.mockResolvedValueOnce('')
     mockRpc.mockResolvedValueOnce({
       data: [{
-        gid: 'org-auth-fallback',
-        role: 'org_super_admin',
-        app_count: 0,
-        created_by: 'owner-123',
-        name: 'Auth Fallback Org',
-        logo: null,
-        password_policy_config: null,
-        enforcing_2fa: false,
+        'gid': 'org-auth-fallback',
+        'role': 'org_super_admin',
+        'app_count': 0,
+        'created_by': 'owner-123',
+        'name': 'Auth Fallback Org',
+        'logo': null,
+        'password_policy_config': null,
+        'enforcing_2fa': false,
         '2fa_has_access': true,
-        password_has_access: true,
-        paying: true,
-        trial_left: 0,
-        can_use_more: true,
+        'password_has_access': true,
+        'paying': true,
+        'trial_left': 0,
+        'can_use_more': true,
       }],
       error: null,
     })


### PR DESCRIPTION
## Summary

Updates the website Console CTA cookie sync so Capgo platform admins receive `capgo_paid_user=1` even when they do not belong to a paid organization.

## Motivation

The website header uses `capgo_paid_user=1` to show the Console button. Paid users already get this cookie from org data, but Capgo platform admins should always get the Console CTA as operators.

## Business Impact

Capgo admins get direct Console navigation from the website without requiring a paid org, while customer-facing behavior remains tied to paid org status. This keeps the simplified header useful for internal operators without loosening console access control.

## Test Plan

- [x] `bunx vitest run tests/organization-store-delete.unit.test.ts tests/auth-sso-provisioning.unit.test.ts tests/website-auth-cookie.unit.test.ts`
- [x] `bunx eslint tests/organization-store-delete.unit.test.ts src/modules/auth.ts src/stores/organization.ts tests/auth-sso-provisioning.unit.test.ts`
- [x] `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## AI-Generated Content

This PR was generated with AI assistance and reviewed through local validation before submission.
