### PR TITLE
ci(android): cap sync before remote build to generate cordova plugins

### DIFF
--- a/.github/workflows/build_mobile_android.yml
+++ b/.github/workflows/build_mobile_android.yml
@@ -43,7 +43,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Prepare mobile project
-        run: bun run build:mobile
+        # Use `cap sync android` instead of build:mobile's `cap copy`. `cap copy`
+        # only pushes web assets + config; `cap sync` also runs `cap update`, which
+        # regenerates the cordova plugins subproject including
+        # android/capacitor-cordova-android-plugins/cordova.variables.gradle.
+        # That dir is gitignored, so the remote builder never receives it unless we
+        # regenerate it here before `capgo build request` uploads the workspace.
+        run: |
+          bun run build
+          bunx cap sync android
       - name: Request Android build through Capgo CLI
         env:
           CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}


### PR DESCRIPTION
## What

In `.github/workflows/build_mobile_android.yml`, replace the **Prepare mobile project** step's `bun run build:mobile` (which ends in `cap copy`) with `bun run build` + `bunx cap sync android`.

## Why

The Android cloud build fails in Gradle (see run https://github.com/Cap-go/capgo/actions/runs/26907330943/job/79375691109):

```
Script '.../android/app/capacitor.build.gradle' line: 10
> Could not read script '.../android/capacitor-cordova-android-plugins/cordova.variables.gradle' as it does not exist.
```

Two repo facts combine to cause this:

1. **`build:mobile` only runs `cap copy`** — `package.json`: `"build:mobile": "vite build && cap copy"`. `cap copy` pushes web assets + config but does **not** run `cap update`, which is the half of `cap sync` that regenerates the cordova plugins subproject (`android/capacitor-cordova-android-plugins/`, including `cordova.variables.gradle`).
2. **That subproject is gitignored** — `android/.gitignore`: `capacitor-cordova-android-plugins`. So it's never committed, and the Capgo cloud builder (which assembles the workspace from the committed/uploaded tree) never receives the file.

The builder's own diagnostic confirms it: *"missing … because `npx cap sync` was not run (or its generated outputs were not committed/pushed)."*

`cap sync` = `cap copy` + `cap update`, so running `cap sync android` regenerates the cordova subproject locally before `capgo build request` uploads the workspace.

## Scope

- **Android workflow only.** The iOS workflow and the shared `build:mobile` npm script are intentionally untouched. (`bunx cap sync` is used rather than `npx` to match the workflow's existing `bunx @capgo/cli` usage.)
- This is **separate** from the bun hoisted-linker fix in #2415 — different root cause (missing generated file vs. dangling `.bun` symlink).

## Test plan

- [ ] Re-run `Build mobile android` against a tag and confirm `cap sync android` regenerates `android/capacitor-cordova-android-plugins/cordova.variables.gradle`, and the remote Gradle `:app:tasks` step no longer fails on the missing script.
- [x] YAML validated locally (`yaml.safe_load`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal Android build process to improve artifact generation consistency.

---

**Note:** This release contains only internal build infrastructure improvements with no direct impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->