### PR TITLE
fix(ios): remove invalid underscore URL scheme for App Store upload

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -26,7 +26,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>capgo</string>
-				<string>ee.forgr.capacitor_go</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## What

Remove the `ee.forgr.capacitor_go` entry from `CFBundleURLSchemes` in `ios/App/App/Info.plist`. Keep `capgo`.

## Why

The iOS build compiles, archives, and reaches App Store Connect upload, where altool rejects it (run https://github.com/Cap-go/capgo/actions/runs/26937037211):

```
The following URL schemes found in your app are not in the correct format: [ee.forgr.capacitor_go].
URL schemes need to begin with an alphabetic character, and be comprised of alphanumeric
characters, the period, the hyphen or the plus sign only. (90158)
```

`ee.forgr.capacitor_go` contains an underscore, which RFC1738 / Apple disallow in URL schemes.

It's safe to remove:
- **Unreferenced** — no usages in `src/`, `capacitor.config.ts`, or iOS deep-link handling.
- **No Android counterpart** — Android uses `https` (universal links) + `capgo`; no reverse-DNS scheme.
- **Never functioned** — underscores are invalid, so nothing could have used it as a scheme.
- `CFBundleURLName` is already `ee.forgr.capacitorgo` (no underscore); only the scheme string had it.

The real custom scheme `capgo` is preserved.

> If a reverse-DNS scheme is wanted for the future, the valid form is `ee.forgr.capacitorgo` — but since it's unused, removal is the minimal fix.

## Verification
- [x] `plutil -lint` passes.
- [ ] New tag from `main` + `Build mobile ios`: confirm App Store Connect upload is accepted (no 90158 URL-scheme rejection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS app URL scheme identifier configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->