### PR TITLE
[codex] fix iOS privacy purpose strings

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -38,15 +38,23 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Allow Camera feature to try it in the sandbox app your are developing</string>
+	<string>Allow camera access to try camera features in the sandbox app you are developing.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Allow calendar access to try calendar features in the sandbox app you are developing.</string>
 	<key>NSMicrophoneUsageDescription</key>
-<string>Allow access to the microphone to record audio.</string>
+	<string>Allow microphone access to record audio in the sandbox app you are developing.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Allow motion access to try motion features in the sandbox app you are developing.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Allow speech recognition to try speech features in the sandbox app you are developing.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Allow location access to try background location features in the sandbox app you are developing.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Allow Geolocation feature to try it in the sandbox app your are developing</string>
+	<string>Allow location access to try geolocation features in the sandbox app you are developing.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Allow Photo Library feature to try it in the sandbox app your are developing</string>
+	<string>Allow photo library write access to try photo features in the sandbox app you are developing.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Allow Photo Library feature to try it in the sandbox app your are developing</string>
+	<string>Allow photo library access to try photo features in the sandbox app you are developing.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -41,6 +41,10 @@
 	<string>Allow camera access to try camera features in the sandbox app you are developing.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Allow calendar access to try calendar features in the sandbox app you are developing.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Allow full calendar access to try calendar features in the sandbox app you are developing.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>Allow calendar write access to try calendar event creation features in the sandbox app you are developing.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Allow microphone access to record audio in the sandbox app you are developing.</string>
 	<key>NSMotionUsageDescription</key>


### PR DESCRIPTION
## Summary (AI generated)

- Added missing iOS privacy purpose strings for calendar, motion, speech recognition, and always-on location access in `ios/App/App/Info.plist`.
- Cleaned up the existing privacy purpose strings for camera, microphone, location, and photo library access so App Review sees clear user-facing descriptions.

## Motivation (AI generated)

App Store Connect rejected build `120568700` for ITMS-90683 because the app bundle was missing `NSCalendarsUsageDescription`, `NSMotionUsageDescription`, and `NSSpeechRecognitionUsageDescription`. Apple also warned that `NSLocationAlwaysAndWhenInUseUsageDescription` was missing, so this adds that key too.

## Business Impact (AI generated)

This unblocks uploading a corrected Capgo `12.56.9` binary to App Store Connect and reduces the chance of a repeated privacy metadata rejection during review.

## Test Plan (AI generated)

- [x] `plutil -lint ios/App/App/Info.plist`
- [x] `bun lint`
- [x] Commit hook passed: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## Screenshots (AI generated)

Not applicable. This is an iOS plist metadata change.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint` where applicable. This PR ran `bun lint`; no backend files changed.
- [x] My change does not require a documentation update.
- [x] My change does not require E2E test coverage.
- [x] I have tested my code manually with plist validation.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized app permission prompt wording for camera, microphone, calendar (read/write), motion, speech recognition, location (when-in-use and always), and photo library (read and add).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->