### PR TITLE
ci(android): use bun hoisted linker for mobile build

### DIFF
--- a/.github/workflows/build_mobile_android.yml
+++ b/.github/workflows/build_mobile_android.yml
@@ -41,7 +41,11 @@ jobs:
         with:
           bun-version: latest
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # Force bun's hoisted (flat) node_modules layout. The monorepo defaults to
+        # bun's isolated linker (node_modules/.bun/<pkg>@<ver>+<peerHash> + symlinks),
+        # which Capacitor's Gradle subprojects can't resolve (../node_modules/@capacitor/
+        # <plugin>/android), producing "No variants exist". Hoisted lays real folders.
+        run: bun install --frozen-lockfile --linker=hoisted
       - name: Prepare mobile project
         # Use `cap sync android` instead of build:mobile's `cap copy`. `cap copy`
         # only pushes web assets + config; `cap sync` also runs `cap update`, which


### PR DESCRIPTION
## What

Add `--linker=hoisted` to the **Android** workflow's `bun install --frozen-lockfile` step, mirroring the iOS workflow.

## Why

With `cap sync` now running (#2416), the Android build gets past the missing-`cordova.variables.gradle` error and reaches Gradle, where it now fails (run https://github.com/Cap-go/capgo/actions/runs/26908303958/job/79379184756):

```
> Could not resolve project :capacitor-action-sheet.
> No matching variant of project :capacitor-action-sheet was found … but:
    - No variants exist.
```

This is bun's **isolated** linker: the monorepo (it has the `cli` workspace) defaults to laying packages out as `node_modules/.bun/<pkg>@<ver>+<peerHash>/…` with top-level symlinks. Capacitor's Gradle subprojects point at flat paths (`../node_modules/@capacitor/<plugin>/android`), so each `:capacitor-*` library project resolves to an empty/symlinked dir, applies no `com.android.library` config, and produces **no variants**. `--linker=hoisted` lays real flat folders, so each plugin's `android/build.gradle` is present and produces a variant.

## ⚠️ Caveat — may not be sufficient alone

`capgo build request` runs its **own** unfrozen `bun install` after this step ("Resolving dependencies / Saved lockfile" in the logs), which falls back to the monorepo's isolated default and can re-create the `.bun` layout before the bundle is zipped. The iOS workflow already has `--linker=hoisted` and still produced a `.bun` path for that reason. If this Android run still fails with `.bun` / "No variants exist", the robust fix is to set `[install] linker = "hoisted"` in the repo-root `bunfig.toml` so **every** `bun install` (including the CLI's internal one) is hoisted.

## Scope

- Android workflow only (matches the existing iOS `--linker=hoisted`).

## Test plan

- [ ] Re-run `Build mobile android` against a tag; confirm node_modules is flat and Gradle resolves the `:capacitor-*` subprojects (no "No variants exist").
- [x] YAML validated locally.
- [x] `--linker=hoisted` confirmed to produce a flat, `.bun`-free layout.