### PR TITLE
ci(ios): use bun hoisted linker for mobile build

### DIFF
--- a/.github/workflows/build_mobile_ios.yml
+++ b/.github/workflows/build_mobile_ios.yml
@@ -40,7 +40,12 @@ jobs:
         with:
           bun-version: latest
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # Force bun's hoisted (flat) node_modules layout. Capacitor's native iOS
+        # tooling hardcodes flat paths like ../node_modules/@capacitor/<plugin>,
+        # which break under bun's default isolated linker (symlinks into a
+        # node_modules/.bun/<pkg>@<ver>+<peerHash> store that can dangle on hash
+        # drift). Hoisted lays real folders at node_modules/@capacitor/<plugin>.
+        run: bun install --frozen-lockfile --linker=hoisted
       - name: Prepare mobile project
         run: bun run build:mobile
       - name: Request iOS build through Capgo CLI


### PR DESCRIPTION
## What

Adds `--linker=hoisted` to the `bun install` step in `.github/workflows/build_mobile_ios.yml` (iOS workflow only).

## Why

The iOS mobile build fails during Capacitor's native plugin resolution with:

```
the package at '/Users/runner/work/.../node_modules/.bun/@capacitor+action-sheet@8.1.1+1b808583819c2ac6/node_modules/@capacitor/action-sheet'
cannot be accessed (... doesn't exist in file system)
```

(see failing run: https://github.com/Cap-go/capgo/actions/runs/26907330943/job/79375691109)

bun's **default isolated linker** lays packages out as symlinks pointing into a hidden store at `node_modules/.bun/<pkg>@<ver>+<peerHash>/node_modules/<pkg>`. The `+<peerHash>` segment encodes resolved peer-dependency versions (`@capacitor/action-sheet` declares `peerDependencies: @capacitor/core >=8.0.0`). Two things collide:

1. **Capacitor hardcodes flat paths** — `android/capacitor.settings.gradle` and `ios/.../Package.swift` reference `../node_modules/@capacitor/<plugin>` literally, then follow the symlink to the real `.bun/...` location.
2. **The store path can dangle** — when the peer hash drifts (e.g. `bun-version: latest` recomputing a different hash than the committed `bun.lock`, or a partial/cached install), the symlink target is missing → the error above.

`--linker=hoisted` switches bun to an npm-style **flat** `node_modules`, so `node_modules/@capacitor/<plugin>` is a real directory that Capacitor resolves without symlink fragility.

## Scope

- iOS workflow **only** — Android workflow and the global `bunfig.toml` are intentionally left untouched, per request.

## Test plan

- [ ] Re-run `Build mobile ios` workflow against a tag and confirm `bun install --frozen-lockfile --linker=hoisted` produces a flat `node_modules` and Capacitor iOS sync resolves `@capacitor/action-sheet` (and other plugins) without the "doesn't exist in file system" error.
- [x] YAML validated locally (`yaml.safe_load`).
- [x] `--linker=<isolated|hoisted>` confirmed as a valid `bun install` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized iOS build process dependency installation to improve build consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->