### PR TITLE
fix(android): add apptopia Maven repo for @capgo/capacitor-appinsights

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,14 +21,16 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        // Custom SDK repositories for @capgo/capacitor-jw-player and
-        // @capgo/capacitor-mux-player. Each plugin declares these in its own
-        // build.gradle, but :app resolves the plugins' transitive implementation
-        // deps (com.jwplayer:*, com.mux.player:android) against :app's repositories,
-        // so they must be visible here too — otherwise resolution only searches
-        // google()/mavenCentral() and fails with "Could not find ...".
+        // Custom SDK repositories for @capgo/capacitor-jw-player,
+        // @capgo/capacitor-mux-player and @capgo/capacitor-appinsights. Each plugin
+        // declares these in its own build.gradle, but :app resolves the plugins'
+        // transitive implementation deps (com.jwplayer:*, com.mux.player:android,
+        // com.appinsights:appinsights) against :app's repositories, so they must be
+        // visible here too — otherwise resolution only searches google()/mavenCentral()
+        // and fails with "Could not find ...".
         maven { url = 'https://mvn.jwplayer.com/content/repositories/releases/' }
         maven { url = 'https://muxinc.jfrog.io/artifactory/default-maven-release-local' }
+        maven { url = 'https://repo.apptopia.com/maven' }
     }
 }
 


### PR DESCRIPTION
## What

Follow-up to #2419. Add the apptopia Maven repo to `android/build.gradle`'s `allprojects.repositories`:

```gradle
maven { url = 'https://repo.apptopia.com/maven' }
```

## Why

With #2419 (jwplayer/mux repos) the Android build still fails on a third proprietary dep (run https://github.com/Cap-go/capgo/actions/runs/26910721733/job/79387710875):

```
Could not find com.appinsights:appinsights:1.0.1
  Required by: :app > :capgo-capacitor-appinsights
```

`@capgo/capacitor-appinsights` declares both the dependency and its repo only in its own `build.gradle`:
- `node_modules/@capgo/capacitor-appinsights/android/build.gradle:74` → `implementation 'com.appinsights:appinsights:1.0.1'`
- `…:60` → `maven { url = "https://repo.apptopia.com/maven" }`

Same mechanism as #2419: `:app` resolves the plugin's transitive dep against `:app`'s repositories, which don't include apptopia. Adding it to `allprojects` fixes it.

Verified public — `repo.apptopia.com/maven/com/appinsights/appinsights/1.0.1/appinsights-1.0.1.{pom,aar}` → HTTP 200, no auth.

## ⚠️ This won't take effect until built from a tag that includes it

The mobile workflows `checkout` `ref: <inputs.tag>`, so `android/build.gradle` is taken from the **tag**, not `main`. Run 26910721733 built `capgo-12.159.0`, which predates #2419 and this PR — so none of the custom repos were present (that's why all three SDKs failed). This + #2419 only help once a **new tag is cut from `main`** with them merged.

## Test plan

- [ ] Cut a tag from `main` (with #2419 + this merged) and run `Build mobile android` against it; confirm `com.jwplayer:*`, `com.mux.player:android`, and `com.appinsights:appinsights` all resolve.