### PR TITLE
fix: use released updater preview loader

### DIFF
--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -279,7 +279,7 @@ include ':capgo-capacitor-textinteraction'
 project(':capgo-capacitor-textinteraction').projectDir = new File('../node_modules/.bun/@capgo+capacitor-textinteraction@8.0.25+1b808583819c2ac6/node_modules/@capgo/capacitor-textinteraction/android')
 
 include ':capgo-capacitor-updater'
-project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.bun/@capgo+capacitor-updater@8.47.6+1b808583819c2ac6/node_modules/@capgo/capacitor-updater/android')
+project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.bun/@capgo+capacitor-updater@8.47.7+1b808583819c2ac6/node_modules/@capgo/capacitor-updater/android')
 
 include ':capgo-capacitor-uploader'
 project(':capgo-capacitor-uploader').projectDir = new File('../node_modules/.bun/@capgo+capacitor-uploader@8.2.1+1b808583819c2ac6/node_modules/@capgo/capacitor-uploader/android')

--- a/bun.lock
+++ b/bun.lock
@@ -104,7 +104,7 @@
         "@capgo/capacitor-speech-synthesis": "^8.0.15",
         "@capgo/capacitor-textinteraction": "^8.0.25",
         "@capgo/capacitor-transitions": "^8.1.6",
-        "@capgo/capacitor-updater": "^8.47.5",
+        "@capgo/capacitor-updater": "^8.47.7",
         "@capgo/capacitor-uploader": "^8.2.1",
         "@capgo/capacitor-video-player": "^8.1.13",
         "@capgo/capacitor-video-thumbnails": "^8.1.11",
@@ -215,7 +215,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "7.124.8",
+      "version": "7.124.10",
       "bin": {
         "capgo": "dist/index.js",
       },
@@ -618,7 +618,7 @@
 
     "@capgo/capacitor-transitions": ["@capgo/capacitor-transitions@8.1.7", "", { "peerDependencies": { "@angular/core": ">=17.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "solid-js": ">=1.0.0", "svelte": ">=4.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@angular/core", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-0YJvNRs7uhIF6CedsJDH3EOh0CVwx4DOnuUds1tOBCCoktpKjhXUwTqF7QePBLZKupJMDrYNdSUZhqDNMRf47A=="],
 
-    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.47.6", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-lI7/yKWBPEYRNdAGZvR36UNPZMzjgzeyWLVMILccUGG/zLYBzdPixhqf5N6gS80ZmH/agbkOk7TftAFm3eDOXg=="],
+    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.47.7", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-Gi9onxH1ysaS40jirR9q69oS1qRidw13oAFzc7rvION+Omc/OLNkC2tqgEw55oVQloIokJKevRNQl4vjcmTliA=="],
 
     "@capgo/capacitor-uploader": ["@capgo/capacitor-uploader@8.2.1", "", { "dependencies": { "idb": "^8.0.2" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-jkOew7h10Auwusu+w0TVGMKXx3wIfj3ipIvX7mZlPdDpgw9RFAEqrOqmTsMfM/h9pbOgooJF5iO0I7346KOfwA=="],
 

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -105,7 +105,7 @@ let package = Package(
         .package(name: "CapgoCapacitorSpeechRecognition", path: "../../../node_modules/.bun/@capgo+capacitor-speech-recognition@8.1.3+1b808583819c2ac6/node_modules/@capgo/capacitor-speech-recognition"),
         .package(name: "CapgoCapacitorSpeechSynthesis", path: "../../../node_modules/.bun/@capgo+capacitor-speech-synthesis@8.0.15+1b808583819c2ac6/node_modules/@capgo/capacitor-speech-synthesis"),
         .package(name: "CapgoCapacitorTextinteraction", path: "../../../node_modules/.bun/@capgo+capacitor-textinteraction@8.0.25+1b808583819c2ac6/node_modules/@capgo/capacitor-textinteraction"),
-        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.bun/@capgo+capacitor-updater@8.47.6+1b808583819c2ac6/node_modules/@capgo/capacitor-updater"),
+        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.bun/@capgo+capacitor-updater@8.47.7+1b808583819c2ac6/node_modules/@capgo/capacitor-updater"),
         .package(name: "CapgoCapacitorUploader", path: "../../../node_modules/.bun/@capgo+capacitor-uploader@8.2.1+1b808583819c2ac6/node_modules/@capgo/capacitor-uploader"),
         .package(name: "CapgoCapacitorVideoPlayer", path: "../../../node_modules/.bun/@capgo+capacitor-video-player@8.1.13+e0c29ead8bde6eb5/node_modules/@capgo/capacitor-video-player"),
         .package(name: "CapgoCapacitorVideoThumbnails", path: "../../../node_modules/.bun/@capgo+capacitor-video-thumbnails@8.1.11+1b808583819c2ac6/node_modules/@capgo/capacitor-video-thumbnails"),

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "@capgo/capacitor-speech-synthesis": "^8.0.15",
     "@capgo/capacitor-textinteraction": "^8.0.25",
     "@capgo/capacitor-transitions": "^8.1.6",
-    "@capgo/capacitor-updater": "^8.47.5",
+    "@capgo/capacitor-updater": "^8.47.7",
     "@capgo/capacitor-uploader": "^8.2.1",
     "@capgo/capacitor-video-player": "^8.1.13",
     "@capgo/capacitor-video-thumbnails": "^8.1.11",


### PR DESCRIPTION
## What
- Bump @capgo/capacitor-updater to 8.47.7.
- Refresh iOS SPM and Android Gradle plugin paths to the released updater package.
- Remove the temporary Capgo-side SplashScreen preview loader workaround from the PR diff.

## Why
- The updater plugin now owns the native preview transition loader, so Capgo should use the released plugin instead of keeping app-side loader glue.

## How
- Rebased the PR onto current main.
- Installed @capgo/capacitor-updater@^8.47.7 with Bun.
- Ran Capacitor sync for iOS and Android.

## Testing
- bun run build
- bun typecheck
- bun lint
- Commit hook typecheck

## Not Tested
- Manual native camera/deeplink preview flow on a device in this turn.