### PR TITLE
ci: choose screenshot upload platform

### DIFF
--- a/.github/workflows/upload_screenshots.yml
+++ b/.github/workflows/upload_screenshots.yml
@@ -28,6 +28,8 @@ jobs:
       FASTLANE_SKIP_UPDATE_CHECK: 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create fastlane Gemfile
         run: |
           mkdir -p "$(dirname "$BUNDLE_GEMFILE")"
@@ -59,6 +61,8 @@ jobs:
       FASTLANE_SKIP_UPDATE_CHECK: 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create fastlane Gemfile
         run: |
           mkdir -p "$(dirname "$BUNDLE_GEMFILE")"

--- a/.github/workflows/upload_screenshots.yml
+++ b/.github/workflows/upload_screenshots.yml
@@ -1,23 +1,52 @@
-name: Upload Android screenshots
+name: Upload screenshots
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}
   cancel-in-progress: false
 
 on:
   workflow_dispatch:
     inputs:
-      validate_only:
-        description: Validate with Google Play without applying screenshot changes
-        required: false
-        default: false
-        type: boolean
+      platform:
+        description: Platform to upload screenshots for
+        required: true
+        type: choice
+        options:
+          - ios
+          - android
 
 permissions:
   contents: read
 
 jobs:
+  upload_ios_screenshots:
+    if: ${{ inputs.platform == 'ios' }}
+    runs-on: macOS-latest
+    timeout-minutes: 30
+    env:
+      BUNDLE_GEMFILE: .bundle/fastlane/Gemfile
+      FASTLANE_SKIP_UPDATE_CHECK: 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - name: Install fastlane
+        run: |
+          mkdir -p "$(dirname "$BUNDLE_GEMFILE")"
+          {
+            echo "source 'https://rubygems.org'"
+            echo "gem 'fastlane'"
+          } > "$BUNDLE_GEMFILE"
+          bundle config set path .bundle/vendor
+          bundle install --jobs 4 --retry 3
+      - name: Upload iOS screenshots
+        env:
+          APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+        run: bundle exec fastlane ios upload_screenshots
+
   upload_android_screenshots:
+    if: ${{ inputs.platform == 'android' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -47,5 +76,4 @@ jobs:
         env:
           ANDROID_JSON_KEY_FILE: ${{ steps.service_account_json_file.outputs.filePath }}
           DEVELOPER_PACKAGE_NAME: ${{ secrets.DEVELOPER_PACKAGE_NAME }}
-          FASTLANE_VALIDATE_ONLY: ${{ inputs.validate_only }}
         run: bundle exec fastlane android upload_screenshots

--- a/.github/workflows/upload_screenshots.yml
+++ b/.github/workflows/upload_screenshots.yml
@@ -28,16 +28,18 @@ jobs:
       FASTLANE_SKIP_UPDATE_CHECK: 'true'
     steps:
       - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'
-      - name: Install fastlane
+      - name: Create fastlane Gemfile
         run: |
           mkdir -p "$(dirname "$BUNDLE_GEMFILE")"
           {
             echo "source 'https://rubygems.org'"
             echo "gem 'fastlane'"
           } > "$BUNDLE_GEMFILE"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - name: Install fastlane
+        run: |
           bundle config set path .bundle/vendor
           bundle install --jobs 4 --retry 3
       - name: Upload iOS screenshots
@@ -54,16 +56,18 @@ jobs:
       FASTLANE_SKIP_UPDATE_CHECK: 'true'
     steps:
       - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'
-      - name: Install fastlane
+      - name: Create fastlane Gemfile
         run: |
           mkdir -p "$(dirname "$BUNDLE_GEMFILE")"
           {
             echo "source 'https://rubygems.org'"
             echo "gem 'fastlane'"
           } > "$BUNDLE_GEMFILE"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - name: Install fastlane
+        run: |
           bundle config set path .bundle/vendor
           bundle install --jobs 4 --retry 3
       - name: Decode Google Play Config File

--- a/.github/workflows/upload_screenshots.yml
+++ b/.github/workflows/upload_screenshots.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Upload iOS screenshots
         env:
           APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
         run: bundle exec fastlane ios upload_screenshots
 
   upload_android_screenshots:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,8 +45,7 @@ platform :android do
       skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: false,
-      sync_image_upload: true,
-      validate_only: ENV['FASTLANE_VALIDATE_ONLY'] == 'true'
+      sync_image_upload: true
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,7 +3,19 @@ default_platform(:ios)
 platform :ios do
   desc 'Upload App Store screenshots using fastlane/Deliverfile'
   lane :upload_screenshots do
-    deliver
+    missing_api_key_env = %w[APPLE_KEY_ID APPLE_ISSUER_ID APPLE_KEY_CONTENT].select { |key| ENV[key].to_s.strip.empty? }
+    unless missing_api_key_env.empty?
+      UI.user_error!("Missing App Store Connect API key environment variables: #{missing_api_key_env.join(', ')}")
+    end
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch('APPLE_KEY_ID'),
+      issuer_id: ENV.fetch('APPLE_ISSUER_ID'),
+      key_content: ENV.fetch('APPLE_KEY_CONTENT'),
+      is_key_content_base64: true
+    )
+
+    deliver(api_key: api_key)
   end
 
   desc 'Submit iOS app for App Store review'


### PR DESCRIPTION
## Summary (AI generated)

- Renames the screenshot upload workflow to `Upload screenshots`.
- Adds a required manual `platform` choice with `ios` and `android` options.
- Runs `bundle exec fastlane ios upload_screenshots` for iOS and `bundle exec fastlane android upload_screenshots` for Android.
- Removes the Google Play validate-only input and removes the Fastlane `validate_only` option.
- Creates the temporary Fastlane Gemfile before `ruby/setup-ruby` so setup-ruby never sees a missing `BUNDLE_GEMFILE`.
- Wires App Store Connect API key secrets into the iOS screenshot lane so `deliver` can authenticate on CI.
- Disables persisted checkout credentials for both screenshot upload jobs.

## Motivation (AI generated)

The manual screenshot upload action should be one workflow where the operator chooses the target platform, without offering a dry-run or verification mode. The Fastlane Gemfile also has to exist before Ruby setup because the job-level `BUNDLE_GEMFILE` environment variable is visible to setup-ruby.

## Business Impact (AI generated)

This reduces release-ops confusion and makes App Store and Google Play screenshot updates follow the same manual workflow shape without a broken setup or non-interactive iOS login failure.

## Test Plan (AI generated)

- [x] Parsed `.github/workflows/upload_screenshots.yml` with Ruby YAML.
- [x] Ran `ruby -c fastlane/Fastfile`.
- [x] Ran `git diff --check`.
- [x] Confirmed no `validate_only`, `FASTLANE_VALIDATE_ONLY`, or verification wording remains in workflow/Fastfile paths.
- [x] Commit hook passed: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`.
- [x] GitHub CI passed.
- [x] CodeRabbit review finished with no unresolved threads.

Generated with AI
