### PR TITLE
feat(build): send actorUserId to the builder for PostHog person attribution

### DIFF
--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -53,6 +53,7 @@ function throwBuilderUnavailable(message: string, moreInfo: Record<string, unkno
  */
 export function buildBuilderPayload(input: {
   orgId: string
+  actorUserId: string
   uploadPath: string
   platform: string
   buildOptions: Record<string, unknown>
@@ -62,7 +63,11 @@ export function buildBuilderPayload(input: {
   delete buildOptions.timeoutSeconds
 
   return {
+    // userId carries the org_id (anonymized owner) — kept for backwards compat.
     userId: input.orgId,
+    // actorUserId is the human user who triggered the build (apikey.user_id). The builder
+    // uses it as the PostHog distinct_id so its build events join this same person.
+    actorUserId: input.actorUserId,
     artifactKey: input.uploadPath,
     fastlane: { lane: input.platform },
     buildOptions,
@@ -226,13 +231,14 @@ async function createBuilderJob(c: Context, input: {
   builderUrl: string
   builderApiKey: string
   orgId: string
+  actorUserId: string
   appId: string
   platform: 'ios' | 'android'
   uploadPath: string
   buildOptions: Record<string, unknown>
   buildCredentials: Record<string, string>
 }): Promise<BuilderJobResponse> {
-  const { builderUrl, builderApiKey, orgId, appId, platform, uploadPath, buildOptions, buildCredentials } = input
+  const { builderUrl, builderApiKey, orgId, actorUserId, appId, platform, uploadPath, buildOptions, buildCredentials } = input
   cloudlog({
     requestId: c.get('requestId'),
     message: 'Calling builder API',
@@ -252,6 +258,7 @@ async function createBuilderJob(c: Context, input: {
       },
       body: JSON.stringify(buildBuilderPayload({
         orgId,
+        actorUserId,
         uploadPath,
         platform,
         buildOptions,
@@ -454,6 +461,7 @@ export async function requestBuild(
     builderUrl,
     builderApiKey,
     orgId: org_id,
+    actorUserId: apikey.user_id,
     appId: app_id,
     platform,
     uploadPath: upload_path,

--- a/tests/builder-payload.unit.test.ts
+++ b/tests/builder-payload.unit.test.ts
@@ -4,7 +4,7 @@ import { builderPayloadTestUtils } from '../supabase/functions/_backend/public/b
 const { buildBuilderPayload } = builderPayloadTestUtils
 
 describe('builder payload shape', () => {
-  it('maps build_options (snake_case input) to buildOptions (camelCase output)', () => {
+  it.concurrent('maps build_options (snake_case input) to buildOptions (camelCase output)', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-123',
       actorUserId: 'user-1',
@@ -20,7 +20,7 @@ describe('builder payload shape', () => {
     expect(payload).not.toHaveProperty('build_options')
   })
 
-  it('maps build_credentials (snake_case input) to buildCredentials (camelCase output)', () => {
+  it.concurrent('maps build_credentials (snake_case input) to buildCredentials (camelCase output)', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-123',
       actorUserId: 'user-1',
@@ -36,7 +36,7 @@ describe('builder payload shape', () => {
     expect(payload).not.toHaveProperty('build_credentials')
   })
 
-  it('does not include a legacy flat credentials field', () => {
+  it.concurrent('does not include a legacy flat credentials field', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-123',
       actorUserId: 'user-1',
@@ -49,7 +49,7 @@ describe('builder payload shape', () => {
     expect(payload).not.toHaveProperty('credentials')
   })
 
-  it('includes userId (org), actorUserId (human), artifactKey, and fastlane with correct values', () => {
+  it.concurrent('includes userId (org), actorUserId (human), artifactKey, and fastlane with correct values', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-456',
       actorUserId: 'user-789',
@@ -65,7 +65,7 @@ describe('builder payload shape', () => {
     expect(payload.fastlane).toEqual({ lane: 'android' })
   })
 
-  it('contains exactly the expected top-level keys', () => {
+  it.concurrent('contains exactly the expected top-level keys', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-789',
       actorUserId: 'user-1',
@@ -99,7 +99,7 @@ describe('builder payload shape', () => {
     expect(payload.buildOptions).toEqual({ platform: 'ios' })
   })
 
-  it('passes through buildOptions and buildCredentials contents unchanged', () => {
+  it.concurrent('passes through buildOptions and buildCredentials contents unchanged', () => {
     const complexOptions = {
       platform: 'ios',
       buildMode: 'debug',

--- a/tests/builder-payload.unit.test.ts
+++ b/tests/builder-payload.unit.test.ts
@@ -7,6 +7,7 @@ describe('builder payload shape', () => {
   it('maps build_options (snake_case input) to buildOptions (camelCase output)', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-123',
+      actorUserId: 'user-1',
       uploadPath: 'orgs/org-123/apps/com.test/native-builds/session.zip',
       platform: 'ios',
       buildOptions: { platform: 'ios', buildMode: 'release', cliVersion: '7.83.0' },
@@ -22,6 +23,7 @@ describe('builder payload shape', () => {
   it('maps build_credentials (snake_case input) to buildCredentials (camelCase output)', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-123',
+      actorUserId: 'user-1',
       uploadPath: 'orgs/org-123/apps/com.test/native-builds/session.zip',
       platform: 'android',
       buildOptions: {},
@@ -37,6 +39,7 @@ describe('builder payload shape', () => {
   it('does not include a legacy flat credentials field', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-123',
+      actorUserId: 'user-1',
       uploadPath: 'path.zip',
       platform: 'ios',
       buildOptions: {},
@@ -46,9 +49,10 @@ describe('builder payload shape', () => {
     expect(payload).not.toHaveProperty('credentials')
   })
 
-  it('includes userId, artifactKey, and fastlane with correct values', () => {
+  it('includes userId (org), actorUserId (human), artifactKey, and fastlane with correct values', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-456',
+      actorUserId: 'user-789',
       uploadPath: 'orgs/org-456/apps/com.example/native-builds/uuid.zip',
       platform: 'android',
       buildOptions: {},
@@ -56,6 +60,7 @@ describe('builder payload shape', () => {
     })
 
     expect(payload.userId).toBe('org-456')
+    expect(payload.actorUserId).toBe('user-789')
     expect(payload.artifactKey).toBe('orgs/org-456/apps/com.example/native-builds/uuid.zip')
     expect(payload.fastlane).toEqual({ lane: 'android' })
   })
@@ -63,6 +68,7 @@ describe('builder payload shape', () => {
   it('contains exactly the expected top-level keys', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-789',
+      actorUserId: 'user-1',
       uploadPath: 'path/to/artifact.zip',
       platform: 'ios',
       buildOptions: { foo: 'bar' },
@@ -71,6 +77,7 @@ describe('builder payload shape', () => {
 
     const keys = Object.keys(payload).sort()
     expect(keys).toEqual([
+      'actorUserId',
       'artifactKey',
       'buildCredentials',
       'buildOptions',
@@ -82,6 +89,7 @@ describe('builder payload shape', () => {
   it.concurrent('drops timeoutSeconds from buildOptions', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-timeout',
+      actorUserId: 'user-1',
       uploadPath: 'path/to/artifact.zip',
       platform: 'ios',
       buildOptions: { platform: 'ios', timeoutSeconds: 999999 },
@@ -106,6 +114,7 @@ describe('builder payload shape', () => {
 
     const payload = buildBuilderPayload({
       orgId: 'org-test',
+      actorUserId: 'user-1',
       uploadPath: 'test/path.zip',
       platform: 'ios',
       buildOptions: complexOptions,


### PR DESCRIPTION
## What
Adds `actorUserId` (the human `apikey.user_id`) to the `POST /jobs` payload sent to the builder.

Today the payload only carries `userId = org_id` (the anonymized owner) — there is no human user. The builder has no telemetry of its own provider/build decisions, and we're adding PostHog events there (`native_build_dispatched` / `native_build_finished`). To attribute those to the **same person** as the backend's `Build Requested` event (which uses `distinct_id = apikey.user_id` + `$groups.organization = org_id`), the builder needs the human user id.

## Changes
- `buildBuilderPayload` + `createBuilderJob` thread `actorUserId` through.
- Handler passes `apikey.user_id`.
- `tests/builder-payload.unit.test.ts` updated (7 pass).

## ⚠️ Deploy order (important)
**Merge + fully deploy this FIRST.** The matching builder change (capgo_builder PR #104) makes `actorUserId` **required** — its `/jobs` endpoint rejects requests without it. So this backend must already be sending the field before that builder version deploys.

1. Merge + deploy this PR (capgo-new).
2. Then merge + deploy capgo_builder #104 (and apply its D1 migration `010_actor_user_id`).

Sending the field while the builder ignores it (this window) is harmless — extra JSON keys are dropped.

## Test plan
- [x] `tests/builder-payload.unit.test.ts` — 7/7 pass
- [x] eslint clean on changed file
- [ ] Verify a real build request still dispatches after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Build request system updated to include additional identifier information in payloads sent to the builder.

* **Tests**
  * Unit tests expanded to validate new payload structure and field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->