### PR TITLE
[codex] fix(security): redact invite token from logs

### DIFF
--- a/supabase/functions/_backend/private/accept_invitation.ts
+++ b/supabase/functions/_backend/private/accept_invitation.ts
@@ -276,7 +276,7 @@ app.post('/', async (c) => {
   }
 
   const baseBody = baseValidationResult.data
-  const { password: _password, captchaToken: _captchaToken, ...baseBodyWithoutSecrets } = baseBody
+  const { password: _password, captchaToken: _captchaToken, magic_invite_string: _magicInviteString, ...baseBodyWithoutSecrets } = baseBody
   cloudlog({ requestId: c.get('requestId'), context: 'accept_invitation raw body', rawBody: baseBodyWithoutSecrets })
 
   const supabaseAdmin = useSupabaseAdmin(c)
@@ -377,7 +377,7 @@ app.post('/', async (c) => {
     ...baseBody,
     password: baseBody.password,
   }
-  const { password: _pwd, captchaToken: _cap, ...bodyWithoutSecrets } = body
+  const { password: _pwd, captchaToken: _cap, magic_invite_string: _magicInviteString2, ...bodyWithoutSecrets } = body
   cloudlog({ requestId: c.get('requestId'), context: 'accept_invitation validated body', body: bodyWithoutSecrets })
 
   // here the real magic happens

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -8,6 +8,26 @@ import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
 const filesUploadFunctionNames = new Set(['files', 'TUS handler'])
+const sensitiveRequestBodyKeys = new Set([
+  'captchaToken',
+  'captcha_token',
+  'invite_magic_string',
+  'magic_invite_string',
+  'password',
+])
+
+function redactSensitiveRequestBody(value: unknown): unknown {
+  if (Array.isArray(value))
+    return value.map(redactSensitiveRequestBody)
+
+  if (!value || typeof value !== 'object')
+    return value
+
+  return Object.fromEntries(Object.entries(value).map(([key, entryValue]) => [
+    key,
+    sensitiveRequestBodyKeys.has(key) ? '[redacted]' : redactSensitiveRequestBody(entryValue),
+  ]))
+}
 
 function isFilesDurableObjectStorageTimeout(functionName: string, error: unknown): boolean {
   if (!filesUploadFunctionNames.has(functionName) || !error || typeof error !== 'object' || !('message' in error))
@@ -37,7 +57,7 @@ export function onError(functionName: string) {
           const textBody = await rawReq?.clone().text()
           if (textBody) {
             try {
-              body = JSON.stringify(JSON.parse(textBody))
+              body = JSON.stringify(redactSensitiveRequestBody(JSON.parse(textBody)))
             }
             catch {
               body = textBody

--- a/tests/accept-invitation-logging.unit.test.ts
+++ b/tests/accept-invitation-logging.unit.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockCloudlog,
+  mockCreateUser,
+  mockEmptySupabase,
+  mockSupabaseAdmin,
+} = vi.hoisted(() => ({
+  mockCloudlog: vi.fn(),
+  mockCreateUser: vi.fn(),
+  mockEmptySupabase: vi.fn(),
+  mockSupabaseAdmin: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: mockCloudlog,
+  cloudlogErr: vi.fn(),
+  serializeError: (error: unknown) => JSON.stringify(error),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  emptySupabase: mockEmptySupabase,
+  supabaseAdmin: mockSupabaseAdmin,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/user_preferences.ts', () => ({
+  syncUserPreferenceTags: vi.fn(),
+}))
+
+const { app } = await import('../supabase/functions/_backend/private/accept_invitation.ts')
+
+const invitation = {
+  email: 'invitee@example.com',
+  first_name: 'Invited',
+  future_uuid: '550e8400-e29b-41d4-a716-446655440000',
+  last_name: 'User',
+  org_id: 'org-test',
+  role: 'read',
+}
+
+function buildSupabaseAdmin() {
+  return {
+    auth: {
+      admin: {
+        createUser: mockCreateUser,
+      },
+    },
+    from(table: string) {
+      if (table === 'tmp_users') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: invitation, error: null }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'orgs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: { password_policy_config: null }, error: null }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'users') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: null, error: null }),
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    },
+  }
+}
+
+describe('accept invitation logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseAdmin.mockReturnValue(buildSupabaseAdmin())
+    mockEmptySupabase.mockReturnValue({})
+    mockCreateUser.mockResolvedValue({
+      data: null,
+      error: { message: 'stop after validated log' },
+    })
+  })
+
+  it('redacts invitation bearer token from raw and validated body logs', async () => {
+    const inviteToken = 'secret-invite-token'
+    const response = await app.request(new Request('http://localhost/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        password: 'Password1!',
+        magic_invite_string: inviteToken,
+        opt_for_newsletters: false,
+        captchaToken: 'captcha-secret',
+      }),
+    }))
+
+    expect(response.status).toBe(500)
+
+    const rawBodyLog = mockCloudlog.mock.calls.find(([entry]) => entry.context === 'accept_invitation raw body')?.[0]
+    const validatedBodyLog = mockCloudlog.mock.calls.find(([entry]) => entry.context === 'accept_invitation validated body')?.[0]
+
+    expect(rawBodyLog?.rawBody).toEqual({ opt_for_newsletters: false })
+    expect(validatedBodyLog?.body).toEqual({ opt_for_newsletters: false })
+    expect(JSON.stringify(mockCloudlog.mock.calls)).not.toContain(inviteToken)
+    expect(JSON.stringify(mockCloudlog.mock.calls)).not.toContain('Password1!')
+    expect(JSON.stringify(mockCloudlog.mock.calls)).not.toContain('captcha-secret')
+  })
+})

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -35,14 +35,14 @@ vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   }),
 }))
 
