### PR TITLE
[codex] fix device debug curl override channel

### DIFF
--- a/src/composables/useDeviceUpdateFormat.ts
+++ b/src/composables/useDeviceUpdateFormat.ts
@@ -1,5 +1,7 @@
 import type { Database } from '~/types/supabase.types'
 
+type DeviceRow = Database['public']['Tables']['devices']['Row']
+
 /**
  * Interface matching the update endpoint expected request format
  * Based on AppInfos from supabase/functions/_backend/utils/types.ts
@@ -16,6 +18,7 @@ export interface UpdateEndpointRequest {
   app_id: string
   device_id: string
   defaultChannel: string
+  channel?: string
 }
 
 /**
@@ -23,9 +26,10 @@ export interface UpdateEndpointRequest {
  */
 export function useDeviceUpdateFormat() {
   function transformDeviceToUpdateRequest(
-    device: Database['public']['Tables']['devices']['Row'],
+    device: DeviceRow,
     appId: string,
     defaultChannel: string = 'production',
+    channelOverrideName?: string | null,
   ): UpdateEndpointRequest {
     return {
       version_name: device.version_name || '',
@@ -39,15 +43,17 @@ export function useDeviceUpdateFormat() {
       app_id: appId,
       device_id: device.device_id || '',
       defaultChannel,
+      ...(channelOverrideName ? { channel: channelOverrideName } : {}),
     }
   }
 
   function copyUpdateRequestToClipboard(
-    device: Database['public']['Tables']['devices']['Row'],
+    device: DeviceRow,
     appId: string,
     defaultChannel: string = 'production',
+    channelOverrideName?: string | null,
   ): Promise<void> {
-    const request = transformDeviceToUpdateRequest(device, appId, defaultChannel)
+    const request = transformDeviceToUpdateRequest(device, appId, defaultChannel, channelOverrideName)
     const jsonString = JSON.stringify(request, null, 2)
     return navigator.clipboard.writeText(jsonString)
   }

--- a/src/pages/app/[app].device.[device].vue
+++ b/src/pages/app/[app].device.[device].vue
@@ -366,9 +366,8 @@ function getCurlCommand() {
   if (!device.value)
     return ''
 
-  // Use the stored default_channel from device, or empty string if not available
   const defaultChannel = device.value.default_channel || ''
-  const requestBody = transformDeviceToUpdateRequest(device.value, packageId.value, defaultChannel)
+  const requestBody = transformDeviceToUpdateRequest(device.value, packageId.value, defaultChannel, channelDevice.value?.name)
   const jsonBody = JSON.stringify(requestBody, null, 2)
 
   return String.raw`curl -X POST '${defaultApiHost}/updates' \

--- a/tests/device-update-format.unit.test.ts
+++ b/tests/device-update-format.unit.test.ts
@@ -1,0 +1,61 @@
+import type { Database } from '../src/types/supabase.types'
+import { describe, expect, it } from 'vitest'
+import { useDeviceUpdateFormat } from '../src/composables/useDeviceUpdateFormat'
+
+type DeviceRow = Database['public']['Tables']['devices']['Row']
+
+describe('device update format helpers', () => {
+  it.concurrent('preserves the stored default channel and includes the override channel', () => {
+    const { transformDeviceToUpdateRequest } = useDeviceUpdateFormat()
+    const device: DeviceRow = {
+      app_id: 'lgbt.vibes.application',
+      custom_id: '',
+      default_channel: 'insiders',
+      device_id: '31de6a5e-80a9-4348-9af1-31e1e9562583',
+      id: 1,
+      is_emulator: false,
+      is_prod: true,
+      key_id: null,
+      os_version: '16',
+      platform: 'android',
+      plugin_version: '7.42.3',
+      updated_at: '2026-06-08T14:14:00.000Z',
+      version: null,
+      version_build: '3.1.0',
+      version_name: '3.1.0-insiders.59',
+    }
+
+    expect(transformDeviceToUpdateRequest(device, 'lgbt.vibes.application', device.default_channel ?? '', 'dev')).toMatchObject({
+      app_id: 'lgbt.vibes.application',
+      device_id: '31de6a5e-80a9-4348-9af1-31e1e9562583',
+      defaultChannel: 'insiders',
+      channel: 'dev',
+    })
+  })
+
+  it.concurrent('omits the override channel when no override is set', () => {
+    const { transformDeviceToUpdateRequest } = useDeviceUpdateFormat()
+    const device = {
+      app_id: 'lgbt.vibes.application',
+      custom_id: '',
+      default_channel: 'insiders',
+      device_id: '31de6a5e-80a9-4348-9af1-31e1e9562583',
+      id: 1,
+      is_emulator: false,
+      is_prod: true,
+      key_id: null,
+      os_version: '16',
+      platform: 'android',
+      plugin_version: '7.42.3',
+      updated_at: '2026-06-08T14:14:00.000Z',
+      version: null,
+      version_build: '3.1.0',
+      version_name: '3.1.0-insiders.59',
+    } satisfies DeviceRow
+
+    expect(transformDeviceToUpdateRequest(device, 'lgbt.vibes.application', device.default_channel ?? '')).toMatchObject({
+      defaultChannel: 'insiders',
+    })
+    expect(transformDeviceToUpdateRequest(device, 'lgbt.vibes.application', device.default_channel ?? '')).not.toHaveProperty('channel')
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Updated the device debug curl payload to use the device channel override when one is set.
- Added a focused unit test for override-before-default channel selection in update request formatting.

## Motivation (AI generated)

The device detail debug curl showed the stored default channel even when the device had an active channel override, making the copied request disagree with the selected override shown in the UI.

## Business Impact (AI generated)

This makes support and debugging workflows more accurate for customers using per-device channel overrides, reducing confusion when reproducing update checks.

## Test Plan (AI generated)

- [x] `bun lint` (passes with one existing jsdoc warning in `src/services/compatibilityEvents.ts`)
- [x] `bunx vitest run tests/device-update-format.unit.test.ts`
- [x] `bun run typecheck:frontend`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## Screenshots (AI generated)

Not included; this changes the generated debug curl payload and is covered by the unit test.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint`.
- [x] My change does not require documentation changes.
- [x] My change has focused unit test coverage.
- [ ] I have tested this manually in the browser.

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device updates now support an optional channel field override capability.
  * Debug curl command generator now includes the selected channel name in generated requests.

* **Tests**
  * Added unit tests for channel override functionality in device update formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->