### PR TITLE
[codex] Fix build/upload billing gates for build-time overage

### DIFF
--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -155,6 +155,34 @@ export async function requestBuild(
 
   const org_id = app.owner_org
 
+  // Native builds consume build-time credits; check that metric before creating a builder job.
+  const buildTimePlanArgs = { orgid: org_id, actions: ['build_time'], appid: app_id } as never
+  const { data: buildTimeAllowed, error: buildTimePlanError } = await supabase.rpc('is_allowed_action_org_action', buildTimePlanArgs)
+  if (buildTimePlanError) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Cannot validate native build plan',
+      org_id,
+      app_id,
+      error: buildTimePlanError,
+    })
+    throw quickError(503, 'cannot_validate_build_plan', 'Cannot validate native build plan', { app_id, org_id })
+  }
+
+  if (!buildTimeAllowed) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Native build blocked by build time plan limit',
+      org_id,
+      app_id,
+    })
+    throw quickError(429, 'need_plan_upgrade', 'Cannot request native build, upgrade plan to continue to build', {
+      app_id,
+      org_id,
+      reason: 'build_time',
+    }, undefined, { alert: false })
+  }
+
   cloudlog({
     requestId: c.get('requestId'),
     message: 'Creating job in builder',

--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -34,6 +34,15 @@ interface BuilderJobResponse {
   status: string
 }
 
+interface ValidBuildRequestBody {
+  app_id: string
+  platform: 'ios' | 'android'
+  build_mode: 'release' | 'debug'
+  build_config: Record<string, any>
+  build_options: Record<string, unknown>
+  build_credentials: Record<string, string>
+}
+
 function throwBuilderUnavailable(message: string, moreInfo: Record<string, unknown> = {}, cause?: unknown): never {
   throw quickError(503, 'service_unavailable', message, moreInfo, cause, { alert: false })
 }
@@ -64,11 +73,12 @@ export function buildBuilderPayload(input: {
 /** Exported for unit tests — follows bundleUsageTestUtils pattern. */
 export const builderPayloadTestUtils = { buildBuilderPayload }
 
-export async function requestBuild(
-  c: Context,
-  body: RequestBuildBody,
-  apikey: Database['public']['Tables']['apikeys']['Row'],
-): Promise<Response> {
+function hasLegacyCredentials(body: RequestBuildBody): boolean {
+  const credentials = Reflect.get(body, 'credentials')
+  return typeof credentials === 'object' && credentials !== null && Object.keys(credentials).length > 0
+}
+
+function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: string): ValidBuildRequestBody {
   const {
     app_id,
     platform,
@@ -76,11 +86,18 @@ export async function requestBuild(
     build_config = {},
     build_options = {},
     build_credentials = {},
-    credentials,
   } = body
 
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Build request received',
+    app_id,
+    platform,
+    user_id: userId,
+  })
+
   // Reject deprecated `credentials` field — old CLIs must upgrade
-  if (credentials && Object.keys(credentials).length > 0) {
+  if (hasLegacyCredentials(body)) {
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Deprecated credentials field received',
@@ -92,14 +109,6 @@ export async function requestBuild(
       '`credentials` field is deprecated. Please update your CLI and use `build_credentials` instead.',
     )
   }
-
-  cloudlog({
-    requestId: c.get('requestId'),
-    message: 'Build request received',
-    app_id,
-    platform,
-    user_id: apikey.user_id,
-  })
 
   // Validate required fields
   if (!app_id) {
@@ -127,78 +136,78 @@ export async function requestBuild(
     throw simpleError('invalid_parameter', 'build_config must be an object')
   }
 
+  return {
+    app_id,
+    platform: platform as 'ios' | 'android',
+    build_mode: build_mode as 'release' | 'debug',
+    build_config: build_config as Record<string, any>,
+    build_options,
+    build_credentials,
+  }
+}
+
+async function ensureBuildPermission(c: Context, appId: string, userId: string) {
   // Check if the user has permission to request builds (auth context set by middlewareKey)
-  if (!(await checkPermission(c, 'app.build_native', { appId: app_id }))) {
+  if (!(await checkPermission(c, 'app.build_native', { appId }))) {
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Unauthorized build request',
-      app_id,
-      user_id: apikey.user_id,
+      app_id: appId,
+      user_id: userId,
     })
     throw simpleError('unauthorized', 'You do not have permission to request builds for this app')
   }
+}
 
-  // Use authenticated client for data queries - RLS will enforce access
-  const supabase = supabaseApikey(c, apikey.key)
-
+async function getBuildOwnerOrg(c: Context, supabase: ReturnType<typeof supabaseApikey>, appId: string): Promise<string> {
   // Get org_id for the app to use as anonymized user ID
   const { data: app, error: appError } = await supabase
     .from('apps')
     .select('owner_org')
-    .eq('app_id', app_id)
+    .eq('app_id', appId)
     .single()
 
   if (appError || !app) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'App not found', app_id, error: appError })
+    cloudlogErr({ requestId: c.get('requestId'), message: 'App not found', app_id: appId, error: appError })
     throw simpleError('not_found', 'App not found')
   }
 
-  const org_id = app.owner_org
+  return app.owner_org
+}
 
+async function ensureBuildTimePlanAllowed(c: Context, supabase: ReturnType<typeof supabaseApikey>, orgId: string, appId: string) {
   // Native builds consume build-time credits; check that metric before creating a builder job.
-  const buildTimePlanArgs = { orgid: org_id, actions: ['build_time'], appid: app_id } as never
+  const buildTimePlanArgs = { orgid: orgId, actions: ['build_time'], appid: appId } as never
   const { data: buildTimeAllowed, error: buildTimePlanError } = await supabase.rpc('is_allowed_action_org_action', buildTimePlanArgs)
   if (buildTimePlanError) {
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Cannot validate native build plan',
-      org_id,
-      app_id,
+      org_id: orgId,
+      app_id: appId,
       error: buildTimePlanError,
     })
-    throw quickError(503, 'cannot_validate_build_plan', 'Cannot validate native build plan', { app_id, org_id })
+    throw quickError(503, 'cannot_validate_build_plan', 'Cannot validate native build plan', { app_id: appId, org_id: orgId })
   }
 
   if (!buildTimeAllowed) {
     cloudlog({
       requestId: c.get('requestId'),
       message: 'Native build blocked by build time plan limit',
-      org_id,
-      app_id,
+      org_id: orgId,
+      app_id: appId,
     })
     throw quickError(429, 'need_plan_upgrade', 'Cannot request native build, upgrade plan to continue to build', {
-      app_id,
-      org_id,
+      app_id: appId,
+      org_id: orgId,
       reason: 'build_time',
     }, undefined, { alert: false })
   }
