### PR TITLE
[codex] Show native preview QR

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1690,6 +1690,7 @@
   "pro-tip-you-can-copy": "Pro tip: you can copy the",
   "public": "public",
   "public-key-prefix": "Public key (first 4 chars)",
+  "qr-code-preview-alt": "QR Code to preview on phone",
   "rbac-not-enabled-for-org": "RBAC is not enabled for this organization.",
   "rbac-system-enabled": "RBAC role management preview",
   "rbac-system-enabled-body": "Editing roles here will use the RBAC system. Legacy roles stay visible during migration.",

--- a/src/components/BundlePreviewFrame.vue
+++ b/src/components/BundlePreviewFrame.vue
@@ -148,7 +148,7 @@ function svgToDataUrl(svg: string): string {
 
 // Generate QR code linking to the preview URL
 function generateQRCode() {
-  if (isNativePlatform || !qrCodeUrl.value) {
+  if (!qrCodeUrl.value) {
     qrCodeDataUrl.value = ''
     return
   }
@@ -189,7 +189,7 @@ async function startNativePreview() {
 <template>
   <div
     v-if="isNativePlatform"
-    class="flex min-h-[calc(100dvh-8rem)] w-full items-center justify-center px-4 py-6"
+    class="flex min-h-[calc(100dvh-8rem)] w-full flex-col items-center justify-center gap-5 px-4 py-6"
   >
     <button
       class="inline-flex min-h-12 w-full max-w-xs items-center justify-center gap-2 rounded-xl bg-blue-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-500/20 transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
@@ -199,6 +199,20 @@ async function startNativePreview() {
       <IconPlay class="h-5 w-5" />
       {{ t('start-preview') }}
     </button>
+
+    <div
+      v-if="qrCodeDataUrl"
+      class="flex w-full max-w-xs flex-col items-center rounded-xl bg-white p-5 shadow-lg dark:bg-gray-800"
+    >
+      <img
+        :src="qrCodeDataUrl"
+        alt="QR Code to preview on phone"
+        class="mb-3 h-44 w-44"
+      >
+      <p class="max-w-40 text-center text-sm text-gray-600 dark:text-gray-400">
+        {{ t('scan-qr-to-preview') }}
+      </p>
+    </div>
   </div>
 
   <div v-else class="relative min-h-[calc(100dvh-8rem)] w-full overflow-y-auto px-3 py-4 md:px-6 md:py-6">

--- a/src/components/BundlePreviewFrame.vue
+++ b/src/components/BundlePreviewFrame.vue
@@ -206,7 +206,7 @@ async function startNativePreview() {
     >
       <img
         :src="qrCodeDataUrl"
-        alt="QR Code to preview on phone"
+        :alt="t('qr-code-preview-alt')"
         class="mb-3 h-44 w-44"
       >
       <p class="max-w-40 text-center text-sm text-gray-600 dark:text-gray-400">
@@ -295,7 +295,7 @@ async function startNativePreview() {
       >
         <img
           :src="qrCodeDataUrl"
-          alt="QR Code to preview on phone"
+          :alt="t('qr-code-preview-alt')"
           class="mb-3 h-44 w-44"
         >
         <p class="text-sm text-center text-gray-600 dark:text-gray-400 max-w-40">


### PR DESCRIPTION
## Summary (AI generated)

- Show the preview QR code on the native Capacitor preview page alongside the start preview button.
- Keep the existing web preview QR behavior unchanged.

## Motivation (AI generated)

When the preview page is opened inside the Capgo native app, users can start the preview directly, but they may still need another phone to scan the same preview link.

## Business Impact (AI generated)

This improves preview sharing and QA workflows for teams testing mobile updates across multiple devices.

## Test Plan (AI generated)

- [x] `bun lint src/components/BundlePreviewFrame.vue`
- [x] `bun run typecheck:frontend`
- [x] commit hook typecheck suite
- [x] `bun test:front`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QR code generation/display now correctly shows native QR data when available.

* **Style**
  * Unified QR presentation with centered card layout and consistent spacing across platforms.

* **Localization**
  * Added translated alt text for the QR image ("QR Code to preview on phone").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->