### PR TITLE
feat(backend): persist bundle compatibility events from on_channel_update

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,10 +8,6 @@
     "src/components.d.ts": [
       "types"
     ],
-    "supabase/functions/_backend/utils/bundle_compatibility.ts": [
-      "exports",
-      "types"
-    ],
     "supabase/functions/_backend/utils/postgres_schema.ts": [
       "exports"
     ],

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -821,6 +821,81 @@ export type Database = {
           },
         ]
       }
+      compatibility_events: {
+        Row: {
+          app_id: string
+          channel_id: number | null
+          channel_name: string
+          created_at: string
+          current_version_id: number | null
+          current_version_name: string
+          id: number
+          offenders: Json
+          org_id: string
+          platform: string
+          previous_version_id: number | null
+          previous_version_name: string
+          resolution_kind: string | null
+          resolution_note: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          source: string
+        }
+        Insert: {
+          app_id: string
+          channel_id?: number | null
+          channel_name: string
+          created_at?: string
+          current_version_id?: number | null
+          current_version_name: string
+          id?: never
+          offenders?: Json
+          org_id: string
+          platform: string
+          previous_version_id?: number | null
+          previous_version_name: string
+          resolution_kind?: string | null
+          resolution_note?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          source: string
+        }
+        Update: {
+          app_id?: string
+          channel_id?: number | null
+          channel_name?: string
+          created_at?: string
+          current_version_id?: number | null
+          current_version_name?: string
+          id?: never
+          offenders?: Json
+          org_id?: string
+          platform?: string
+          previous_version_id?: number | null
+          previous_version_name?: string
+          resolution_kind?: string | null
+          resolution_note?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "compatibility_events_app_id_fkey"
+            columns: ["app_id"]
+            isOneToOne: false
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
+          },
+          {
+            foreignKeyName: "compatibility_events_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "orgs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       cron_tasks: {
         Row: {
           batch_size: number | null
@@ -3072,6 +3147,10 @@ export type Database = {
     }
     Functions: {
       accept_invitation_to_org: { Args: { org_id: string }; Returns: string }
+      acknowledge_compatibility_event: {
+        Args: { event_id: number; note: string }
+        Returns: undefined
+      }
       apikey_has_current_org_create_capability: {
         Args: { p_apikey_rbac_id: string }
         Returns: boolean

--- a/supabase/functions/_backend/triggers/compatibility_events.ts
+++ b/supabase/functions/_backend/triggers/compatibility_events.ts
@@ -1,0 +1,239 @@
+import type { CompatibilitySummary, NativePackage } from '../utils/bundle_compatibility.ts'
+import type { Database } from '../utils/supabase.types.ts'
+import { comparePackages, summarizeCompatibility } from '../utils/bundle_compatibility.ts'
+
+/**
+ * Pure decision logic for the `compatibility_events` feature.
+ *
+ * These functions are intentionally side-effect free: they take fully-resolved
+ * inputs (channel rows, bundle metadata) and return plain data describing the
+ * rows the handler should upsert / resolve. All I/O (loading `native_packages`,
+ * upserting, auto-resolving) stays in `on_channel_update.ts` so this module is
+ * trivially unit-testable.
+ *
+ * Source of truth: docs/superpowers/specs/2026-06-03-compatibility-events-design.md
+ */
+
+type ChannelRow = Database['public']['Tables']['channels']['Row']
+
+export type CompatibilityPlatform = 'ios' | 'android' | 'electron'
+
+export const COMPATIBILITY_PLATFORMS: readonly CompatibilityPlatform[] = ['ios', 'android', 'electron']
+
+export type CompatibilityEventSource = 'default_channel_version_changed' | 'default_channel_changed'
+
+/** Metadata snapshot for one bundle, resolved by the handler from `app_versions`. */
+export interface CompatibilityBundle {
+  id: number
+  name: string
+  /** Raw `native_packages` (may be null/empty); decision logic applies exclusions. */
+  nativePackages: NativePackage[] | null
+}
+
+/**
+ * One previous-default candidate for a platform on which the new channel is the
+ * current default. `bundle` is the previous default bundle that users currently
+ * have installed; `source` distinguishes Case A (switch) from Case B (version
+ * change).
+ */
+export interface PreviousDefault {
+  platform: CompatibilityPlatform
+  source: CompatibilityEventSource
+  bundle: CompatibilityBundle | null
+}
+
+export interface DecideCompatibilityEventsInput {
+  /** The new/current default channel row (`c.get('webhookBody')`). */
+  newChannel: Pick<ChannelRow, 'id' | 'app_id' | 'owner_org' | 'name' | 'version' | 'public' | 'ios' | 'android' | 'electron' | 'disable_auto_update'>
+  /** The bundle the new default channel now points at (`app_versions` of `newChannel.version`). */
+  currentBundle: CompatibilityBundle | null
+  /** Per-platform previous-default candidates the handler resolved. */
+  previousDefaults: readonly PreviousDefault[]
+}
+
+/**
+ * Row shape inserted into `public.compatibility_events`. Defined locally because
+ * the generated Supabase types lag the migration; the handler casts the typed
+ * client at the single upsert call-site.
+ */
+export interface CompatibilityEventInsert {
+  org_id: string
+  app_id: string
+  source: CompatibilityEventSource
+  platform: CompatibilityPlatform
+  channel_id: number | null
+  channel_name: string
+  current_version_id: number | null
+  current_version_name: string
+  previous_version_id: number | null
+  previous_version_name: string
+  offenders: string[]
+}
+
+/**
+ * Metadata strategy: when the default channel forces an exact version match the
+ * native-compatibility verdict does not gate delivery, mirroring the Bento email
+ * gating. Skip these entirely.
+ */
+function usesMetadataStrategy(channel: Pick<ChannelRow, 'disable_auto_update'>): boolean {
+  return channel.disable_auto_update === 'version_number'
+}
+
+/**
+ * A bundle contributes to the verdict only if it carries `native_packages`. A
+ * missing/empty array means we cannot compute a meaningful diff, so we exclude
+ * the comparison (matching the existing email behavior).
+ */
+function hasNativePackages(bundle: CompatibilityBundle | null | undefined): bundle is CompatibilityBundle & { nativePackages: NativePackage[] } {
+  return Boolean(bundle && Array.isArray(bundle.nativePackages) && bundle.nativePackages.length > 0)
+}
+
+/**
+ * Compute the incompatible events to upsert for one channel change.
+ *
+ * For each platform the new channel is currently default on, compare the current
+ * default bundle (candidate, shipped OTA) against the previous default bundle
+ * (baseline, already installed). Emit one event per platform that is
+ * **incompatible**, snapshotting offenders + version names so the row survives
+ * the 90-day bundle purge.
+ *
+ * Exclusions (return no events for the platform):
+ * - new channel is not public (not a default);
+ * - the channel platform flag is false;
+ * - `disable_auto_update = 'version_number'` (metadata strategy);
+ * - either bundle is missing `native_packages`;
+ * - current and previous bundle are the same bundle id (no real change).
+ *
+ * Soft-deleted baselines are NOT dropped: a previous bundle that is flagged
+ * `deleted` but still carries `native_packages` is a valid baseline (users still
+ * run it). The handler only excludes when the metadata is genuinely unavailable.
+ */
+export function decideCompatibilityEvents(input: DecideCompatibilityEventsInput): CompatibilityEventInsert[] {
+  const { newChannel, currentBundle, previousDefaults } = input
+
+  // The new channel must be a default (public) for any platform to matter.
+  if (!newChannel.public)
+    return []
+
+  // Metadata strategy disables the OTA-compatibility gate entirely.
+  if (usesMetadataStrategy(newChannel))
+    return []
+
+  // No current bundle metadata -> cannot compute a verdict.
+  if (!hasNativePackages(currentBundle))
+    return []
+
+  const events: CompatibilityEventInsert[] = []
+
+  for (const previous of previousDefaults) {
+    // The channel must currently be default for this platform.
+    if (!newChannel[previous.platform])
+      continue
+
+    // Missing baseline metadata -> skip (exclusion), but never because the row
+    // was merely soft-deleted.
+    if (!hasNativePackages(previous.bundle))
+      continue
+
+    // Same bundle on both sides -> nothing changed for this platform.
+    if (previous.bundle.id === currentBundle.id)
+      continue
+
+    const summary: CompatibilitySummary = summarizeCompatibility(
+      comparePackages(currentBundle.nativePackages, previous.bundle.nativePackages),
+    )
+
+    if (summary.compatible)
+      continue
+
+    events.push({
+      org_id: newChannel.owner_org,
+      app_id: newChannel.app_id,
+      source: previous.source,
+      platform: previous.platform,
+      channel_id: newChannel.id,
+      channel_name: newChannel.name,
+      current_version_id: currentBundle.id,
+      current_version_name: currentBundle.name,
+      previous_version_id: previous.bundle.id,
+      previous_version_name: previous.bundle.name,
+      offenders: summary.offenders,
+    })
+  }
+
+  return events
+}
+
+/** Minimal shape of an unresolved event the auto-resolver reasons about. */
+export interface UnresolvedCompatibilityEvent {
+  id: number
+  platform: CompatibilityPlatform
+  previous_version_id: number | null
+  previous_version_name: string
+  current_version_id: number | null
+}
+
+/** The current default (post-change) bundle for a platform, resolved by the handler. */
+export interface CurrentDefaultForPlatform {
+  platform: CompatibilityPlatform
+  bundle: CompatibilityBundle | null
+}
+
+export interface CompatibilityAutoResolve {
+  id: number
+  note: string
+}
+
+/**
+ * Decide which unresolved events should auto-resolve.
+ *
+ * An event auto-resolves when the **current** default bundle for its platform is
+ * now OTA-compatible with the event's `previous_version` (the baseline users had
+ * when the event was raised) — e.g. a revert to a compatible bundle, or a fixed
+ * bundle. This is descriptive only: we attach a generated note explaining the
+ * state cleared; we never prompt anyone to revert.
+ *
+ * Critically it must NOT fire on a native-identical *successor*: if the current
+ * default is the very same bundle that raised the event (`current_version_id`),
+ * the stranded users are still stranded — only a different, compatible default
+ * clears it. We therefore skip when the current default bundle id equals the
+ * event's `current_version_id`.
+ */
+export function decideAutoResolves(
+  unresolvedEvents: readonly UnresolvedCompatibilityEvent[],
+  currentDefaultByPlatform: readonly CurrentDefaultForPlatform[],
+  bundlesById: ReadonlyMap<number, CompatibilityBundle>,
+): CompatibilityAutoResolve[] {
+  const currentByPlatform = new Map(currentDefaultByPlatform.map(entry => [entry.platform, entry.bundle]))
+  const resolves: CompatibilityAutoResolve[] = []
+
+  for (const event of unresolvedEvents) {
+    const currentBundle = currentByPlatform.get(event.platform)
+    if (!hasNativePackages(currentBundle))
+      continue
+
+    // The successor that raised the event is not a resolution: an OTA-identical
+    // re-upload leaves users stranded. Only a *different* compatible default
+    // clears it.
+    if (event.current_version_id != null && currentBundle.id === event.current_version_id)
+      continue
+
+    if (event.previous_version_id == null)
+      continue
+
+    const baseline = bundlesById.get(event.previous_version_id)
+    if (!hasNativePackages(baseline))
+      continue
+
+    const summary = summarizeCompatibility(comparePackages(currentBundle.nativePackages, baseline.nativePackages))
+    if (!summary.compatible)
+      continue
+
+    resolves.push({
+      id: event.id,
+      note: `Default channel returned to ${currentBundle.name}, which is compatible with ${event.previous_version_name}.`,
+    })
+  }
+
+  return resolves
+}

--- a/supabase/functions/_backend/triggers/compatibility_events.ts
+++ b/supabase/functions/_backend/triggers/compatibility_events.ts
@@ -1,6 +1,6 @@
 import type { CompatibilitySummary, NativePackage } from '../utils/bundle_compatibility.ts'
 import type { Database } from '../utils/supabase.types.ts'
-import { comparePackages, summarizeCompatibility } from '../utils/bundle_compatibility.ts'
+import { compareNativePackages, summarizeBundleCompatibility } from '../utils/bundle_compatibility.ts'
 
 /**
  * Pure decision logic for the `compatibility_events` feature.
@@ -139,8 +139,8 @@ export function decideCompatibilityEvents(input: DecideCompatibilityEventsInput)
     if (previous.bundle.id === currentBundle.id)
       continue
 
-    const summary: CompatibilitySummary = summarizeCompatibility(
-      comparePackages(currentBundle.nativePackages, previous.bundle.nativePackages),
+    const summary: CompatibilitySummary = summarizeBundleCompatibility(
+      compareNativePackages(currentBundle.nativePackages, previous.bundle.nativePackages),
     )
 
     if (summary.compatible)
@@ -225,7 +225,7 @@ export function decideAutoResolves(
     if (!hasNativePackages(baseline))
       continue
 
-    const summary = summarizeCompatibility(comparePackages(currentBundle.nativePackages, baseline.nativePackages))
+    const summary = summarizeBundleCompatibility(compareNativePackages(currentBundle.nativePackages, baseline.nativePackages))
     if (!summary.compatible)
       continue
 

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -175,7 +175,7 @@ function sanitizeNativePackages(raw: unknown): NativePackage[] | null {
  * version. Must be called BEFORE the demotion update runs. The decision layer
  * only consumes this as the Case A baseline when the record NEWLY became the
  * public default for the platform (a real switch); on a non-switch edit the value
- * is ignored, so the prior `updated_at`-ordered baseline can no longer mis-fire.
+ * is ignored, so the prior `updated_at`-ordered baseline can no longer misfire.
  * The ordering here is only a tiebreaker; in practice a single other channel is
  * public per platform.
  */

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -26,6 +26,11 @@ export const app = new Hono<MiddlewareKeyVariables>()
 const UPDATE_RETRY_ATTEMPTS = 3
 const UPDATE_RETRY_DELAY_MS = 300
 const COMPATIBILITY_DEDUP_CONFLICT = 'app_id,channel_id,platform,current_version_id,previous_version_id'
+// Upper bound on unresolved events scanned per auto-resolve pass: bounds the
+// in-memory result set and the per-row UPDATE blast radius for busy apps. Far
+// above any realistic count of distinct unresolved (version × platform) events;
+// anything beyond is revisited on the next channel update.
+const COMPATIBILITY_AUTO_RESOLVE_SCAN_LIMIT = 200
 type ChannelRow = Database['public']['Tables']['channels']['Row']
 type ChannelPlatformScope = 'ios' | 'android' | 'electron'
 
@@ -319,6 +324,8 @@ async function autoResolveCompatibilityEvents(
     .select('id, platform, previous_version_id, previous_version_name, current_version_id')
     .eq('app_id', record.app_id)
     .is('resolved_at', null)
+    .order('id', { ascending: false })
+    .limit(COMPATIBILITY_AUTO_RESOLVE_SCAN_LIMIT)
 
   if (error || !unresolved || unresolved.length === 0) {
     if (error) {

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -1,16 +1,31 @@
 import type { Context } from 'hono'
+import type { NativePackage } from '../utils/bundle_compatibility.ts'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
+import type {
+  CompatibilityBundle,
+  CompatibilityEventInsert,
+  CompatibilityPlatform,
+  CurrentDefaultForPlatform,
+  PreviousDefault,
+  UnresolvedCompatibilityEvent,
+} from './compatibility_events.ts'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { retryWithBackoff } from '../utils/retry.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import {
+  COMPATIBILITY_PLATFORMS,
+  decideAutoResolves,
+  decideCompatibilityEvents,
+} from './compatibility_events.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 const UPDATE_RETRY_ATTEMPTS = 3
 const UPDATE_RETRY_DELAY_MS = 300
+const COMPATIBILITY_DEDUP_CONFLICT = 'app_id,channel_id,platform,current_version_id,previous_version_id'
 type ChannelRow = Database['public']['Tables']['channels']['Row']
 type ChannelPlatformScope = 'ios' | 'android' | 'electron'
 
@@ -93,6 +108,267 @@ async function getCurrentPublicWinner(
   return winner?.id === currentRecord.id ? currentRecord : null
 }
 
+/**
+ * Load a bundle's compatibility metadata (`native_packages` + name) by version
+ * id. Returns null when the id is missing or the row cannot be loaded; the
+ * decision layer treats a null/empty bundle as an exclusion. We do NOT filter on
+ * `deleted`: a soft-deleted baseline is still a valid installed-on-device
+ * baseline as long as its metadata survives.
+ */
+async function loadCompatibilityBundle(
+  c: Context<MiddlewareKeyVariables>,
+  versionId: number | null | undefined,
+): Promise<CompatibilityBundle | null> {
+  if (versionId == null)
+    return null
+
+  const { data, error } = await supabaseAdmin(c)
+    .from('app_versions')
+    .select('id, name, native_packages')
+    .eq('id', versionId)
+    .maybeSingle()
+
+  if (error || !data) {
+    if (error) {
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'Failed to load bundle for compatibility event',
+        error,
+        versionId,
+      })
+    }
+    return null
+  }
+
+  return {
+    id: data.id,
+    name: data.name,
+    nativePackages: sanitizeNativePackages(data.native_packages),
+  }
+}
+
+/**
+ * Keep only entries that satisfy the CLI's `nativePackageSchema` shape — a
+ * non-empty string `name` AND `version`. Malformed entries are dropped rather
+ * than fed into `comparePackages`. When nothing usable survives we return null so
+ * the decision layer treats the bundle as "cannot compute" (an exclusion) instead
+ * of comparing against garbage.
+ */
+function sanitizeNativePackages(raw: unknown): NativePackage[] | null {
+  if (!Array.isArray(raw))
+    return null
+
+  const usable = raw.filter((pkg): pkg is NativePackage =>
+    Boolean(pkg)
+    && typeof (pkg as NativePackage).name === 'string'
+    && (pkg as NativePackage).name.length > 0
+    && typeof (pkg as NativePackage).version === 'string'
+    && (pkg as NativePackage).version.length > 0,
+  )
+
+  return usable.length > 0 ? usable : null
+}
+
+/**
+ * Find the channel this update is about to demote for a platform — a different
+ * channel that is still public for that platform right now — and return its id +
+ * version. Must be called BEFORE the demotion update runs. The decision layer
+ * only consumes this as the Case A baseline when the record NEWLY became the
+ * public default for the platform (a real switch); on a non-switch edit the value
+ * is ignored, so the prior `updated_at`-ordered baseline can no longer mis-fire.
+ * The ordering here is only a tiebreaker; in practice a single other channel is
+ * public per platform.
+ */
+async function getPreviousDefaultChannel(
+  c: Context<MiddlewareKeyVariables>,
+  appId: string,
+  scope: ChannelPlatformScope,
+  excludeChannelId: number,
+): Promise<{ id: number, version: number | null } | null> {
+  const { data, error } = await supabaseAdmin(c)
+    .from('channels')
+    .select('id, version')
+    .eq('app_id', appId)
+    .eq('public', true)
+    .eq(scope, true)
+    .neq('id', excludeChannelId)
+    .order('updated_at', { ascending: false })
+    .order('created_at', { ascending: false })
+    .order('id', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Failed to resolve previous default channel for compatibility event',
+      error,
+      app_id: appId,
+      scope,
+    })
+    return null
+  }
+
+  return data ?? null
+}
+
+/**
+ * Compute and persist `compatibility_events` for one channel update. Fully
+ * guarded: any failure here is logged and swallowed so it can never break the
+ * channel winner reconciliation that already ran. `previousDefaultChannelByPlatform`
+ * carries the Case A baseline channel captured before demotion.
+ */
+async function persistCompatibilityEvents(
+  c: Context<MiddlewareKeyVariables>,
+  record: ChannelRow,
+  oldRecord: ChannelRow | undefined,
+  previousDefaultChannelByPlatform: Partial<Record<CompatibilityPlatform, { id: number, version: number | null } | null>>,
+): Promise<void> {
+  try {
+    // The new default's current bundle (candidate shipped OTA).
+    const currentBundle = await loadCompatibilityBundle(c, record.version)
+
+    // Resolve a previous-default candidate per platform the channel is default on.
+    // Switch-aware: a platform only contributes when the record is the CURRENT
+    // public default for it, and we distinguish a same-channel version bump
+    // (Case B) from a genuine default switch (Case A). A non-switch edit on an
+    // already-public winner (name/flag toggle, or no version delta) emits nothing.
+    const previousDefaults: PreviousDefault[] = []
+    for (const platform of COMPATIBILITY_PLATFORMS) {
+      const recordIsDefault = Boolean(record.public && record[platform])
+      if (!recordIsDefault)
+        continue
+
+      const oldWasDefault = Boolean(oldRecord && oldRecord.public && oldRecord[platform])
+
+      if (oldWasDefault) {
+        // Case B — same-channel version change. Only fires on an actual version
+        // delta; an identical version (pure name/flag edit) yields no event.
+        if (oldRecord && oldRecord.version != null && oldRecord.version !== record.version) {
+          previousDefaults.push({
+            platform,
+            source: 'default_channel_version_changed',
+            bundle: await loadCompatibilityBundle(c, oldRecord.version),
+          })
+        }
+      }
+      else {
+        // Case A — default-channel switch: record NEWLY became the public default
+        // for this platform. The baseline is the channel this update demotes,
+        // captured before the demotion update ran.
+        const demotedChannel = previousDefaultChannelByPlatform[platform]
+        if (demotedChannel) {
+          previousDefaults.push({
+            platform,
+            source: 'default_channel_changed',
+            bundle: await loadCompatibilityBundle(c, demotedChannel.version),
+          })
+        }
+      }
+    }
+
+    const events = decideCompatibilityEvents({ newChannel: record, currentBundle, previousDefaults })
+
+    for (const event of events) {
+      await updateChannelsWithRetry(
+        c,
+        async () => await (supabaseAdmin(c) as any)
+          .from('compatibility_events')
+          .upsert(event as CompatibilityEventInsert, { onConflict: COMPATIBILITY_DEDUP_CONFLICT }),
+        { app_id: event.app_id, channel_id: event.channel_id, platform: event.platform, op: 'compatibility_event_upsert' },
+      )
+    }
+
+    await autoResolveCompatibilityEvents(c, record, currentBundle, previousDefaults)
+  }
+  catch (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Failed to persist compatibility events',
+      error,
+      app_id: record.app_id,
+      channel_id: record.id,
+    })
+  }
+}
+
+/**
+ * Auto-resolve unresolved events for this app whose platform's current default is
+ * now OTA-compatible with the event's previous (baseline) bundle. Writes a
+ * generated note and `resolution_kind = 'auto_compatible'` (`resolved_by = null`).
+ */
+async function autoResolveCompatibilityEvents(
+  c: Context<MiddlewareKeyVariables>,
+  record: ChannelRow,
+  currentBundle: CompatibilityBundle | null,
+  previousDefaults: readonly PreviousDefault[],
+): Promise<void> {
+  // Compute the current default bundle per platform FIRST. If the record is not a
+  // current public default on any platform, nothing here can auto-resolve, so we
+  // skip the unresolved-events SELECT entirely.
+  const currentDefaultByPlatform: CurrentDefaultForPlatform[] = []
+  for (const platform of COMPATIBILITY_PLATFORMS) {
+    if (record.public && record[platform])
+      currentDefaultByPlatform.push({ platform, bundle: currentBundle })
+  }
+  if (currentDefaultByPlatform.length === 0)
+    return
+
+  const { data: unresolved, error } = await (supabaseAdmin(c) as any)
+    .from('compatibility_events')
+    .select('id, platform, previous_version_id, previous_version_name, current_version_id')
+    .eq('app_id', record.app_id)
+    .is('resolved_at', null)
+
+  if (error || !unresolved || unresolved.length === 0) {
+    if (error) {
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'Failed to load unresolved compatibility events for auto-resolve',
+        error,
+        app_id: record.app_id,
+      })
+    }
+    return
+  }
+
+  // Resolve baseline bundles referenced by the unresolved events.
+  const bundlesById = new Map<number, CompatibilityBundle>()
+  if (currentBundle)
+    bundlesById.set(currentBundle.id, currentBundle)
+  for (const previous of previousDefaults) {
+    if (previous.bundle)
+      bundlesById.set(previous.bundle.id, previous.bundle)
+  }
+  const events = unresolved as UnresolvedCompatibilityEvent[]
+  for (const event of events) {
+    if (event.previous_version_id != null && !bundlesById.has(event.previous_version_id)) {
+      const loaded = await loadCompatibilityBundle(c, event.previous_version_id)
+      if (loaded)
+        bundlesById.set(loaded.id, loaded)
+    }
+  }
+
+  const resolves = decideAutoResolves(events, currentDefaultByPlatform, bundlesById)
+
+  for (const resolve of resolves) {
+    await updateChannelsWithRetry(
+      c,
+      async () => await (supabaseAdmin(c) as any)
+        .from('compatibility_events')
+        .update({
+          resolved_at: new Date().toISOString(),
+          resolved_by: null,
+          resolution_kind: 'auto_compatible',
+          resolution_note: resolve.note,
+        })
+        .eq('id', resolve.id)
+        .is('resolved_at', null),
+      { event_id: resolve.id, op: 'compatibility_event_auto_resolve' },
+    )
+  }
+}
+
 app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['channels']['Row']
   cloudlog({ requestId: c.get('requestId'), message: 'record', record })
