### PR TITLE
[codex] fix translation AI exhaustion

### DIFF
--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -118,6 +118,31 @@ interface TranslationQueuePayload {
 type MessageEntry = [string, string]
 type TranslationStoreEntryInput = Omit<TranslationStoreEntry, 'updatedAt'>
 
+interface ReadyTranslationWriteInput {
+  batchCount?: number
+  checksum: string
+  claimedBatchIndex?: number
+  env: TranslationWorkerBindings
+  messages: Record<string, string>
+  model: string
+  nextBatchIndex: number
+  readyRequest: Request
+  requestId: string | undefined
+  targetLanguage: string
+}
+
+interface TranslatedBatchPersistenceInput {
+  batchIndex: number
+  batches: MessageEntry[][]
+  checksum: string
+  env: TranslationWorkerBindings
+  mergedMessages: Record<string, string>
+  model: string
+  readyRequest: Request
+  requestId: string | undefined
+  targetLanguage: string
+}
+
 class PublicHttpError extends Error {
   constructor(
     readonly status: number,
@@ -129,7 +154,7 @@ class PublicHttpError extends Error {
 }
 
 const sourceMessageCatalog = sourceMessages as Record<string, string>
-const sourceCatalogChecksumPromise = sha256Hex(JSON.stringify(sourceMessageCatalog))
+const sourceCatalogChecksumPromise = sha256Hex(JSON.stringify(sourceMessageCatalog)) // NOSONAR: top-level await is disallowed by lint config.
 let translationStoreInitialized = false
 let lastTranslationStoreCleanupAt = 0
 
@@ -1065,7 +1090,19 @@ async function nextProcessableBatchIndex(env: TranslationWorkerBindings, storedE
   return released ? claimedBatchIndex : null
 }
 
-async function writeReadyTranslation(env: TranslationWorkerBindings, checksum: string, targetLanguage: string, model: string, messages: Record<string, string>, nextBatchIndex: number, readyRequest: Request, requestId: string | undefined, batchCount?: number, claimedBatchIndex?: number) {
+async function writeReadyTranslation(input: ReadyTranslationWriteInput) {
+  const {
+    batchCount,
+    checksum,
+    claimedBatchIndex,
+    env,
+    messages,
+    model,
+    nextBatchIndex,
+    readyRequest,
+    requestId,
+    targetLanguage,
+  } = input
   const readyEntry = translationStoreEntry({
     checksum,
     messages,
@@ -1109,11 +1146,33 @@ async function translateOwnedBatch(ai: AiBinding, env: TranslationWorkerBindings
   }
 }
 
-async function persistTranslatedBatch(env: TranslationWorkerBindings, checksum: string, targetLanguage: string, model: string, mergedMessages: Record<string, string>, batchIndex: number, batches: MessageEntry[][], readyRequest: Request, requestId: string | undefined) {
+async function persistTranslatedBatch(input: TranslatedBatchPersistenceInput) {
+  const {
+    batchIndex,
+    batches,
+    checksum,
+    env,
+    mergedMessages,
+    model,
+    readyRequest,
+    requestId,
+    targetLanguage,
+  } = input
   const followingBatchIndex = batchIndex + 1
 
   if (followingBatchIndex >= batches.length) {
-    await writeReadyTranslation(env, checksum, targetLanguage, model, mergedMessages, followingBatchIndex, readyRequest, requestId, batches.length, batchIndex)
+    await writeReadyTranslation({
+      batchCount: batches.length,
+      checksum,
+      claimedBatchIndex: batchIndex,
+      env,
+      messages: mergedMessages,
+      model,
+      nextBatchIndex: followingBatchIndex,
+      readyRequest,
+      requestId,
+      targetLanguage,
+    })
     return
   }
 
@@ -1162,7 +1221,16 @@ async function processTranslationQueueBatch(env: TranslationWorkerBindings, body
     return
 
   if (nextBatchIndex >= batches.length) {
-    await writeReadyTranslation(env, checksum, targetLanguage, model, storedEntry.messages, nextBatchIndex, readyRequest, requestId)
+    await writeReadyTranslation({
+      checksum,
+      env,
+      messages: storedEntry.messages,
+      model,
+      nextBatchIndex,
+      readyRequest,
+      requestId,
+      targetLanguage,
+    })
     return
   }
 
@@ -1186,7 +1254,17 @@ async function processTranslationQueueBatch(env: TranslationWorkerBindings, body
     ...storedEntry.messages,
     ...translatedBatch,
   }
-  await persistTranslatedBatch(env, checksum, targetLanguage, model, mergedMessages, batchIndex, batches, readyRequest, requestId)
+  await persistTranslatedBatch({
+    batchIndex,
+    batches,
+    checksum,
+    env,
+    mergedMessages,
+    model,
+    readyRequest,
+    requestId,
+    targetLanguage,
+  })
 }
 
 async function fetchHandler(request: Request, env: TranslationWorkerBindings) {

--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -1,9 +1,10 @@
 import type { D1Database, ExecutionContext, MessageBatch, Queue } from '@cloudflare/workers-types'
 import sourceMessages from '../../messages/en.json' with { type: 'json' }
 
-const CACHE_TTL_SECONDS = 5 * 60
 const PENDING_TRANSLATION_STORE_TTL_SECONDS = 60 * 60
-const READY_TRANSLATION_STORE_TTL_SECONDS = 7 * 24 * 60 * 60
+const READY_TRANSLATION_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+const READY_TRANSLATION_STORE_TTL_SECONDS = READY_TRANSLATION_CACHE_TTL_SECONDS
+const READY_TRANSLATION_REFRESH_AFTER_SECONDS = 5 * 60
 const DEFAULT_TRANSLATION_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast'
 const MAX_BATCH_CHARACTERS = 6_000
 const MAX_BATCH_ITEMS = 60
@@ -36,6 +37,23 @@ const SUPPORTED_LANGUAGES = new Set([
   'zh-cn',
 ])
 
+const DEFAULT_TRANSLATION_ALLOWED_LANGUAGES = new Set([
+  'de',
+  'es',
+  'fr',
+  'hi',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'pl',
+  'pt',
+  'ru',
+  'tr',
+  'vi',
+  'zh',
+])
+
 const LANGUAGE_NAMES: Record<string, string> = {
   'de': 'German',
   'en': 'English',
@@ -64,6 +82,7 @@ interface TranslationWorkerBindings {
   AI?: AiBinding
   DB_TRANSLATIONS?: D1Database
   ENV_NAME?: string
+  TRANSLATION_ALLOWED_LANGUAGES?: string
   TRANSLATION_MESSAGES_QUEUE?: Queue<Required<TranslationQueuePayload>>
   TRANSLATION_MODEL?: string
 }
@@ -182,6 +201,26 @@ function getTranslationModel(env: TranslationWorkerBindings) {
 function targetLanguageLabel(targetLanguage: string) {
   const label = LANGUAGE_NAMES[targetLanguage]
   return typeof label === 'string' ? label : targetLanguage
+}
+
+function normalizeLanguageCode(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function configuredTranslationAllowedLanguages(env: TranslationWorkerBindings) {
+  if (typeof env.TRANSLATION_ALLOWED_LANGUAGES !== 'string')
+    return DEFAULT_TRANSLATION_ALLOWED_LANGUAGES
+
+  return new Set(
+    env.TRANSLATION_ALLOWED_LANGUAGES
+      .split(/[,\s]+/)
+      .map(normalizeLanguageCode)
+      .filter(language => language !== 'en' && SUPPORTED_LANGUAGES.has(language)),
+  )
+}
+
+function isTranslationLanguageAllowed(env: TranslationWorkerBindings, targetLanguage: string) {
+  return configuredTranslationAllowedLanguages(env).has(targetLanguage)
 }
 
 async function sha256Hex(value: string) {
@@ -565,7 +604,7 @@ function isPendingTranslationStale(entry: TranslationStoreEntry) {
 }
 
 function isReadyTranslationFresh(entry: TranslationStoreEntry) {
-  return entry.status === 'ready' && nowSeconds() - entry.updatedAt < CACHE_TTL_SECONDS
+  return entry.status === 'ready' && nowSeconds() - entry.updatedAt < READY_TRANSLATION_REFRESH_AFTER_SECONDS
 }
 
 function isTranslationBatchLeaseExpired(entry: TranslationStoreEntry) {
@@ -796,7 +835,7 @@ async function cacheReadyTranslationPayload(requestId: string | undefined, ready
   try {
     await workerCache().put(readyRequest, new Response(JSON.stringify(payload), {
       headers: {
-        'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`,
+        'Cache-Control': `public, max-age=${READY_TRANSLATION_CACHE_TTL_SECONDS}`,
         'Content-Type': 'application/json',
       },
     }))
@@ -874,7 +913,7 @@ async function readyTranslationResponse(requestId: string | undefined, readyRequ
   const payload = readyPayloadFromStore(entry)
   await cacheReadyTranslationPayload(requestId, readyRequest, payload, targetLanguage)
   return jsonResponse(payload, 200, {
-    'Cache-Control': `public, max-age=0, s-maxage=${CACHE_TTL_SECONDS}`,
+    'Cache-Control': `public, max-age=0, s-maxage=${READY_TRANSLATION_CACHE_TTL_SECONDS}`,
   })
 }
 
@@ -951,6 +990,9 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
   if (targetLanguage === 'en')
     fail(400, 'unsupported_translation_language', 'English messages are already bundled')
 
+  if (!isTranslationLanguageAllowed(env, targetLanguage))
+    fail(400, 'unsupported_translation_language', 'Target language is not enabled')
+
   const checksum = await currentSourceChecksum()
   const model = getTranslationModel(env)
   const readyRequest = buildTranslationCacheRequest(checksum, targetLanguage)
@@ -958,7 +1000,7 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
   const cached = await matchReadyTranslationPayload(readyRequest)
   if (cached) {
     return jsonResponse(cached, 200, {
-      'Cache-Control': `public, max-age=0, s-maxage=${CACHE_TTL_SECONDS}`,
+      'Cache-Control': `public, max-age=0, s-maxage=${READY_TRANSLATION_CACHE_TTL_SECONDS}`,
     })
   }
 
@@ -992,14 +1034,14 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
   return pendingTranslationResponse(checksum)
 }
 
-function queuedTargetLanguage(body: TranslationQueuePayload, requestId: string | undefined) {
+function queuedTargetLanguage(body: TranslationQueuePayload, env: TranslationWorkerBindings, requestId: string | undefined) {
   const targetLanguage = typeof body.targetLanguage === 'string' ? body.targetLanguage.trim().toLowerCase() : ''
-  if (SUPPORTED_LANGUAGES.has(targetLanguage) && targetLanguage !== 'en')
+  if (SUPPORTED_LANGUAGES.has(targetLanguage) && targetLanguage !== 'en' && isTranslationLanguageAllowed(env, targetLanguage))
     return targetLanguage
 
   cloudlogErr({
     requestId,
-    message: 'Ignoring unsupported queued translation language',
+    message: 'Ignoring disabled or unsupported queued translation language',
     targetLanguage,
   })
   return null
@@ -1108,7 +1150,7 @@ async function persistTranslatedBatch(env: TranslationWorkerBindings, checksum: 
 }
 
 async function processTranslationQueueBatch(env: TranslationWorkerBindings, body: TranslationQueuePayload, requestId?: string) {
-  const targetLanguage = queuedTargetLanguage(body, requestId)
+  const targetLanguage = queuedTargetLanguage(body, env, requestId)
   if (!targetLanguage)
     return
 
@@ -1214,11 +1256,13 @@ export default {
 export const __translationWorkerTestUtils__ = {
   buildBatches,
   claimedTranslationBatchIndex,
+  currentSourceChecksum,
   isReadyTranslationFresh,
   isTranslationBatchLeaseExpired,
   keepTranslation,
   normalizeBatchIndex,
   parseTranslationObject,
+  readyTranslationCacheTtlSeconds: READY_TRANSLATION_CACHE_TTL_SECONDS,
   translationBatchClaimMarker,
   translationBatchIndexFromStore,
   translationStoreTtlSeconds,

--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -1,10 +1,9 @@
 import type { D1Database, ExecutionContext, MessageBatch, Queue } from '@cloudflare/workers-types'
 import sourceMessages from '../../messages/en.json' with { type: 'json' }
 
+const CACHE_TTL_SECONDS = 5 * 60
 const PENDING_TRANSLATION_STORE_TTL_SECONDS = 60 * 60
-const READY_TRANSLATION_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
-const READY_TRANSLATION_STORE_TTL_SECONDS = READY_TRANSLATION_CACHE_TTL_SECONDS
-const READY_TRANSLATION_REFRESH_AFTER_SECONDS = 5 * 60
+const READY_TRANSLATION_STORE_TTL_SECONDS = 7 * 24 * 60 * 60
 const DEFAULT_TRANSLATION_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast'
 const MAX_BATCH_CHARACTERS = 6_000
 const MAX_BATCH_ITEMS = 60
@@ -37,7 +36,7 @@ const SUPPORTED_LANGUAGES = new Set([
   'zh-cn',
 ])
 
-const DEFAULT_TRANSLATION_ALLOWED_LANGUAGES = new Set([
+const TRANSLATION_ALLOWED_LANGUAGES = new Set([
   'de',
   'es',
   'fr',
@@ -82,7 +81,6 @@ interface TranslationWorkerBindings {
   AI?: AiBinding
   DB_TRANSLATIONS?: D1Database
   ENV_NAME?: string
-  TRANSLATION_ALLOWED_LANGUAGES?: string
   TRANSLATION_MESSAGES_QUEUE?: Queue<Required<TranslationQueuePayload>>
   TRANSLATION_MODEL?: string
 }
@@ -203,24 +201,8 @@ function targetLanguageLabel(targetLanguage: string) {
   return typeof label === 'string' ? label : targetLanguage
 }
 
-function normalizeLanguageCode(value: string) {
-  return value.trim().toLowerCase()
-}
-
-function configuredTranslationAllowedLanguages(env: TranslationWorkerBindings) {
-  if (typeof env.TRANSLATION_ALLOWED_LANGUAGES !== 'string')
-    return DEFAULT_TRANSLATION_ALLOWED_LANGUAGES
-
-  return new Set(
-    env.TRANSLATION_ALLOWED_LANGUAGES
-      .split(/[,\s]+/)
-      .map(normalizeLanguageCode)
-      .filter(language => language !== 'en' && SUPPORTED_LANGUAGES.has(language)),
-  )
-}
-
-function isTranslationLanguageAllowed(env: TranslationWorkerBindings, targetLanguage: string) {
-  return configuredTranslationAllowedLanguages(env).has(targetLanguage)
+function isTranslationLanguageAllowed(targetLanguage: string) {
+  return TRANSLATION_ALLOWED_LANGUAGES.has(targetLanguage)
 }
 
 async function sha256Hex(value: string) {
@@ -604,7 +586,7 @@ function isPendingTranslationStale(entry: TranslationStoreEntry) {
 }
 
 function isReadyTranslationFresh(entry: TranslationStoreEntry) {
-  return entry.status === 'ready' && nowSeconds() - entry.updatedAt < READY_TRANSLATION_REFRESH_AFTER_SECONDS
+  return entry.status === 'ready' && nowSeconds() - entry.updatedAt < CACHE_TTL_SECONDS
 }
 
 function isTranslationBatchLeaseExpired(entry: TranslationStoreEntry) {
@@ -835,7 +817,7 @@ async function cacheReadyTranslationPayload(requestId: string | undefined, ready
   try {
     await workerCache().put(readyRequest, new Response(JSON.stringify(payload), {
       headers: {
-        'Cache-Control': `public, max-age=${READY_TRANSLATION_CACHE_TTL_SECONDS}`,
+        'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`,
         'Content-Type': 'application/json',
       },
     }))
@@ -913,7 +895,7 @@ async function readyTranslationResponse(requestId: string | undefined, readyRequ
   const payload = readyPayloadFromStore(entry)
   await cacheReadyTranslationPayload(requestId, readyRequest, payload, targetLanguage)
   return jsonResponse(payload, 200, {
-    'Cache-Control': `public, max-age=0, s-maxage=${READY_TRANSLATION_CACHE_TTL_SECONDS}`,
+    'Cache-Control': `public, max-age=0, s-maxage=${CACHE_TTL_SECONDS}`,
   })
 }
 
@@ -990,7 +972,7 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
   if (targetLanguage === 'en')
     fail(400, 'unsupported_translation_language', 'English messages are already bundled')
 
-  if (!isTranslationLanguageAllowed(env, targetLanguage))
+  if (!isTranslationLanguageAllowed(targetLanguage))
     fail(400, 'unsupported_translation_language', 'Target language is not enabled')
 
   const checksum = await currentSourceChecksum()
@@ -1000,7 +982,7 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
   const cached = await matchReadyTranslationPayload(readyRequest)
   if (cached) {
     return jsonResponse(cached, 200, {
-      'Cache-Control': `public, max-age=0, s-maxage=${READY_TRANSLATION_CACHE_TTL_SECONDS}`,
+      'Cache-Control': `public, max-age=0, s-maxage=${CACHE_TTL_SECONDS}`,
     })
   }
 
@@ -1034,9 +1016,9 @@ async function handleTranslationMessages(request: Request, env: TranslationWorke
   return pendingTranslationResponse(checksum)
 }
 
-function queuedTargetLanguage(body: TranslationQueuePayload, env: TranslationWorkerBindings, requestId: string | undefined) {
+function queuedTargetLanguage(body: TranslationQueuePayload, requestId: string | undefined) {
   const targetLanguage = typeof body.targetLanguage === 'string' ? body.targetLanguage.trim().toLowerCase() : ''
-  if (SUPPORTED_LANGUAGES.has(targetLanguage) && targetLanguage !== 'en' && isTranslationLanguageAllowed(env, targetLanguage))
+  if (SUPPORTED_LANGUAGES.has(targetLanguage) && targetLanguage !== 'en' && isTranslationLanguageAllowed(targetLanguage))
     return targetLanguage
 
   cloudlogErr({
@@ -1150,7 +1132,7 @@ async function persistTranslatedBatch(env: TranslationWorkerBindings, checksum: 
 }
 
 async function processTranslationQueueBatch(env: TranslationWorkerBindings, body: TranslationQueuePayload, requestId?: string) {
-  const targetLanguage = queuedTargetLanguage(body, env, requestId)
+  const targetLanguage = queuedTargetLanguage(body, requestId)
   if (!targetLanguage)
     return
 
@@ -1256,13 +1238,11 @@ export default {
 export const __translationWorkerTestUtils__ = {
   buildBatches,
   claimedTranslationBatchIndex,
-  currentSourceChecksum,
   isReadyTranslationFresh,
   isTranslationBatchLeaseExpired,
   keepTranslation,
   normalizeBatchIndex,
   parseTranslationObject,
-  readyTranslationCacheTtlSeconds: READY_TRANSLATION_CACHE_TTL_SECONDS,
   translationBatchClaimMarker,
   translationBatchIndexFromStore,
   translationStoreTtlSeconds,

--- a/cloudflare_workers/translation/wrangler.jsonc
+++ b/cloudflare_workers/translation/wrangler.jsonc
@@ -22,8 +22,7 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-prod",
-        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
+        "ENV_NAME": "capgo_translation_console-prod"
       },
       "observability": {
         "enabled": true,
@@ -70,8 +69,7 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-preprod",
-        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
+        "ENV_NAME": "capgo_translation_console-preprod"
       },
       "observability": {
         "enabled": true
@@ -117,8 +115,7 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-alpha",
-        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
+        "ENV_NAME": "capgo_translation_console-alpha"
       },
       "observability": {
         "enabled": true
@@ -164,8 +161,7 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-local",
-        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
+        "ENV_NAME": "capgo_translation_console-local"
       },
       "d1_databases": [
         {

--- a/cloudflare_workers/translation/wrangler.jsonc
+++ b/cloudflare_workers/translation/wrangler.jsonc
@@ -22,7 +22,8 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-prod"
+        "ENV_NAME": "capgo_translation_console-prod",
+        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
       },
       "observability": {
         "enabled": true,
@@ -69,7 +70,8 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-preprod"
+        "ENV_NAME": "capgo_translation_console-preprod",
+        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
       },
       "observability": {
         "enabled": true
@@ -115,7 +117,8 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-alpha"
+        "ENV_NAME": "capgo_translation_console-alpha",
+        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
       },
       "observability": {
         "enabled": true
@@ -161,7 +164,8 @@
         "binding": "AI"
       },
       "vars": {
-        "ENV_NAME": "capgo_translation_console-local"
+        "ENV_NAME": "capgo_translation_console-local",
+        "TRANSLATION_ALLOWED_LANGUAGES": "de,es,fr,hi,id,it,ja,ko,pl,pt,ru,tr,vi,zh"
       },
       "d1_databases": [
         {

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -104,44 +104,6 @@ describe('translation queue helpers', () => {
     })).toBe(false)
   })
 
-  it('serves current ready translations with a week-long shared cache', async () => {
-    const cache = stubWorkerCache()
-    const checksum = await __translationWorkerTestUtils__.currentSourceChecksum()
-    const now = Math.floor(Date.now() / 1000)
-    const latestReadyEntry = {
-      checksum,
-      messages: JSON.stringify({ account: 'Compte' }),
-      model: 'model',
-      next_batch_index: 1,
-      status: 'ready',
-      target_language: 'fr',
-      updated_at: now - 30,
-    }
-    const db = createTranslationStoreMock(latestReadyEntry)
-    const queue = {
-      send: vi.fn(),
-    }
-    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
-      body: JSON.stringify({ targetLanguage: 'fr' }),
-      headers: { 'Content-Type': 'application/json' },
-      method: 'POST',
-    }), {
-      DB_TRANSLATIONS: db,
-      TRANSLATION_MESSAGES_QUEUE: queue,
-    } as any)
-    const payload = await response.json() as { checksum: string, messages: Record<string, string>, status: string }
-    const cacheTtl = __translationWorkerTestUtils__.readyTranslationCacheTtlSeconds
-
-    expect(response.status).toBe(200)
-    expect(response.headers.get('cache-control')).toBe(`public, max-age=0, s-maxage=${cacheTtl}`)
-    expect(payload.status).toBe('ready')
-    expect(payload.checksum).toBe(checksum)
-    expect(cache.put).toHaveBeenCalledTimes(1)
-    const cachePutCalls = cache.put.mock.calls as unknown as [Request, Response][]
-    expect(cachePutCalls[0][1].headers.get('cache-control')).toBe(`public, max-age=${cacheTtl}`)
-    expect(queue.send).not.toHaveBeenCalled()
-  })
-
   it('serves a recent saved translation without queueing a refresh', async () => {
     stubWorkerCache()
     const now = Math.floor(Date.now() / 1000)
@@ -243,26 +205,6 @@ describe('translation queue helpers', () => {
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
     }), {
-      TRANSLATION_MESSAGES_QUEUE: queue,
-    } as any)
-    const payload = await response.json() as { error: string, message: string }
-
-    expect(response.status).toBe(400)
-    expect(payload.error).toBe('unsupported_translation_language')
-    expect(payload.message).toBe('Target language is not enabled')
-    expect(queue.send).not.toHaveBeenCalled()
-  })
-
-  it('honors a tighter configured public generation allow-list', async () => {
-    const queue = {
-      send: vi.fn(),
-    }
-    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
-      body: JSON.stringify({ targetLanguage: 'de' }),
-      headers: { 'Content-Type': 'application/json' },
-      method: 'POST',
-    }), {
-      TRANSLATION_ALLOWED_LANGUAGES: 'fr',
       TRANSLATION_MESSAGES_QUEUE: queue,
     } as any)
     const payload = await response.json() as { error: string, message: string }

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -104,6 +104,44 @@ describe('translation queue helpers', () => {
     })).toBe(false)
   })
 
+  it('serves current ready translations with a week-long shared cache', async () => {
+    const cache = stubWorkerCache()
+    const checksum = await __translationWorkerTestUtils__.currentSourceChecksum()
+    const now = Math.floor(Date.now() / 1000)
+    const latestReadyEntry = {
+      checksum,
+      messages: JSON.stringify({ account: 'Compte' }),
+      model: 'model',
+      next_batch_index: 1,
+      status: 'ready',
+      target_language: 'fr',
+      updated_at: now - 30,
+    }
+    const db = createTranslationStoreMock(latestReadyEntry)
+    const queue = {
+      send: vi.fn(),
+    }
+    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'fr' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }), {
+      DB_TRANSLATIONS: db,
+      TRANSLATION_MESSAGES_QUEUE: queue,
+    } as any)
+    const payload = await response.json() as { checksum: string, messages: Record<string, string>, status: string }
+    const cacheTtl = __translationWorkerTestUtils__.readyTranslationCacheTtlSeconds
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe(`public, max-age=0, s-maxage=${cacheTtl}`)
+    expect(payload.status).toBe('ready')
+    expect(payload.checksum).toBe(checksum)
+    expect(cache.put).toHaveBeenCalledTimes(1)
+    const cachePutCalls = cache.put.mock.calls as unknown as [Request, Response][]
+    expect(cachePutCalls[0][1].headers.get('cache-control')).toBe(`public, max-age=${cacheTtl}`)
+    expect(queue.send).not.toHaveBeenCalled()
+  })
+
   it('serves a recent saved translation without queueing a refresh', async () => {
     stubWorkerCache()
     const now = Math.floor(Date.now() / 1000)
@@ -194,5 +232,66 @@ describe('translation queue helpers', () => {
     expect(response.status).toBe(202)
     expect(payload.status).toBe('pending')
     expect(queue.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects supported aliases outside the public generation allow-list before queueing', async () => {
+    const queue = {
+      send: vi.fn(),
+    }
+    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'pt-br' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }), {
+      TRANSLATION_MESSAGES_QUEUE: queue,
+    } as any)
+    const payload = await response.json() as { error: string, message: string }
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('unsupported_translation_language')
+    expect(payload.message).toBe('Target language is not enabled')
+    expect(queue.send).not.toHaveBeenCalled()
+  })
+
+  it('honors a tighter configured public generation allow-list', async () => {
+    const queue = {
+      send: vi.fn(),
+    }
+    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'de' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }), {
+      TRANSLATION_ALLOWED_LANGUAGES: 'fr',
+      TRANSLATION_MESSAGES_QUEUE: queue,
+    } as any)
+    const payload = await response.json() as { error: string, message: string }
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('unsupported_translation_language')
+    expect(payload.message).toBe('Target language is not enabled')
+    expect(queue.send).not.toHaveBeenCalled()
+  })
+
+  it('ignores queued translations outside the generation allow-list before AI work', async () => {
+    const ai = {
+      run: vi.fn(),
+    }
+    const message = {
+      ack: vi.fn(),
+      body: {
+        batchIndex: 0,
+        checksum: 'checksum',
+        model: 'model',
+        targetLanguage: 'pt-br',
+      },
+      retry: vi.fn(),
+    }
+
+    await translationWorker.queue({ messages: [message] } as any, { AI: ai } as any, {} as any)
+
+    expect(ai.run).not.toHaveBeenCalled()
+    expect(message.ack).toHaveBeenCalledTimes(1)
+    expect(message.retry).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Hard-coded the translation generation allow-list in the Cloudflare translation worker.
- Reject public translation requests for supported-but-disabled language aliases before D1, queue, or Workers AI work.
- Ignore disabled queued translation messages before Workers AI work, acknowledging them without retry.
- Added focused regression coverage for public and queued allow-list enforcement.

## Motivation (AI generated)

GHSA-366q-7846-wg57 reported that unauthenticated callers could repeatedly trigger full Workers AI catalog translations across the supported language surface. The worker needed a bounded generation surface: only the approved in-code language list can trigger translation work.

## Business Impact (AI generated)

This reduces Workers AI cost and quota exhaustion risk while keeping approved console translations available. It avoids deployment-time configuration drift because the allowed generation list now lives directly in code.

## Test Plan (AI generated)

- [x] bun lint
- [x] bunx eslint cloudflare_workers/translation/index.ts tests/translation-queue.unit.test.ts
- [x] bunx vitest run tests/translation-queue.unit.test.ts
- [x] bun run typecheck:backend
- [x] pre-commit hook: bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Translation requests for supported-but-not-enabled target languages are now rejected with HTTP 400 and an `unsupported_translation_language` error.
  * Queued translations targeting disabled or unsupported languages are ignored and dropped before processing.

* **Tests**
  * Added unit tests verifying request rejection for disallowed language aliases and that disabled queued messages are not processed and are acknowledged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->