### PR TITLE
fix(android): resolve Cast OptionsProvider manifest merge conflict

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"
@@ -48,6 +49,15 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- Google Cast: @capgo/capacitor-jw-player and @capgo/capacitor-ivs-player both
+             declare OPTIONS_PROVIDER_CLASS_NAME, but Android allows only one Cast
+             OptionsProvider per app, which fails manifest merge. Force a single winner
+             here. Swap the value to ee.forgr.ivsplayer.CastOptionsProvider to use IVS. -->
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="ee.forgr.capacitor_jw_player.CastOptionsProvider"
+            tools:replace="android:value" />
     </application>
 
     <!-- Permissions -->


### PR DESCRIPTION
## What

Declare the Google Cast `OPTIONS_PROVIDER_CLASS_NAME` meta-data once in `android/app/src/main/AndroidManifest.xml` with `tools:replace="android:value"` (and add the `tools` namespace), forcing a single winner.

## Why

After all SDK deps resolve (jwplayer/mux/appinsights — #2419/#2420), the Android build gets to manifest merge (651 Gradle tasks executed) and fails (run https://github.com/Cap-go/capgo/actions/runs/26914441096/job/79400617029):

```
Attribute meta-data#com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME@value
  value=(ee.forgr.ivsplayer.CastOptionsProvider) from [:capgo-capacitor-ivs-player]
  is also present at [:capgo-capacitor-jw-player] value=(ee.forgr.capacitor_jw_player.CastOptionsProvider).
Suggestion: add 'tools:replace="android:value"' to <meta-data> element to override.
```

`@capgo/capacitor-jw-player` and `@capgo/capacitor-ivs-player` each register their own Cast `OptionsProvider`. Android (Google Cast) supports only **one** OptionsProvider per app, so the merger can't reconcile the two values. The standard resolution is to declare the meta-data in the app manifest with `tools:replace="android:value"` and pick one.

## Choice

This keeps **JW Player**'s provider (`ee.forgr.capacitor_jw_player.CastOptionsProvider`). It's a one-value swap to `ee.forgr.ivsplayer.CastOptionsProvider` if IVS Cast should be the active one instead. (Functionally only one Cast integration can be live; both build fine.)

The app manifest is committed and user-owned — `cap sync` doesn't regenerate it — so this persists into the build.

## Test plan

- [ ] Cut a new tag from `main` (with this merged) and run `Build mobile android`; confirm manifest merge succeeds and the build proceeds past `processReleaseManifest`.
- [x] XML validated locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Cast support, enabling users to stream content to compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->