### PR TITLE
fix(android): add JW Player and Mux Maven repos for cloud build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,14 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // Custom SDK repositories for @capgo/capacitor-jw-player and
+        // @capgo/capacitor-mux-player. Each plugin declares these in its own
+        // build.gradle, but :app resolves the plugins' transitive implementation
+        // deps (com.jwplayer:*, com.mux.player:android) against :app's repositories,
+        // so they must be visible here too — otherwise resolution only searches
+        // google()/mavenCentral() and fails with "Could not find ...".
+        maven { url = 'https://mvn.jwplayer.com/content/repositories/releases/' }
+        maven { url = 'https://muxinc.jfrog.io/artifactory/default-maven-release-local' }
     }
 }
 


### PR DESCRIPTION
## What

Add the JW Player and Mux SDK Maven repositories to `android/build.gradle`'s `allprojects.repositories`:

```gradle
maven { url = 'https://mvn.jwplayer.com/content/repositories/releases/' }
maven { url = 'https://muxinc.jfrog.io/artifactory/default-maven-release-local' }
```

## Why

With the bun isolated-store path issues resolved, the Android cloud build now resolves every `:capacitor-*` plugin and reaches Gradle dependency resolution (108 tasks executed), where it fails (run https://github.com/Cap-go/capgo/actions/runs/26909741724/job/79384248845):

```
Could not find com.jwplayer:jwplayer-common:4.25.0
Could not find com.jwplayer:jwplayer-chromecast:4.25.0
Could not find com.mux.player:android:1.0.0
  Required by: :app > :capgo-capacitor-jw-player
               :app > :capgo-capacitor-mux-player
```

`@capgo/capacitor-jw-player` and `@capgo/capacitor-mux-player` declare their SDK repos **only in their own `build.gradle`**:
- `node_modules/@capgo/capacitor-jw-player/android/build.gradle` → `https://mvn.jwplayer.com/content/repositories/releases/`
- `node_modules/@capgo/capacitor-mux-player/android/build.gradle` → `https://muxinc.jfrog.io/artifactory/default-maven-release-local`

But `:app`'s `releaseRuntimeClasspath` resolves those plugins' transitive `implementation` deps (`com.jwplayer:*`, `com.mux.player:android`) against **`:app`'s** repositories — `allprojects { repositories { google(); mavenCentral() } }` — which never search the custom repos. (No `repositoriesMode` override is involved.) Adding the repos to `allprojects` makes them visible to `:app`'s resolution.

`android/build.gradle` is committed and lives in the uploaded `android/` dir, and `cap sync` does not overwrite the root `build.gradle`, so this persists into the cloud build.

## Public — no credentials needed

Verified both repos serve the exact artifacts publicly:
- `…/com/jwplayer/jwplayer-common/4.25.0/jwplayer-common-4.25.0.pom` → HTTP 200
- `…/com/mux/player/android/1.0.0/android-1.0.0.pom` → HTTP 200

So URL-only repo declarations suffice (no secret/auth required).

## Scope / context

Separate domain from the bun work — this is Android Maven config for two third-party video SDKs, newly exposed now that the build gets far enough to resolve them.

## Test plan

- [ ] Re-run `Build mobile android` against a tag; confirm `com.jwplayer:*` and `com.mux.player:android` resolve from the added repos and `:app:releaseRuntimeClasspath` no longer fails.