### PR TITLE
fix(ios): bump MARKETING_VERSION to 12.56.9 for App Store submission

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 12.56.8;
+				MARKETING_VERSION = 12.56.9;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = ee.forgr.capacitorgo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -329,7 +329,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 12.56.8;
+				MARKETING_VERSION = 12.56.9;
 				PRODUCT_BUNDLE_IDENTIFIER = ee.forgr.capacitorgo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";


### PR DESCRIPTION
## What

Bump `MARKETING_VERSION` from `12.56.8` → `12.56.9` in `ios/App/App.xcodeproj/project.pbxproj` (both Debug and Release configs).

## Why

The iOS cloud build now compiles all ~140 SPM packages, archives, and reaches the App Store Connect upload — where altool rejects it (run https://github.com/Cap-go/capgo/actions/runs/26914433880/job/79400575574):

```
This bundle is invalid. The value for key CFBundleShortVersionString [12.56.8] in the Info.plist
file must contain a higher version than that of the previously approved version [12.56.8].
Invalid Pre-Release Train. The train version '12.56.8' is closed for new build submissions.
```

`Info.plist` resolves `CFBundleShortVersionString = $(MARKETING_VERSION)`, which was pinned at `12.56.8` — a marketing version already submitted/approved, so that version "train" is closed and Apple won't accept new builds under it. The build auto-bumps `CFBundleVersion` (build number) via `agvtool new-version`, but **not** the marketing version, so every run re-submits `12.56.8`. Bumping the marketing version unblocks the upload.

(Note: the iOS app's `12.56.x` version line is independent of the repo/console `12.159.x` scheme — different products.)

## Follow-up consideration

This is a manual bump. Long-term, the release pipeline could auto-bump `MARKETING_VERSION` (e.g. via `agvtool new-marketing-version` in the build step) so this doesn't recur each App Store submission — out of scope here.

## Test plan

- [ ] Cut a new tag from `main` (with this merged) and run `Build mobile ios`; confirm the App Store Connect upload is accepted (no CFBundleShortVersionString/closed-train rejection).
- [x] Both Debug + Release MARKETING_VERSION updated; diff verified.