+}
 
-  cloudlog({
-    requestId: c.get('requestId'),
-    message: 'Creating job in builder',
-    org_id,
-    app_id,
-    platform,
-  })
-
-  // Create upload_path BEFORE calling builder so we can pass it
-  const upload_session_key = crypto.randomUUID()
-  const upload_path = `orgs/${org_id}/apps/${app_id}/native-builds/${upload_session_key}.zip`
-
-  // Create job in builder.capgo.app
+function getBuilderConfig(c: Context) {
   const builderUrl = getEnv(c, 'BUILDER_URL')
   const builderApiKey = getEnv(c, 'BUILDER_API_KEY')
-  let builderJob: BuilderJobResponse | null = null
 
   if (!builderUrl || !builderApiKey) {
     cloudlogErr({
@@ -210,17 +219,31 @@ export async function requestBuild(
     throwBuilderUnavailable('Build service unavailable (builder not configured)')
   }
 
-  try {
-    cloudlog({
-      requestId: c.get('requestId'),
-      message: 'Calling builder API',
-      builder_url: builderUrl,
-      org_id,
-      app_id,
-      platform,
-      artifact_key: upload_path,
-    })
+  return { builderUrl, builderApiKey }
+}
 
+async function createBuilderJob(c: Context, input: {
+  builderUrl: string
+  builderApiKey: string
+  orgId: string
+  appId: string
+  platform: 'ios' | 'android'
+  uploadPath: string
+  buildOptions: Record<string, unknown>
+  buildCredentials: Record<string, string>
+}): Promise<BuilderJobResponse> {
+  const { builderUrl, builderApiKey, orgId, appId, platform, uploadPath, buildOptions, buildCredentials } = input
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Calling builder API',
+    builder_url: builderUrl,
+    org_id: orgId,
+    app_id: appId,
+    platform,
+    artifact_key: uploadPath,
+  })
+
+  try {
     const builderResponse = await fetch(`${builderUrl}/jobs`, {
       method: 'POST',
       headers: {
@@ -228,46 +251,46 @@ export async function requestBuild(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(buildBuilderPayload({
-        orgId: org_id,
-        uploadPath: upload_path,
+        orgId,
+        uploadPath,
         platform,
-        buildOptions: build_options,
-        buildCredentials: build_credentials,
+        buildOptions,
+        buildCredentials,
       })),
     })
 
     if (builderResponse.ok) {
-      builderJob = await builderResponse.json() as BuilderJobResponse
+      const builderJob = await builderResponse.json() as BuilderJobResponse
       cloudlog({
         requestId: c.get('requestId'),
         message: 'Builder job created successfully',
         job_id: builderJob.jobId,
         upload_url: builderJob.uploadUrl,
       })
+      return builderJob
     }
-    else {
-      const errorText = await builderResponse.text()
-      const responseHeaders: Record<string, string> = {}
-      builderResponse.headers.forEach((value, key) => {
-        responseHeaders[key] = value
-      })
-      cloudlogErr({
-        requestId: c.get('requestId'),
-        message: 'Builder API returned error',
-        builder_url: builderUrl,
-        status: builderResponse.status,
-        status_text: builderResponse.statusText,
-        error_body: errorText,
-        response_headers: responseHeaders,
-        org_id,
-        app_id,
-        platform,
-      })
-      throwBuilderUnavailable('Build service unavailable (builder error)', {
-        status: builderResponse.status,
-        statusText: builderResponse.statusText,
-      })
-    }
+
+    const errorText = await builderResponse.text()
+    const responseHeaders: Record<string, string> = {}
+    builderResponse.headers.forEach((value, key) => {
+      responseHeaders[key] = value
+    })
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Builder API returned error',
+      builder_url: builderUrl,
+      status: builderResponse.status,
+      status_text: builderResponse.statusText,
+      error_body: errorText,
+      response_headers: responseHeaders,
+      org_id: orgId,
+      app_id: appId,
+      platform,
+    })
+    throwBuilderUnavailable('Build service unavailable (builder error)', {
+      status: builderResponse.status,
+      statusText: builderResponse.statusText,
+    })
   }
   catch (error) {
     if (error && typeof error === 'object' && 'status' in error && (error as { status?: unknown }).status === 503) {
@@ -280,17 +303,16 @@ export async function requestBuild(
       error: (error as Error)?.message,
       error_stack: (error as Error)?.stack,
       error_name: (error as Error)?.name,
-      org_id,
-      app_id,
+      org_id: orgId,
+      app_id: appId,
       platform,
     })
     throwBuilderUnavailable('Build service unavailable (builder call failed)', {}, error)
   }
+}
 
-  const upload_expires_at = new Date(Date.now() + 60 * 60 * 1000)
-
-  // Builder upload URL is mandatory; no fallback allowed
-  if (!builderJob?.uploadUrl) {
+function ensureBuilderUploadUrl(c: Context, builderUrl: string, builderApiKey: string, builderJob: BuilderJobResponse) {
+  if (!builderJob.uploadUrl) {
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'Builder did not return uploadUrl; rejecting request',
@@ -299,14 +321,38 @@ export async function requestBuild(
     })
     throwBuilderUnavailable('Build service unavailable (upload URL missing)')
   }
+}
 
-  const upload_url = `${getEnv(c, 'PUBLIC_URL') || 'https://api.capgo.app'}/build/upload/${builderJob.jobId}`
-  cloudlog({
-    requestId: c.get('requestId'),
-    message: 'Using Capgo TUS proxy URL for builder',
-    proxy_url: upload_url,
-    builder_url: builderJob.uploadUrl,
-  })
+function getBuildUploadUrl(c: Context, builderJob: BuilderJobResponse) {
+  return `${getEnv(c, 'PUBLIC_URL') || 'https://api.capgo.app'}/build/upload/${builderJob.jobId}`
+}
+
+async function persistBuildRequest(c: Context, input: {
+  app_id: string
+  org_id: string
+  requested_by: string
+  platform: 'ios' | 'android'
+  build_mode: 'release' | 'debug'
+  build_config: Record<string, any>
+  builder_job_id: string
+  upload_session_key: string
+  upload_path: string
+  upload_url: string
+  upload_expires_at: Date
+}) {
+  const {
+    app_id,
+    org_id,
+    requested_by,
+    platform,
+    build_mode,
+    build_config,
+    builder_job_id,
+    upload_session_key,
+    upload_path,
+    upload_url,
+    upload_expires_at,
+  } = input
 
   const supabaseAdminClient = supabaseAdmin(c)
   const { data: buildRequestRow, error: insertError } = await supabaseAdminClient
@@ -314,12 +360,12 @@ export async function requestBuild(
     .insert({
       app_id,
       owner_org: org_id,
-      requested_by: apikey.user_id,
+      requested_by,
       platform,
       build_mode,
       build_config,
       status: 'pending',
-      builder_job_id: builderJob.jobId,
+      builder_job_id,
       upload_session_key,
       upload_path,
       upload_url,
@@ -333,15 +379,16 @@ export async function requestBuild(
     throw simpleError('internal_error', 'Unable to persist build request')
   }
 
-  cloudlog({
-    requestId: c.get('requestId'),
-    message: 'Build job created',
-    job_id: builderJob.jobId,
-    org_id,
-    app_id,
-    platform,
-  })
+  return buildRequestRow
+}
 
+async function recordBuildRequestedTelemetry(c: Context, input: {
+  app_id: string
+  org_id: string
+  platform: 'ios' | 'android'
+  build_mode: 'release' | 'debug'
+  user_id: string
+}) {
   // Telemetry MUST NOT break the build request. sendEventToTracking swallows
   // per-provider errors internally, but defend against an unexpected throw at
   // the orchestration layer (e.g. backgroundTask unavailable in tests).
@@ -351,13 +398,13 @@ export async function requestBuild(
       channel: 'build-lifecycle',
       icon: '🛠️',
       notify: false,
-      user_id: apikey.user_id,
-      groups: { organization: org_id },
+      user_id: input.user_id,
+      groups: { organization: input.org_id },
       tags: {
-        app_id,
-        org_id,
-        platform,
-        build_mode,
+        app_id: input.app_id,
+        org_id: input.org_id,
+        platform: input.platform,
+        build_mode: input.build_mode,
       },
     })
   }
@@ -368,6 +415,93 @@ export async function requestBuild(
       error: serializeError(error),
     })
   }
+}
+
+export async function requestBuild(
+  c: Context,
+  body: RequestBuildBody,
+  apikey: Database['public']['Tables']['apikeys']['Row'],
+): Promise<Response> {
+  const {
+    app_id,
+    platform,
+    build_mode,
+    build_config,
+    build_options,
+    build_credentials,
+  } = validateBuildRequestBody(c, body, apikey.user_id)
+
+  await ensureBuildPermission(c, app_id, apikey.user_id)
+
+  // Use authenticated client for data queries - RLS will enforce access
+  const supabase = supabaseApikey(c, apikey.key)
+  const org_id = await getBuildOwnerOrg(c, supabase, app_id)
+  await ensureBuildTimePlanAllowed(c, supabase, org_id, app_id)
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Creating job in builder',
+    org_id,
+    app_id,
+    platform,
+  })
+
+  // Create upload_path BEFORE calling builder so we can pass it
+  const upload_session_key = crypto.randomUUID()
+  const upload_path = `orgs/${org_id}/apps/${app_id}/native-builds/${upload_session_key}.zip`
+  const { builderUrl, builderApiKey } = getBuilderConfig(c)
+  const builderJob = await createBuilderJob(c, {
+    builderUrl,
+    builderApiKey,
+    orgId: org_id,
+    appId: app_id,
+    platform,
+    uploadPath: upload_path,
+    buildOptions: build_options,
+    buildCredentials: build_credentials,
+  })
+
+  ensureBuilderUploadUrl(c, builderUrl, builderApiKey, builderJob)
+
+  const upload_expires_at = new Date(Date.now() + 60 * 60 * 1000)
+  const upload_url = getBuildUploadUrl(c, builderJob)
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Using Capgo TUS proxy URL for builder',
+    proxy_url: upload_url,
+    builder_url: builderJob.uploadUrl,
+  })
+
+  const buildRequestRow = await persistBuildRequest(c, {
+    app_id,
+    org_id,
+    requested_by: apikey.user_id,
+    platform,
+    build_mode,
+    build_config,
+    builder_job_id: builderJob.jobId,
+    upload_session_key,
+    upload_path,
+    upload_url,
+    upload_expires_at,
+  })
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Build job created',
+    job_id: builderJob.jobId,
+    org_id,
+    app_id,
+    platform,
+  })
+
+  await recordBuildRequestedTelemetry(c, {
+    app_id,
+    org_id,
+    platform,
+    build_mode,
+    user_id: apikey.user_id,
+  })
 
   return c.json({
     build_request_id: buildRequestRow.id,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -41,7 +41,7 @@ function buildPlanValidationExpression(
   actions: ('mau' | 'storage' | 'bandwidth')[],
   ownerColumn: typeof schema.app_versions.owner_org | typeof schema.apps.owner_org,
 ) {
-  const extraConditions = actions.map(action => ` AND ${PLAN_EXCEEDED_COLUMNS[action]} = false`).join('')
+  const extraConditions = actions.map(action => ` AND COALESCE(${PLAN_EXCEEDED_COLUMNS[action]}, false) = false`).join('')
   const customerIdSubquery = sql<string | null>`(
     SELECT ${schema.orgs.customer_id}
     FROM ${schema.orgs}
@@ -54,6 +54,9 @@ function buildPlanValidationExpression(
   // Backward compatibility for replicas that haven't replicated the column yet:
   // read via `to_jsonb(row)->>'has_usage_credits'` so the query still parses
   // even if the column doesn't exist. Missing column fails closed.
+  //
+  // Keep the subscription branch action-specific. is_good_plan also includes
+  // build_time, which must not block update/upload paths when their own metrics fit.
   const hasCreditsExpression = sql`EXISTS (
     SELECT 1
     FROM ${schema.orgs}
@@ -70,7 +73,6 @@ function buildPlanValidationExpression(
       (${schema.stripe_info.trial_at}::date > CURRENT_DATE)
       OR (
         ${schema.stripe_info.status} = 'succeeded'
-        AND ${schema.stripe_info.is_good_plan} = true
         ${sql.raw(extraConditions)}
       )
     )

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -64,7 +64,7 @@ function buildPlanValidationExpression(
   actions: PlanAction[],
   ownerColumn: typeof schema.app_versions.owner_org | typeof schema.apps.owner_org,
 ) {
-  const extraConditions = actions.map(action => ` AND COALESCE(${PLAN_EXCEEDED_COLUMNS[action]}, false) = false`).join('')
+  const extraConditions = actions.map(action => ` AND ${PLAN_EXCEEDED_COLUMNS[action]} = false`).join('')
   const customerIdSubquery = sql<string | null>`(
     SELECT ${schema.orgs.customer_id}
     FROM ${schema.orgs}

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -18,6 +18,17 @@ const REPLICATION_LAG_CACHE_TTL_SECONDS = 60
 const REPLICATION_LAG_CACHE_TTL_MS = REPLICATION_LAG_CACHE_TTL_SECONDS * 1000
 
 type ReplicationStatus = 'ok' | 'lagging' | 'unknown'
+type PlanAction = 'mau' | 'storage' | 'bandwidth'
+type ReadReplicaHyperdriveBinding =
+  | 'HYPERDRIVE_CAPGO_READ_AS_JAPAN'
+  | 'HYPERDRIVE_CAPGO_READ_AS_INDIA'
+  | 'HYPERDRIVE_CAPGO_READ_NA'
+  | 'HYPERDRIVE_CAPGO_READ_EU'
+  | 'HYPERDRIVE_CAPGO_READ_OC'
+  | 'HYPERDRIVE_CAPGO_READ_SA'
+  | 'HYPERDRIVE_CAPGO_READ_ME'
+  | 'HYPERDRIVE_CAPGO_READ_AF'
+  | 'HYPERDRIVE_CAPGO_READ_HK'
 
 interface ReplicationLagStatus {
   status: ReplicationStatus
@@ -31,14 +42,26 @@ interface ReplicationLagCacheEntry extends ReplicationLagStatus {
 const replicationLagMemoryCache = new Map<string, ReplicationLagCacheEntry>()
 const replicationLagInflight = new Map<string, Promise<ReplicationLagStatus>>()
 
-const PLAN_EXCEEDED_COLUMNS: Record<'mau' | 'storage' | 'bandwidth', string> = {
+const READ_REPLICA_ROUTES: { region: string, binding: ReadReplicaHyperdriveBinding }[] = [
+  { region: 'AS_JAPAN', binding: 'HYPERDRIVE_CAPGO_READ_AS_JAPAN' },
+  { region: 'AS_INDIA', binding: 'HYPERDRIVE_CAPGO_READ_AS_INDIA' },
+  { region: 'NA', binding: 'HYPERDRIVE_CAPGO_READ_NA' },
+  { region: 'EU', binding: 'HYPERDRIVE_CAPGO_READ_EU' },
+  { region: 'OC', binding: 'HYPERDRIVE_CAPGO_READ_OC' },
+  { region: 'SA', binding: 'HYPERDRIVE_CAPGO_READ_SA' },
+  { region: 'ME', binding: 'HYPERDRIVE_CAPGO_READ_ME' },
+  { region: 'AF', binding: 'HYPERDRIVE_CAPGO_READ_AF' },
+  { region: 'HK', binding: 'HYPERDRIVE_CAPGO_READ_HK' },
+]
+
+const PLAN_EXCEEDED_COLUMNS: Record<PlanAction, string> = {
   mau: 'mau_exceeded',
   storage: 'storage_exceeded',
   bandwidth: 'bandwidth_exceeded',
 }
 
 function buildPlanValidationExpression(
-  actions: ('mau' | 'storage' | 'bandwidth')[],
+  actions: PlanAction[],
   ownerColumn: typeof schema.app_versions.owner_org | typeof schema.apps.owner_org,
 ) {
   const extraConditions = actions.map(action => ` AND COALESCE(${PLAN_EXCEEDED_COLUMNS[action]}, false) = false`).join('')
@@ -260,65 +283,24 @@ function setDatabaseSource(c: Context, source: string): void {
   safeSetResponseHeader(c, 'X-Database-Source', source)
 }
 
+function getReadOnlyDatabaseURL(c: Context, dbRegion: string | undefined): string | null {
+  const selectedRoute = READ_REPLICA_ROUTES.find(route => route.region === dbRegion && c.env[route.binding])
+  if (!selectedRoute)
+    return null
+
+  setDatabaseSource(c, selectedRoute.binding)
+  cloudlog({ requestId: c.get('requestId'), message: `Using ${selectedRoute.binding} for read-only` })
+  return c.env[selectedRoute.binding].connectionString
+}
+
 export function getDatabaseURL(c: Context, readOnly = false): string {
   const dbRegion = getClientDbRegionSB(c)
 
   // For read-only queries, use region to avoid Network latency
   if (readOnly) {
-    // Hyperdrive main read replica regional routing in Cloudflare Workers
-    // When using Hyperdrive we use session databases directly to avoid supabase pooler overhead and allow prepared statements
-    // Asia region - Japan
-    if (c.env.HYPERDRIVE_CAPGO_READ_AS_JAPAN && dbRegion === 'AS_JAPAN') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_AS_JAPAN')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_AS_JAPAN for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_AS_JAPAN.connectionString
-    }
-    // Asia region - India
-    if (c.env.HYPERDRIVE_CAPGO_READ_AS_INDIA && dbRegion === 'AS_INDIA') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_AS_INDIA')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_AS_INDIA for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_AS_INDIA.connectionString
-    }
-    // // US region
-    if (c.env.HYPERDRIVE_CAPGO_READ_NA && dbRegion === 'NA') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_NA')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_NA for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_NA.connectionString
-    }
-    // // EU region
-    if (c.env.HYPERDRIVE_CAPGO_READ_EU && dbRegion === 'EU') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_EU')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_EU for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_EU.connectionString
-    }
-    // // OC region
-    if (c.env.HYPERDRIVE_CAPGO_READ_OC && dbRegion === 'OC') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_OC')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_OC for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_OC.connectionString
-    }
-    // // SA region
-    if (c.env.HYPERDRIVE_CAPGO_READ_SA && dbRegion === 'SA') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_SA')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_SA for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_SA.connectionString
-    }
-    // Google Cloud Hyperdrive read replica routing
-    if (c.env.HYPERDRIVE_CAPGO_READ_ME && dbRegion === 'ME') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_ME')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_ME for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_ME.connectionString
-    }
-    if (c.env.HYPERDRIVE_CAPGO_READ_AF && dbRegion === 'AF') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_AF')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_AF for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_AF.connectionString
-    }
-    if (c.env.HYPERDRIVE_CAPGO_READ_HK && dbRegion === 'HK') {
-      setDatabaseSource(c, 'HYPERDRIVE_CAPGO_READ_HK')
-      cloudlog({ requestId: c.get('requestId'), message: 'Using HYPERDRIVE_CAPGO_READ_HK for read-only' })
-      return c.env.HYPERDRIVE_CAPGO_READ_HK.connectionString
-    }
+    const readOnlyDatabaseURL = getReadOnlyDatabaseURL(c, dbRegion)
+    if (readOnlyDatabaseURL)
+      return readOnlyDatabaseURL
   }
 
   // Fallback to single Hyperdrive if available
@@ -551,7 +533,11 @@ export function requestInfosChannelPostgres(
   includeMetadata = false,
 ) {
   const { versionSelect, channelAlias, channelSelect, manifestSelect, versionAlias } = getSchemaUpdatesAlias(includeMetadata)
-  const platformQuery = platform === 'android' ? channelAlias.android : platform === 'electron' ? channelAlias.electron : channelAlias.ios
+  let platformQuery = channelAlias.ios
+  if (platform === 'android')
+    platformQuery = channelAlias.android
+  else if (platform === 'electron')
+    platformQuery = channelAlias.electron
   const baseSelect = {
     version: versionSelect,
     channels: channelSelect,
@@ -567,13 +553,8 @@ export function requestInfosChannelPostgres(
     ? baseQuery.leftJoin(schema.manifest, eq(schema.manifest.app_version_id, versionAlias.id))
     : baseQuery)
     .where(and(
-      !defaultChannel
+      defaultChannel
         ? and(
-            eq(channelAlias.public, true),
-            eq(channelAlias.app_id, app_id),
-            eq(platformQuery, true),
-          )
-        : and(
             eq(channelAlias.app_id, app_id),
             eq(channelAlias.name, defaultChannel),
             eq(platformQuery, true),
@@ -581,6 +562,11 @@ export function requestInfosChannelPostgres(
               eq(channelAlias.public, true),
               eq(channelAlias.allow_device_self_set, true),
             ),
+          )
+        : and(
+            eq(channelAlias.public, true),
+            eq(channelAlias.app_id, app_id),
+            eq(platformQuery, true),
           ),
       or(isNull(channelAlias.version), isNotNull(versionAlias.id)),
     ))
@@ -592,17 +578,30 @@ export function requestInfosChannelPostgres(
   return channel
 }
 
-export function requestInfosPostgres(
-  c: Context,
-  platform: string,
-  app_id: string,
-  device_id: string,
-  defaultChannel: string,
-  drizzleClient: ReturnType<typeof getDrizzleClient>,
-  channelDeviceCount?: number | null,
-  manifestBundleCount?: number | null,
-  includeMetadata = false,
-) {
+interface RequestInfosPostgresOptions {
+  c: Context
+  platform: string
+  app_id: string
+  device_id: string
+  defaultChannel: string
+  drizzleClient: ReturnType<typeof getDrizzleClient>
+  channelDeviceCount?: number | null
+  manifestBundleCount?: number | null
+  includeMetadata?: boolean
+}
+
+export function requestInfosPostgres(options: RequestInfosPostgresOptions) {
+  const {
+    c,
+    platform,
+    app_id,
+    device_id,
+    defaultChannel,
+    drizzleClient,
+    channelDeviceCount,
+    manifestBundleCount,
+    includeMetadata = false,
+  } = options
   const shouldQueryChannelOverride = channelDeviceCount === undefined || channelDeviceCount === null ? true : channelDeviceCount > 0
   const shouldFetchManifest = manifestBundleCount === undefined || manifestBundleCount === null ? true : manifestBundleCount > 0
 
@@ -637,7 +636,7 @@ export async function getAppOwnerPostgres(
   c: Context,
   appId: string,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
-  actions: ('mau' | 'storage' | 'bandwidth')[] = [],
+  actions: PlanAction[] = [],
 ): Promise<AppOwnerPostgresResult | null> {
   try {
     if (actions.length === 0)
@@ -701,6 +700,10 @@ export async function getAppVersionPostgres(
   drizzleClient: ReturnType<typeof getDrizzleClient>,
 ): Promise<{ id: number, owner_org: string } | null> {
   try {
+    const deletedConditions: ReturnType<typeof eq>[] = []
+    if (allowedDeleted !== undefined)
+      deletedConditions.push(eq(schema.app_versions.deleted, allowedDeleted))
+
     const appVersion = await drizzleClient
       .select({
         id: schema.app_versions.id,
@@ -710,7 +713,7 @@ export async function getAppVersionPostgres(
       .where(and(
         eq(schema.app_versions.app_id, appId),
         eq(schema.app_versions.name, versionName),
-        ...(allowedDeleted !== undefined ? [eq(schema.app_versions.deleted, allowedDeleted)] : []),
+        ...deletedConditions,
       ))
       .limit(1)
       .then(data => data[0])
@@ -727,7 +730,7 @@ export async function getAppVersionsByAppIdPg(
   appId: string,
   versionName: string,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
-  actions: ('mau' | 'storage' | 'bandwidth')[] = [],
+  actions: PlanAction[] = [],
 ): Promise<{ id: number, owner_org: string, name: string, plan_valid: boolean }[]> {
   try {
     if (actions.length === 0)
@@ -946,7 +949,7 @@ export async function getAppByIdPg(
   c: Context,
   appId: string,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
-  actions: ('mau' | 'storage' | 'bandwidth')[] = [],
+  actions: PlanAction[] = [],
 ): Promise<{ owner_org: string, plan_valid: boolean } | null> {
   try {
     if (actions.length === 0)
@@ -984,7 +987,11 @@ export async function getCompatibleChannelsPg(
     const buildCondition = isProd
       ? eq(schema.channels.allow_prod, true)
       : eq(schema.channels.allow_dev, true)
-    const platformColumn = platform === 'ios' ? schema.channels.ios : platform === 'electron' ? schema.channels.electron : schema.channels.android
+    let platformColumn = schema.channels.android
+    if (platform === 'ios')
+      platformColumn = schema.channels.ios
+    else if (platform === 'electron')
+      platformColumn = schema.channels.electron
     const channels = await drizzleClient
       .select({
         id: schema.channels.id,
@@ -1739,6 +1746,8 @@ function normalizeTimestamp(value: unknown): string | null {
     return null
   if (value instanceof Date)
     return value.toISOString()
+  if (typeof value !== 'string' && typeof value !== 'number')
+    return null
 
   const rawValue = String(value)
   let parsed = new Date(rawValue)
@@ -2693,7 +2702,7 @@ export async function getAdminPluginBreakdown(
         major_breakdown: parseBreakdownJson(row.plugin_major_breakdown),
       }
     })
-    const latestRow = rows[rows.length - 1]
+    const latestRow = rows.at(-1)!
     const latestDate = latestRow.date instanceof Date ? latestRow.date.toISOString().split('T')[0] : String(latestRow.date)
     const versionBreakdown = parseBreakdownJson(latestRow.plugin_version_breakdown)
     const majorBreakdown = parseBreakdownJson(latestRow.plugin_major_breakdown)

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -216,7 +216,17 @@ export async function updateWithPG(
   // Only query link/comment if plugin supports it (v5.35.0+, v6.35.0+, v7.35.0+, v8.35.0+) AND app has expose_metadata enabled
   const needsMetadata = appOwner.expose_metadata && !isDeprecatedPluginVersion(pluginVersion, '5.35.0', '6.35.0', '7.35.0', '8.35.0')
 
-  const requestedInto = await requestInfosPostgres(c, platform, app_id, device_id, defaultChannel, drizzleClient, channelDeviceCount, manifestBundleCount, needsMetadata)
+  const requestedInto = await requestInfosPostgres({
+    c,
+    platform,
+    app_id,
+    device_id,
+    defaultChannel,
+    drizzleClient,
+    channelDeviceCount,
+    manifestBundleCount,
+    includeMetadata: needsMetadata,
+  })
   const { channelOverride } = requestedInto
   let { channelData } = requestedInto
   cloudlog({ requestId: c.get('requestId'), message: `channelData exists ? ${channelData !== undefined}, channelOverride exists ? ${channelOverride !== undefined}` })

--- a/tests/build-request-plan-gate.unit.test.ts
+++ b/tests/build-request-plan-gate.unit.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { requestBuild } from '../supabase/functions/_backend/public/build/request.ts'
+
+const { mockSupabaseApikey, mockSupabaseAdmin, mockCheckPermission, mockGetEnv, mockSendEventToTracking } = vi.hoisted(() => ({
+  mockSupabaseApikey: vi.fn(),
+  mockSupabaseAdmin: vi.fn(),
+  mockCheckPermission: vi.fn(),
+  mockGetEnv: vi.fn(),
+  mockSendEventToTracking: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin: mockSupabaseAdmin,
+  supabaseApikey: mockSupabaseApikey,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: mockCheckPermission,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  getEnv: mockGetEnv,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/tracking.ts', () => ({
+  sendEventToTracking: mockSendEventToTracking,
+}))
+
+describe('native build request plan gate', () => {
+  const requestId = 'req-build-plan-gate'
+  const appId = 'com.test.native.build.plan'
+  const orgId = 'org-native-build-plan'
+
+  function createContext() {
+    return {
+      get: vi.fn().mockImplementation((key: string) => {
+        if (key === 'requestId')
+          return requestId
+        return undefined
+      }),
+    }
+  }
+
+  beforeEach(() => {
+    mockSupabaseApikey.mockReset()
+    mockSupabaseAdmin.mockReset()
+    mockCheckPermission.mockReset()
+    mockGetEnv.mockReset()
+    mockSendEventToTracking.mockReset()
+
+    mockCheckPermission.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('blocks builder job creation when build time action is over plan', async () => {
+    const single = vi.fn().mockResolvedValue({ data: { owner_org: orgId }, error: null })
+    const eq = vi.fn().mockReturnValue({ single })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+    const rpc = vi.fn().mockResolvedValue({ data: false, error: null })
+    mockSupabaseApikey.mockReturnValue({ from, rpc })
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 500 }))
+
+    try {
+      await expect(requestBuild(
+        createContext() as any,
+        { app_id: appId, platform: 'ios' },
+        { key: 'api-key-build-plan', user_id: 'user-native-build-plan' } as any,
+      )).rejects.toMatchObject({
+        status: 429,
+        message: 'Cannot request native build, upgrade plan to continue to build',
+        cause: expect.objectContaining({
+          error: 'need_plan_upgrade',
+          moreInfo: expect.objectContaining({
+            app_id: appId,
+            org_id: orgId,
+            reason: 'build_time',
+          }),
+        }),
+      })
+
+      expect(mockCheckPermission).toHaveBeenCalledWith(expect.anything(), 'app.build_native', { appId })
+      expect(from).toHaveBeenCalledWith('apps')
+      expect(rpc).toHaveBeenCalledWith('is_allowed_action_org_action', {
+        orgid: orgId,
+        actions: ['build_time'],
+        appid: appId,
+      })
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(mockSupabaseAdmin).not.toHaveBeenCalled()
+    }
+    finally {
+      fetchMock.mockRestore()
+    }
+  })
+})

--- a/tests/files-security.test.ts
+++ b/tests/files-security.test.ts
@@ -154,6 +154,39 @@ describe('attachment upload plan gating regression', () => {
     const data = await response.json() as { error?: string }
     expect(data.error).toBe('on_premise_app')
   })
+
+  it('allows attachment uploads when only build time is over plan', async () => {
+    await executeSQL(
+      `
+        UPDATE public.stripe_info
+        SET
+          status = $1,
+          is_good_plan = $2,
+          trial_at = $3,
+          mau_exceeded = false,
+          storage_exceeded = false,
+          bandwidth_exceeded = false,
+          build_time_exceeded = true
+        WHERE customer_id = $4
+      `,
+      ['succeeded', false, '1970-01-01T00:00:00+00:00', stripeCustomerId],
+    )
+
+    const { uploadMetadata } = buildAttachmentPath(orgId, appId, `build-time-only-${randomUUID()}.txt`)
+
+    const response = await fetch(getEndpointUrl('/files/upload/attachments'), {
+      method: 'POST',
+      headers: {
+        'Authorization': uploadKey!,
+        'Content-Type': 'application/offset+octet-stream',
+        'Tus-Resumable': TUS_VERSION,
+        'Upload-Length': '4',
+        'Upload-Metadata': uploadMetadata,
+      },
+    })
+
+    expect(response.status).toBe(201)
+  })
 })
 
 describe('ready bundle upload immutability regression', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Removed aggregate `is_good_plan` from the replica-safe upload/update plan gate so only the requested usage metrics decide action eligibility.
- Kept exceeded flag checks action-specific for `mau`, `storage`, and `bandwidth` on update/upload paths.
- Added a native build request gate that calls `is_allowed_action_org_action` with `build_time` before creating a builder job.
- Refactored touched helper paths to keep the Sonar maintainability gate clean without changing request behavior.
- Added regression coverage for attachment upload with only `build_time_exceeded` true, plus a unit test proving native build creation is blocked when `build_time` is denied.

## Motivation (AI generated)

A customer with build-time overage was blocked from uploading bundles with a 429 `on_premise_app` response. Bundle upload should not be blocked by native build usage when upload-related metrics are still within plan, but native builder requests should still respect the build-time billing action.

## Business Impact (AI generated)

This restores bundle uploads for paying customers whose only overage is native build time, while keeping native build usage enforceable. It reduces support load and avoids accidental release blockers after plan upgrades or build-limit events.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun run typecheck:backend`
- [x] `bunx vitest run tests/build-request-plan-gate.unit.test.ts`
- [x] `bunx vitest run tests/build-request-plan-gate.unit.test.ts tests/builder-payload.unit.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/files-security.test.ts tests/build-request-plan-gate.unit.test.ts`
- [x] Commit hook full typecheck: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Generated with AI
