### PR TITLE
fix(plugin): sync forced device overrides to kv

### DIFF
--- a/cloudflare_workers/api/index.ts
+++ b/cloudflare_workers/api/index.ts
@@ -1,6 +1,7 @@
 import { app as accept_invitation } from '../../supabase/functions/_backend/private/accept_invitation.ts'
 import { app as admin_credits } from '../../supabase/functions/_backend/private/admin_credits.ts'
 import { app as admin_stats } from '../../supabase/functions/_backend/private/admin_stats.ts'
+import { app as channel_device } from '../../supabase/functions/_backend/private/channel_device.ts'
 import { app as channel_stats } from '../../supabase/functions/_backend/private/channel_stats.ts'
 import { app as config } from '../../supabase/functions/_backend/private/config.ts'
 import { app as configBuilder } from '../../supabase/functions/_backend/private/config_builder.ts'
@@ -105,6 +106,7 @@ appPrivate.route('/config', config)
 appPrivate.route('/config/builder', configBuilder)
 appPrivate.route('/accept_invitation', accept_invitation)
 appPrivate.route('/devices', devices_priv)
+appPrivate.route('/channel_device', channel_device)
 appPrivate.route('/log_as', log_as)
 appPrivate.route('/invite_new_user_to_org', invite_new_user_to_org)
 appPrivate.route('/invite_existing_user_to_org', invite_existing_user_to_org)

--- a/cloudflare_workers/api/wrangler.jsonc
+++ b/cloudflare_workers/api/wrangler.jsonc
@@ -192,7 +192,8 @@
       },
       "vars": {
         "ENV_NAME": "capgo_api-local"
-      }
+      },
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "00000000000000000000000000000001" }]
     }
   }
 }

--- a/cloudflare_workers/api/wrangler.jsonc
+++ b/cloudflare_workers/api/wrangler.jsonc
@@ -70,7 +70,8 @@
           "database_name": "capgo_prod_storeapps",
           "database_id": "81236a0c-db6e-454d-87da-944fa9bc100c"
         }
-      ]
+      ],
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "2860ca0f6b1e416fb8651792895cbffa" }]
     },
     "preprod": {
       "name": "capgo_api-preprod",
@@ -125,7 +126,8 @@
           "database_name": "capgo_prod_storeapps",
           "database_id": "81236a0c-db6e-454d-87da-944fa9bc100c"
         }
-      ]
+      ],
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "9c405a5248604951a2a12125799bc21b" }]
     },
     "alpha": {
       "name": "capgo_api-alpha",
@@ -180,7 +182,8 @@
           "database_name": "capgo_prod_storeapps",
           "database_id": "81236a0c-db6e-454d-87da-944fa9bc100c"
         }
