### PR TITLE
[codex] clarify channel identifiers

### DIFF
--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { getBaseData, getSupabaseClient, PLUGIN_BASE_URL, resetAndSeedAppData, resetAppData, resetAppDataStats } from './test-utils.ts'
 
 interface ChannelInfo {
-  id: string
+  id: number
   name: string
   public: boolean
   allow_self_set: boolean


### PR DESCRIPTION
## Summary (AI generated)

- Updated the `/channel_self` test response interface so `ChannelInfo.id` is typed as `number`.
- Clarified CLI/MCP channel docs and source descriptions so `channelId` is documented as a channel name, not the numeric database ID.

## Motivation (AI generated)

The endpoint maps `channels.id` from the Drizzle schema, where the column is configured as a numeric bigint value. The test-only response type was stale and claimed the ID was a string. Public channel docs also needed clearer wording because channel commands use names like `production`, while numeric IDs are internal database identifiers.

## Business Impact (AI generated)

This keeps test types and public docs aligned with the backend response shape, reducing confusion for users and maintainers working with channels.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run supabase:with-env -- bunx vitest run tests/channel_self.test.ts`
- [x] `bun run cli:check`
