### PR TITLE
[codex] improve trial plan chart legend

### DIFF
--- a/src/components/admin/AdminMultiLineChart.vue
+++ b/src/components/admin/AdminMultiLineChart.vue
@@ -140,8 +140,14 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
       position: 'bottom',
       labels: {
         color: isDark.value ? '#d1d5db' : '#4b5563',
+        boxHeight: 10,
+        boxWidth: 10,
+        font: {
+          size: 12,
+          weight: 500,
+        },
+        padding: 18,
         usePointStyle: true,
-        padding: 15,
       },
     },
     tooltip: {

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -582,13 +582,17 @@ const trialPlanBreakdownPlanNames = computed(() => {
   return totals.map(plan => plan.plan_name)
 })
 
-function getTrialPlanChartColor(planName: string) {
-  const colors = ['#119eff', '#10b981', '#f59e0b', '#ec4899', '#8b5cf6', '#14b8a6', '#ef4444']
-  let hash = 0
-  for (let index = 0; index < planName.length; index++)
-    hash = (hash * 31 + planName.charCodeAt(index)) >>> 0
+const trialPlanChartColors: Record<string, string> = {
+  Solo: '#119eff',
+  Maker: '#d97706',
+  Team: '#8b5cf6',
+  Enterprise: '#059669',
+}
 
-  return colors[hash % colors.length]
+const fallbackTrialPlanChartColors = ['#119eff', '#d97706', '#8b5cf6', '#059669', '#db2777', '#0f766e', '#dc2626']
+
+function getTrialPlanChartColor(planName: string, index: number) {
+  return trialPlanChartColors[planName] ?? fallbackTrialPlanChartColors[index % fallbackTrialPlanChartColors.length]
 }
 
 const trialPlanBreakdownTrendSeries = computed(() => {
@@ -597,13 +601,13 @@ const trialPlanBreakdownTrendSeries = computed(() => {
     return []
 
   return trialPlanBreakdownPlanNames.value
-    .map(planName => ({
+    .map((planName, index) => ({
       label: planName,
       data: trend.map(item => ({
         date: item.date,
         value: item.plans[planName] ?? 0,
       })),
-      color: getTrialPlanChartColor(planName),
+      color: getTrialPlanChartColor(planName, index),
     }))
     .filter(series => series.data.some(item => item.value > 0))
 })


### PR DESCRIPTION
## Summary (AI generated)

- Assigned stable, distinct colors to the trial-plan trend series so Solo and Team no longer collide in the New Trials by Plan chart.
- Increased admin multi-line chart legend marker size, text size, and label spacing for easier scanning.

## Motivation (AI generated)

The New Trials by Plan chart used a hash-based color picker, which gave Solo and Team the same blue color and made the legend ambiguous. Fixed plan colors make the chart easier to read and keep each known plan visually distinct.

## Business Impact (AI generated)

This improves admin dashboard readability and reduces the chance of misreading trial-plan trends when reviewing acquisition and conversion quality.

## Test Plan (AI generated)

- [x] `bun lint` (passes; existing warning remains in `src/services/compatibilityEvents.ts`)
- [x] `bun run typecheck:frontend`
- [x] Commit hook ran `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- [x] `bun run build`
- [x] Headless route screenshot attempted; local admin route redirected to login and Turnstile blocked completing login, so chart visual capture was not available locally.

## Screenshots (AI generated)

Not included because the local admin route redirected to login during the headless check.

## Checklist (AI generated)

- [x] Relevant frontend lint/typecheck/build validation passed.
- [x] This change does not require documentation updates.
- [ ] E2E coverage was not added because this is a small presentational chart styling fix.

Generated with AI