-      ]
+      ],
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "16a85350d8a246ff857a645c8f51d6ae" }]
     },
     "local": {
       "name": "capgo_api-local",

--- a/src/pages/app/[app].channel.[channel].devices.vue
+++ b/src/pages/app/[app].channel.[channel].devices.vue
@@ -8,7 +8,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import plusOutline from '~icons/ion/add-outline'
 import IconAlertCircle from '~icons/lucide/alert-circle'
-import { useSupabase } from '~/services/supabase'
+import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { withBuiltinChannelVersion } from '~/services/versions'
 import { useAppDetailStore } from '~/stores/appDetail'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -115,6 +115,28 @@ async function customDeviceOverwritePart4(
   await dialogStore.onDialogDismiss()
 }
 
+async function setChannelDeviceOverride(deviceId: string) {
+  const { data: currentSession } = await supabase.auth.getSession()!
+  const currentJwt = currentSession.session?.access_token
+  if (!currentJwt)
+    throw new Error('Missing session')
+
+  const response = await fetch(`${defaultApiHost}/private/channel_device`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'authorization': `Bearer ${currentJwt}`,
+    },
+    body: JSON.stringify({
+      app_id: route.params.app as string,
+      channel_id: Number(route.params.channel),
+      device_id: deviceId.toLowerCase(),
+    }),
+  })
+  if (!response.ok)
+    throw new Error(`Cannot set channel override: HTTP ${response.status}`)
+}
+
 async function customDeviceOverwritePart5(
   deviceId: string,
   platform: 'ios' | 'android',
@@ -141,16 +163,11 @@ async function customDeviceOverwritePart5(
     return
   }
 
-  const { error: overwriteError } = await supabase.functions.invoke('private/channel_device', {
-    body: {
-      app_id: route.params.app as string,
-      channel_id: Number(route.params.channel),
-      device_id: deviceId.toLowerCase(),
-    },
-  })
-
-  if (overwriteError) {
-    console.error('overwriteError', overwriteError)
+  try {
+    await setChannelDeviceOverride(deviceId)
+  }
+  catch (error) {
+    console.error('overwriteError', error)
     toast.error(t('cannot-create-overwrite'))
     return
   }

--- a/src/pages/app/[app].channel.[channel].devices.vue
+++ b/src/pages/app/[app].channel.[channel].devices.vue
@@ -141,13 +141,13 @@ async function customDeviceOverwritePart5(
     return
   }
 
-  const { error: overwriteError } = await supabase.from('channel_devices')
-    .insert({
+  const { error: overwriteError } = await supabase.functions.invoke('private/channel_device', {
+    body: {
       app_id: route.params.app as string,
       channel_id: Number(route.params.channel),
       device_id: deviceId.toLowerCase(),
-      owner_org: channel.value?.owner_org ?? '',
-    })
+    },
+  })
 
   if (overwriteError) {
     console.error('overwriteError', overwriteError)

--- a/src/pages/app/[app].device.[device].vue
+++ b/src/pages/app/[app].device.[device].vue
@@ -17,7 +17,6 @@ import { checkPermissions } from '~/services/permissions'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useAppDetailStore } from '~/stores/appDetail'
 import { useDisplayStore } from '~/stores/display'
-import { useOrganizationStore } from '~/stores/organization'
 
 interface Channel {
   version: Database['public']['Tables']['app_versions']['Row']
@@ -32,7 +31,6 @@ const packageId = ref<string>('')
 const id = ref<string>()
 const isLoading = ref(true)
 const appDetailStore = useAppDetailStore()
-const organizationStore = useOrganizationStore()
 
 const device = ref<Database['public']['Tables']['devices']['Row']>()
 const channels = ref<(Database['public']['Tables']['channels']['Row'] & Channel)[]>([])
@@ -215,26 +213,27 @@ async function loadData() {
 }
 
 async function upsertDevChannel(device: string, channelId: number) {
-  const currentGid = organizationStore.currentOrganization?.gid
-  if (!currentGid)
-    return
-  return supabase
-    .from('channel_devices')
-    .upsert({
+  const { error } = await supabase.functions.invoke('private/channel_device', {
+    body: {
       device_id: device.toLowerCase(),
       channel_id: channelId,
       app_id: packageId.value,
-      owner_org: currentGid,
-    }, { onConflict: 'app_id,device_id' })
-    .throwOnError()
+    },
+  })
+  if (error)
+    throw error
 }
 
 async function delDevChannel(device: string) {
-  return supabase
-    .from('channel_devices')
-    .delete()
-    .eq('device_id', device.toLowerCase())
-    .eq('app_id', packageId.value)
+  const { error } = await supabase.functions.invoke('private/channel_device', {
+    method: 'DELETE',
+    body: {
+      device_id: device.toLowerCase(),
+      app_id: packageId.value,
+    },
+  })
+  if (error)
+    throw error
 }
 
 function closeChannelDropdown() {

--- a/src/pages/app/[app].device.[device].vue
+++ b/src/pages/app/[app].device.[device].vue
@@ -213,27 +213,46 @@ async function loadData() {
 }
 
 async function upsertDevChannel(device: string, channelId: number) {
-  const { error } = await supabase.functions.invoke('private/channel_device', {
-    body: {
+  const { data: currentSession } = await supabase.auth.getSession()!
+  const currentJwt = currentSession.session?.access_token
+  if (!currentJwt)
+    throw new Error('Missing session')
+
+  const response = await fetch(`${defaultApiHost}/private/channel_device`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'authorization': `Bearer ${currentJwt}`,
+    },
+    body: JSON.stringify({
       device_id: device.toLowerCase(),
       channel_id: channelId,
       app_id: packageId.value,
-    },
+    }),
   })
-  if (error)
-    throw error
+  if (!response.ok)
+    throw new Error(`Cannot set channel override: HTTP ${response.status}`)
 }
 
 async function delDevChannel(device: string) {
-  const { error } = await supabase.functions.invoke('private/channel_device', {
+  const { data: currentSession } = await supabase.auth.getSession()!
+  const currentJwt = currentSession.session?.access_token
+  if (!currentJwt)
+    throw new Error('Missing session')
+
+  const response = await fetch(`${defaultApiHost}/private/channel_device`, {
     method: 'DELETE',
-    body: {
+    headers: {
+      'Content-Type': 'application/json',
+      'authorization': `Bearer ${currentJwt}`,
+    },
+    body: JSON.stringify({
       device_id: device.toLowerCase(),
       app_id: packageId.value,
-    },
+    }),
   })
-  if (error)
-    throw error
+  if (!response.ok)
+    throw new Error(`Cannot delete channel override: HTTP ${response.status}`)
 }
 
 function closeChannelDropdown() {

--- a/src/pages/app/[app].device.[device].vue
+++ b/src/pages/app/[app].device.[device].vue
@@ -260,46 +260,37 @@ function closeChannelDropdown() {
     channelDropdown.value.removeAttribute('open')
   }
 }
-async function onSelectChannel(value: string) {
-  if (!canManageDevices.value) {
-    toast.error(t('no-permission'))
-    return
-  }
 
-  // Check if selected channel is the public (default) channel
-  if (value !== 'none') {
-    const selectedChannel = channels.value.find(ch => ch.id === Number(value))
+function isPublicChannelSelection(value: string) {
+  if (value === 'none')
+    return false
+  const selectedChannel = channels.value.find(ch => ch.id === Number(value))
+  return selectedChannel?.public === true
+}
 
-    if (selectedChannel?.public === true) {
-      // If trying to set override to default channel, remove any existing override
-      if (channelDevice.value && device.value?.device_id) {
-        await delDevChannel(device.value?.device_id)
-        toast.info(t('channel-override-ignored-default'))
-        await loadData()
-      }
-      else {
-        toast.info(t('channel-override-ignored-default'))
-      }
-      closeChannelDropdown()
-      return
-    }
-  }
-
-  if (channelDevice.value && value === 'none') {
-    if (device.value?.device_id)
-      await delDevChannel(device.value?.device_id)
-    toast.success(t('unlink-channel'))
-    toast.info(t('cloud-replication-delay'))
+async function handlePublicChannelSelection() {
+  const deviceId = device.value?.device_id
+  if (channelDevice.value && deviceId) {
+    await delDevChannel(deviceId)
     await loadData()
   }
-  else if (value !== 'none') {
-    if (!device.value?.device_id) {
-      toast.error(t('channel-link-fail'))
-      return
-    }
+  toast.info(t('channel-override-ignored-default'))
+}
 
+async function unlinkDeviceChannel() {
+  const deviceId = device.value?.device_id
+  if (deviceId)
+    await delDevChannel(deviceId)
+  toast.success(t('unlink-channel'))
+  toast.info(t('cloud-replication-delay'))
+  await loadData()
+}
+
+async function linkDeviceChannel(value: string) {
+  const deviceId = device.value?.device_id
+  if (deviceId) {
     try {
-      await upsertDevChannel(device.value?.device_id, Number(value))
+      await upsertDevChannel(deviceId, Number(value))
       toast.success(t('channel-linked'))
       toast.info(t('cloud-replication-delay'))
       await loadData()
@@ -308,6 +299,26 @@ async function onSelectChannel(value: string) {
       console.error(error)
       toast.error(t('channel-link-fail'))
     }
+  }
+  else {
+    toast.error(t('channel-link-fail'))
+  }
+}
+
+async function onSelectChannel(value: string) {
+  if (!canManageDevices.value) {
+    toast.error(t('no-permission'))
+    return
+  }
+
+  if (isPublicChannelSelection(value)) {
+    await handlePublicChannelSelection()
+  }
+  else if (channelDevice.value && value === 'none') {
+    await unlinkDeviceChannel()
+  }
+  else if (value !== 'none') {
+    await linkDeviceChannel(value)
   }
   else {
     toast.error(t('channel-link-fail'))
@@ -353,8 +364,8 @@ function getCurlCommand() {
   const requestBody = transformDeviceToUpdateRequest(device.value, packageId.value, defaultChannel)
   const jsonBody = JSON.stringify(requestBody, null, 2)
 
-  return `curl -X POST '${defaultApiHost}/updates' \\
-  -H 'Content-Type: application/json' \\
+  return String.raw`curl -X POST '${defaultApiHost}/updates' \
+  -H 'Content-Type: application/json' \
   -d '${jsonBody}'`
 }
 

--- a/src/pages/app/[app].device.[device].vue
+++ b/src/pages/app/[app].device.[device].vue
@@ -311,20 +311,27 @@ async function onSelectChannel(value: string) {
     return
   }
 
-  if (isPublicChannelSelection(value)) {
-    await handlePublicChannelSelection()
+  try {
+    if (isPublicChannelSelection(value)) {
+      await handlePublicChannelSelection()
+    }
+    else if (channelDevice.value && value === 'none') {
+      await unlinkDeviceChannel()
+    }
+    else if (value !== 'none') {
+      await linkDeviceChannel(value)
+    }
+    else {
+      toast.error(t('channel-link-fail'))
+    }
   }
-  else if (channelDevice.value && value === 'none') {
-    await unlinkDeviceChannel()
-  }
-  else if (value !== 'none') {
-    await linkDeviceChannel(value)
-  }
-  else {
+  catch (error) {
+    console.error(error)
     toast.error(t('channel-link-fail'))
   }
-
-  closeChannelDropdown()
+  finally {
+    closeChannelDropdown()
+  }
 }
 
 watchEffect(async () => {

--- a/src/pages/app/[app].device.[device].vue
+++ b/src/pages/app/[app].device.[device].vue
@@ -281,15 +281,9 @@ async function onSelectChannel(value: string) {
 
     try {
       await upsertDevChannel(device.value?.device_id, Number(value))
-        .then(async () => {
-          toast.success(t('channel-linked'))
-          toast.info(t('cloud-replication-delay'))
-          return loadData()
-        })
-        .catch(async (error) => {
-          console.error(error)
-          toast.error(t('channel-link-fail'))
-        })
+      toast.success(t('channel-linked'))
+      toast.info(t('cloud-replication-delay'))
+      await loadData()
     }
     catch (error) {
       console.error(error)

--- a/supabase/functions/_backend/private/channel_device.ts
+++ b/supabase/functions/_backend/private/channel_device.ts
@@ -1,0 +1,138 @@
+import type { Context } from 'hono'
+import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { Database } from '../utils/supabase.types.ts'
+import { type } from 'arktype'
+import { Hono } from 'hono/tiny'
+import { safeParseSchema } from '../utils/ark_validation.ts'
+import { syncChannelSelfOverride, syncChannelSelfOverrideDelete } from '../utils/channelSelfStore.ts'
+import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
+import { middlewareV2 } from '../utils/hono_middleware.ts'
+import { checkPermission } from '../utils/rbac.ts'
+import { supabaseWithAuth } from '../utils/supabase.ts'
+import { isValidAppId } from '../utils/utils.ts'
+
+const setBodySchema = type({
+  app_id: 'string',
+  device_id: 'string.uuid',
+  channel_id: 'number.integer >= 1',
+})
+
+const deleteBodySchema = type({
+  app_id: 'string',
+  device_id: 'string.uuid',
+})
+
+interface SetChannelDeviceBody {
+  app_id: string
+  device_id: string
+  channel_id: number
+}
+
+interface DeleteChannelDeviceBody {
+  app_id: string
+  device_id: string
+}
+
+type ChannelRow = Pick<Database['public']['Tables']['channels']['Row'], 'id' | 'app_id' | 'owner_org' | 'public'>
+
+export const app = new Hono<MiddlewareKeyVariables>()
+
+app.use('/', useCors)
+
+async function requireManageDevices(c: Context<MiddlewareKeyVariables>, appId: string) {
+  if (!isValidAppId(appId)) {
+    throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: appId })
+  }
+
+  if (!(await checkPermission(c, 'app.manage_devices', { appId }))) {
+    quickError(403, 'permission_denied', 'Permission denied: app.manage_devices', { appId })
+  }
+}
+
+async function getWritableChannel(c: Context<MiddlewareKeyVariables>, body: SetChannelDeviceBody): Promise<ChannelRow> {
+  const supabase = supabaseWithAuth(c, c.get('auth')!)
+  const { data: channel, error } = await supabase
+    .from('channels')
+    .select('id, app_id, owner_org, public')
+    .eq('app_id', body.app_id)
+    .eq('id', body.channel_id)
+    .single()
+
+  if (error || !channel) {
+    quickError(404, 'channel_not_found', 'Cannot find channel', { appId: body.app_id, channelId: body.channel_id, error })
+  }
+
+  if (channel.public) {
+    throw simpleError('public_channel_override', 'Cannot set channel override for public channel')
+  }
+
+  return channel
+}
+
+export async function setChannelDeviceOverride(c: Context<MiddlewareKeyVariables>, body: SetChannelDeviceBody) {
+  await requireManageDevices(c, body.app_id)
+
+  const channel = await getWritableChannel(c, body)
+  const supabase = supabaseWithAuth(c, c.get('auth')!)
+  const override = {
+    app_id: body.app_id,
+    channel_id: channel.id,
+    device_id: body.device_id.toLowerCase(),
+    owner_org: channel.owner_org,
+  }
+
+  const { error } = await supabase
+    .from('channel_devices')
+    .upsert(override, { onConflict: 'app_id,device_id' })
+
+  if (error) {
+    quickError(500, 'channel_device_error', 'Error setting channel override', { error })
+  }
+
+  if (!(await syncChannelSelfOverride(c, override))) {
+    quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+  }
+
+  return c.json(BRES)
+}
+
+export async function deleteChannelDeviceOverride(c: Context<MiddlewareKeyVariables>, body: DeleteChannelDeviceBody) {
+  await requireManageDevices(c, body.app_id)
+
+  const supabase = supabaseWithAuth(c, c.get('auth')!)
+  const { error } = await supabase
+    .from('channel_devices')
+    .delete()
+    .eq('device_id', body.device_id.toLowerCase())
+    .eq('app_id', body.app_id)
+
+  if (error) {
+    quickError(500, 'channel_device_error', 'Error deleting channel override', { error })
+  }
+
+  if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id))) {
+    quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+  }
+
+  return c.json(BRES)
+}
+
+app.post('/', middlewareV2(['all', 'write']), async (c) => {
+  const body = await parseBody<SetChannelDeviceBody>(c)
+  const parsedBodyResult = safeParseSchema(setBodySchema, body)
+  if (!parsedBodyResult.success) {
+    throw simpleError('invalid_json_body', 'Invalid JSON body', { body, parsedBodyResult })
+  }
+
+  return setChannelDeviceOverride(c, parsedBodyResult.data)
+})
+
+app.delete('/', middlewareV2(['all', 'write']), async (c) => {
+  const body = await parseBody<DeleteChannelDeviceBody>(c)
+  const parsedBodyResult = safeParseSchema(deleteBodySchema, body)
+  if (!parsedBodyResult.success) {
+    throw simpleError('invalid_json_body', 'Invalid JSON body', { body, parsedBodyResult })
+  }
+
+  return deleteChannelDeviceOverride(c, parsedBodyResult.data)
+})

--- a/supabase/functions/_backend/private/channel_device.ts
+++ b/supabase/functions/_backend/private/channel_device.ts
@@ -4,7 +4,7 @@ import type { Database } from '../utils/supabase.types.ts'
 import { type } from 'arktype'
 import { Hono } from 'hono/tiny'
 import { safeParseSchema } from '../utils/ark_validation.ts'
-import { syncChannelSelfOverride, syncChannelSelfOverrideDelete } from '../utils/channelSelfStore.ts'
+import { shouldSyncChannelSelfOverrideForPluginVersion, syncChannelSelfOverride, syncChannelSelfOverrideDelete } from '../utils/channelSelfStore.ts'
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareV2 } from '../utils/hono_middleware.ts'
 import { checkPermission } from '../utils/rbac.ts'
@@ -34,6 +34,7 @@ interface DeleteChannelDeviceBody {
 }
 
 type ChannelRow = Pick<Database['public']['Tables']['channels']['Row'], 'id' | 'app_id' | 'owner_org' | 'public'>
+type PrivateDeviceClient = ReturnType<typeof supabaseWithAuth>
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -69,6 +70,21 @@ async function getWritableChannel(c: Context<MiddlewareKeyVariables>, body: SetC
   return channel
 }
 
+async function getDevicePluginVersion(c: Context<MiddlewareKeyVariables>, supabase: PrivateDeviceClient, appId: string, deviceId: string) {
+  const { data, error } = await supabase
+    .from('devices')
+    .select('plugin_version')
+    .eq('app_id', appId)
+    .eq('device_id', deviceId.toLowerCase())
+    .maybeSingle()
+
+  if (error) {
+    quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
+  }
+
+  return data?.plugin_version ?? null
+}
+
 export async function setChannelDeviceOverride(c: Context<MiddlewareKeyVariables>, body: SetChannelDeviceBody) {
   await requireManageDevices(c, body.app_id)
 
@@ -89,8 +105,14 @@ export async function setChannelDeviceOverride(c: Context<MiddlewareKeyVariables
     quickError(500, 'channel_device_error', 'Error setting channel override', { error })
   }
 
-  if (!(await syncChannelSelfOverride(c, override))) {
-    quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+  const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
+  if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
+    if (!(await syncChannelSelfOverride(c, {
+      ...override,
+      plugin_version: pluginVersion,
+    }))) {
+      quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+    }
   }
 
   return c.json(BRES)
@@ -100,6 +122,7 @@ export async function deleteChannelDeviceOverride(c: Context<MiddlewareKeyVariab
   await requireManageDevices(c, body.app_id)
 
   const supabase = supabaseWithAuth(c, c.get('auth')!)
+  const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
   const { error } = await supabase
     .from('channel_devices')
     .delete()
@@ -110,8 +133,10 @@ export async function deleteChannelDeviceOverride(c: Context<MiddlewareKeyVariab
     quickError(500, 'channel_device_error', 'Error deleting channel override', { error })
   }
 
-  if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id))) {
-    quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+  if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
+    if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id, pluginVersion))) {
+      quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+    }
   }
 
   return c.json(BRES)

--- a/supabase/functions/_backend/private/channel_device.ts
+++ b/supabase/functions/_backend/private/channel_device.ts
@@ -1,10 +1,10 @@
 import type { Context } from 'hono'
-import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { AuthInfo, MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { type } from 'arktype'
 import { Hono } from 'hono/tiny'
 import { safeParseSchema } from '../utils/ark_validation.ts'
-import { shouldSyncChannelSelfOverrideForPluginVersion, syncChannelSelfOverride, syncChannelSelfOverrideDelete } from '../utils/channelSelfStore.ts'
+import { syncLegacyChannelSelfOverrideDeleteForDevice, syncLegacyChannelSelfOverrideForDevice } from '../utils/channelSelfStore.ts'
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareV2 } from '../utils/hono_middleware.ts'
 import { checkPermission } from '../utils/rbac.ts'
@@ -34,11 +34,18 @@ interface DeleteChannelDeviceBody {
 }
 
 type ChannelRow = Pick<Database['public']['Tables']['channels']['Row'], 'id' | 'app_id' | 'owner_org' | 'public'>
-type PrivateDeviceClient = ReturnType<typeof supabaseWithAuth>
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.use('/', useCors)
+
+function requireAuth(c: Context<MiddlewareKeyVariables>): AuthInfo {
+  const auth = c.get('auth')
+  if (!auth) {
+    quickError(401, 'not_authorized', 'Not authorized')
+  }
+  return auth
+}
 
 async function requireManageDevices(c: Context<MiddlewareKeyVariables>, appId: string) {
   if (!isValidAppId(appId)) {
@@ -51,7 +58,7 @@ async function requireManageDevices(c: Context<MiddlewareKeyVariables>, appId: s
 }
 
 async function getWritableChannel(c: Context<MiddlewareKeyVariables>, body: SetChannelDeviceBody): Promise<ChannelRow> {
-  const supabase = supabaseWithAuth(c, c.get('auth')!)
+  const supabase = supabaseWithAuth(c, requireAuth(c))
   const { data: channel, error } = await supabase
     .from('channels')
     .select('id, app_id, owner_org, public')
@@ -70,26 +77,11 @@ async function getWritableChannel(c: Context<MiddlewareKeyVariables>, body: SetC
   return channel
 }
 
-async function getDevicePluginVersion(c: Context<MiddlewareKeyVariables>, supabase: PrivateDeviceClient, appId: string, deviceId: string) {
-  const { data, error } = await supabase
-    .from('devices')
-    .select('plugin_version')
-    .eq('app_id', appId)
-    .eq('device_id', deviceId.toLowerCase())
-    .maybeSingle()
-
-  if (error) {
-    quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
-  }
-
-  return data?.plugin_version ?? null
-}
-
 export async function setChannelDeviceOverride(c: Context<MiddlewareKeyVariables>, body: SetChannelDeviceBody) {
   await requireManageDevices(c, body.app_id)
 
   const channel = await getWritableChannel(c, body)
-  const supabase = supabaseWithAuth(c, c.get('auth')!)
+  const supabase = supabaseWithAuth(c, requireAuth(c))
   const override = {
     app_id: body.app_id,
     channel_id: channel.id,
@@ -105,14 +97,8 @@ export async function setChannelDeviceOverride(c: Context<MiddlewareKeyVariables
     quickError(500, 'channel_device_error', 'Error setting channel override', { error })
   }
 
-  const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
-  if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
-    if (!(await syncChannelSelfOverride(c, {
-      ...override,
-      plugin_version: pluginVersion,
-    }))) {
-      quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
-    }
+  if (!(await syncLegacyChannelSelfOverrideForDevice(c, supabase, override))) {
+    quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
   }
 
   return c.json(BRES)
@@ -121,8 +107,7 @@ export async function setChannelDeviceOverride(c: Context<MiddlewareKeyVariables
 export async function deleteChannelDeviceOverride(c: Context<MiddlewareKeyVariables>, body: DeleteChannelDeviceBody) {
   await requireManageDevices(c, body.app_id)
 
-  const supabase = supabaseWithAuth(c, c.get('auth')!)
-  const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
+  const supabase = supabaseWithAuth(c, requireAuth(c))
   const { error } = await supabase
     .from('channel_devices')
     .delete()
@@ -133,10 +118,8 @@ export async function deleteChannelDeviceOverride(c: Context<MiddlewareKeyVariab
     quickError(500, 'channel_device_error', 'Error deleting channel override', { error })
   }
 
-  if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
-    if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id, pluginVersion))) {
-      quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
-    }
+  if (!(await syncLegacyChannelSelfOverrideDeleteForDevice(c, supabase, body.app_id, body.device_id))) {
+    quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
   }
 
   return c.json(BRES)

--- a/supabase/functions/_backend/public/device/delete.ts
+++ b/supabase/functions/_backend/public/device/delete.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
-import { BRES, simpleError } from '../../utils/hono.ts'
+import { syncChannelSelfOverrideDelete } from '../../utils/channelSelfStore.ts'
+import { BRES, quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
 import { isValidAppId } from '../../utils/utils.ts'
@@ -14,6 +15,9 @@ export interface DeviceLink {
 export async function deleteOverride(c: Context, body: DeviceLink, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
   if (!body.app_id) {
     throw simpleError('missing_app_id', 'Missing app_id', { body })
+  }
+  if (!body.device_id) {
+    throw simpleError('missing_device_id', 'Missing device_id', { body })
   }
   if (!isValidAppId(body.app_id)) {
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
@@ -30,6 +34,9 @@ export async function deleteOverride(c: Context, body: DeviceLink, apikey: Datab
     .eq('device_id', body.device_id)
   if (errorChannel) {
     throw simpleError('invalid_app_id', 'You can\'t access this app', { app_id: body.app_id })
+  }
+  if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id))) {
+    throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store', { app_id: body.app_id, device_id: body.device_id })
   }
   return c.json(BRES)
 }

--- a/supabase/functions/_backend/public/device/delete.ts
+++ b/supabase/functions/_backend/public/device/delete.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
-import { syncChannelSelfOverrideDelete } from '../../utils/channelSelfStore.ts'
+import { shouldSyncChannelSelfOverrideForPluginVersion, syncChannelSelfOverrideDelete } from '../../utils/channelSelfStore.ts'
 import { BRES, quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
@@ -10,6 +10,23 @@ export interface DeviceLink {
   app_id: string
   device_id: string
   channel?: string
+}
+
+type PublicDeviceClient = ReturnType<typeof supabaseApikey>
+
+async function getDevicePluginVersion(c: Context, supabase: PublicDeviceClient, appId: string, deviceId: string) {
+  const { data, error } = await supabase
+    .from('devices')
+    .select('plugin_version')
+    .eq('app_id', appId)
+    .eq('device_id', deviceId.toLowerCase())
+    .maybeSingle()
+
+  if (error) {
+    throw quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
+  }
+
+  return data?.plugin_version ?? null
 }
 
 export async function deleteOverride(c: Context, body: DeviceLink, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
@@ -27,7 +44,9 @@ export async function deleteOverride(c: Context, body: DeviceLink, apikey: Datab
     throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
   }
 
-  const { error: errorChannel } = await supabaseApikey(c, apikey.key)
+  const supabase = supabaseApikey(c, apikey.key)
+  const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
+  const { error: errorChannel } = await supabase
     .from('channel_devices')
     .delete()
     .eq('app_id', body.app_id)
@@ -35,8 +54,10 @@ export async function deleteOverride(c: Context, body: DeviceLink, apikey: Datab
   if (errorChannel) {
     throw simpleError('invalid_app_id', 'You can\'t access this app', { app_id: body.app_id })
   }
-  if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id))) {
-    throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store', { app_id: body.app_id, device_id: body.device_id })
+  if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
+    if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id, pluginVersion))) {
+      throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store', { app_id: body.app_id, device_id: body.device_id })
+    }
   }
   return c.json(BRES)
 }

--- a/supabase/functions/_backend/public/device/delete.ts
+++ b/supabase/functions/_backend/public/device/delete.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import type { Database } from '../../utils/supabase.types.ts'
-import { shouldSyncChannelSelfOverrideForPluginVersion, syncChannelSelfOverrideDelete } from '../../utils/channelSelfStore.ts'
+import { syncLegacyChannelSelfOverrideDeleteForDevice } from '../../utils/channelSelfStore.ts'
 import { BRES, quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
@@ -10,23 +10,6 @@ export interface DeviceLink {
   app_id: string
   device_id: string
   channel?: string
-}
-
-type PublicDeviceClient = ReturnType<typeof supabaseApikey>
-
-async function getDevicePluginVersion(c: Context, supabase: PublicDeviceClient, appId: string, deviceId: string) {
-  const { data, error } = await supabase
-    .from('devices')
-    .select('plugin_version')
-    .eq('app_id', appId)
-    .eq('device_id', deviceId.toLowerCase())
-    .maybeSingle()
-
-  if (error) {
-    throw quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
-  }
-
-  return data?.plugin_version ?? null
 }
 
 export async function deleteOverride(c: Context, body: DeviceLink, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
@@ -45,7 +28,6 @@ export async function deleteOverride(c: Context, body: DeviceLink, apikey: Datab
   }
 
   const supabase = supabaseApikey(c, apikey.key)
-  const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
   const { error: errorChannel } = await supabase
     .from('channel_devices')
     .delete()
@@ -54,10 +36,8 @@ export async function deleteOverride(c: Context, body: DeviceLink, apikey: Datab
   if (errorChannel) {
     throw simpleError('invalid_app_id', 'You can\'t access this app', { app_id: body.app_id })
   }
-  if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
-    if (!(await syncChannelSelfOverrideDelete(c, body.app_id, body.device_id, pluginVersion))) {
-      throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store', { app_id: body.app_id, device_id: body.device_id })
-    }
+  if (!(await syncLegacyChannelSelfOverrideDeleteForDevice(c, supabase, body.app_id, body.device_id))) {
+    throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store', { app_id: body.app_id, device_id: body.device_id })
   }
   return c.json(BRES)
 }

--- a/supabase/functions/_backend/public/device/post.ts
+++ b/supabase/functions/_backend/public/device/post.ts
@@ -2,28 +2,11 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import type { DeviceLink } from './delete.ts'
-import { shouldSyncChannelSelfOverrideForPluginVersion, syncChannelSelfOverride } from '../../utils/channelSelfStore.ts'
+import { syncLegacyChannelSelfOverrideForDevice } from '../../utils/channelSelfStore.ts'
 import { BRES, quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey, updateOrCreateChannelDevice } from '../../utils/supabase.ts'
 import { isValidAppId } from '../../utils/utils.ts'
-
-type PublicDeviceClient = ReturnType<typeof supabaseApikey>
-
-async function getDevicePluginVersion(c: Context, supabase: PublicDeviceClient, appId: string, deviceId: string) {
-  const { data, error } = await supabase
-    .from('devices')
-    .select('plugin_version')
-    .eq('app_id', appId)
-    .eq('device_id', deviceId.toLowerCase())
-    .maybeSingle()
-
-  if (error) {
-    throw quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
-  }
-
-  return data?.plugin_version ?? null
-}
 
 export async function post(c: Context<MiddlewareKeyVariables, any, object>, body: DeviceLink, apikey: Database['public']['Tables']['apikeys']['Row']) {
   if (!body.device_id || !body.app_id) {
@@ -69,16 +52,12 @@ export async function post(c: Context<MiddlewareKeyVariables, any, object>, body
     if (channelDeviceError) {
       throw quickError(500, 'channel_device_error', 'Error setting channel override', { channelDeviceError })
     }
-    const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
-    if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
-      if (!(await syncChannelSelfOverride(c, {
-        device_id: body.device_id,
-        channel_id: dataChannel.id,
-        app_id: body.app_id,
-        plugin_version: pluginVersion,
-      }))) {
-        throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
-      }
+    if (!(await syncLegacyChannelSelfOverrideForDevice(c, supabase, {
+      device_id: body.device_id,
+      channel_id: dataChannel.id,
+      app_id: body.app_id,
+    }))) {
+      throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
     }
   }
   return c.json(BRES)

--- a/supabase/functions/_backend/public/device/post.ts
+++ b/supabase/functions/_backend/public/device/post.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import type { DeviceLink } from './delete.ts'
+import { syncChannelSelfOverride } from '../../utils/channelSelfStore.ts'
 import { BRES, quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey, updateOrCreateChannelDevice } from '../../utils/supabase.ts'
@@ -49,6 +50,13 @@ export async function post(c: Context<MiddlewareKeyVariables, any, object>, body
     })
     if (channelDeviceError) {
       throw quickError(500, 'channel_device_error', 'Error setting channel override', { channelDeviceError })
+    }
+    if (!(await syncChannelSelfOverride(c, {
+      device_id: body.device_id,
+      channel_id: dataChannel.id,
+      app_id: body.app_id,
+    }))) {
+      throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
     }
   }
   return c.json(BRES)

--- a/supabase/functions/_backend/public/device/post.ts
+++ b/supabase/functions/_backend/public/device/post.ts
@@ -2,11 +2,28 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import type { DeviceLink } from './delete.ts'
-import { syncChannelSelfOverride } from '../../utils/channelSelfStore.ts'
+import { shouldSyncChannelSelfOverrideForPluginVersion, syncChannelSelfOverride } from '../../utils/channelSelfStore.ts'
 import { BRES, quickError, simpleError } from '../../utils/hono.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey, updateOrCreateChannelDevice } from '../../utils/supabase.ts'
 import { isValidAppId } from '../../utils/utils.ts'
+
+type PublicDeviceClient = ReturnType<typeof supabaseApikey>
+
+async function getDevicePluginVersion(c: Context, supabase: PublicDeviceClient, appId: string, deviceId: string) {
+  const { data, error } = await supabase
+    .from('devices')
+    .select('plugin_version')
+    .eq('app_id', appId)
+    .eq('device_id', deviceId.toLowerCase())
+    .maybeSingle()
+
+  if (error) {
+    throw quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
+  }
+
+  return data?.plugin_version ?? null
+}
 
 export async function post(c: Context<MiddlewareKeyVariables, any, object>, body: DeviceLink, apikey: Database['public']['Tables']['apikeys']['Row']) {
   if (!body.device_id || !body.app_id) {
@@ -28,8 +45,9 @@ export async function post(c: Context<MiddlewareKeyVariables, any, object>, body
 
   // if channel set channel_override to it
   if (body.channel) {
+    const supabase = supabaseApikey(c, apikey.key)
     // get channel by name
-    const { data: dataChannel, error: dbError } = await supabaseApikey(c, apikey.key)
+    const { data: dataChannel, error: dbError } = await supabase
       .from('channels')
       .select()
       .eq('app_id', body.app_id)
@@ -51,12 +69,16 @@ export async function post(c: Context<MiddlewareKeyVariables, any, object>, body
     if (channelDeviceError) {
       throw quickError(500, 'channel_device_error', 'Error setting channel override', { channelDeviceError })
     }
-    if (!(await syncChannelSelfOverride(c, {
-      device_id: body.device_id,
-      channel_id: dataChannel.id,
-      app_id: body.app_id,
-    }))) {
-      throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+    const pluginVersion = await getDevicePluginVersion(c, supabase, body.app_id, body.device_id)
+    if (shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)) {
+      if (!(await syncChannelSelfOverride(c, {
+        device_id: body.device_id,
+        channel_id: dataChannel.id,
+        app_id: body.app_id,
+        plugin_version: pluginVersion,
+      }))) {
+        throw quickError(500, 'channel_self_store_error', 'Error syncing channel override store')
+      }
     }
   }
   return c.json(BRES)

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -1,8 +1,11 @@
 import type { Context } from 'hono'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import type { MiddlewareKeyVariables } from './hono.ts'
+import type { Database } from './supabase.types.ts'
 import { parse } from '@std/semver'
 import { getRuntimeKey } from 'hono/adapter'
 import { CacheHelper } from './cache.ts'
+import { quickError } from './hono.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { isDeprecatedPluginVersion } from './utils.ts'
 
@@ -39,6 +42,8 @@ interface ChannelSelfOverridePayload {
 }
 
 type ChannelSelfContext = Context<MiddlewareKeyVariables>
+type ChannelSelfDeviceClient = SupabaseClient<Database>
+type ChannelSelfOverrideSyncInput = Omit<ChannelSelfOverrideWrite, 'plugin_version'>
 
 function getChannelSelfStore(c: ChannelSelfContext) {
   return c.env?.CHANNEL_SELF_STORE ?? null
@@ -101,6 +106,34 @@ export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: str
   catch {
     return false
   }
+}
+
+async function getChannelSelfOverridePluginVersion(c: ChannelSelfContext, supabase: ChannelSelfDeviceClient, appId: string, deviceId: string) {
+  const { data, error } = await supabase
+    .from('devices')
+    .select('plugin_version')
+    .eq('app_id', appId)
+    .eq('device_id', deviceId.toLowerCase())
+    .maybeSingle()
+
+  if (error) {
+    quickError(500, 'device_error', 'Error reading device plugin version', { error, app_id: appId, device_id: deviceId })
+  }
+
+  return data?.plugin_version ?? null
+}
+
+export async function syncLegacyChannelSelfOverrideForDevice(c: ChannelSelfContext, supabase: ChannelSelfDeviceClient, override: ChannelSelfOverrideSyncInput) {
+  const pluginVersion = await getChannelSelfOverridePluginVersion(c, supabase, override.app_id, override.device_id)
+  return syncChannelSelfOverride(c, {
+    ...override,
+    plugin_version: pluginVersion,
+  })
+}
+
+export async function syncLegacyChannelSelfOverrideDeleteForDevice(c: ChannelSelfContext, supabase: ChannelSelfDeviceClient, appId: string, deviceId: string) {
+  const pluginVersion = await getChannelSelfOverridePluginVersion(c, supabase, appId, deviceId)
+  return syncChannelSelfOverrideDelete(c, appId, deviceId, pluginVersion)
 }
 
 export async function syncChannelSelfOverride(c: ChannelSelfContext, override: ChannelSelfOverrideWrite) {

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -17,6 +17,12 @@ export interface ChannelSelfOverride {
   }
 }
 
+export interface ChannelSelfOverrideWrite {
+  app_id: string
+  device_id: string
+  channel_id: number
+}
+
 interface ChannelSelfOverridePayload {
   app_id: string
   device_id: string
@@ -70,6 +76,27 @@ function fromPayload(appId: string, deviceId: string, payload: ChannelSelfOverri
 
 export function isChannelSelfStoreEnabled(c: ChannelSelfContext) {
   return Boolean(getChannelSelfStore(c))
+}
+
+export async function syncChannelSelfOverride(c: ChannelSelfContext, override: ChannelSelfOverrideWrite) {
+  if (!isChannelSelfStoreEnabled(c))
+    return true
+
+  const normalizedDeviceId = override.device_id.toLowerCase()
+  return setChannelSelfOverride(c, override.app_id, normalizedDeviceId, {
+    app_id: override.app_id,
+    device_id: normalizedDeviceId,
+    channel_id: {
+      id: override.channel_id,
+    },
+  })
+}
+
+export async function syncChannelSelfOverrideDelete(c: ChannelSelfContext, appId: string, deviceId: string) {
+  if (!isChannelSelfStoreEnabled(c))
+    return true
+
+  return deleteChannelSelfOverride(c, appId, deviceId.toLowerCase())
 }
 
 export async function getChannelSelfOverride(c: ChannelSelfContext, appId: string, deviceId: string): Promise<ChannelSelfOverride | null> {

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -79,8 +79,10 @@ export function isChannelSelfStoreEnabled(c: ChannelSelfContext) {
 }
 
 export async function syncChannelSelfOverride(c: ChannelSelfContext, override: ChannelSelfOverrideWrite) {
-  if (!isChannelSelfStoreEnabled(c))
-    return true
+  if (!isChannelSelfStoreEnabled(c)) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: override.app_id, device_id: override.device_id })
+    return false
+  }
 
   const normalizedDeviceId = override.device_id.toLowerCase()
   return setChannelSelfOverride(c, override.app_id, normalizedDeviceId, {
@@ -93,8 +95,10 @@ export async function syncChannelSelfOverride(c: ChannelSelfContext, override: C
 }
 
 export async function syncChannelSelfOverrideDelete(c: ChannelSelfContext, appId: string, deviceId: string) {
-  if (!isChannelSelfStoreEnabled(c))
-    return true
+  if (!isChannelSelfStoreEnabled(c)) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: appId, device_id: deviceId })
+    return false
+  }
 
   return deleteChannelSelfOverride(c, appId, deviceId.toLowerCase())
 }

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -108,6 +108,18 @@ export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: str
   }
 }
 
+function shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
+  if (!pluginVersion)
+    return true
+
+  try {
+    return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
+  }
+  catch {
+    return true
+  }
+}
+
 async function getChannelSelfOverridePluginVersion(c: ChannelSelfContext, supabase: ChannelSelfDeviceClient, appId: string, deviceId: string) {
   const { data, error } = await supabase
     .from('devices')
@@ -159,7 +171,7 @@ export async function syncChannelSelfOverride(c: ChannelSelfContext, override: C
 }
 
 export async function syncChannelSelfOverrideDelete(c: ChannelSelfContext, appId: string, deviceId: string, pluginVersion?: string | null) {
-  if (!shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion))
+  if (!shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion))
     return true
 
   if (!isChannelSelfStoreEnabled(c)) {

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from './hono.ts'
+import { getRuntimeKey } from 'hono/adapter'
 import { CacheHelper } from './cache.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 
@@ -78,10 +79,18 @@ export function isChannelSelfStoreEnabled(c: ChannelSelfContext) {
   return Boolean(getChannelSelfStore(c))
 }
 
+function shouldRequireChannelSelfStore() {
+  // Supabase/Deno fallback cannot bind Cloudflare KV; Cloudflare API traffic must fail if the KV binding is missing.
+  return getRuntimeKey() === 'workerd'
+}
+
 export async function syncChannelSelfOverride(c: ChannelSelfContext, override: ChannelSelfOverrideWrite) {
   if (!isChannelSelfStoreEnabled(c)) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: override.app_id, device_id: override.device_id })
-    return false
+    if (shouldRequireChannelSelfStore()) {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: override.app_id, device_id: override.device_id })
+      return false
+    }
+    return true
   }
 
   const normalizedDeviceId = override.device_id.toLowerCase()
@@ -96,8 +105,11 @@ export async function syncChannelSelfOverride(c: ChannelSelfContext, override: C
 
 export async function syncChannelSelfOverrideDelete(c: ChannelSelfContext, appId: string, deviceId: string) {
   if (!isChannelSelfStoreEnabled(c)) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: appId, device_id: deviceId })
-    return false
+    if (shouldRequireChannelSelfStore()) {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: appId, device_id: deviceId })
+      return false
+    }
+    return true
   }
 
   return deleteChannelSelfOverride(c, appId, deviceId.toLowerCase())

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -16,6 +16,7 @@ const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
 const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
 const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
 const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
+const CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION = '0.0.0'
 
 // TODO: Delete this legacy channel_self KV/cache bridge once old plugin versions are no longer used. // NOSONAR
 // The cache layer only exists for those old versions so channel_self writes do not hit the primary database.
@@ -99,6 +100,8 @@ function shouldRequireChannelSelfStore() {
 export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
   if (!pluginVersion)
     return false
+  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
+    return true
 
   try {
     return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
@@ -110,6 +113,8 @@ export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: str
 
 function shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
   if (!pluginVersion)
+    return true
+  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
     return true
 
   try {

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -1,12 +1,18 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from './hono.ts'
+import { parse } from '@std/semver'
 import { getRuntimeKey } from 'hono/adapter'
 import { CacheHelper } from './cache.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
+import { isDeprecatedPluginVersion } from './utils.ts'
 
 const CHANNEL_SELF_CACHE_PATH = '/.channel-self-override-v1'
 const CHANNEL_SELF_CACHE_TTL_SECONDS = 60
 const CHANNEL_SELF_KV_CACHE_TTL_SECONDS = 60
+const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
+const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
+const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
+const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
 
 // TODO: Delete this legacy channel_self KV/cache bridge once old plugin versions are no longer used. // NOSONAR
 // The cache layer only exists for those old versions so channel_self writes do not hit the primary database.
@@ -22,6 +28,7 @@ export interface ChannelSelfOverrideWrite {
   app_id: string
   device_id: string
   channel_id: number
+  plugin_version?: string | null
 }
 
 interface ChannelSelfOverridePayload {
@@ -84,7 +91,22 @@ function shouldRequireChannelSelfStore() {
   return getRuntimeKey() === 'workerd'
 }
 
+export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
+  if (!pluginVersion)
+    return false
+
+  try {
+    return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
+  }
+  catch {
+    return false
+  }
+}
+
 export async function syncChannelSelfOverride(c: ChannelSelfContext, override: ChannelSelfOverrideWrite) {
+  if (!shouldSyncChannelSelfOverrideForPluginVersion(override.plugin_version))
+    return true
+
   if (!isChannelSelfStoreEnabled(c)) {
     if (shouldRequireChannelSelfStore()) {
       cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: override.app_id, device_id: override.device_id })
@@ -103,7 +125,10 @@ export async function syncChannelSelfOverride(c: ChannelSelfContext, override: C
   })
 }
 
-export async function syncChannelSelfOverrideDelete(c: ChannelSelfContext, appId: string, deviceId: string) {
+export async function syncChannelSelfOverrideDelete(c: ChannelSelfContext, appId: string, deviceId: string, pluginVersion?: string | null) {
+  if (!shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion))
+    return true
+
   if (!isChannelSelfStoreEnabled(c)) {
     if (shouldRequireChannelSelfStore()) {
       cloudlogErr({ requestId: c.get('requestId'), message: 'Missing channel_self override store binding', app_id: appId, device_id: deviceId })

--- a/supabase/functions/private/index.ts
+++ b/supabase/functions/private/index.ts
@@ -2,6 +2,7 @@ import { app as accept_invitation } from '../_backend/private/accept_invitation.
 import { app as admin_credits } from '../_backend/private/admin_credits.ts'
 import { app as admin_stats } from '../_backend/private/admin_stats.ts'
 import { app as channel_stats } from '../_backend/private/channel_stats.ts'
+import { app as channel_device } from '../_backend/private/channel_device.ts'
 import { app as config } from '../_backend/private/config.ts'
 import { app as configBuilder } from '../_backend/private/config_builder.ts'
 import { app as create_device } from '../_backend/private/create_device.ts'
@@ -52,6 +53,7 @@ appGlobal.route('/website_stats', publicStats)
 appGlobal.route('/config', config)
 appGlobal.route('/config/builder', configBuilder)
 appGlobal.route('/devices', devices_priv)
+appGlobal.route('/channel_device', channel_device)
 appGlobal.route('/create_device', create_device)
 appGlobal.route('/channel_stats', channel_stats)
 appGlobal.route('/download_link', download_link)

--- a/tests/channel-device-override-kv.unit.test.ts
+++ b/tests/channel-device-override-kv.unit.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const checkPermissionMock = vi.fn()
+const isValidAppIdMock = vi.fn()
+const supabaseApikeyMock = vi.fn()
+const supabaseWithAuthMock = vi.fn()
+const syncChannelSelfOverrideDeleteMock = vi.fn()
+const syncChannelSelfOverrideMock = vi.fn()
+const updateOrCreateChannelDeviceMock = vi.fn()
+
+vi.mock('../supabase/functions/_backend/utils/channelSelfStore.ts', () => ({
+  syncChannelSelfOverride: syncChannelSelfOverrideMock,
+  syncChannelSelfOverrideDelete: syncChannelSelfOverrideDeleteMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
+  BRES: { status: 'ok' },
+  parseBody: vi.fn(),
+  quickError: (status: number, error: string, message: string, details: Record<string, unknown> = {}) => {
+    const issue = new Error(message)
+    ;(issue as Error & { cause?: unknown }).cause = { status, error, ...details }
+    throw issue
+  },
+  simpleError: (error: string, message: string, details: Record<string, unknown> = {}) => {
+    const issue = new Error(message)
+    ;(issue as Error & { cause?: unknown }).cause = { error, ...details }
+    throw issue
+  },
+  useCors: async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono_middleware.ts', () => ({
+  middlewareV2: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: checkPermissionMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseApikey: supabaseApikeyMock,
+  supabaseWithAuth: supabaseWithAuthMock,
+  updateOrCreateChannelDevice: updateOrCreateChannelDeviceMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  isValidAppId: isValidAppIdMock,
+}))
+
+function createContext() {
+  return {
+    get: vi.fn((key: string) => {
+      if (key === 'auth') {
+        return {
+          apikey: null,
+          authType: 'jwt',
+          jwt: 'Bearer jwt-test',
+          userId: 'user-test',
+        }
+      }
+      if (key === 'requestId')
+        return 'request-test'
+      return undefined
+    }),
+    json: vi.fn((body: unknown) => body),
+  }
+}
+
+function createChannelSelect(channel = { id: 42, app_id: 'com.test.app', owner_org: 'org-test', public: false }) {
+  return {
+    select() {
+      return this
+    },
+    eq() {
+      return this
+    },
+    single: vi.fn(async () => ({ data: channel, error: null })),
+  }
+}
+
+function createPublicApiSupabase() {
+  return {
+    from(table: string) {
+      if (table === 'channels')
+        return createChannelSelect()
+      if (table === 'channel_devices') {
+        return {
+          delete() {
+            return this
+          },
+          eq() {
+            return this
+          },
+          then(resolve: (value: { error: null }) => unknown) {
+            return Promise.resolve(resolve({ error: null }))
+          },
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    },
+  }
+}
+
+function createPrivateSupabase() {
+  const upsertMock = vi.fn(async () => ({ error: null }))
+  const deleteResult = { error: null }
+  const deleteChain = {
+    delete() {
+      return this
+    },
+    eq() {
+      return this
+    },
+    then(resolve: (value: { error: null }) => unknown) {
+      return Promise.resolve(resolve(deleteResult))
+    },
+  }
+
+  return {
+    deleteChain,
+    upsertMock,
+    client: {
+      from(table: string) {
+        if (table === 'channels')
+          return createChannelSelect()
+        if (table === 'channel_devices') {
+          return {
+            upsert: upsertMock,
+            ...deleteChain,
+          }
+        }
+        throw new Error(`Unexpected table: ${table}`)
+      },
+    },
+  }
+}
+
+describe('channel device override KV sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkPermissionMock.mockResolvedValue(true)
+    isValidAppIdMock.mockReturnValue(true)
+    supabaseApikeyMock.mockReturnValue(createPublicApiSupabase())
+    syncChannelSelfOverrideMock.mockResolvedValue(true)
+    syncChannelSelfOverrideDeleteMock.mockResolvedValue(true)
+    updateOrCreateChannelDeviceMock.mockResolvedValue({ error: null })
+  })
+
+  it('mirrors public device API channel override writes into channel_self KV', async () => {
+    const { post } = await import('../supabase/functions/_backend/public/device/post.ts')
+    const c = createContext()
+
+    await post(c as any, {
+      app_id: 'com.test.app',
+      channel: 'beta',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    }, { key: 'capg-key' } as any)
+
+    expect(updateOrCreateChannelDeviceMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+      owner_org: 'org-test',
+    }))
+    expect(syncChannelSelfOverrideMock).toHaveBeenCalledWith(expect.anything(), {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })
+  })
+
+  it('mirrors public device API channel override deletes into channel_self KV', async () => {
+    const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
+    const c = createContext()
+
+    await deleteOverride(c as any, {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    }, { key: 'capg-key' } as any)
+
+    expect(syncChannelSelfOverrideDeleteMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'com.test.app',
+      '11111111-1111-4111-8111-111111111111',
+    )
+  })
+
+  it('mirrors dashboard channel override writes into channel_self KV', async () => {
+    const privateSupabase = createPrivateSupabase()
+    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
+    const { setChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
+    const c = createContext()
+
+    await setChannelDeviceOverride(c as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })
+
+    expect(privateSupabase.upsertMock).toHaveBeenCalledWith({
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+      owner_org: 'org-test',
+    }, { onConflict: 'app_id,device_id' })
+    expect(syncChannelSelfOverrideMock).toHaveBeenCalledWith(expect.anything(), {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+      owner_org: 'org-test',
+    })
+  })
+
+  it('mirrors dashboard channel override deletes into channel_self KV', async () => {
+    const privateSupabase = createPrivateSupabase()
+    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
+    const { deleteChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
+    const c = createContext()
+
+    await deleteChannelDeviceOverride(c as any, {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })
+
+    expect(syncChannelSelfOverrideDeleteMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'com.test.app',
+      '11111111-1111-4111-8111-111111111111',
+    )
+  })
+})

--- a/tests/channel-device-override-kv.unit.test.ts
+++ b/tests/channel-device-override-kv.unit.test.ts
@@ -169,6 +169,18 @@ describe('channel device override KV sync', () => {
     })
   })
 
+  it('fails public device API channel override writes when KV sync fails', async () => {
+    syncChannelSelfOverrideMock.mockResolvedValue(false)
+    const { post } = await import('../supabase/functions/_backend/public/device/post.ts')
+    const c = createContext()
+
+    await expect(post(c as any, {
+      app_id: 'com.test.app',
+      channel: 'beta',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    }, { key: 'capg-key' } as any)).rejects.toThrow('Error syncing channel override store')
+  })
+
   it('mirrors public device API channel override deletes into channel_self KV', async () => {
     const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
     const c = createContext()
@@ -183,6 +195,17 @@ describe('channel device override KV sync', () => {
       'com.test.app',
       '11111111-1111-4111-8111-111111111111',
     )
+  })
+
+  it('fails public device API channel override deletes when KV sync fails', async () => {
+    syncChannelSelfOverrideDeleteMock.mockResolvedValue(false)
+    const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
+    const c = createContext()
+
+    await expect(deleteOverride(c as any, {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    }, { key: 'capg-key' } as any)).rejects.toThrow('Error syncing channel override store')
   })
 
   it('mirrors dashboard channel override writes into channel_self KV', async () => {
@@ -211,6 +234,20 @@ describe('channel device override KV sync', () => {
     })
   })
 
+  it('fails dashboard channel override writes when KV sync fails', async () => {
+    const privateSupabase = createPrivateSupabase()
+    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
+    syncChannelSelfOverrideMock.mockResolvedValue(false)
+    const { setChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
+    const c = createContext()
+
+    await expect(setChannelDeviceOverride(c as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })).rejects.toThrow('Error syncing channel override store')
+  })
+
   it('mirrors dashboard channel override deletes into channel_self KV', async () => {
     const privateSupabase = createPrivateSupabase()
     supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
@@ -227,5 +264,18 @@ describe('channel device override KV sync', () => {
       'com.test.app',
       '11111111-1111-4111-8111-111111111111',
     )
+  })
+
+  it('fails dashboard channel override deletes when KV sync fails', async () => {
+    const privateSupabase = createPrivateSupabase()
+    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
+    syncChannelSelfOverrideDeleteMock.mockResolvedValue(false)
+    const { deleteChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
+    const c = createContext()
+
+    await expect(deleteChannelDeviceOverride(c as any, {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })).rejects.toThrow('Error syncing channel override store')
   })
 })

--- a/tests/channel-device-override-kv.unit.test.ts
+++ b/tests/channel-device-override-kv.unit.test.ts
@@ -4,15 +4,13 @@ const checkPermissionMock = vi.fn()
 const isValidAppIdMock = vi.fn()
 const supabaseApikeyMock = vi.fn()
 const supabaseWithAuthMock = vi.fn()
-const shouldSyncChannelSelfOverrideForPluginVersionMock = vi.fn()
-const syncChannelSelfOverrideDeleteMock = vi.fn()
-const syncChannelSelfOverrideMock = vi.fn()
+const syncLegacyChannelSelfOverrideDeleteForDeviceMock = vi.fn()
+const syncLegacyChannelSelfOverrideForDeviceMock = vi.fn()
 const updateOrCreateChannelDeviceMock = vi.fn()
 
 vi.mock('../supabase/functions/_backend/utils/channelSelfStore.ts', () => ({
-  shouldSyncChannelSelfOverrideForPluginVersion: shouldSyncChannelSelfOverrideForPluginVersionMock,
-  syncChannelSelfOverride: syncChannelSelfOverrideMock,
-  syncChannelSelfOverrideDelete: syncChannelSelfOverrideDeleteMock,
+  syncLegacyChannelSelfOverrideDeleteForDevice: syncLegacyChannelSelfOverrideDeleteForDeviceMock,
+  syncLegacyChannelSelfOverrideForDevice: syncLegacyChannelSelfOverrideForDeviceMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
@@ -162,13 +160,12 @@ describe('channel device override KV sync', () => {
     checkPermissionMock.mockResolvedValue(true)
     isValidAppIdMock.mockReturnValue(true)
     supabaseApikeyMock.mockReturnValue(createPublicApiSupabase())
-    shouldSyncChannelSelfOverrideForPluginVersionMock.mockImplementation((pluginVersion: string | null | undefined) => pluginVersion === '7.33.0')
-    syncChannelSelfOverrideMock.mockResolvedValue(true)
-    syncChannelSelfOverrideDeleteMock.mockResolvedValue(true)
+    syncLegacyChannelSelfOverrideForDeviceMock.mockResolvedValue(true)
+    syncLegacyChannelSelfOverrideDeleteForDeviceMock.mockResolvedValue(true)
     updateOrCreateChannelDeviceMock.mockResolvedValue({ error: null })
   })
 
-  it('mirrors public device API channel override writes into channel_self KV', async () => {
+  it('syncs public device API channel override writes through the legacy channel_self helper', async () => {
     const { post } = await import('../supabase/functions/_backend/public/device/post.ts')
     const c = createContext()
 
@@ -184,31 +181,15 @@ describe('channel device override KV sync', () => {
       device_id: '11111111-1111-4111-8111-111111111111',
       owner_org: 'org-test',
     }))
-    expect(syncChannelSelfOverrideMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(syncLegacyChannelSelfOverrideForDeviceMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
       app_id: 'com.test.app',
       channel_id: 42,
       device_id: '11111111-1111-4111-8111-111111111111',
-      plugin_version: '7.33.0',
     })
   })
 
-  it('does not mirror public device API channel override writes for new plugin devices', async () => {
-    supabaseApikeyMock.mockReturnValue(createPublicApiSupabase('7.34.0'))
-    const { post } = await import('../supabase/functions/_backend/public/device/post.ts')
-    const c = createContext()
-
-    await post(c as any, {
-      app_id: 'com.test.app',
-      channel: 'beta',
-      device_id: '11111111-1111-4111-8111-111111111111',
-    }, { key: 'capg-key' } as any)
-
-    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
-    expect(syncChannelSelfOverrideMock).not.toHaveBeenCalled()
-  })
-
   it('fails public device API channel override writes when KV sync fails', async () => {
-    syncChannelSelfOverrideMock.mockResolvedValue(false)
+    syncLegacyChannelSelfOverrideForDeviceMock.mockResolvedValue(false)
     const { post } = await import('../supabase/functions/_backend/public/device/post.ts')
     const c = createContext()
 
@@ -219,7 +200,7 @@ describe('channel device override KV sync', () => {
     }, { key: 'capg-key' } as any)).rejects.toThrow('Error syncing channel override store')
   })
 
-  it('mirrors public device API channel override deletes into channel_self KV', async () => {
+  it('syncs public device API channel override deletes through the legacy channel_self helper', async () => {
     const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
     const c = createContext()
 
@@ -228,30 +209,16 @@ describe('channel device override KV sync', () => {
       device_id: '11111111-1111-4111-8111-111111111111',
     }, { key: 'capg-key' } as any)
 
-    expect(syncChannelSelfOverrideDeleteMock).toHaveBeenCalledWith(
+    expect(syncLegacyChannelSelfOverrideDeleteForDeviceMock).toHaveBeenCalledWith(
+      expect.anything(),
       expect.anything(),
       'com.test.app',
       '11111111-1111-4111-8111-111111111111',
-      '7.33.0',
     )
   })
 
-  it('does not mirror public device API channel override deletes for new plugin devices', async () => {
-    supabaseApikeyMock.mockReturnValue(createPublicApiSupabase('7.34.0'))
-    const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
-    const c = createContext()
-
-    await deleteOverride(c as any, {
-      app_id: 'com.test.app',
-      device_id: '11111111-1111-4111-8111-111111111111',
-    }, { key: 'capg-key' } as any)
-
-    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
-    expect(syncChannelSelfOverrideDeleteMock).not.toHaveBeenCalled()
-  })
-
   it('fails public device API channel override deletes when KV sync fails', async () => {
-    syncChannelSelfOverrideDeleteMock.mockResolvedValue(false)
+    syncLegacyChannelSelfOverrideDeleteForDeviceMock.mockResolvedValue(false)
     const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
     const c = createContext()
 
@@ -261,7 +228,7 @@ describe('channel device override KV sync', () => {
     }, { key: 'capg-key' } as any)).rejects.toThrow('Error syncing channel override store')
   })
 
-  it('mirrors dashboard channel override writes into channel_self KV', async () => {
+  it('syncs dashboard channel override writes through the legacy channel_self helper', async () => {
     const privateSupabase = createPrivateSupabase()
     supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
     const { setChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
@@ -279,35 +246,18 @@ describe('channel device override KV sync', () => {
       device_id: '11111111-1111-4111-8111-111111111111',
       owner_org: 'org-test',
     }, { onConflict: 'app_id,device_id' })
-    expect(syncChannelSelfOverrideMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(syncLegacyChannelSelfOverrideForDeviceMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
       app_id: 'com.test.app',
       channel_id: 42,
       device_id: '11111111-1111-4111-8111-111111111111',
       owner_org: 'org-test',
-      plugin_version: '7.33.0',
     })
-  })
-
-  it('does not mirror dashboard channel override writes for new plugin devices', async () => {
-    const privateSupabase = createPrivateSupabase('7.34.0')
-    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
-    const { setChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
-    const c = createContext()
-
-    await setChannelDeviceOverride(c as any, {
-      app_id: 'com.test.app',
-      channel_id: 42,
-      device_id: '11111111-1111-4111-8111-111111111111',
-    })
-
-    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
-    expect(syncChannelSelfOverrideMock).not.toHaveBeenCalled()
   })
 
   it('fails dashboard channel override writes when KV sync fails', async () => {
     const privateSupabase = createPrivateSupabase()
     supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
-    syncChannelSelfOverrideMock.mockResolvedValue(false)
+    syncLegacyChannelSelfOverrideForDeviceMock.mockResolvedValue(false)
     const { setChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
     const c = createContext()
 
@@ -318,7 +268,7 @@ describe('channel device override KV sync', () => {
     })).rejects.toThrow('Error syncing channel override store')
   })
 
-  it('mirrors dashboard channel override deletes into channel_self KV', async () => {
+  it('syncs dashboard channel override deletes through the legacy channel_self helper', async () => {
     const privateSupabase = createPrivateSupabase()
     supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
     const { deleteChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
@@ -329,33 +279,18 @@ describe('channel device override KV sync', () => {
       device_id: '11111111-1111-4111-8111-111111111111',
     })
 
-    expect(syncChannelSelfOverrideDeleteMock).toHaveBeenCalledWith(
+    expect(syncLegacyChannelSelfOverrideDeleteForDeviceMock).toHaveBeenCalledWith(
+      expect.anything(),
       expect.anything(),
       'com.test.app',
       '11111111-1111-4111-8111-111111111111',
-      '7.33.0',
     )
-  })
-
-  it('does not mirror dashboard channel override deletes for new plugin devices', async () => {
-    const privateSupabase = createPrivateSupabase('7.34.0')
-    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
-    const { deleteChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
-    const c = createContext()
-
-    await deleteChannelDeviceOverride(c as any, {
-      app_id: 'com.test.app',
-      device_id: '11111111-1111-4111-8111-111111111111',
-    })
-
-    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
-    expect(syncChannelSelfOverrideDeleteMock).not.toHaveBeenCalled()
   })
 
   it('fails dashboard channel override deletes when KV sync fails', async () => {
     const privateSupabase = createPrivateSupabase()
     supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
-    syncChannelSelfOverrideDeleteMock.mockResolvedValue(false)
+    syncLegacyChannelSelfOverrideDeleteForDeviceMock.mockResolvedValue(false)
     const { deleteChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
     const c = createContext()
 

--- a/tests/channel-device-override-kv.unit.test.ts
+++ b/tests/channel-device-override-kv.unit.test.ts
@@ -4,11 +4,13 @@ const checkPermissionMock = vi.fn()
 const isValidAppIdMock = vi.fn()
 const supabaseApikeyMock = vi.fn()
 const supabaseWithAuthMock = vi.fn()
+const shouldSyncChannelSelfOverrideForPluginVersionMock = vi.fn()
 const syncChannelSelfOverrideDeleteMock = vi.fn()
 const syncChannelSelfOverrideMock = vi.fn()
 const updateOrCreateChannelDeviceMock = vi.fn()
 
 vi.mock('../supabase/functions/_backend/utils/channelSelfStore.ts', () => ({
+  shouldSyncChannelSelfOverrideForPluginVersion: shouldSyncChannelSelfOverrideForPluginVersionMock,
   syncChannelSelfOverride: syncChannelSelfOverrideMock,
   syncChannelSelfOverrideDelete: syncChannelSelfOverrideDeleteMock,
 }))
@@ -78,11 +80,28 @@ function createChannelSelect(channel = { id: 42, app_id: 'com.test.app', owner_o
   }
 }
 
-function createPublicApiSupabase() {
+function createDeviceSelect(pluginVersion: string | null = '7.33.0') {
+  return {
+    select() {
+      return this
+    },
+    eq() {
+      return this
+    },
+    maybeSingle: vi.fn(async () => ({
+      data: pluginVersion ? { plugin_version: pluginVersion } : null,
+      error: null,
+    })),
+  }
+}
+
+function createPublicApiSupabase(pluginVersion: string | null = '7.33.0') {
   return {
     from(table: string) {
       if (table === 'channels')
         return createChannelSelect()
+      if (table === 'devices')
+        return createDeviceSelect(pluginVersion)
       if (table === 'channel_devices') {
         return {
           delete() {
@@ -101,7 +120,7 @@ function createPublicApiSupabase() {
   }
 }
 
-function createPrivateSupabase() {
+function createPrivateSupabase(pluginVersion: string | null = '7.33.0') {
   const upsertMock = vi.fn(async () => ({ error: null }))
   const deleteResult = { error: null }
   const deleteChain = {
@@ -123,6 +142,8 @@ function createPrivateSupabase() {
       from(table: string) {
         if (table === 'channels')
           return createChannelSelect()
+        if (table === 'devices')
+          return createDeviceSelect(pluginVersion)
         if (table === 'channel_devices') {
           return {
             upsert: upsertMock,
@@ -141,6 +162,7 @@ describe('channel device override KV sync', () => {
     checkPermissionMock.mockResolvedValue(true)
     isValidAppIdMock.mockReturnValue(true)
     supabaseApikeyMock.mockReturnValue(createPublicApiSupabase())
+    shouldSyncChannelSelfOverrideForPluginVersionMock.mockImplementation((pluginVersion: string | null | undefined) => pluginVersion === '7.33.0')
     syncChannelSelfOverrideMock.mockResolvedValue(true)
     syncChannelSelfOverrideDeleteMock.mockResolvedValue(true)
     updateOrCreateChannelDeviceMock.mockResolvedValue({ error: null })
@@ -166,7 +188,23 @@ describe('channel device override KV sync', () => {
       app_id: 'com.test.app',
       channel_id: 42,
       device_id: '11111111-1111-4111-8111-111111111111',
+      plugin_version: '7.33.0',
     })
+  })
+
+  it('does not mirror public device API channel override writes for new plugin devices', async () => {
+    supabaseApikeyMock.mockReturnValue(createPublicApiSupabase('7.34.0'))
+    const { post } = await import('../supabase/functions/_backend/public/device/post.ts')
+    const c = createContext()
+
+    await post(c as any, {
+      app_id: 'com.test.app',
+      channel: 'beta',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    }, { key: 'capg-key' } as any)
+
+    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
+    expect(syncChannelSelfOverrideMock).not.toHaveBeenCalled()
   })
 
   it('fails public device API channel override writes when KV sync fails', async () => {
@@ -194,7 +232,22 @@ describe('channel device override KV sync', () => {
       expect.anything(),
       'com.test.app',
       '11111111-1111-4111-8111-111111111111',
+      '7.33.0',
     )
+  })
+
+  it('does not mirror public device API channel override deletes for new plugin devices', async () => {
+    supabaseApikeyMock.mockReturnValue(createPublicApiSupabase('7.34.0'))
+    const { deleteOverride } = await import('../supabase/functions/_backend/public/device/delete.ts')
+    const c = createContext()
+
+    await deleteOverride(c as any, {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    }, { key: 'capg-key' } as any)
+
+    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
+    expect(syncChannelSelfOverrideDeleteMock).not.toHaveBeenCalled()
   })
 
   it('fails public device API channel override deletes when KV sync fails', async () => {
@@ -231,7 +284,24 @@ describe('channel device override KV sync', () => {
       channel_id: 42,
       device_id: '11111111-1111-4111-8111-111111111111',
       owner_org: 'org-test',
+      plugin_version: '7.33.0',
     })
+  })
+
+  it('does not mirror dashboard channel override writes for new plugin devices', async () => {
+    const privateSupabase = createPrivateSupabase('7.34.0')
+    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
+    const { setChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
+    const c = createContext()
+
+    await setChannelDeviceOverride(c as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })
+
+    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
+    expect(syncChannelSelfOverrideMock).not.toHaveBeenCalled()
   })
 
   it('fails dashboard channel override writes when KV sync fails', async () => {
@@ -263,7 +333,23 @@ describe('channel device override KV sync', () => {
       expect.anything(),
       'com.test.app',
       '11111111-1111-4111-8111-111111111111',
+      '7.33.0',
     )
+  })
+
+  it('does not mirror dashboard channel override deletes for new plugin devices', async () => {
+    const privateSupabase = createPrivateSupabase('7.34.0')
+    supabaseWithAuthMock.mockReturnValue(privateSupabase.client)
+    const { deleteChannelDeviceOverride } = await import('../supabase/functions/_backend/private/channel_device.ts')
+    const c = createContext()
+
+    await deleteChannelDeviceOverride(c as any, {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+    })
+
+    expect(shouldSyncChannelSelfOverrideForPluginVersionMock).toHaveBeenCalledWith('7.34.0')
+    expect(syncChannelSelfOverrideDeleteMock).not.toHaveBeenCalled()
   })
 
   it('fails dashboard channel override deletes when KV sync fails', async () => {

--- a/tests/channel-self-store-plugin-version.unit.test.ts
+++ b/tests/channel-self-store-plugin-version.unit.test.ts
@@ -45,24 +45,28 @@ function createDeviceClient(pluginVersion: string | null) {
   }
 }
 
+const pluginVersionCases: [string | null, boolean][] = [
+  ['5.33.9', true],
+  ['5.34.0', false],
+  ['6.33.9', true],
+  ['6.34.0', false],
+  ['7.33.9', true],
+  ['7.34.0', false],
+  ['7.42.0', false],
+  ['8.0.0', false],
+  ['', false],
+  [null, false],
+  ['invalid', false],
+]
+
 describe('channel_self override KV plugin version gate', () => {
-  it.each([
-    ['5.33.9', true],
-    ['5.34.0', false],
-    ['6.33.9', true],
-    ['6.34.0', false],
-    ['7.33.9', true],
-    ['7.34.0', false],
-    ['7.42.0', false],
-    ['8.0.0', false],
-    ['', false],
-    [null, false],
-    ['invalid', false],
-  ])('returns %s for %s', (pluginVersion, expected) => {
-    expect(shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)).toBe(expected)
+  pluginVersionCases.forEach(([pluginVersion, expected]) => {
+    it.concurrent(`returns ${expected} for ${pluginVersion ?? 'null'}`, () => {
+      expect(shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)).toBe(expected)
+    })
   })
 
-  it('writes channel_self KV for legacy plugin devices', async () => {
+  it.concurrent('writes channel_self KV for legacy plugin devices', async () => {
     const store = createStore()
 
     await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient('7.33.9') as any, {
@@ -80,7 +84,7 @@ describe('channel_self override KV plugin version gate', () => {
     })
   })
 
-  it('does not write channel_self KV for new plugin devices', async () => {
+  it.concurrent('does not write channel_self KV for new plugin devices', async () => {
     const store = createStore()
 
     await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient('7.34.0') as any, {
@@ -92,7 +96,31 @@ describe('channel_self override KV plugin version gate', () => {
     expect(store.put).not.toHaveBeenCalled()
   })
 
-  it('deletes channel_self KV for legacy plugin devices', async () => {
+  it.concurrent('does not write channel_self KV for missing plugin versions', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient(null) as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: 'DEVICE-ID',
+    })
+
+    expect(store.put).not.toHaveBeenCalled()
+  })
+
+  it.concurrent('does not write channel_self KV for unparsable plugin versions', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient('invalid') as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: 'DEVICE-ID',
+    })
+
+    expect(store.put).not.toHaveBeenCalled()
+  })
+
+  it.concurrent('deletes channel_self KV for legacy plugin devices', async () => {
     const store = createStore()
 
     await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('7.33.9') as any, 'com.test.app', 'DEVICE-ID')
@@ -100,7 +128,23 @@ describe('channel_self override KV plugin version gate', () => {
     expect(store.delete).toHaveBeenCalledWith('channel_self:v1:com.test.app:device-id')
   })
 
-  it('does not delete channel_self KV for new plugin devices', async () => {
+  it.concurrent('deletes channel_self KV for missing plugin versions', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient(null) as any, 'com.test.app', 'DEVICE-ID')
+
+    expect(store.delete).toHaveBeenCalledWith('channel_self:v1:com.test.app:device-id')
+  })
+
+  it.concurrent('deletes channel_self KV for unparsable plugin versions', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('invalid') as any, 'com.test.app', 'DEVICE-ID')
+
+    expect(store.delete).toHaveBeenCalledWith('channel_self:v1:com.test.app:device-id')
+  })
+
+  it.concurrent('does not delete channel_self KV for new plugin devices', async () => {
     const store = createStore()
 
     await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('7.42.0') as any, 'com.test.app', 'DEVICE-ID')

--- a/tests/channel-self-store-plugin-version.unit.test.ts
+++ b/tests/channel-self-store-plugin-version.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldSyncChannelSelfOverrideForPluginVersion } from '../supabase/functions/_backend/utils/channelSelfStore.ts'
+
+describe('channel_self override KV plugin version gate', () => {
+  it.each([
+    ['5.33.9', true],
+    ['5.34.0', false],
+    ['6.33.9', true],
+    ['6.34.0', false],
+    ['7.33.9', true],
+    ['7.34.0', false],
+    ['7.42.0', false],
+    ['8.0.0', false],
+    ['', false],
+    [null, false],
+    ['invalid', false],
+  ])('returns %s for %s', (pluginVersion, expected) => {
+    expect(shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)).toBe(expected)
+  })
+})

--- a/tests/channel-self-store-plugin-version.unit.test.ts
+++ b/tests/channel-self-store-plugin-version.unit.test.ts
@@ -54,6 +54,7 @@ const pluginVersionCases: [string | null, boolean][] = [
   ['7.34.0', false],
   ['7.42.0', false],
   ['8.0.0', false],
+  ['0.0.0', true],
   ['', false],
   [null, false],
   ['invalid', false],
@@ -120,6 +121,18 @@ describe('channel_self override KV plugin version gate', () => {
     expect(store.put).not.toHaveBeenCalled()
   })
 
+  it.concurrent('writes channel_self KV for injected placeholder devices', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient('0.0.0') as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: 'DEVICE-ID',
+    })
+
+    expect(store.put).toHaveBeenCalledTimes(1)
+  })
+
   it.concurrent('deletes channel_self KV for legacy plugin devices', async () => {
     const store = createStore()
 
@@ -140,6 +153,14 @@ describe('channel_self override KV plugin version gate', () => {
     const store = createStore()
 
     await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('invalid') as any, 'com.test.app', 'DEVICE-ID')
+
+    expect(store.delete).toHaveBeenCalledWith('channel_self:v1:com.test.app:device-id')
+  })
+
+  it.concurrent('deletes channel_self KV for injected placeholder devices', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('0.0.0') as any, 'com.test.app', 'DEVICE-ID')
 
     expect(store.delete).toHaveBeenCalledWith('channel_self:v1:com.test.app:device-id')
   })

--- a/tests/channel-self-store-plugin-version.unit.test.ts
+++ b/tests/channel-self-store-plugin-version.unit.test.ts
@@ -1,6 +1,49 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { shouldSyncChannelSelfOverrideForPluginVersion } from '../supabase/functions/_backend/utils/channelSelfStore.ts'
+import { shouldSyncChannelSelfOverrideForPluginVersion, syncLegacyChannelSelfOverrideDeleteForDevice, syncLegacyChannelSelfOverrideForDevice } from '../supabase/functions/_backend/utils/channelSelfStore.ts'
+
+function createContext(store: { put: ReturnType<typeof vi.fn>, delete: ReturnType<typeof vi.fn> }) {
+  return {
+    env: {
+      CHANNEL_SELF_STORE: store,
+    },
+    get: vi.fn((key: string) => {
+      if (key === 'requestId')
+        return 'request-test'
+      return undefined
+    }),
+    req: {
+      url: 'https://api.capgo.test/updates',
+    },
+  }
+}
+
+function createStore() {
+  return {
+    delete: vi.fn(async (_key: string) => undefined),
+    put: vi.fn(async (_key: string, _value: string) => undefined),
+  }
+}
+
+function createDeviceClient(pluginVersion: string | null) {
+  return {
+    from(table: string) {
+      expect(table).toBe('devices')
+      return {
+        select() {
+          return this
+        },
+        eq() {
+          return this
+        },
+        maybeSingle: vi.fn(async () => ({
+          data: pluginVersion ? { plugin_version: pluginVersion } : null,
+          error: null,
+        })),
+      }
+    },
+  }
+}
 
 describe('channel_self override KV plugin version gate', () => {
   it.each([
@@ -17,5 +60,51 @@ describe('channel_self override KV plugin version gate', () => {
     ['invalid', false],
   ])('returns %s for %s', (pluginVersion, expected) => {
     expect(shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion)).toBe(expected)
+  })
+
+  it('writes channel_self KV for legacy plugin devices', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient('7.33.9') as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: 'DEVICE-ID',
+    })
+
+    expect(store.put).toHaveBeenCalledTimes(1)
+    expect(store.put.mock.calls[0][0]).toBe('channel_self:v1:com.test.app:device-id')
+    expect(JSON.parse(store.put.mock.calls[0][1])).toMatchObject({
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: 'device-id',
+    })
+  })
+
+  it('does not write channel_self KV for new plugin devices', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideForDevice(createContext(store) as any, createDeviceClient('7.34.0') as any, {
+      app_id: 'com.test.app',
+      channel_id: 42,
+      device_id: 'DEVICE-ID',
+    })
+
+    expect(store.put).not.toHaveBeenCalled()
+  })
+
+  it('deletes channel_self KV for legacy plugin devices', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('7.33.9') as any, 'com.test.app', 'DEVICE-ID')
+
+    expect(store.delete).toHaveBeenCalledWith('channel_self:v1:com.test.app:device-id')
+  })
+
+  it('does not delete channel_self KV for new plugin devices', async () => {
+    const store = createStore()
+
+    await syncLegacyChannelSelfOverrideDeleteForDevice(createContext(store) as any, createDeviceClient('7.42.0') as any, 'com.test.app', 'DEVICE-ID')
+
+    expect(store.delete).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
Generated with AI.

- Adds a private dashboard endpoint for channel device override set/delete that writes Postgres and mirrors the override into `CHANNEL_SELF_STORE`.
- Mirrors public `/device` API override set/delete operations into `CHANNEL_SELF_STORE` as well.
- Updates dashboard forced-device flows to call the backend endpoint instead of writing `channel_devices` directly.

## Motivation
Generated with AI.

Old plugin versions read forced device overrides from the legacy channel_self KV bridge. Dashboard and API writes still only updated Postgres, so old-plugin devices could miss channel overrides even after the `/updates` version gate fix.

## Business Impact
Generated with AI.

Restores forced channel override behavior for customers still running old plugin versions while preserving the main goal of avoiding hot-path primary database writes for those legacy plugin requests.

## Test Plan
Generated with AI.

- [x] `bunx vitest run tests/channel-device-override-kv.unit.test.ts tests/channel-self-pg-client.unit.test.ts tests/update-channel-self-store.unit.test.ts`
- [x] `bun lint`
- [x] `bun lint:backend`
- [x] `bun typecheck`
- [x] `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a private API for managing per-device channel overrides.

* **Improvements**
  * More reliable synchronization of channel override changes to legacy storage.
  * UI now uses the private API for override actions, with clearer success/error feedback and preserved replication-delay notice.
  * Validation and error handling for override operations have been strengthened.

* **Tests**
  * Added unit tests covering override flows and legacy sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->