### PR TITLE
[codex] Fix iOS SwiftPM package resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -215,7 +215,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "7.124.12",
+      "version": "7.124.13",
       "bin": {
         "capgo": "dist/index.js",
       },

--- a/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0c179d9141773b7facf8458d81f2f987504c8a05b674dfb858d2708f4dc1906e",
+  "originHash" : "5d0926ee4d0720dd022efe982e5449ea78a881ae719d3efeed1bcf106f7bbe3f",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "992959f0467c781eb6a1637e69d87481238c3672",
-        "version" : "8.3.4"
+        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
+        "version" : "8.4.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jwplayer/JWPlayerKit-package.git",
       "state" : {
-        "revision" : "da2d38272c660cd6c34dc4cfd7a6820be65db235",
-        "version" : "4.26.1"
+        "revision" : "d5e3b35adf991191b829e745e71b29781bceb276",
+        "version" : "4.26.2"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-hybrid-common.git",
       "state" : {
-        "revision" : "aaefa0d667d225e51e13c0e3b3e13c3026f0254a",
-        "version" : "18.7.0"
+        "revision" : "a9d25f3d300cdb515b0cce464b59ebb29ad9ec14",
+        "version" : "18.10.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "6b95744e70f1edc43f89f2b522b0832ddfdd41a1",
-        "version" : "5.73.0"
+        "revision" : "92e2804a6b84b3b7ce60bfe7e9ff63dc9524ef5b",
+        "version" : "5.76.0"
       }
     },
     {


### PR DESCRIPTION
## Summary (AI generated)

- Refreshed the iOS workspace SwiftPM resolved package pins to match the current generated Capacitor SwiftPM package graph.
- Updated `bun.lock` so the local CLI workspace version matches `cli/package.json`.

## Motivation (AI generated)

The iOS simulator build was failing while compiling the `ion-ios-camera` asset catalog from a stale DerivedData/SwiftPM checkout. Refreshing dependency metadata lets Xcode resolve the current package graph cleanly instead of reusing older pins.

## Business Impact (AI generated)

This restores the local iOS simulator build path, reducing friction for mobile validation and keeping dependency metadata consistent for contributors and CI.

## Test Plan (AI generated)

- [x] `bun install --frozen-lockfile`
- [x] `bun lint`
- [x] pre-commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- [x] `bun run build:mobile`
- [x] `xcodebuild -quiet -workspace ios/App/App.xcworkspace -scheme App -configuration Debug -destination 'platform=iOS Simulator,id=F688C88A-C182-41FF-995F-A90ADE5056A0' CODE_SIGNING_ALLOWED=NO build`

Generated with AI
