### PR TITLE
fix(cli): rewrite bun isolated-store paths in native build bundle

### DIFF
--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1119,11 +1119,14 @@ export async function zipDirectory(projectDir: string, outputPath: string, platf
   addDirectoryToZip(zip, projectDir, '', platform, nativeDeps, platformDir)
   addNativePackagesFromNodeModules(zip, parseNodeModulesPaths(options.nodeModules), platform, nativeDeps, platformDir)
 
-  // Rewrite pnpm store paths (node_modules/.pnpm/…/node_modules/@scope/pkg)
-  // to standard flat paths (node_modules/@scope/pkg).
-  // Scan all text-based entries because pnpm paths leak into Podfile, Podfile.lock,
-  // Pods.xcodeproj/project.pbxproj, .xcconfig files, Manifest.lock, settings.gradle, etc.
+  // Rewrite isolated-linker store paths to standard flat paths (node_modules/@scope/pkg).
+  // Both pnpm (node_modules/.pnpm/…/node_modules/@scope/pkg) and bun's isolated linker
+  // (node_modules/.bun/@scope+pkg@ver+hash/node_modules/@scope/pkg) leak store paths into
+  // Package.swift, Podfile, Podfile.lock, Pods.xcodeproj/project.pbxproj, .xcconfig files,
+  // Manifest.lock, settings.gradle, etc. The cloud builder only ships the flat plugin dirs,
+  // so these store paths must be collapsed back to node_modules/@scope/pkg.
   const pnpmPathPattern = /node_modules\/\.pnpm\/[^/\n\r]+(?:\/[^/\n\r]+)*\/node_modules\//g
+  const bunPathPattern = /node_modules\/\.bun\/[^/\n\r]+(?:\/[^/\n\r]+)*\/node_modules\//g
   const textExtensions = new Set([
     '',
     '.gradle',
@@ -1148,7 +1151,7 @@ export async function zipDirectory(projectDir: string, outputPath: string, platf
     if (!textExtensions.has(ext) && basename !== 'Podfile')
       continue
     const original = entry.getData().toString('utf-8')
-    let rewritten = original.replace(pnpmPathPattern, 'node_modules/')
+    let rewritten = original.replace(pnpmPathPattern, 'node_modules/').replace(bunPathPattern, 'node_modules/')
 
     // pnpm can leave deep relative paths in iOS files like Package.swift and Pods output.
     // Collapse any excessive ../ before project-root ios/ or node_modules/ paths back to

--- a/cli/test/test-build-zip-filter.mjs
+++ b/cli/test/test-build-zip-filter.mjs
@@ -248,6 +248,122 @@ await t('generated build zip supports nested Capacitor Podfile paths in monorepo
   }
 })
 
+await t('generated build zip rewrites bun isolated-store paths to flat node_modules (ios Package.swift)', async () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
+  const zipPath = join(testRoot, 'build.zip')
+
+  try {
+    writeFile(
+      join(testRoot, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@capacitor/core': '^8.0.0',
+          '@capacitor/action-sheet': '^8.1.1',
+        },
+      }, null, 2),
+    )
+
+    writeFile(
+      join(testRoot, 'capacitor.config.json'),
+      JSON.stringify({
+        ios: { path: 'ios' },
+        appId: 'com.example.app',
+        appName: 'Example',
+      }, null, 2),
+    )
+
+    // `cap sync` run under bun's isolated linker bakes the .bun store path into Package.swift.
+    writeFile(
+      join(testRoot, 'ios/App/CapApp-SPM/Package.swift'),
+      'let package = Package(name: "CapApp-SPM", dependencies: [.package(name: "CapacitorActionSheet", path: "../../../node_modules/.bun/@capacitor+action-sheet@8.1.1+1b808583819c2ac6/node_modules/@capacitor/action-sheet")])\n',
+    )
+
+    writeFile(join(testRoot, 'www', 'index.html'), '<!doctype html><html></html>')
+    writeFile(
+      join(testRoot, 'node_modules', '@capacitor', 'action-sheet', 'package.json'),
+      JSON.stringify({ name: '@capacitor/action-sheet', version: '8.1.1' }, null, 2),
+    )
+    writeFile(
+      join(testRoot, 'node_modules', '@capacitor', 'action-sheet', 'Package.swift'),
+      'let package = Package(name: "CapacitorActionSheet")\n',
+    )
+
+    await zipDirectory(testRoot, zipPath, 'ios', {
+      ios: { path: 'ios' },
+    })
+
+    const zip = new AdmZip(zipPath)
+    const entries = zip.getEntries().map(entry => entry.entryName).sort()
+
+    assert.ok(entries.includes('node_modules/@capacitor/action-sheet/package.json'), 'missing plugin package.json in zip')
+    assert.equal(
+      zip.readAsText('ios/App/CapApp-SPM/Package.swift'),
+      'let package = Package(name: "CapApp-SPM", dependencies: [.package(name: "CapacitorActionSheet", path: "../../../node_modules/@capacitor/action-sheet")])\n',
+    )
+  }
+  finally {
+    rmSync(testRoot, { recursive: true, force: true })
+  }
+})
+
+await t('generated build zip rewrites bun isolated-store paths to flat node_modules (android settings.gradle)', async () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
+  const zipPath = join(testRoot, 'build.zip')
+
+  try {
+    writeFile(
+      join(testRoot, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@capacitor/core': '^8.0.0',
+          '@capacitor/action-sheet': '^8.1.1',
+        },
+      }, null, 2),
+    )
+
+    writeFile(
+      join(testRoot, 'capacitor.config.json'),
+      JSON.stringify({
+        android: { path: 'android' },
+        appId: 'com.example.app',
+        appName: 'Example',
+      }, null, 2),
+    )
+
+    // `cap sync` run under bun's isolated linker bakes the .bun store path into settings.gradle.
+    writeFile(
+      join(testRoot, 'android/capacitor.settings.gradle'),
+      'include \':capacitor-action-sheet\'\nproject(\':capacitor-action-sheet\').projectDir = new File(\'../node_modules/.bun/@capacitor+action-sheet@8.1.1+1b808583819c2ac6/node_modules/@capacitor/action-sheet/android\')\n',
+    )
+
+    writeFile(join(testRoot, 'www', 'index.html'), '<!doctype html><html></html>')
+    writeFile(
+      join(testRoot, 'node_modules', '@capacitor', 'action-sheet', 'package.json'),
+      JSON.stringify({ name: '@capacitor/action-sheet', version: '8.1.1' }, null, 2),
+    )
+    writeFile(
+      join(testRoot, 'node_modules', '@capacitor', 'action-sheet', 'android', 'build.gradle'),
+      'apply plugin: \'com.android.library\'\n',
+    )
+
+    await zipDirectory(testRoot, zipPath, 'android', {
+      android: { path: 'android' },
+    })
+
+    const zip = new AdmZip(zipPath)
+    const entries = zip.getEntries().map(entry => entry.entryName).sort()
+
+    assert.ok(entries.includes('node_modules/@capacitor/action-sheet/android/build.gradle'), 'missing plugin android build.gradle in zip')
+    assert.equal(
+      zip.readAsText('android/capacitor.settings.gradle'),
+      'include \':capacitor-action-sheet\'\nproject(\':capacitor-action-sheet\').projectDir = new File(\'../node_modules/@capacitor/action-sheet/android\')\n',
+    )
+  }
+  finally {
+    rmSync(testRoot, { recursive: true, force: true })
+  }
+})
+
 await t('generated build zip includes SPM and CocoaPods metadata when both managers are configured', async () => {
   const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
   const zipPath = join(testRoot, 'build.zip')


### PR DESCRIPTION
## TL;DR

This is the **actual** fix for the cloud native-build failures. `cap sync` run under bun's isolated linker bakes the `.bun` store path into the committed native project files, and `build request` uploads them verbatim. The CLI already flattens **pnpm**'s `.pnpm` store paths but not bun's `.bun` — so bun paths reach the builder, which only ships the flat plugin dirs, and the build fails.

## Evidence

On `main`, both files contain hardcoded bun store paths for every plugin:

```
ios/App/CapApp-SPM/Package.swift:15
  .package(name: "CapacitorActionSheet", path: "../../../node_modules/.bun/@capacitor+action-sheet@8.1.1+1b808583819c2ac6/node_modules/@capacitor/action-sheet")
android/capacitor.settings.gradle:6
  project(':capacitor-action-sheet').projectDir = new File('../node_modules/.bun/@capacitor+action-sheet@8.1.1+1b808583819c2ac6/node_modules/@capacitor/action-sheet/android')
```

Those exact paths show up in the failing builds:

- **iOS** (`-resolvePackageDependencies`): `the package at '…/node_modules/.bun/@capacitor+action-sheet@8.1.1+1b808583819c2ac6/…' cannot be accessed (… doesn't exist in file system)`
- **Android** (Gradle): `Could not resolve project :capacitor-action-sheet > No matching variant … - No variants exist.`

## Why the linker flags didn't fix it

`--linker=hoisted` on the build workflows (#2415 iOS, #2417 Android) only changes how `node_modules` is laid out on the runner. But `cap sync` writes the **literal `.bun` store path into the committed `Package.swift` / `capacitor.settings.gradle`**, which are uploaded as-is. iOS uses `cap copy` (can't fully `cap sync` from Linux), so those committed paths are never even regenerated. Layout flags can't fix a hardcoded string in a config file.

## The fix

`zipDirectory` (`cli/src/build/request.ts`) already has `pnpmPathPattern` that rewrites `node_modules/.pnpm/…/node_modules/` → flat `node_modules/` across all text entries (Package.swift, Podfile, pbxproj, settings.gradle, …). This adds the symmetric `bunPathPattern` for `node_modules/.bun/…/node_modules/`. `extractNativeDependencies` already normalizes bun store paths to flat names (`lastIndexOf('node_modules/')`), so the flat plugin content is already included in the zip — the only missing piece was rewriting the paths inside the config files.

```js
const bunPathPattern = /node_modules\/\.bun\/[^/\n\r]+(?:\/[^/\n\r]+)*\/node_modules\//g
...
let rewritten = original.replace(pnpmPathPattern, 'node_modules/').replace(bunPathPattern, 'node_modules/')
```

Fixes both iOS and Android in one place, independent of package-manager layout or `cap copy` vs `cap sync`.

## Tests

Adds two cases to `cli/test/test-build-zip-filter.mjs` (mirroring the existing pnpm test):
- iOS: `.bun` path in `Package.swift` → rewritten to `../../../node_modules/@capacitor/action-sheet`, plugin files present in zip.
- Android: `.bun` path in `capacitor.settings.gradle` → rewritten to `../node_modules/@capacitor/action-sheet/android`, plugin `build.gradle` present in zip.

Full `test-build-zip-filter.mjs` suite passes (including the existing pnpm cases).

## Follow-up notes

- The `--linker=hoisted` workflow flags (#2415, #2417) are now redundant for fixing this, though harmless. Can be reverted separately if desired.
- A complementary hardening would be `[install] linker = "hoisted"` in the repo `bunfig.toml` so locally-generated config files don't carry `.bun` paths in the first place — but this CLI rewrite is the robust fix that works regardless of what's committed.

## Test plan

- [x] `bun test/test-build-zip-filter.mjs` passes (new iOS + Android cases + existing pnpm).
- [ ] Re-run `Build mobile ios` and `Build mobile android` against a tag; confirm the uploaded bundle's `Package.swift` / `capacitor.settings.gradle` contain flat `node_modules/@capacitor/...` paths and the native build resolves all `:capacitor-*` / SPM packages.