@@ -106,9 +382,15 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
     throw simpleError('no_app_id', 'No app id included the request', { record })
   }
 
+  const oldRecord = c.get('oldRecord') as ChannelRow | undefined
+  // Capture the demoted prior default per platform (Case A baseline) BEFORE the
+  // demotion update runs. After demotion it would no longer be `public = true`.
+  const previousDefaultChannelByPlatform: Partial<Record<CompatibilityPlatform, { id: number, version: number | null } | null>> = {}
+
   if (record.public && record.ios) {
     const currentWinner = await getCurrentPublicWinner(c, record, 'ios')
     if (currentWinner) {
+      previousDefaultChannelByPlatform.ios = await getPreviousDefaultChannel(c, currentWinner.app_id, 'ios', record.id)
       await updateChannelsWithRetry(
         c,
         async () => await supabaseAdmin(c)
@@ -125,6 +407,7 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
   if (record.public && record.android) {
     const currentWinner = await getCurrentPublicWinner(c, record, 'android')
     if (currentWinner) {
+      previousDefaultChannelByPlatform.android = await getPreviousDefaultChannel(c, currentWinner.app_id, 'android', record.id)
       await updateChannelsWithRetry(
         c,
         async () => await supabaseAdmin(c)
@@ -141,6 +424,7 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
   if (record.public && record.electron) {
     const currentWinner = await getCurrentPublicWinner(c, record, 'electron')
     if (currentWinner) {
+      previousDefaultChannelByPlatform.electron = await getPreviousDefaultChannel(c, currentWinner.app_id, 'electron', record.id)
       await updateChannelsWithRetry(
         c,
         async () => await supabaseAdmin(c)
@@ -153,6 +437,10 @@ app.post('/', middlewareAPISecret, triggerValidator('channels', 'UPDATE'), async
       )
     }
   }
+
+  // Compute + persist compatibility events. Fully guarded so it can never break
+  // the channel winner reconciliation above.
+  await persistCompatibilityEvents(c, record, oldRecord, previousDefaultChannelByPlatform)
 
   return c.json(BRES)
 })

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -272,7 +272,7 @@ async function persistCompatibilityEvents(
     for (const event of events) {
       await updateChannelsWithRetry(
         c,
-        async () => await (supabaseAdmin(c) as any)
+        async () => await supabaseAdmin(c)
           .from('compatibility_events')
           .upsert(event as CompatibilityEventInsert, { onConflict: COMPATIBILITY_DEDUP_CONFLICT }),
         { app_id: event.app_id, channel_id: event.channel_id, platform: event.platform, op: 'compatibility_event_upsert' },
@@ -314,7 +314,7 @@ async function autoResolveCompatibilityEvents(
   if (currentDefaultByPlatform.length === 0)
     return
 
-  const { data: unresolved, error } = await (supabaseAdmin(c) as any)
+  const { data: unresolved, error } = await supabaseAdmin(c)
     .from('compatibility_events')
     .select('id, platform, previous_version_id, previous_version_name, current_version_id')
     .eq('app_id', record.app_id)
@@ -354,7 +354,7 @@ async function autoResolveCompatibilityEvents(
   for (const resolve of resolves) {
     await updateChannelsWithRetry(
       c,
-      async () => await (supabaseAdmin(c) as any)
+      async () => await supabaseAdmin(c)
         .from('compatibility_events')
         .update({
           resolved_at: new Date().toISOString(),

--- a/supabase/functions/_backend/utils/bundle_compatibility.ts
+++ b/supabase/functions/_backend/utils/bundle_compatibility.ts
@@ -1,9 +1,5 @@
 import { parseRange, rangeIntersects } from '@std/semver'
 
-// NOTE: temporarily unreferenced after the live-computed dashboard alert was
-// removed (see PR). The upcoming compatibility-events backend (verdicts
-// persisted from on_channel_update) consumes these helpers — when that lands,
-// drop the knip.json ignoreIssues entry for this file.
 export interface NativePackage {
   name: string
   version: string

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -821,6 +821,81 @@ export type Database = {
           },
         ]
       }
+      compatibility_events: {
+        Row: {
+          app_id: string
+          channel_id: number | null
+          channel_name: string
+          created_at: string
+          current_version_id: number | null
+          current_version_name: string
+          id: number
+          offenders: Json
+          org_id: string
+          platform: string
+          previous_version_id: number | null
+          previous_version_name: string
+          resolution_kind: string | null
+          resolution_note: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          source: string
+        }
+        Insert: {
+          app_id: string
+          channel_id?: number | null
+          channel_name: string
+          created_at?: string
+          current_version_id?: number | null
+          current_version_name: string
+          id?: never
+          offenders?: Json
+          org_id: string
+          platform: string
+          previous_version_id?: number | null
+          previous_version_name: string
+          resolution_kind?: string | null
+          resolution_note?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          source: string
+        }
+        Update: {
+          app_id?: string
+          channel_id?: number | null
+          channel_name?: string
+          created_at?: string
+          current_version_id?: number | null
+          current_version_name?: string
+          id?: never
+          offenders?: Json
+          org_id?: string
+          platform?: string
+          previous_version_id?: number | null
+          previous_version_name?: string
+          resolution_kind?: string | null
+          resolution_note?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "compatibility_events_app_id_fkey"
+            columns: ["app_id"]
+            isOneToOne: false
+            referencedRelation: "apps"
+            referencedColumns: ["app_id"]
+          },
+          {
+            foreignKeyName: "compatibility_events_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "orgs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       cron_tasks: {
         Row: {
           batch_size: number | null
@@ -3072,6 +3147,10 @@ export type Database = {
     }
     Functions: {
       accept_invitation_to_org: { Args: { org_id: string }; Returns: string }
+      acknowledge_compatibility_event: {
+        Args: { event_id: number; note: string }
+        Returns: undefined
+      }
       apikey_has_current_org_create_capability: {
         Args: { p_apikey_rbac_id: string }
         Returns: boolean

--- a/supabase/migrations/20260605104908_compatibility_events.sql
+++ b/supabase/migrations/20260605104908_compatibility_events.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS public.compatibility_events (
   app_id               text NOT NULL REFERENCES public.apps(app_id) ON DELETE CASCADE,
   source               text NOT NULL,            -- default_channel_version_changed | default_channel_changed
   platform             text NOT NULL,            -- ios | android | electron
-  channel_id           bigint,
+  channel_id           bigint,                   -- nullable snapshot; intentionally NO FK (event must survive channel deletion)
   channel_name         text NOT NULL,
   current_version_id   bigint,
   current_version_name text NOT NULL,

--- a/supabase/migrations/20260605104908_compatibility_events.sql
+++ b/supabase/migrations/20260605104908_compatibility_events.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS public.compatibility_events (
+  id                   bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  org_id               uuid NOT NULL REFERENCES public.orgs(id) ON DELETE CASCADE,
+  app_id               text NOT NULL REFERENCES public.apps(app_id) ON DELETE CASCADE,
+  source               text NOT NULL,            -- default_channel_version_changed | default_channel_changed
+  platform             text NOT NULL,            -- ios | android | electron
+  channel_id           bigint,
+  channel_name         text NOT NULL,
+  current_version_id   bigint,
+  current_version_name text NOT NULL,
+  previous_version_id  bigint,
+  previous_version_name text NOT NULL,
+  offenders            jsonb NOT NULL DEFAULT '[]'::jsonb,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  resolved_at          timestamptz,
+  resolved_by          uuid,
+  resolution_kind      text,                     -- auto_compatible | accepted
+  resolution_note      text
+);
+
+-- idempotent upsert target for the async handler
+CREATE UNIQUE INDEX IF NOT EXISTS uq_compatibility_events_dedup
+  ON public.compatibility_events (app_id, channel_id, platform, current_version_id, previous_version_id) NULLS NOT DISTINCT;
+CREATE INDEX IF NOT EXISTS idx_compatibility_events_app_created
+  ON public.compatibility_events (app_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compatibility_events_unresolved
+  ON public.compatibility_events (app_id) WHERE resolved_at IS NULL;
+
+ALTER TABLE public.compatibility_events ENABLE ROW LEVEL SECURITY;
+
+-- Read for users with RBAC app-read on this app; no INSERT/UPDATE policy => only
+-- the service role (handler) and SECURITY DEFINER RPCs can write.
+CREATE POLICY "compatibility_events_select" ON public.compatibility_events
+  FOR SELECT TO authenticated
+  USING ( public.rbac_check_permission(public.rbac_perm_app_read(), org_id, app_id, NULL::bigint) );
+
+-- Manual accept: app.write, sets the resolution fields, requires a reason.
+CREATE OR REPLACE FUNCTION public.acknowledge_compatibility_event(event_id bigint, note text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE v_org uuid; v_app text;
+BEGIN
+  IF note IS NULL OR length(btrim(note)) = 0 THEN
+    RAISE EXCEPTION 'reason_required';
+  END IF;
+  SELECT org_id, app_id INTO v_org, v_app
+    FROM public.compatibility_events WHERE id = event_id;
+  IF v_org IS NULL THEN RETURN; END IF;            -- unknown id: no-op
+  -- RBAC: app upload-bundle permission (release managers); NOT legacy min_rights.
+  -- Adjust the perm key in review if a different role should be allowed to accept.
+  IF NOT public.rbac_check_permission_direct(
+        public.rbac_perm_app_upload_bundle(), auth.uid(), v_org, v_app, NULL::bigint) THEN
+    RETURN;                                         -- unauthorized: no-op (no oracle)
+  END IF;
+  UPDATE public.compatibility_events
+    SET resolved_at = now(), resolved_by = auth.uid(),
+        resolution_kind = 'accepted', resolution_note = note
+    WHERE id = event_id AND resolved_at IS NULL;
+END; $$;
+
+ALTER FUNCTION public.acknowledge_compatibility_event(bigint, text) OWNER TO "postgres";
+REVOKE ALL ON FUNCTION public.acknowledge_compatibility_event(bigint, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.acknowledge_compatibility_event(bigint, text) TO authenticated;

--- a/supabase/migrations/20260605104908_compatibility_events.sql
+++ b/supabase/migrations/20260605104908_compatibility_events.sql
@@ -34,6 +34,22 @@ CREATE POLICY "compatibility_events_select" ON public.compatibility_events
   FOR SELECT TO authenticated
   USING ( public.rbac_check_permission(public.rbac_perm_app_read(), org_id, app_id, NULL::bigint) );
 
+-- Explicit deny for every user-facing write (AGENTS.md RLS Rule 1.5: never rely
+-- on implicit deny). Only the service-role handler (bypasses RLS) and the
+-- SECURITY DEFINER accept RPC (runs as owner) may write; user-context roles
+-- (incl. anon API-key traffic) must never INSERT/UPDATE/DELETE directly.
+CREATE POLICY "compatibility_events_deny_insert" ON public.compatibility_events
+  AS RESTRICTIVE FOR INSERT TO anon, authenticated
+  WITH CHECK (false);
+
+CREATE POLICY "compatibility_events_deny_update" ON public.compatibility_events
+  AS RESTRICTIVE FOR UPDATE TO anon, authenticated
+  USING (false) WITH CHECK (false);
+
+CREATE POLICY "compatibility_events_deny_delete" ON public.compatibility_events
+  AS RESTRICTIVE FOR DELETE TO anon, authenticated
+  USING (false);
+
 -- Manual accept: app.write, sets the resolution fields, requires a reason.
 CREATE OR REPLACE FUNCTION public.acknowledge_compatibility_event(event_id bigint, note text)
 RETURNS void

--- a/tests/compatibility-events-decide.unit.test.ts
+++ b/tests/compatibility-events-decide.unit.test.ts
@@ -1,0 +1,256 @@
+import type {
+  CompatibilityBundle,
+  CurrentDefaultForPlatform,
+  DecideCompatibilityEventsInput,
+  PreviousDefault,
+  UnresolvedCompatibilityEvent,
+} from '../supabase/functions/_backend/triggers/compatibility_events.ts'
+import type { NativePackage } from '../supabase/functions/_backend/utils/bundle_compatibility.ts'
+import { describe, expect, it } from 'vitest'
+import {
+  decideAutoResolves,
+  decideCompatibilityEvents,
+} from '../supabase/functions/_backend/triggers/compatibility_events.ts'
+
+// ---- fixtures -------------------------------------------------------------
+
+const PKG_V6: NativePackage[] = [{ name: '@capacitor/core', version: '6.0.0' }]
+// Major bump → version ranges do not intersect → incompatible.
+const PKG_V7: NativePackage[] = [{ name: '@capacitor/core', version: '7.0.0' }]
+// Same native packages as v7 (a native-identical successor).
+const PKG_V7_DUP: NativePackage[] = [{ name: '@capacitor/core', version: '7.0.0' }]
+
+function bundle(id: number, name: string, nativePackages: NativePackage[] | null): CompatibilityBundle {
+  return { id, name, nativePackages }
+}
+
+function newChannel(overrides: Partial<DecideCompatibilityEventsInput['newChannel']> = {}): DecideCompatibilityEventsInput['newChannel'] {
+  return {
+    id: 101,
+    app_id: 'com.test.app',
+    owner_org: 'org-1',
+    name: 'production',
+    version: 700,
+    public: true,
+    ios: true,
+    android: false,
+    electron: false,
+    disable_auto_update: 'major',
+    ...overrides,
+  }
+}
+
+describe('decideCompatibilityEvents', () => {
+  it('emits an event for a same-channel incompatible version change (Case B)', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      org_id: 'org-1',
+      app_id: 'com.test.app',
+      source: 'default_channel_version_changed',
+      platform: 'ios',
+      channel_id: 101,
+      channel_name: 'production',
+      current_version_id: 700,
+      current_version_name: '7.0.0',
+      previous_version_id: 600,
+      previous_version_name: '6.0.0',
+      offenders: ['@capacitor/core'],
+    })
+  })
+
+  it('emits an event for a default-channel switch (Case A)', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0].source).toBe('default_channel_changed')
+    expect(events[0].previous_version_id).toBe(600)
+  })
+
+  it('emits no event when the change is OTA-compatible', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '6.0.1', PKG_V6),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(0)
+  })
+
+  it('emits no event under the metadata (version_number) strategy', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel({ disable_auto_update: 'version_number' }),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(0)
+  })
+
+  it('emits no event when the current bundle has no native_packages', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '7.0.0', null),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(0)
+  })
+
+  it('emits no event when the previous bundle has no native_packages', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', []),
+      }],
+    })
+
+    expect(events).toHaveLength(0)
+  })
+
+  it('does not drop a soft-deleted baseline (still has native_packages)', () => {
+    // A soft-deleted previous bundle is still a valid baseline as long as its
+    // metadata is present: we must still raise the event.
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(1)
+  })
+
+  it('fans out one event per default platform (ios + android, not electron)', () => {
+    const previous = (platform: PreviousDefault['platform']): PreviousDefault => ({
+      platform,
+      source: 'default_channel_version_changed',
+      bundle: bundle(600, '6.0.0', PKG_V6),
+    })
+
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel({ ios: true, android: true, electron: false }),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [previous('ios'), previous('android'), previous('electron')],
+    })
+
+    const platforms = events.map(e => e.platform).sort()
+    expect(platforms).toEqual(['android', 'ios'])
+  })
+
+  it('emits no event when the channel is not public', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel({ public: false }),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(600, '6.0.0', PKG_V6),
+      }],
+    })
+
+    expect(events).toHaveLength(0)
+  })
+
+  it('emits no event when previous and current are the same bundle id', () => {
+    const events = decideCompatibilityEvents({
+      newChannel: newChannel(),
+      currentBundle: bundle(700, '7.0.0', PKG_V7),
+      previousDefaults: [{
+        platform: 'ios',
+        source: 'default_channel_version_changed',
+        bundle: bundle(700, '7.0.0', PKG_V7),
+      }],
+    })
+
+    expect(events).toHaveLength(0)
+  })
+})
+
+describe('decideAutoResolves', () => {
+  function unresolved(overrides: Partial<UnresolvedCompatibilityEvent> = {}): UnresolvedCompatibilityEvent {
+    return {
+      id: 1,
+      platform: 'ios',
+      previous_version_id: 600,
+      previous_version_name: '6.0.0',
+      current_version_id: 700,
+      ...overrides,
+    }
+  }
+
+  it('auto-resolves when the current default is now compatible with the baseline', () => {
+    // Reverted to a v6-compatible default (id 800) — compatible with baseline 600.
+    const currentDefault: CurrentDefaultForPlatform[] = [{ platform: 'ios', bundle: bundle(800, '6.0.1', PKG_V6) }]
+    const bundles = new Map([[600, bundle(600, '6.0.0', PKG_V6)]])
+
+    const resolves = decideAutoResolves([unresolved()], currentDefault, bundles)
+
+    expect(resolves).toHaveLength(1)
+    expect(resolves[0].id).toBe(1)
+    expect(resolves[0].note).toContain('6.0.1')
+    expect(resolves[0].note).toContain('6.0.0')
+  })
+
+  it('does NOT auto-resolve on a native-identical successor', () => {
+    // The current default is the very same bundle that raised the event: users
+    // are still stranded, so the event must stay open.
+    const currentDefault: CurrentDefaultForPlatform[] = [{ platform: 'ios', bundle: bundle(700, '7.0.0', PKG_V7) }]
+    const bundles = new Map([[600, bundle(600, '6.0.0', PKG_V6)]])
+
+    const resolves = decideAutoResolves([unresolved({ current_version_id: 700 })], currentDefault, bundles)
+
+    expect(resolves).toHaveLength(0)
+  })
+
+  it('does NOT auto-resolve a different-but-still-incompatible successor (id ≠ current, native re-uploaded)', () => {
+    // A new bundle id (900) but native-identical to the incompatible v7: still
+    // incompatible with the v6 baseline, so it must not clear the event.
+    const currentDefault: CurrentDefaultForPlatform[] = [{ platform: 'ios', bundle: bundle(900, '7.0.1', PKG_V7_DUP) }]
+    const bundles = new Map([[600, bundle(600, '6.0.0', PKG_V6)]])
+
+    const resolves = decideAutoResolves([unresolved({ current_version_id: 700 })], currentDefault, bundles)
+
+    expect(resolves).toHaveLength(0)
+  })
+
+  it('does NOT auto-resolve when the current default for the platform is unknown', () => {
+    const resolves = decideAutoResolves([unresolved()], [], new Map([[600, bundle(600, '6.0.0', PKG_V6)]]))
+    expect(resolves).toHaveLength(0)
+  })
+})

