### PR TITLE
fix(plugin): restore dashboard channel overrides

### DIFF
--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -172,13 +172,12 @@ export async function updateWithPG(
   }
   await setAppStatus(c, app_id, 'cloud', appOwner.allow_device_custom_id)
   const pluginVersion = parse(plugin_version)
-  const channelSelfStoreEnabled = hasChannelSelfStoreBinding(c)
-  const shouldUseChannelSelfStore = channelSelfStoreEnabled && usesLegacyChannelSelfStoreVersion(pluginVersion)
+  const shouldUseChannelSelfStore = usesLegacyChannelSelfStoreVersion(pluginVersion) && hasChannelSelfStoreBinding(c)
   const channelSelfOverride = shouldUseChannelSelfStore
     ? await getStoredChannelSelfOverride(c, app_id, device_id)
     : null
   const channelDeviceCount = appOwner.channel_device_count ?? 0
-  const effectiveChannelDeviceCount = channelSelfStoreEnabled ? 0 : channelDeviceCount
+  const effectiveChannelDeviceCount = channelDeviceCount
   const manifestBundleCount = appOwner.manifest_bundle_count ?? 0
   const bypassChannelOverrides = !channelSelfOverride && effectiveChannelDeviceCount <= 0
   // v5 is deprecated if < 5.10.0, v6 is deprecated if < 6.25.0, v7 is deprecated if < 7.25.0

--- a/tests/update-channel-self-store.unit.test.ts
+++ b/tests/update-channel-self-store.unit.test.ts
@@ -96,7 +96,7 @@ describe('updates channel_self store override routing', () => {
 
     expect(requestInfosPostgresMock).toHaveBeenCalledWith(expect.objectContaining({
       app_id: 'com.test.app',
-      channelDeviceCount: 0,
+      channelDeviceCount: 12,
       channelSelfOverrideChannelId: 42,
       defaultChannel: '',
       device_id: '11111111-1111-4111-8111-111111111111',
@@ -114,7 +114,7 @@ describe('updates channel_self store override routing', () => {
     expect(getChannelSelfOverrideMock).not.toHaveBeenCalled()
     expect(requestInfosPostgresMock).toHaveBeenCalledWith(expect.objectContaining({
       app_id: 'com.test.app',
-      channelDeviceCount: 0,
+      channelDeviceCount: 12,
       channelSelfOverrideChannelId: undefined,
       defaultChannel: '',
       device_id: '11111111-1111-4111-8111-111111111111',
@@ -132,7 +132,7 @@ describe('updates channel_self store override routing', () => {
     expect(getChannelSelfOverrideMock).toHaveBeenCalledOnce()
     expect(requestInfosPostgresMock).toHaveBeenCalledWith(expect.objectContaining({
       app_id: 'com.test.app',
-      channelDeviceCount: 0,
+      channelDeviceCount: 12,
       channelSelfOverrideChannelId: undefined,
       defaultChannel: '',
       device_id: '11111111-1111-4111-8111-111111111111',


### PR DESCRIPTION
## Summary (AI generated)

- Stop treating the presence of `CHANNEL_SELF_STORE` as a reason to skip Postgres `channel_devices` overrides in `/updates`.
- Gate KV override reads by legacy plugin version first, then check whether the KV binding is available.
- Update the focused `/updates` channel-self store unit test so real `channel_device_count` continues through the request path.

## Motivation (AI generated)

Dashboard-set device channel overrides are stored in Postgres `channel_devices`, while the KV bridge only covers legacy plugin `setChannel` writes. Because production workers always bind `CHANNEL_SELF_STORE`, the previous logic zeroed `channelDeviceCount` and made dashboard overrides unreachable on `/updates`.

## Business Impact (AI generated)

This restores forced channel overrides from the dashboard for affected apps and prevents devices from silently falling back to their configured `defaultChannel`. It fixes users being blocked by the wrong channel policy or receiving no update even when an override exists.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/channel-self-pg-client.unit.test.ts tests/update-channel-self-store.unit.test.ts`
- [x] `bun lint:backend`
- [x] `git diff --check`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of channel device count calculations in channel self-store scenarios by removing unintended forced zeroing behavior and refactoring related logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->