### PR TITLE
fix(android): coexist app + pdf-generator FileProviders via subclass

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,20 +40,20 @@
 
         </activity>
 
-        <!-- @capgo/capacitor-pdf-generator also declares an androidx.core.content.FileProvider
-             (different authority + paths). The manifest merger keys providers by android:name,
-             so it conflicts on authorities/resource. tools:replace makes the app's FileProvider
-             authoritative (${applicationId}.fileprovider + @xml/file_paths) and resolves the merge. -->
+        <!-- Use a uniquely-named FileProvider subclass (.AppFileProvider) so the app's
+             provider doesn't collide by android:name with @capgo/capacitor-pdf-generator's
+             androidx.core.content.FileProvider during manifest merge. Both providers then
+             coexist, each keeping its own authority + paths — so PDF share (which looks up
+             ${applicationId}.capgo.pdfgenerator.fileprovider) keeps working. FileProvider
+             resolves by authority at runtime, so the subclass is transparent to Capacitor. -->
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".AppFileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true"
-            tools:replace="android:authorities">
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths"
-                tools:replace="android:resource"></meta-data>
+                android:resource="@xml/file_paths"></meta-data>
         </provider>
     </application>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,14 +40,20 @@
 
         </activity>
 
+        <!-- @capgo/capacitor-pdf-generator also declares an androidx.core.content.FileProvider
+             (different authority + paths). The manifest merger keys providers by android:name,
+             so it conflicts on authorities/resource. tools:replace makes the app's FileProvider
+             authoritative (${applicationId}.fileprovider + @xml/file_paths) and resolves the merge. -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true">
+            android:grantUriPermissions="true"
+            tools:replace="android:authorities">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths"></meta-data>
+                android:resource="@xml/file_paths"
+                tools:replace="android:resource"></meta-data>
         </provider>
     </application>
 

--- a/android/app/src/main/java/ee/forgr/capacitor_go/AppFileProvider.java
+++ b/android/app/src/main/java/ee/forgr/capacitor_go/AppFileProvider.java
@@ -1,0 +1,19 @@
+package ee.forgr.capacitor_go;
+
+import androidx.core.content.FileProvider;
+
+/**
+ * App-specific FileProvider subclass.
+ *
+ * Using a distinct class name (instead of the bare androidx.core.content.FileProvider)
+ * avoids an AndroidManifest merge collision with @capgo/capacitor-pdf-generator, which
+ * declares its own androidx.core.content.FileProvider. The manifest merger keys providers
+ * by android:name, so two providers sharing that name conflict on authorities/resource.
+ *
+ * FileProvider resolves by authority at runtime, not by class name, so this subclass is
+ * transparent: Capacitor keeps using the ${applicationId}.fileprovider authority, and the
+ * plugin keeps its own ${applicationId}.capgo.pdfgenerator.fileprovider authority. Both
+ * providers coexist with their own file_paths resources.
+ */
+public class AppFileProvider extends FileProvider {
+}


### PR DESCRIPTION
## What

Resolve the Android manifest-merge conflict between the app's FileProvider and `@capgo/capacitor-pdf-generator`'s by giving the **app** a uniquely-named `FileProvider` subclass (`.AppFileProvider`) — instead of `tools:replace` (which broke PDF share).

## Why

On `capgo-12.159.4` the Android build reaches `:app:processReleaseMainManifest` and fails (run https://github.com/Cap-go/capgo/actions/runs/26937039128):

```
provider#androidx.core.content.FileProvider@authorities
  value=(ee.forgr.capacitor_go.fileprovider) from AndroidManifest.xml:45
  is also present at [:capgo-capacitor-pdf-generator] value=(...capgo.pdfgenerator.fileprovider)
meta-data#android.support.FILE_PROVIDER_PATHS@resource
  value=(@xml/file_paths) ... is also present at [...] value=(@xml/capgo_pdf_generator_paths)
```

Both the app and the plugin declare `androidx.core.content.FileProvider`. The manifest merger keys `<provider>` by `android:name`, so the two collide on `authorities`/`resource`.

## Why not `tools:replace`

`tools:replace="android:authorities"` makes the app's provider win, which **removes** the plugin's `${applicationId}.capgo.pdfgenerator.fileprovider` authority from the merged manifest. The plugin's `type: 'share'` path calls `FileProvider.getUriForFile(context, "${applicationId}.capgo.pdfgenerator.fileprovider", file)`, which would then throw `IllegalArgumentException` instead of opening the share sheet. Build green, feature broken — not acceptable. (Thanks to the reviewer who caught this.)

## The fix

The conflict is purely the merger's `android:name` keying — at runtime providers are resolved by **authority**, so two FileProviders with different authorities coexist fine. Give the app's provider a distinct class name:

- New `android/app/src/main/java/ee/forgr/capacitor_go/AppFileProvider.java` — `class AppFileProvider extends FileProvider {}`.
- App manifest `<provider android:name=".AppFileProvider" android:authorities="${applicationId}.fileprovider" .../>` with `@xml/file_paths` (no `tools:replace`).

Now the merged manifest keeps **both** providers:
- app → `.AppFileProvider`, authority `${applicationId}.fileprovider`, `@xml/file_paths`
- plugin → `androidx.core.content.FileProvider`, authority `${applicationId}.capgo.pdfgenerator.fileprovider`, `@xml/capgo_pdf_generator_paths`

`FileProvider.getUriForFile()` resolves by authority, so Capacitor (uses `${applicationId}.fileprovider`) and pdf-generator (uses its own authority) both work. No runtime regression.

> Long-term, the cleanest fix is for `@capgo/capacitor-pdf-generator` to subclass its own FileProvider under a unique name so it never collides with any host app — worth an upstream issue. This PR is the app-side fix.

## Verification
- [x] AndroidManifest.xml valid XML; no `tools:replace`.
- [ ] New tag from `main` + `Build mobile android`: confirm `processReleaseMainManifest` passes and the build proceeds.
- [ ] Smoke-test PDF `type: 'share'` opens the share sheet (plugin authority preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android FileProvider declaration and added a matching provider subclass.
  * Kept existing authorities, exported flag, URI permission grants, and metadata unchanged.
  * No runtime changes to file access behavior expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->