-function createContext() {
+function createContext(request?: Request) {
   return {
     get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
     json: (body: unknown, status: number) => ({ body, status }),
     req: {
-      method: 'GET',
-      raw: new Request('https://example.com/functions/v1/app', { method: 'GET' }),
-      url: 'https://example.com/functions/v1/app',
+      method: request?.method ?? 'GET',
+      raw: request ?? new Request('https://example.com/functions/v1/app', { method: 'GET' }),
+      url: request?.url ?? 'https://example.com/functions/v1/app',
     },
   } as any
 }
@@ -62,6 +62,50 @@ afterEach(() => {
 })
 
 describe('onError PostHog capture', () => {
+  it('redacts sensitive JSON request body fields before Discord alerts', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const error = new HTTPException(500, {
+      cause: {
+        error: 'internal_error',
+        message: 'Something broke',
+        moreInfo: {},
+      },
+    })
+
+    const response = await onError('private')(error, createContext(new Request('https://example.com/functions/v1/private/accept_invitation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        captchaToken: 'captcha-secret',
+        magic_invite_string: 'invite-secret',
+        nested: {
+          password: 'NestedPassword1!',
+        },
+        opt_for_newsletters: false,
+        password: 'Password1!',
+      }),
+    })))
+
+    expect(response.status).toBe(500)
+    expect(sendDiscordAlert500Mock).toHaveBeenCalledOnce()
+
+    const alertBody = sendDiscordAlert500Mock.mock.calls[0]?.[2]
+    expect(alertBody).toBe(JSON.stringify({
+      captchaToken: '[redacted]',
+      magic_invite_string: '[redacted]',
+      nested: {
+        password: '[redacted]',
+      },
+      opt_for_newsletters: false,
+      password: '[redacted]',
+    }))
+    expect(alertBody).not.toContain('captcha-secret')
+    expect(alertBody).not.toContain('invite-secret')
+    expect(alertBody).not.toContain('NestedPassword1!')
+    expect(alertBody).not.toContain('Password1!')
+  })
+
   it('captures backend HTTP exceptions in PostHog', async () => {
     const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
 


### PR DESCRIPTION
## Summary (AI generated)

- Redacts `magic_invite_string` from the `accept_invitation raw body` log payload.
- Redacts `magic_invite_string` from the `accept_invitation validated body` log payload.
- Adds a focused regression test proving invitation bearer tokens, passwords, and captcha tokens are not sent to `cloudlog`.

## Motivation (AI generated)

GHSA-jw88-732f-wqhr reported that `accept_invitation` logs could include `magic_invite_string`, which acts as an invitation bearer token and lookup key. The route already stripped password and captcha values before logging; this applies the same treatment to the invitation token.

## Business Impact (AI generated)

This reduces the risk of invitation-token disclosure through hosting or observability logs without changing the invitation acceptance flow. It preserves user onboarding behavior while tightening log hygiene for a security advisory.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/accept-invitation-logging.unit.test.ts`
- [x] `bun lint:backend`
- [x] `bunx eslint tests/accept-invitation-logging.unit.test.ts`
- [x] `bun lint`
- [x] Commit hook typechecks: `bun run cli:typecheck`, `bun run typecheck:backend`, `bun run typecheck:frontend`

## Screenshots (AI generated)

Not applicable; backend logging-only change.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [x] My change does not require documentation changes.
- [x] E2E coverage is not required for this backend logging-only change; focused unit coverage was added.
- [x] Manual UI testing is not applicable for this backend logging-only change.

Generated with AI