--- a/tests/compatibility-events-handler.test.ts
+++ b/tests/compatibility-events-handler.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const PKG_V6 = [{ name: '@capacitor/core', version: '6.0.0' }]
+const PKG_V7 = [{ name: '@capacitor/core', version: '7.0.0' }]
+
+// app_versions rows the handler will load by id.
+const appVersions: Record<number, { id: number, name: string, native_packages: unknown[] | null }> = {
+  600: { id: 600, name: '6.0.0', native_packages: PKG_V6 },
+  700: { id: 700, name: '7.0.0', native_packages: PKG_V7 },
+}
+
+const { eventStore, dedupKey, supabaseAdmin } = vi.hoisted(() => {
+  const store: any[] = []
+  const key = (r: any) => [r.app_id, r.channel_id, r.platform, r.current_version_id, r.previous_version_id].join('|')
+  return { eventStore: store, dedupKey: key, supabaseAdmin: vi.fn() }
+})
+
+// A tiny chainable query builder. Each `from(table)` returns a builder whose
+// terminal methods (maybeSingle / upsert / update / is) resolve against an
+// in-memory model. The handler only needs the channels winner lookup to return
+// "this is the sole public default" and app_versions/compatibility_events.
+function makeBuilder(table: string, ctx: { appVersionsById: typeof appVersions, events: any[] }) {
+  const state: any = { table, filters: {}, op: 'select' }
+  const builder: any = {}
+  const chain = (mutate: () => void) => {
+    mutate()
+    return builder
+  }
+  Object.assign(builder, {
+    select: () => builder,
+    update: (patch: any) => chain(() => Object.assign(state, { op: 'update', patch })),
+    upsert: (row: any) => chain(() => Object.assign(state, { op: 'upsert', row })),
+    eq: (col: string, val: any) => chain(() => { state.filters[col] = val }),
+    neq: (col: string, val: any) => chain(() => { state.filters[`neq_${col}`] = val }),
+    is: (col: string, val: any) => chain(() => { state.filters[`is_${col}`] = val }),
+    order: () => builder,
+    limit: () => builder,
+    maybeSingle: async () => terminate(state, ctx),
+    single: async () => terminate(state, ctx),
+    then: (resolve: any, reject: any) => terminate(state, ctx).then(resolve, reject),
+  })
+  return builder
+}
+
+async function terminate(state: any, ctx: { appVersionsById: typeof appVersions, events: any[] }) {
+  const { table, op, filters } = state
+
+  if (table === 'channels') {
+    // getCurrentChannel: select by id -> return the record as a public default.
+    if (op === 'select' && filters.id != null && filters.public == null) {
+      return { data: { id: filters.id, app_id: 'com.test.app', public: true, ios: true, android: false, electron: false, updated_at: 't', created_at: 't' }, error: null }
+    }
+    // getCurrentPublicWinner: select id where public + platform -> the record itself wins.
+    if (op === 'select' && filters.public === true && filters.neq_id == null) {
+      return { data: { id: filters.id ?? 101, version: 700 }, error: null }
+    }
+    // getPreviousDefaultChannel: excludes record.id -> no other public default (Case B).
+    if (op === 'select' && filters.public === true && filters.neq_id != null) {
+      return { data: null, error: null }
+    }
+    // demotion update -> no-op success
+    if (op === 'update') {
+      return { data: null, error: null }
+    }
+    return { data: null, error: null }
+  }
+
+  if (table === 'app_versions') {
+    const row = ctx.appVersionsById[filters.id]
+    return { data: row ?? null, error: null }
+  }
+
+  if (table === 'compatibility_events') {
+    if (op === 'upsert') {
+      const row = state.row
+      const k = dedupKey(row)
+      const existing = ctx.events.find(e => dedupKey(e) === k)
+      if (existing) {
+        // ON CONFLICT DO UPDATE: overwrite the payload columns of the existing
+        // row. The insert payload never carries the resolution columns, so an
+        // already-resolved row keeps its resolved_at / resolution_kind /
+        // resolution_note across a redelivery.
+        Object.assign(existing, row)
+        return { data: null, error: null }
+      }
+      ctx.events.push({
+        id: ctx.events.length + 1,
+        resolved_at: null,
+        resolved_by: null,
+        resolution_kind: null,
+        resolution_note: null,
+        ...row,
+      })
+      return { data: null, error: null }
+    }
+    if (op === 'update') {
+      const target = ctx.events.find(e => e.id === filters.id && e.resolved_at == null)
+      if (target)
+        Object.assign(target, state.patch)
+      return { data: null, error: null }
+    }
+    // select unresolved for app
+    const unresolved = ctx.events.filter(e => e.app_id === filters.app_id && e.resolved_at == null)
+    return { data: unresolved, error: null }
+  }
+
+  return { data: null, error: null }
+}
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+  cloudlogErr: vi.fn(),
+}))
+
+// Stub the API-secret guard and provide a minimal triggerValidator that mirrors
+// the real one (sets webhookBody + oldRecord for UPDATE payloads).
+vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
+  BRES: { status: 'ok' },
+  middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => next(),
+  simpleError: (code: string, message: string) => new Error(`${code}: ${message}`),
+  triggerValidator: () => async (c: any, next: () => Promise<void>) => {
+    const body = await c.req.json()
+    if (body.type === 'UPDATE' && body.record) {
+      c.set('webhookBody', body.record)
+      c.set('oldRecord', body.old_record)
+    }
+    await next()
+  },
+}))
+
+const { app } = await import('../supabase/functions/_backend/triggers/on_channel_update.ts')
+
+function channelRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    app_id: 'com.test.app',
+    owner_org: 'org-1',
+    name: 'production',
+    version: 700,
+    public: true,
+    ios: true,
+    android: false,
+    electron: false,
+    disable_auto_update: 'major',
+    created_at: 't',
+    updated_at: 't',
+    created_by: 'user-1',
+    ...overrides,
+  }
+}
+
+function updatePayload(record: Record<string, unknown>, oldRecord: Record<string, unknown>) {
+  return {
+    type: 'UPDATE',
+    table: 'channels',
+    schema: 'public',
+    record,
+    old_record: oldRecord,
+  }
+}
+
+function post(body: unknown) {
+  return app.request(new Request('http://local/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }))
+}
+
+describe('on_channel_update compatibility events (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    eventStore.length = 0
+    supabaseAdmin.mockImplementation(() => ({
+      from: (table: string) => makeBuilder(table, { appVersionsById: appVersions, events: eventStore }),
+    }))
+  })
+
+  it('records one incompatible event on a default-channel version change (Case B)', async () => {
+    const response = await post(updatePayload(channelRecord({ version: 700 }), channelRecord({ version: 600 })))
+
+    expect(response.status).toBe(200)
+    expect(eventStore).toHaveLength(1)
+    expect(eventStore[0]).toMatchObject({
+      app_id: 'com.test.app',
+      org_id: 'org-1',
+      source: 'default_channel_version_changed',
+      platform: 'ios',
+      channel_id: 101,
+      channel_name: 'production',
+      current_version_id: 700,
+      current_version_name: '7.0.0',
+      previous_version_id: 600,
+      previous_version_name: '6.0.0',
+      offenders: ['@capacitor/core'],
+    })
+  })
+
+  it('is idempotent: re-POSTing the same payload does not duplicate the row', async () => {
+    const payload = updatePayload(channelRecord({ version: 700 }), channelRecord({ version: 600 }))
+
+    await post(payload)
+    await post(payload)
+
+    expect(eventStore).toHaveLength(1)
+  })
+
+  it('preserves a resolved row across a redelivery (ON CONFLICT DO UPDATE keeps resolution columns)', async () => {
+    const payload = updatePayload(channelRecord({ version: 700 }), channelRecord({ version: 600 }))
+
+    await post(payload)
+    expect(eventStore).toHaveLength(1)
+
+    // Someone (auto-resolve or manual accept) resolves the row out of band.
+    Object.assign(eventStore[0], {
+      resolved_at: '2026-06-03T00:00:00.000Z',
+      resolved_by: 'user-9',
+      resolution_kind: 'accepted',
+      resolution_note: 'reviewed',
+    })
+
+    // A redelivery of the same webhook re-upserts the payload columns but must
+    // NOT clobber the resolution columns (they are absent from the insert).
+    await post(payload)
+
+    expect(eventStore).toHaveLength(1)
+    expect(eventStore[0]).toMatchObject({
+      resolved_at: '2026-06-03T00:00:00.000Z',
+      resolved_by: 'user-9',
+      resolution_kind: 'accepted',
+      resolution_note: 'reviewed',
+    })
+  })
+
+  it('records no event when the version change is OTA-compatible', async () => {
+    // 6.0.0 -> 6.0.0 (same packages): compatible, no event. Use a distinct
+    // current bundle id so it is treated as a real change but still compatible.
+    appVersions[650] = { id: 650, name: '6.0.1', native_packages: PKG_V6 }
+    const response = await post(updatePayload(channelRecord({ version: 650 }), channelRecord({ version: 600 })))
+
+    expect(response.status).toBe(200)
+    expect(eventStore).toHaveLength(0)
+  })
+
+  it('fans out one event per default platform (ios + android, not electron)', async () => {
+    const platforms = { ios: true, android: true, electron: false }
+    const response = await post(updatePayload(
+      channelRecord({ version: 700, ...platforms }),
+      channelRecord({ version: 600, ...platforms }),
+    ))
+
+    expect(response.status).toBe(200)
+    expect(eventStore).toHaveLength(2)
+    expect(eventStore.map(e => e.platform).sort()).toEqual(['android', 'ios'])
+    expect(eventStore.some(e => e.platform === 'electron')).toBe(false)
+  })
+
+  it('auto-resolves an unresolved event when the default reverts to a compatible bundle', async () => {
+    // The reverted default (id 800) ships v6 packages, compatible with baseline 600.
+    appVersions[800] = { id: 800, name: '6.0.1', native_packages: PKG_V6 }
+
+    // Seed one open ios event raised earlier (baseline 600 -> incompatible 700).
+    eventStore.push({
+      id: 1,
+      app_id: 'com.test.app',
+      channel_id: 101,
+      platform: 'ios',
+      current_version_id: 700,
+      previous_version_id: 600,
+      previous_version_name: '6.0.0',
+      resolved_at: null,
+      resolved_by: null,
+      resolution_kind: null,
+      resolution_note: null,
+    })
+
+    // oldRecord version equals record version -> no NEW event is created; only the
+    // auto-resolve path runs against the now-compatible default (800).
+    const response = await post(updatePayload(
+      channelRecord({ version: 800 }),
+      channelRecord({ version: 800 }),
+    ))
+
+    expect(response.status).toBe(200)
+    expect(eventStore).toHaveLength(1)
+    expect(eventStore[0].resolved_at).not.toBeNull()
+    expect(eventStore[0].resolution_kind).toBe('auto_compatible')
+    expect(eventStore[0].resolved_by).toBeNull()
+  })
+})

