### PR TITLE
fix(db): remove stale device replication trigger

### DIFF
--- a/supabase/migrations/20260608094944_remove_stale_device_replication_trigger.sql
+++ b/supabase/migrations/20260608094944_remove_stale_device_replication_trigger.sql
@@ -1,0 +1,15 @@
+-- Remove stale D1/device replication wiring that points at the obsolete
+-- replicate_data queue. Current migrations never create this trigger, but it
+-- still exists in production from the old replication system.
+DROP TRIGGER IF EXISTS replicate_devices ON public.devices;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pgmq.list_queues()
+    WHERE queue_name = 'replicate_data'
+  ) THEN
+    PERFORM pgmq.drop_queue('replicate_data');
+  END IF;
+END $$;

--- a/supabase/tests/58_test_stale_device_replication_removed.sql
+++ b/supabase/tests/58_test_stale_device_replication_removed.sql
@@ -1,0 +1,48 @@
+BEGIN;
+
+SELECT plan(3);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE
+      NOT t.tgisinternal
+      AND n.nspname = 'public'
+      AND c.relname = 'devices'
+      AND t.tgname = 'replicate_devices'
+  ),
+  'stale replicate_devices trigger is absent'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1
+    FROM pgmq.list_queues()
+    WHERE queue_name = 'replicate_data'
+  ),
+  'obsolete replicate_data queue is absent'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_proc p ON p.oid = t.tgfoid
+    WHERE
+      NOT t.tgisinternal
+      AND n.nspname = 'public'
+      AND c.relname = 'apps'
+      AND t.tgname = 'on_app_create'
+      AND p.proname = 'trigger_http_queue_post_to_function'
+  ),
+  'active queue trigger system remains intact'
+);
+
+SELECT * FROM finish(); -- noqa: AM04
+
+ROLLBACK;


### PR DESCRIPTION
## Summary (AI generated)

- Drop the stale production-only `replicate_devices` trigger from `public.devices`.
- Drop the obsolete `replicate_data` pgmq queue when it is present.
- Add pgTAP coverage proving the stale path is absent while the active queue trigger system remains intact.

## Motivation (AI generated)

The GHSA points at old device/D1 replication wiring that is no longer created by current migrations but still exists in production. If that trigger fires without its old queue, writes to `public.devices` can fail even though the linked replication system is dead code.

## Business Impact (AI generated)

This removes a stale production failure path from device registration/update flows without touching the active queue-based trigger system used elsewhere. It reduces operational risk and avoids support incidents caused by obsolete replication code.

## Test Plan (AI generated)

- [x] `bun run lint:backend`
- [x] `PGSSLMODE=disable bunx supabase test db --db-url 'postgresql://postgres:postgres@127.0.0.1:57362/postgres' supabase/tests/58_test_stale_device_replication_removed.sql`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- [ ] CI

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated database components to improve system stability and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->