### PR TITLE
fix(ios): hide signup link in native app

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -894,6 +894,7 @@ onMounted(checkLogin)
                   <div v-else>
                     <FormKit id="login-account" type="form" :actions="false" @submit="handlePasswordSubmit">
                       <div class="space-y-5">
+                        <!-- Password managers need this hidden username field to pair the password with the selected email. -->
                         <input
                           type="email"
                           :value="emailForLogin"

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -894,7 +894,12 @@ onMounted(checkLogin)
                   <div v-else>
                     <FormKit id="login-account" type="form" :actions="false" @submit="handlePasswordSubmit">
                       <div class="space-y-5">
-                        <!-- Password managers need this hidden username field to pair the password with the selected email. -->
+                        <!--
+                      Hidden email input placed inside the form so browsers and password managers
+                      can associate the password field with the correct account (autocomplete="username").
+                      Uses opacity+absolute positioning instead of display:none so browsers still
+                      detect it for autofill purposes.
+                    -->
                         <input
                           type="email"
                           :value="emailForLogin"

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -115,7 +115,7 @@ const authGhostButtonClass = [
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[var(--color-azure-500)]',
 ].join(' ')
 
-const registerUrl = window.location.host === 'console.capgo.app' ? 'https://capgo.app/register/' : `/register/`
+const registerUrl = globalThis.location.host === 'console.capgo.app' ? 'https://capgo.app/register/' : `/register/`
 
 function focusLoginEmailInput(attempt = 0) {
   globalThis.setTimeout(() => {
@@ -149,7 +149,7 @@ function scheduleCaptchaInitTimeout() {
 
   clearCaptchaInitTimeout()
   captchaInitTimeout = setTimeout(() => {
-    if (!turnstileToken.value && !window.turnstile) {
+    if (!turnstileToken.value && !(globalThis as typeof globalThis & { turnstile?: unknown }).turnstile) {
       captchaStatus.value = 'unavailable'
       console.error('Turnstile failed to initialize')
     }
@@ -374,7 +374,7 @@ async function handleSsoLogin() {
   const domain = emailForLogin.value.split('@')[1]
 
   try {
-    const redirectUrl = new URL('/sso-callback', window.location.origin)
+    const redirectUrl = new URL('/sso-callback', globalThis.location.origin)
     if (route.query.to && typeof route.query.to === 'string') {
       redirectUrl.searchParams.set('to', route.query.to)
     }
@@ -402,7 +402,7 @@ async function handleSsoLogin() {
     }
 
     if (data?.url) {
-      window.location.href = data.url
+      globalThis.location.href = data.url
     }
   }
   catch (err) {
@@ -485,7 +485,7 @@ async function checkAuthUser() {
 }
 
 async function checkMagicLink() {
-  const parsedUrl = new URL(route.fullPath, window.location.origin)
+  const parsedUrl = new URL(route.fullPath, globalThis.location.origin)
 
   const hash = parsedUrl.hash
   const params = new URLSearchParams(hash.slice(1))
@@ -537,12 +537,12 @@ async function openScan() {
 
 async function checkLogin() {
   try {
-    const parsedUrl = new URL(route.fullPath, window.location.origin)
+    const parsedUrl = new URL(route.fullPath, globalThis.location.origin)
     const params = new URLSearchParams(parsedUrl.search)
 
     if (params.get('message') === 'sso_account_linked') {
       parsedUrl.searchParams.delete('message')
-      window.history.replaceState({}, '', parsedUrl.toString())
+      globalThis.history.replaceState({}, '', parsedUrl.toString())
       toast.success(t('sso-account-linked'))
     }
 
@@ -552,7 +552,7 @@ async function checkLogin() {
     if (!!accessToken && !!refreshToken) {
       parsedUrl.searchParams.delete('access_token')
       parsedUrl.searchParams.delete('refresh_token')
-      window.history.replaceState({}, '', parsedUrl.toString())
+      globalThis.history.replaceState({}, '', parsedUrl.toString())
 
       querySessionAccessToken.value = accessToken
       querySessionRefreshToken.value = refreshToken
@@ -819,6 +819,7 @@ onMounted(checkLogin)
                           {{ t('dont-have-an-account') }}
                         </span>
                         <a
+                          v-if="!isMobile"
                           :href="registerUrl"
                           data-test="register"
                           :class="authInlineLinkClass"
@@ -893,12 +894,6 @@ onMounted(checkLogin)
                   <div v-else>
                     <FormKit id="login-account" type="form" :actions="false" @submit="handlePasswordSubmit">
                       <div class="space-y-5">
-                        <!--
-                      Hidden email input placed inside the form so browsers and password managers
-                      can associate the password field with the correct account (autocomplete="username").
-                      Uses opacity+absolute positioning instead of display:none so browsers still
-                      detect it for autofill purposes.
-                    -->
                         <input
                           type="email"
                           :value="emailForLogin"
@@ -985,6 +980,7 @@ onMounted(checkLogin)
 
                         <div :class="authPanelClass">
                           <a
+                            v-if="!isMobile"
                             :href="registerUrl"
                             data-test="register"
                             :class="authInlineLinkClass"


### PR DESCRIPTION
## Summary (AI generated)

- Hide the "Create a free account" links on the login page when running inside a native Capacitor app.
- Keep web registration behavior unchanged.

## Motivation (AI generated)

Apple App Review flagged the iOS app for exposing account registration from inside the app. The native app should not show a signup call to action during review.

## Business Impact (AI generated)

This should reduce App Review risk for the iOS submission while preserving the existing web signup funnel and logged-in product experience.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run build`
- [x] Commit hook typecheck passed

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Register link now properly hidden on mobile devices for improved mobile responsiveness.
  * More reliable redirect and SSO behavior during login and magic-link flows to prevent navigation issues.
  * Improved CAPTCHA (Turnstile) initialization reliability to reduce occasional verification failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->