### PR TITLE
fix(ci): parallelize translation worker deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -205,8 +205,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy_translation_worker:
-    needs: [changes, supabase_deploy, deploy_api]
-    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.translation == 'true' && (needs.supabase_deploy.result == 'success' || (needs.supabase_deploy.result == 'skipped' && needs.changes.outputs.supabase != 'true')) && (needs.deploy_api.result == 'success' || (needs.deploy_api.result == 'skipped' && needs.changes.outputs.api != 'true')) }}
+    needs: [changes, supabase_deploy]
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.translation == 'true' && (needs.supabase_deploy.result == 'success' || (needs.supabase_deploy.result == 'skipped' && needs.changes.outputs.supabase != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/supabase/functions/_backend/public/organization/post.ts
+++ b/supabase/functions/_backend/public/organization/post.ts
@@ -103,7 +103,6 @@ export async function post(
     management_email: body.email ?? self.email ?? '',
     customer_id: pendingCustomerId,
     website,
-    onboarding: { intent: body.intent ?? 'unknown' },
   }
   const { error: errorOrg } = await supabase
     .from('orgs')

--- a/tests/organization-put-stripe-sync.unit.test.ts
+++ b/tests/organization-put-stripe-sync.unit.test.ts
@@ -77,7 +77,6 @@ function createOrgRow(overrides: Partial<OrgRow> & Pick<OrgRow, 'id' | 'name' | 
     management_email: 'billing@capgo.app',
     max_apikey_expiration_days: null,
     name: 'Old Name',
-    onboarding: { intent: 'unknown' },
     password_policy_config: null,
     require_apikey_expiration: false,
     required_encryption_key: null,


### PR DESCRIPTION
## Summary (AI generated)

- Removed `deploy_api` from the translation worker deploy job dependencies.
- Kept the translation worker gated on deploy scope and Supabase deploy status, matching the other Cloudflare worker deploy jobs.
- Removed stale `onboarding` properties from org insert/test data because `orgs` has no matching schema column and CI typecheck rejected it.

## Motivation (AI generated)

The translation worker deploy was serialized behind the API deploy because `deploy_translation_worker` listed `deploy_api` in `needs` and checked its result. It can deploy independently, so it should run in parallel with API, files, and plugin worker deploys after the shared prerequisites complete.

The stale org `onboarding` field also blocked this PR in CI and would be sent as an unknown `orgs` column at runtime, so it was removed instead of changing schema for this workflow fix.

## Business Impact (AI generated)

This reduces release pipeline latency when translation and API deploys are both in scope, without changing deployed worker code. It also keeps organization creation aligned with the current database schema.

## Test Plan (AI generated)

- [x] `bunx prettier --check .github/workflows/build_and_deploy.yml`
- [x] YAML parse check with Ruby
- [x] `bun lint && bun lint:backend`
- [x] `bun typecheck`
- [x] `bunx vitest run tests/organization-put-stripe-sync.unit.test.ts`
- [ ] Wait for GitHub CI to complete and address any failures.

Generated with AI