### PR TITLE
[codex] clarify channel name docs

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -434,7 +434,7 @@ const channel = program
   .description(`📢 Manage distribution channels for app updates in Capgo Cloud, controlling how updates are delivered to devices.`)
 
 channel
-  .command('add [channelId] [appId]')
+  .command('add [channelName] [appId]')
   .alias('a')
   .description(`➕ Create a new channel for app distribution in Capgo Cloud to manage update delivery.
 
@@ -447,7 +447,7 @@ Example: npx @capgo/cli@latest channel add production com.example.app --default`
   .option('--supa-anon <supaAnon>', optionDescriptions.supaAnon)
 
 channel
-  .command('delete [channelId] [appId]')
+  .command('delete [channelName] [appId]')
   .alias('d')
   .description(`🗑️ Delete a channel from Capgo Cloud, optionally removing associated bundles to free up resources.
 
@@ -489,7 +489,7 @@ Example: npx @capgo/cli@latest channel currentBundle production com.example.app`
   .option('--supa-anon <supaAnon>', optionDescriptions.supaAnon)
 
 channel
-  .command('set [channelId] [appId]')
+  .command('set [channelName] [appId]')
   .alias('s')
   .description(`⚙️ Configure settings for a channel, such as linking a bundle, setting update strategies (major, minor, metadata, patch, none), or device targeting (iOS, Android, dev, prod, emulator, device).
 

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -324,7 +324,7 @@ export async function startMcpServer(): Promise<void> {
     'Create a new distribution channel for an app',
     {
       appId: z.string().describe('App ID'),
-      channelId: z.string().describe('Channel name/ID to create'),
+      channelId: z.string().describe('Channel name to create'),
       default: z.boolean().optional().describe('Set as default channel'),
       selfAssign: z.boolean().optional().describe('Allow devices to self-assign to this channel'),
     },
@@ -378,7 +378,7 @@ export async function startMcpServer(): Promise<void> {
     'Delete a channel from an app',
     {
       appId: z.string().describe('App ID'),
-      channelId: z.string().describe('Channel name/ID to delete'),
+      channelId: z.string().describe('Channel name to delete'),
       deleteBundle: z.boolean().optional().describe('Also delete the bundle linked to this channel'),
     },
     async ({ appId, channelId, deleteBundle }) => {
@@ -397,7 +397,7 @@ export async function startMcpServer(): Promise<void> {
     'Get the current bundle linked to a specific channel',
     {
       appId: z.string().describe('App ID'),
-      channelId: z.string().describe('Channel name/ID'),
+      channelId: z.string().describe('Channel name'),
     },
     async ({ appId, channelId }) => {
       const result = await sdk.getCurrentBundle(appId, channelId)

--- a/cli/src/schemas/sdk.ts
+++ b/cli/src/schemas/sdk.ts
@@ -167,7 +167,7 @@ export type DeleteOldKeyOptions = z.infer<typeof deleteOldKeyOptionsSchema>
 // ============================================================================
 
 export const addChannelOptionsSchema = z.object({
-  channelId: z.string(),
+  channelId: z.string().describe('Channel name'),
   appId: z.string(),
   default: z.boolean().optional(),
   selfAssign: z.boolean().optional(),
@@ -179,7 +179,7 @@ export const addChannelOptionsSchema = z.object({
 export type AddChannelOptions = z.infer<typeof addChannelOptionsSchema>
 
 export const updateChannelOptionsSchema = z.object({
-  channelId: z.string(),
+  channelId: z.string().describe('Channel name'),
   appId: z.string(),
   bundle: z.string().optional(),
   state: z.string().optional(),

--- a/cli/webdocs/channel.mdx
+++ b/cli/webdocs/channel.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 📢 Manage distribution channels for app updates in Capgo Cloud, controlling how updates are delivered to devices.
 
+Channel commands use the channel name, such as `production`, `beta`, or `development`.
+The numeric channel `id` returned by API responses is an internal database identifier.
 
 ### <a id="channel-add"></a> ➕ **Add**
 
@@ -156,4 +158,3 @@ npx @capgo/cli@latest channel set production com.example.app --bundle 1.0.0 --st
 | **--ignore-metadata-check** | <code>boolean</code> | Ignore checking node_modules compatibility if present in the bundle |
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
-

--- a/cli/webdocs/mcp.mdx
+++ b/cli/webdocs/mcp.mdx
@@ -24,6 +24,10 @@ Available tools exposed via MCP:
   - capgo_star_all_repositories
   - capgo_get_account_id, capgo_doctor, capgo_get_stats
   - capgo_request_build, capgo_generate_encryption_keys
+
+For channel tools, `channelId` means the channel name, such as `production`.
+Numeric channel IDs returned by API responses are internal database identifiers.
+
 Example usage with Claude Desktop:
   Add to claude_desktop_config.json:
   {
@@ -38,6 +42,5 @@ Example usage with Claude Desktop:
 **Example:**
 
 ```bash
-npx @capgo/cli mcp
+npx @capgo/cli@latest mcp
 ```
-


### PR DESCRIPTION
## Summary (AI generated)

- Clarified CLI command argument docs so channel commands refer to `channelName` instead of `channelId`.
- Updated MCP channel tool descriptions so `channelId` is documented as the channel name.
- Added website docs notes explaining that numeric channel IDs are internal database identifiers.

## Motivation (AI generated)

Channel commands operate on channel names such as `production` or `beta`, while the numeric `id` returned by API/database-backed responses is a separate internal identifier. The docs could be read as saying callers should pass a string database ID.

## Business Impact (AI generated)

This reduces channel setup confusion for CLI and MCP users and keeps public docs aligned with the backend/test fix already merged in #2422.

## Test Plan (AI generated)

- [x] `bun run lint`
- [x] `bun run cli:check`
- [x] `bun run --cwd cli test:analytics` after investigating one transient local analytics failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that channel commands use channel names (e.g., `production`, `beta`) rather than numeric IDs, which are internal database identifiers.
  * Updated MCP server documentation to reflect channel name semantics.
  * Updated MCP server startup command example to use latest package reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->