### PR TITLE
[codex] Harden manifest update RLS policy

### DIFF
--- a/supabase/migrations/20260608143906_fix_manifest_update_rls_policy.sql
+++ b/supabase/migrations/20260608143906_fix_manifest_update_rls_policy.sql
@@ -1,0 +1,12 @@
+DROP POLICY IF EXISTS
+"Prevent users from updating manifest entries" -- noqa: RF05
+ON public.manifest;
+
+CREATE POLICY
+"Prevent users from updating manifest entries" -- noqa: RF05
+ON public.manifest
+AS RESTRICTIVE
+FOR UPDATE
+TO authenticated, anon
+USING (false)
+WITH CHECK (false);

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -3,7 +3,7 @@
 BEGIN;
 
 -- Plan the number of tests
-SELECT plan(45);
+SELECT plan(46);
 
 -- Test app_versions policies
 SELECT
@@ -318,6 +318,26 @@ SELECT
             'Prevent users from updating manifest entries'
         ],
         'manifest should have correct policies'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM pg_policies
+            WHERE
+                schemaname = 'public'
+                AND tablename = 'manifest'
+                AND policyname = 'Prevent users from updating manifest entries'
+                AND permissive = 'RESTRICTIVE'
+                AND cmd = 'UPDATE'
+                AND roles @> ARRAY['anon', 'authenticated']::name []
+                AND array_length(roles, 1) = 2
+                AND qual = 'false'
+                AND with_check = 'false'
+        ),
+        1::bigint,
+        'manifest update deny policy should match restrictive role shape'
     );
 
 -- Test deploy_history policies


### PR DESCRIPTION
## Summary (AI generated)

- Recreate the manifest UPDATE deny policy as `AS RESTRICTIVE` for both `anon` and `authenticated`.
- Add pgTAP coverage that checks the policy command, roles, permissiveness, and deny expressions.

## Motivation (AI generated)

The existing manifest UPDATE policy only targeted `authenticated` and was permissive by default. `anon` requests were still implicitly denied today, but a future permissive anon UPDATE policy could bypass that deny shape.

## Business Impact (AI generated)

This keeps manifest rows system-managed and reduces the chance of accidental API-key write access to update bundle manifest metadata in a future RLS change.

## Test Plan (AI generated)

- [x] `bun scripts/supabase-worktree.ts test db supabase/tests/26_test_rls_policies.sql`
- [x] `bun run lint:backend`
- [x] Commit hook typechecks: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Generated with AI