--- a/tests/compatibility-events.test.ts
+++ b/tests/compatibility-events.test.ts
@@ -1,0 +1,256 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { randomUUID } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  getSupabaseClient,
+  PRODUCT_ID,
+  SUPABASE_ANON_KEY,
+  SUPABASE_BASE_URL,
+  TEST_EMAIL,
+  USER_EMAIL,
+  USER_EMAIL_NONMEMBER,
+  USER_ID,
+  USER_PASSWORD,
+  USER_PASSWORD_NONMEMBER,
+} from './test-utils.ts'
+
+// Unique identifiers per run so parallel/repeat runs never collide.
+const testRunId = randomUUID()
+const ORG_ID = testRunId
+const APP_ID = `com.compat_events.${testRunId.slice(0, 8)}`
+const STRIPE_CUSTOMER_ID = `cus_compat_events_${testRunId.slice(0, 8)}`
+
+// The compatibility_events table and acknowledge_compatibility_event RPC are added
+// by a migration that postdates the generated Supabase types, so the typed client
+// does not know about them yet. Use an untyped view of each client for those calls.
+type UntypedClient = SupabaseClient<any, 'public', any>
+
+interface CompatibilityEventRow {
+  id: number
+  resolved_at: string | null
+  resolved_by: string | null
+  resolution_kind: string | null
+  resolution_note: string | null
+}
+
+async function signInClient(email: string, password: string): Promise<UntypedClient> {
+  if (!SUPABASE_BASE_URL || !SUPABASE_ANON_KEY)
+    throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY are required for compatibility_events tests')
+
+  const publicClient = createClient(SUPABASE_BASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false },
+  })
+  const { data, error } = await publicClient.auth.signInWithPassword({ email, password })
+  if (error || !data.session?.access_token)
+    throw error ?? new Error(`Unable to sign in as ${email}`)
+
+  return createClient(SUPABASE_BASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false },
+    global: {
+      headers: { Authorization: `Bearer ${data.session.access_token}` },
+    },
+  }) as UntypedClient
+}
+
+function compatTable(client: SupabaseClient<any>) {
+  return (client as UntypedClient).from('compatibility_events')
+}
+
+// The uq_compatibility_events_dedup index covers
+// (app_id, channel_id, platform, current_version_id, previous_version_id) with
+// NULLS NOT DISTINCT, so a synthetic distinct channel_id per row keeps every
+// inserted test event unique even when the other columns repeat.
+let nextChannelId = 1
+
+async function insertEvent(values: {
+  platform: string
+  channelName?: string
+  currentVersionName?: string
+  previousVersionName?: string
+  source?: string
+}): Promise<number> {
+  const { data, error } = await compatTable(getSupabaseClient())
+    .insert({
+      org_id: ORG_ID,
+      app_id: APP_ID,
+      source: values.source ?? 'default_channel_version_changed',
+      platform: values.platform,
+      channel_id: nextChannelId++,
+      channel_name: values.channelName ?? 'production',
+      current_version_name: values.currentVersionName ?? '2.0.0',
+      previous_version_name: values.previousVersionName ?? '1.0.0',
+    })
+    .select('id')
+    .single()
+  if (error || !data)
+    throw error ?? new Error('Failed to insert compatibility_event')
+  return (data as { id: number }).id
+}
+
+async function getEventById(id: number): Promise<CompatibilityEventRow> {
+  const { data, error } = await compatTable(getSupabaseClient())
+    .select('id, resolved_at, resolved_by, resolution_kind, resolution_note')
+    .eq('id', id)
+    .single()
+  if (error || !data)
+    throw error ?? new Error(`Compatibility event ${id} not found`)
+  return data as CompatibilityEventRow
+}
+
+let memberClient: UntypedClient
+let nonMemberClient: UntypedClient
+
+beforeAll(async () => {
+  const supabase = getSupabaseClient()
+
+  // Clean any leftovers from a previous aborted run (best effort).
+  await supabase.from('stripe_info').delete().eq('customer_id', STRIPE_CUSTOMER_ID)
+  await supabase.from('org_users').delete().eq('org_id', ORG_ID)
+  await supabase.from('orgs').delete().eq('id', ORG_ID)
+
+  const { error: stripeError } = await supabase.from('stripe_info').insert({
+    subscription_id: `sub_compat_events_${testRunId.slice(0, 8)}`,
+    customer_id: STRIPE_CUSTOMER_ID,
+    status: 'succeeded' as const,
+    product_id: PRODUCT_ID,
+    is_good_plan: true,
+  })
+  if (stripeError)
+    throw stripeError
+
+  // use_new_rbac=false keeps the org on the legacy permission path, where a
+  // super_admin org member resolves app.read (RLS) and app.upload_bundle (RPC).
+  const { error: orgError } = await supabase.from('orgs').insert({
+    id: ORG_ID,
+    customer_id: STRIPE_CUSTOMER_ID,
+    name: `Compatibility Events Test Org ${testRunId.slice(0, 8)}`,
+    created_by: USER_ID,
+    management_email: TEST_EMAIL,
+    use_new_rbac: false,
+  })
+  if (orgError)
+    throw orgError
+
+  const { error: orgUserError } = await supabase.from('org_users').insert({
+    org_id: ORG_ID,
+    user_id: USER_ID,
+    user_right: 'super_admin',
+  })
+  if (orgUserError)
+    throw orgUserError
+
+  const { error: appError } = await supabase.from('apps').insert({
+    owner_org: ORG_ID,
+    app_id: APP_ID,
+    name: 'Compatibility Events Test App',
+    icon_url: 'https://example.com/icon.png',
+  })
+  if (appError)
+    throw appError
+
+  memberClient = await signInClient(USER_EMAIL, USER_PASSWORD)
+  nonMemberClient = await signInClient(USER_EMAIL_NONMEMBER, USER_PASSWORD_NONMEMBER)
+}, 120000)
+
+afterAll(async () => {
+  const supabase = getSupabaseClient()
+  // app delete cascades compatibility_events, but delete explicitly to be safe.
+  await supabase.from('compatibility_events' as any).delete().eq('app_id', APP_ID)
+  await supabase.from('apps').delete().eq('app_id', APP_ID)
+  await supabase.from('org_users').delete().eq('org_id', ORG_ID)
+  await supabase.from('orgs').delete().eq('id', ORG_ID)
+  await supabase.from('stripe_info').delete().eq('customer_id', STRIPE_CUSTOMER_ID)
+}, 120000)
+
+describe('compatibility_events RLS read access', () => {
+  it('lets an org member read their app\'s compatibility events but hides them from non-members', async () => {
+    const eventId = await insertEvent({ platform: 'ios' })
+
+    const { data: memberRows, error: memberError } = await compatTable(memberClient)
+      .select('id, resolved_at')
+      .eq('app_id', APP_ID)
+    expect(memberError).toBeNull()
+    expect(memberRows).not.toBeNull()
+    expect((memberRows as { id: number }[]).some(row => row.id === eventId)).toBe(true)
+
+    const { data: nonMemberRows, error: nonMemberError } = await compatTable(nonMemberClient)
+      .select('id')
+      .eq('app_id', APP_ID)
+    expect(nonMemberError).toBeNull()
+    expect(nonMemberRows).toEqual([])
+  })
+})
+
+describe('acknowledge_compatibility_event RPC', () => {
+  it('lets an authorized member accept an unresolved event with a note', async () => {
+    const eventId = await insertEvent({ platform: 'android' })
+    const note = 'Reviewed and confirmed compatible'
+
+    const { error } = await memberClient.rpc('acknowledge_compatibility_event', {
+      event_id: eventId,
+      note,
+    })
+    expect(error).toBeNull()
+
+    const row = await getEventById(eventId)
+    expect(row.resolved_at).not.toBeNull()
+    expect(row.resolved_by).toBe(USER_ID)
+    expect(row.resolution_kind).toBe('accepted')
+    expect(row.resolution_note).toBe(note)
+  })
+
+  it('rejects an empty/whitespace note and leaves the event unresolved', async () => {
+    const eventId = await insertEvent({ platform: 'electron' })
+
+    const { error } = await memberClient.rpc('acknowledge_compatibility_event', {
+      event_id: eventId,
+      note: '   ',
+    })
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('reason_required')
+
+    const row = await getEventById(eventId)
+    expect(row.resolved_at).toBeNull()
+    expect(row.resolution_kind).toBeNull()
+  })
+
+  it('is a silent no-op when a non-member tries to accept an event', async () => {
+    const eventId = await insertEvent({ platform: 'ios', channelName: 'beta' })
+
+    const { error } = await nonMemberClient.rpc('acknowledge_compatibility_event', {
+      event_id: eventId,
+      note: 'Not allowed to do this',
+    })
+    // No existence oracle: unauthorized callers get no error, just a no-op.
+    expect(error).toBeNull()
+
+    const row = await getEventById(eventId)
+    expect(row.resolved_at).toBeNull()
+    expect(row.resolved_by).toBeNull()
+  })
+
+  it('is a silent no-op for an unknown event id', async () => {
+    const { error } = await memberClient.rpc('acknowledge_compatibility_event', {
+      event_id: 9_999_999_999,
+      note: 'Does not exist',
+    })
+    expect(error).toBeNull()
+  })
+})
+
+describe('compatibility_events cascade', () => {
+  it('removes compatibility events when their app is deleted', async () => {
+    const supabase = getSupabaseClient()
+    await insertEvent({ platform: 'android', channelName: 'cascade' })
+
+    const { data: before } = await compatTable(supabase).select('id').eq('app_id', APP_ID)
+    expect((before as unknown[]).length).toBeGreaterThan(0)
+
+    await supabase.from('apps').delete().eq('app_id', APP_ID).throwOnError()
+
+    const { data: after, error } = await compatTable(supabase).select('id').eq('app_id', APP_ID)
+    expect(error).toBeNull()
+    expect(after).toEqual([])
+  })
+})

