### PR TITLE
[codex] support impersonation by email or org

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2037,6 +2037,7 @@
   "used-to-create": "Account with this email used to exist, cannot recreate",
   "user": "User",
   "user-already-invited": "This user is already invited to this organization",
+  "user-email-or-org-id": "User ID, email, or organization ID",
   "user-id": "User Id",
   "user-registration": "User registration",
   "user-registrations": "User registrations",

--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -29,7 +29,7 @@ const isLoading = ref(false)
 const logAsInput = ref('')
 
 async function openLogAsDialog() {
-  let userId = ''
+  let identifier = ''
   logAsInput.value = ''
 
   dialogStore.openDialog({
@@ -42,17 +42,17 @@ async function openLogAsDialog() {
       {
         text: t('log-as'),
         handler: () => {
-          userId = logAsInput.value
+          identifier = logAsInput.value
         },
       },
     ],
   })
   await dialogStore.onDialogDismiss()
 
-  if (userId) {
+  if (identifier) {
     isLoading.value = true
     try {
-      await logAsUser(userId, router)
+      await logAsUser(identifier, router)
     }
     finally {
       isLoading.value = false
@@ -146,7 +146,7 @@ async function logOut() {
         <input
           v-model="logAsInput"
           type="text"
-          :placeholder="t('user-id')"
+          :placeholder="t('user-email-or-org-id')"
           class="p-3 w-full rounded-lg border border-gray-300 dark:text-white dark:bg-gray-800 dark:border-gray-600"
           @keydown.enter="$event.preventDefault()"
         >

--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -65,7 +65,7 @@ function resetSpoofedUser() {
     toast.error('Stop Spoofed, will reload')
     setTimeout(() => {
       router.replace('/dashboard').then(() => {
-        window.location.reload()
+        globalThis.location.reload()
       })
     }, 1000)
   }

--- a/src/pages/log-as/[userId].vue
+++ b/src/pages/log-as/[userId].vue
@@ -10,16 +10,16 @@ const isLoading = ref(true)
 const errorMessage = ref('')
 
 onMounted(async () => {
-  const targetUserId = route.params.userId
+  const targetIdentifier = route.params.userId
 
-  if (!targetUserId || typeof targetUserId !== 'string') {
-    errorMessage.value = 'Missing user id'
+  if (!targetIdentifier || typeof targetIdentifier !== 'string') {
+    errorMessage.value = 'Missing user id, email, or org id'
     isLoading.value = false
     return
   }
 
   try {
-    await logAsUser(targetUserId, router)
+    await logAsUser(targetIdentifier, router)
   }
   catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Failed to log in as the requested user'
@@ -33,7 +33,7 @@ onMounted(async () => {
     <div v-if="isLoading" class="flex flex-col items-center space-y-4">
       <Spinner class="w-8 h-8" />
       <p class="text-gray-700 dark:text-gray-300">
-        Attempting to log you in as the requested user...
+        Attempting to log you in as the requested account...
       </p>
     </div>
     <div v-else class="space-y-2 text-center">

--- a/src/services/logAs.ts
+++ b/src/services/logAs.ts
@@ -49,7 +49,7 @@ export async function logAsUser(identifier: string, router: Router) {
     toast.success('Spoofed, will reload')
     setTimeout(() => {
       router.replace('/dashboard').then(() => {
-        window.location.reload()
+        globalThis.location.reload()
       })
     }, 1000)
   }

--- a/src/services/logAs.ts
+++ b/src/services/logAs.ts
@@ -12,18 +12,18 @@ function getErrorMessage(error: unknown) {
   return 'Cannot log in, see console'
 }
 
-export async function logAsUser(userId: string, router: Router) {
+export async function logAsUser(identifier: string, router: Router) {
   const toastId = toast.loading('Logging as...')
   try {
-    if (!userId)
-      throw new Error('Missing user id')
+    if (!identifier)
+      throw new Error('Missing user id, email, or org id')
 
     if (isSpoofed())
       unspoofUser()
 
     const supabase = useSupabase()
     const { data, error } = await supabase.functions.invoke('private/log_as', {
-      body: { user_id: userId },
+      body: { identifier },
     })
 
     if (error)

--- a/supabase/functions/_backend/private/log_as.ts
+++ b/supabase/functions/_backend/private/log_as.ts
@@ -1,13 +1,172 @@
+import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { type } from 'arktype'
 import { Hono } from 'hono/tiny'
 import { safeParseSchema } from '../utils/ark_validation.ts'
 import { middlewareAuth, parseBody, simpleError, useCors } from '../utils/hono.ts'
+import { closeClient, getPgClient } from '../utils/pg.ts'
 import { emptySupabase, supabaseAdmin as useSupabaseAdmin, supabaseClient as useSupabaseClient } from '../utils/supabase.ts'
 
-const bodySchema = type({
-  user_id: 'string.uuid',
+export const bodySchema = type({
+  'user_id?': 'string',
+  'email?': 'string',
+  'org_id?': 'string',
+  'identifier?': 'string',
 })
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+$/
+
+export type LogAsBody = {
+  user_id?: string
+  email?: string
+  org_id?: string
+  identifier?: string
+}
+
+export type LogAsIdentifier =
+  | { kind: 'user_id', value: string }
+  | { kind: 'email', value: string }
+  | { kind: 'org_id', value: string }
+  | { kind: 'identifier', value: string }
+
+type SupabaseAdmin = Awaited<ReturnType<typeof useSupabaseAdmin>>
+
+function normalizeIdentifierValue(value: string | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+function assertUuid(value: string, field: string) {
+  if (!UUID_REGEX.test(value))
+    throw simpleError('invalid_identifier', `${field} must be a valid UUID`, { field })
+}
+
+function assertEmail(value: string) {
+  if (!EMAIL_REGEX.test(value))
+    throw simpleError('invalid_identifier', 'email must be a valid email address')
+}
+
+export function resolveLogAsIdentifier(body: LogAsBody): LogAsIdentifier {
+  const identifiers: LogAsIdentifier[] = []
+
+  const userId = normalizeIdentifierValue(body.user_id)
+  if (userId) {
+    assertUuid(userId, 'user_id')
+    identifiers.push({ kind: 'user_id', value: userId })
+  }
+
+  const email = normalizeIdentifierValue(body.email)
+  if (email) {
+    assertEmail(email)
+    identifiers.push({ kind: 'email', value: email.toLowerCase() })
+  }
+
+  const orgId = normalizeIdentifierValue(body.org_id)
+  if (orgId) {
+    assertUuid(orgId, 'org_id')
+    identifiers.push({ kind: 'org_id', value: orgId })
+  }
+
+  const identifier = normalizeIdentifierValue(body.identifier)
+  if (identifier) {
+    if (!UUID_REGEX.test(identifier) && !EMAIL_REGEX.test(identifier))
+      throw simpleError('invalid_identifier', 'identifier must be a user id, email, or organization id')
+    identifiers.push(EMAIL_REGEX.test(identifier)
+      ? { kind: 'email', value: identifier.toLowerCase() }
+      : { kind: 'identifier', value: identifier })
+  }
+
+  if (identifiers.length !== 1) {
+    throw simpleError('invalid_identifier', 'Provide exactly one of user_id, email, org_id, or identifier', {
+      provided: identifiers.map(identifier => identifier.kind),
+    })
+  }
+
+  return identifiers[0]
+}
+
+async function getUserEmailById(supabaseAdmin: SupabaseAdmin, userId: string): Promise<{ email: string | null, error: unknown }> {
+  const { data: userData, error: userError } = await supabaseAdmin.auth.admin.getUserById(userId)
+
+  return {
+    email: userData?.user?.email ?? null,
+    error: userError,
+  }
+}
+
+async function getUserEmailByAuthEmail(c: Context<MiddlewareKeyVariables>, email: string): Promise<string | null> {
+  const pgClient = getPgClient(c)
+
+  try {
+    const result = await pgClient.query<{ email: string | null }>(
+      `
+        SELECT email
+        FROM auth.users
+        WHERE email IS NOT NULL
+          AND lower(email) = lower($1)
+        ORDER BY created_at ASC, id ASC
+        LIMIT 1
+      `,
+      [email],
+    )
+
+    return result.rows[0]?.email ?? null
+  }
+  catch (error) {
+    throw simpleError('user_lookup_error', 'User lookup error', { email, error })
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
+}
+
+async function getOrgOwnerUserId(supabaseAdmin: SupabaseAdmin, orgId: string): Promise<string | null> {
+  const { data: orgData, error: orgError } = await supabaseAdmin
+    .from('orgs')
+    .select('created_by')
+    .eq('id', orgId)
+    .maybeSingle()
+
+  if (orgError)
+    throw simpleError('org_lookup_error', 'Organization lookup error', { orgId, orgError })
+
+  return orgData?.created_by ?? null
+}
+
+async function getOrgOwnerEmail(supabaseAdmin: SupabaseAdmin, orgId: string): Promise<string> {
+  const ownerUserId = await getOrgOwnerUserId(supabaseAdmin, orgId)
+
+  if (!ownerUserId)
+    throw simpleError('org_does_not_exist', 'Organization does not exist', { orgId })
+
+  const { email, error } = await getUserEmailById(supabaseAdmin, ownerUserId)
+  if (!email)
+    throw simpleError('org_owner_does_not_exist', 'Organization owner does not exist', { orgId, ownerUserId, error })
+
+  return email
+}
+
+async function resolveUserEmail(c: Context<MiddlewareKeyVariables>, supabaseAdmin: SupabaseAdmin, identifier: LogAsIdentifier): Promise<string> {
+  if (identifier.kind === 'email') {
+    const email = await getUserEmailByAuthEmail(c, identifier.value)
+    if (!email)
+      throw simpleError('user_does_not_exist', 'User does not exist', { email: identifier.value })
+    return email
+  }
+
+  if (identifier.kind === 'org_id')
+    return getOrgOwnerEmail(supabaseAdmin, identifier.value)
+
+  const { email, error } = await getUserEmailById(supabaseAdmin, identifier.value)
+  if (email)
+    return email
+
+  if (identifier.kind === 'identifier' && UUID_REGEX.test(identifier.value))
+    return getOrgOwnerEmail(supabaseAdmin, identifier.value)
+
+  throw simpleError('user_does_not_exist', 'User does not exist', { userId: identifier.value, error })
+}
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -38,15 +197,8 @@ app.post('/', middlewareAuth, async (c) => {
   if (!isAdmin)
     throw simpleError('not_admin', 'Not admin')
 
-  const user_id = parsedBodyResult.data.user_id
-
-  const { data: userData, error: userError } = await supabaseAdmin.auth.admin.getUserById(user_id)
-
-  if (userError || !userData?.user?.email) {
-    throw simpleError('user_does_not_exist', 'User does not exist', { userError })
-  }
-
-  const userEmail = userData?.user?.email
+  const identifier = resolveLogAsIdentifier(parsedBodyResult.data)
+  const userEmail = await resolveUserEmail(c, supabaseAdmin, identifier)
 
   const { data: magicLink, error: magicError } = await supabaseAdmin.auth.admin.generateLink({
     type: 'magiclink',

--- a/supabase/functions/_backend/private/log_as.ts
+++ b/supabase/functions/_backend/private/log_as.ts
@@ -121,28 +121,82 @@ async function getUserEmailByAuthEmail(c: Context<MiddlewareKeyVariables>, email
   }
 }
 
-async function getOrgOwnerUserId(supabaseAdmin: SupabaseAdmin, orgId: string): Promise<string | null> {
-  const { data: orgData, error: orgError } = await supabaseAdmin
-    .from('orgs')
-    .select('created_by')
-    .eq('id', orgId)
-    .maybeSingle()
+async function getOrgOwner(c: Context<MiddlewareKeyVariables>, orgId: string): Promise<{ userId: string, email: string } | null> {
+  const pgClient = getPgClient(c)
 
-  if (orgError)
-    throw simpleError('org_lookup_error', 'Organization lookup error', { orgId, orgError })
+  try {
+    const result = await pgClient.query<{ user_id: string, email: string }>(
+      `
+        WITH target_org AS (
+          SELECT id, created_by
+          FROM public.orgs
+          WHERE id = $1
+        ),
+        current_admins AS (
+          SELECT
+            org_users.user_id,
+            auth.users.email,
+            org_users.created_at AS granted_at
+          FROM target_org
+          JOIN public.org_users
+            ON org_users.org_id = target_org.id
+            AND org_users.user_right = 'super_admin'::public.user_min_right
+            AND org_users.app_id IS NULL
+            AND org_users.channel_id IS NULL
+          JOIN auth.users
+            ON auth.users.id = org_users.user_id
+            AND auth.users.email IS NOT NULL
+          UNION
+          SELECT
+            role_bindings.principal_id AS user_id,
+            auth.users.email,
+            role_bindings.granted_at
+          FROM target_org
+          JOIN public.role_bindings
+            ON role_bindings.org_id = target_org.id
+            AND role_bindings.principal_type = public.rbac_principal_user()
+            AND role_bindings.scope_type = public.rbac_scope_org()
+            AND (role_bindings.expires_at IS NULL OR role_bindings.expires_at > now())
+          JOIN public.roles
+            ON roles.id = role_bindings.role_id
+            AND roles.name = public.rbac_role_org_super_admin()
+            AND roles.scope_type = public.rbac_scope_org()
+          JOIN auth.users
+            ON auth.users.id = role_bindings.principal_id
+            AND auth.users.email IS NOT NULL
+        )
+        SELECT current_admins.user_id, current_admins.email
+        FROM target_org
+        JOIN current_admins ON true
+        ORDER BY
+          (current_admins.user_id = target_org.created_by) DESC,
+          current_admins.granted_at ASC,
+          current_admins.user_id ASC
+        LIMIT 1
+      `,
+      [orgId],
+    )
 
-  return orgData?.created_by ?? null
+    const owner = result.rows[0]
+    return owner ? { userId: owner.user_id, email: owner.email } : null
+  }
+  catch (error) {
+    throw simpleError('org_lookup_error', 'Organization lookup error', { orgId, error })
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
 }
 
-async function getOrgOwnerEmail(supabaseAdmin: SupabaseAdmin, orgId: string): Promise<string> {
-  const ownerUserId = await getOrgOwnerUserId(supabaseAdmin, orgId)
+async function getOrgOwnerEmail(c: Context<MiddlewareKeyVariables>, supabaseAdmin: SupabaseAdmin, orgId: string): Promise<string> {
+  const owner = await getOrgOwner(c, orgId)
 
-  if (!ownerUserId)
+  if (!owner)
     throw simpleError('org_does_not_exist', 'Organization does not exist', { orgId })
 
-  const { email, error } = await getUserEmailById(supabaseAdmin, ownerUserId)
+  const { email, error } = await getUserEmailById(supabaseAdmin, owner.userId)
   if (!email)
-    throw simpleError('org_owner_does_not_exist', 'Organization owner does not exist', { orgId, ownerUserId, error })
+    throw simpleError('org_owner_does_not_exist', 'Organization owner does not exist', { orgId, ownerUserId: owner.userId, error })
 
   return email
 }
@@ -156,14 +210,14 @@ async function resolveUserEmail(c: Context<MiddlewareKeyVariables>, supabaseAdmi
   }
 
   if (identifier.kind === 'org_id')
-    return getOrgOwnerEmail(supabaseAdmin, identifier.value)
+    return getOrgOwnerEmail(c, supabaseAdmin, identifier.value)
 
   const { email, error } = await getUserEmailById(supabaseAdmin, identifier.value)
   if (email)
     return email
 
   if (identifier.kind === 'identifier' && UUID_REGEX.test(identifier.value))
-    return getOrgOwnerEmail(supabaseAdmin, identifier.value)
+    return getOrgOwnerEmail(c, supabaseAdmin, identifier.value)
 
   throw simpleError('user_does_not_exist', 'User does not exist', { userId: identifier.value, error })
 }

--- a/supabase/functions/_backend/private/log_as.ts
+++ b/supabase/functions/_backend/private/log_as.ts
@@ -34,7 +34,7 @@ type SupabaseAdmin = Awaited<ReturnType<typeof useSupabaseAdmin>>
 
 function normalizeIdentifierValue(value: string | undefined): string | null {
   const normalized = value?.trim()
-  return normalized ? normalized : null
+  return normalized || null
 }
 
 function assertUuid(value: string, field: string) {

--- a/tests/log-as.test.ts
+++ b/tests/log-as.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { getAuthHeadersForCredentials, getEndpointUrl, ORG_ID_2, USER_ADMIN_EMAIL, USER_ID, USER_ID_2, USER_ID_STATS } from './test-utils.ts'
+
+let adminHeaders: Record<string, string>
+
+function getJwtSub(jwt: string): string {
+  const payload = JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString('utf8')) as { sub?: string }
+  return payload.sub ?? ''
+}
+
+async function callLogAs(body: Record<string, string>) {
+  const response = await fetch(getEndpointUrl('/private/log_as'), {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify(body),
+  })
+
+  const data = await response.json() as { jwt?: string, refreshToken?: string, error?: string }
+
+  expect(response.status).toBe(200)
+  expect(data.error).toBeUndefined()
+  expect(data.jwt).toBeTruthy()
+  expect(data.refreshToken).toBeTruthy()
+
+  return data.jwt!
+}
+
+describe('[POST] /private/log_as', () => {
+  beforeAll(async () => {
+    adminHeaders = await getAuthHeadersForCredentials(USER_ADMIN_EMAIL, 'adminadmin')
+  })
+
+  it('keeps user_id impersonation compatibility', async () => {
+    const jwt = await callLogAs({ user_id: USER_ID })
+
+    expect(getJwtSub(jwt)).toBe(USER_ID)
+  })
+
+  it('impersonates a user by auth email', async () => {
+    const jwt = await callLogAs({ identifier: 'stats@capgo.app' })
+
+    expect(getJwtSub(jwt)).toBe(USER_ID_STATS)
+  })
+
+  it('impersonates an organization owner by org id', async () => {
+    const jwt = await callLogAs({ org_id: ORG_ID_2 })
+
+    expect(getJwtSub(jwt)).toBe(USER_ID_2)
+  })
+
+  it('treats an unresolved UUID identifier as an organization id', async () => {
+    const jwt = await callLogAs({ identifier: ORG_ID_2 })
+
+    expect(getJwtSub(jwt)).toBe(USER_ID_2)
+  })
+})

--- a/tests/log-as.test.ts
+++ b/tests/log-as.test.ts
@@ -1,7 +1,8 @@
 import { beforeAll, describe, expect, it } from 'vitest'
-import { getAuthHeadersForCredentials, getEndpointUrl, ORG_ID_2, USER_ADMIN_EMAIL, USER_ID, USER_ID_2, USER_ID_STATS } from './test-utils.ts'
+import { getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, ORG_ID_2, USER_ADMIN_EMAIL, USER_ID, USER_ID_2, USER_ID_STATS } from './test-utils.ts'
 
 let adminHeaders: Record<string, string>
+const STALE_CREATED_BY_ORG_ID = 'f7a8b9c0-d1e2-4f3a-9b4c-5d6e7f8a9b05'
 
 function getJwtSub(jwt: string): string {
   const payload = JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString('utf8')) as { sub?: string }
@@ -25,6 +26,50 @@ async function callLogAs(body: Record<string, string>) {
   return data.jwt!
 }
 
+async function seedStaleCreatedByOrg() {
+  const supabase = getSupabaseClient()
+
+  const { error: cleanupError } = await supabase
+    .from('orgs')
+    .delete()
+    .eq('id', STALE_CREATED_BY_ORG_ID)
+  expect(cleanupError).toBeNull()
+
+  const { error: orgError } = await supabase
+    .from('orgs')
+    .insert({
+      id: STALE_CREATED_BY_ORG_ID,
+      created_by: USER_ID,
+      name: 'Log as stale created_by org',
+      management_email: 'log-as-stale-owner@capgo.app',
+      use_new_rbac: true,
+    })
+  expect(orgError).toBeNull()
+
+  const { error: currentAdminError } = await supabase
+    .from('org_users')
+    .insert({
+      org_id: STALE_CREATED_BY_ORG_ID,
+      user_id: USER_ID_2,
+      user_right: 'super_admin',
+    })
+  expect(currentAdminError).toBeNull()
+
+  const { error: staleLegacyError } = await supabase
+    .from('org_users')
+    .delete()
+    .eq('org_id', STALE_CREATED_BY_ORG_ID)
+    .eq('user_id', USER_ID)
+  expect(staleLegacyError).toBeNull()
+
+  const { error: staleBindingError } = await supabase
+    .from('role_bindings')
+    .delete()
+    .eq('org_id', STALE_CREATED_BY_ORG_ID)
+    .eq('principal_id', USER_ID)
+  expect(staleBindingError).toBeNull()
+}
+
 describe('[POST] /private/log_as', () => {
   beforeAll(async () => {
     adminHeaders = await getAuthHeadersForCredentials(USER_ADMIN_EMAIL, 'adminadmin')
@@ -44,6 +89,14 @@ describe('[POST] /private/log_as', () => {
 
   it('impersonates an organization owner by org id', async () => {
     const jwt = await callLogAs({ org_id: ORG_ID_2 })
+
+    expect(getJwtSub(jwt)).toBe(USER_ID_2)
+  })
+
+  it('impersonates a current organization owner when created_by is stale', async () => {
+    await seedStaleCreatedByOrg()
+
+    const jwt = await callLogAs({ org_id: STALE_CREATED_BY_ORG_ID })
 
     expect(getJwtSub(jwt)).toBe(USER_ID_2)
   })


### PR DESCRIPTION
## Summary (AI generated)

- Allow platform-admin impersonation to resolve a target by user ID, email, organization ID, or a generic identifier.
- Resolve organization IDs to `orgs.created_by` and preserve existing user-ID behavior for old links.
- Update the admin UI copy and add backend coverage for user ID, email, and org-owner impersonation.

## Motivation (AI generated)

Admins often have a customer email or organization ID available while debugging support cases, but not the target user UUID. This removes that lookup friction while keeping the impersonation endpoint behind the existing `is_platform_admin` check.

## Business Impact (AI generated)

Support and operations can reach customer accounts faster during troubleshooting, reducing response time without adding new platform-admin write powers.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun run lint:backend`
- [x] `bun run typecheck:backend`
- [x] `bun run typecheck:frontend`
- [x] `bun run supabase:with-env -- bunx vitest run tests/log-as.test.ts`

Generated with AI