--- a/tests/security-definer-execute-hardening.test.ts
+++ b/tests/security-definer-execute-hardening.test.ts
@@ -74,6 +74,7 @@ const ANON_ALLOWED_PROCS = [
 
 const AUTHENTICATED_ONLY_PROCS = [
   'public.accept_invitation_to_org(uuid)',
+  'public.acknowledge_compatibility_event(bigint, text)',
   'public.check_org_members_2fa_enabled(uuid)',
   'public.check_org_members_password_policy(uuid)',
   'public.count_non_compliant_bundles(uuid, text)',


### PR DESCRIPTION
## What

**PR 2 of 3** (follows #2437). Computes bundle-compatibility verdicts **once, at write time**, and persists them — replacing the removed live-computed approach with data the dashboard can read in a single indexed SELECT (PR 3).

## How it works

- New table **`public.compatibility_events`** — one snapshotted row per incompatible default-channel change: source, platform, channel, current/previous version ids **and names**, `offenders` (the incompatible package diff), plus resolution fields (`resolved_at/by`, `resolution_kind`, `resolution_note`). Snapshots make rows immune to the 90-day bundle purge.
- **Computation lives in `on_channel_update`** (the existing channels DB-trigger → pgmq → backend handler): source-agnostic (CLI/web/API/SQL all flow through it), **async** (queue-drained — can never block channel writes), guarded (try/catch; a failure can't break winner reconciliation). Covers both cases:
  - **version change** on a default channel (`previous = oldRecord.version`)
  - **default-channel switch** (`previous =` the demoted prior winner's version, loaded by id)
- **Auto-resolve with generated reasons**: when a later change makes the default compatible with an event's baseline again, the handler resolves it (`resolution_kind = 'auto_compatible'`, generated note). It deliberately does **not** fire for a native-identical successor (still incompatible with the stranded baseline).
- **Manual accept RPC** `acknowledge_compatibility_event(event_id, note)` — SECURITY DEFINER, `search_path=''`, RBAC-gated (`rbac_check_permission_direct(rbac_perm_app_upload_bundle(), ...)`), requires a non-empty reason, silent no-op for unknown/unauthorized ids (no existence oracle). No UI consumes it yet — kept for the planned Accept button.
- **RLS**: SELECT only, gated by `rbac_check_permission(rbac_perm_app_read(), ...)`; no INSERT/UPDATE policies (service-role handler + definer RPC are the only writers). FK `ON DELETE CASCADE` for app/org. Idempotent upsert via a `NULLS NOT DISTINCT` unique dedup index (queue may redeliver).
- Removes the temporary `knip.json` exception from #2437 — `utils/bundle_compatibility.ts` has real consumers again.

## Decisions taken (flag if you disagree)

1. **"Default channel" = the public download channel, per platform** (what devices actually receive; matches the Bento email) — not `apps.default_upload_channel` (which #2408 used).
2. **Accept RPC included now** (tiny, tested, hardening-covered) even though the Accept UI comes later.

## Known follow-ups

- Generated Supabase types don't include `compatibility_events` until `types:local` runs against a migrated DB — the handler uses `(supabaseAdmin(c) as any)` with the row types defined locally. Happy to regen types in this PR if CI/your flow prefers.
- **PR 3**: simple dashboard warning banner reading the newest unresolved event (one SELECT) + deploy-refresh.

## Test plan

- [x] `typecheck:backend` clean; eslint + oxlint clean
- [x] `bun run lint:deadcode` (knip) clean **without** the exception
- [x] Pure decide-logic + handler tests: **20/20** (both cases, per-platform fan-out, exclusions — `version_number` strategy, missing native_packages — idempotent redelivery, resolution-survives-redelivery, auto-resolve incl. the native-identical-successor non-fire)
- [x] DB integration: **6/6** against local Postgres (RLS member/non-member isolation, accept RPC sets resolution fields, reason-required error, unauthorized/unknown-id no-ops, app-delete cascade)
- [x] Migration applies cleanly on a fresh DB (validated via psql; RBAC helper arities verified)
- [x] `acknowledge_compatibility_event(bigint, text)` added to `AUTHENTICATED_ONLY_PROCS` hardening coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added compatibility event tracking system to monitor app version compatibility across platforms (iOS, Android, and Electron).
* Enabled automatic resolution of compatibility issues when app versions restore compatibility with previous baselines.
* Added capability to acknowledge and document resolution of compatibility events with custom notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->