### PR TITLE
fix(admin): count active trials in plan stats

### DIFF
--- a/supabase/migrations/20260609165512_fix_trial_org_status_count.sql
+++ b/supabase/migrations/20260609165512_fix_trial_org_status_count.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION "public"."count_all_plans_v2"()
+RETURNS TABLE("plan_name" character varying, "count" bigint)
+LANGUAGE "plpgsql"
+SET "search_path" TO ''
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH ActiveSubscriptions AS (
+    SELECT DISTINCT ON (si.customer_id)
+      p.name AS product_name,
+      si.customer_id
+    FROM public.stripe_info si
+    INNER JOIN public.plans p ON si.product_id = p.stripe_id
+    WHERE si.status = 'succeeded'
+    ORDER BY si.customer_id, si.created_at DESC
+  ),
+  TrialUsers AS (
+    SELECT DISTINCT ON (si.customer_id)
+      'Trial'::character varying AS product_name,
+      si.customer_id
+    FROM public.stripe_info si
+    WHERE si.trial_at > NOW()
+      AND si.status IS DISTINCT FROM 'succeeded'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM ActiveSubscriptions a
+        WHERE a.customer_id = si.customer_id
+      )
+    ORDER BY si.customer_id, si.created_at DESC
+  )
+  SELECT
+    product_name AS plan_name,
+    COUNT(*) AS count
+  FROM (
+    SELECT product_name, customer_id FROM ActiveSubscriptions
+    UNION ALL
+    SELECT product_name, customer_id FROM TrialUsers
+  ) all_subs
+  GROUP BY product_name;
+END;
+$$;
+
+ALTER FUNCTION "public"."count_all_plans_v2"() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."count_all_plans_v2"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."count_all_plans_v2"() FROM "anon";
+REVOKE ALL ON FUNCTION "public"."count_all_plans_v2"() FROM "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."count_all_plans_v2"() TO "service_role";

--- a/supabase/tests/59_test_count_all_plans_v2.sql
+++ b/supabase/tests/59_test_count_all_plans_v2.sql
@@ -1,0 +1,90 @@
+BEGIN;
+
+SELECT plan(1);
+
+CREATE OR REPLACE FUNCTION my_tests() RETURNS SETOF TEXT AS $$
+DECLARE
+  before_trial_count bigint;
+  after_trial_count bigint;
+  solo_product_id character varying;
+  solo_price_id character varying;
+BEGIN
+  SELECT stripe_id, price_m_id
+  INTO solo_product_id, solo_price_id
+  FROM public.plans
+  WHERE name = 'Solo'
+  LIMIT 1;
+
+  DELETE FROM public.stripe_info
+  WHERE customer_id IN (
+    'cus_count_all_plans_created_trial',
+    'cus_count_all_plans_updated_trial',
+    'cus_count_all_plans_paid_future_trial'
+  );
+
+  SELECT COALESCE(MAX(count), 0)
+  INTO before_trial_count
+  FROM public.count_all_plans_v2()
+  WHERE plan_name = 'Trial';
+
+  INSERT INTO public.stripe_info (
+    customer_id,
+    status,
+    product_id,
+    price_id,
+    trial_at,
+    is_good_plan,
+    subscription_anchor_start,
+    subscription_anchor_end
+  )
+  VALUES
+    (
+      'cus_count_all_plans_created_trial',
+      'created'::public.stripe_status,
+      solo_product_id,
+      solo_price_id,
+      NOW() + interval '7 days',
+      false,
+      NOW(),
+      NOW() + interval '1 month'
+    ),
+    (
+      'cus_count_all_plans_updated_trial',
+      'updated'::public.stripe_status,
+      solo_product_id,
+      solo_price_id,
+      NOW() + interval '7 days',
+      false,
+      NOW(),
+      NOW() + interval '1 month'
+    ),
+    (
+      'cus_count_all_plans_paid_future_trial',
+      'succeeded'::public.stripe_status,
+      solo_product_id,
+      solo_price_id,
+      NOW() + interval '7 days',
+      true,
+      NOW(),
+      NOW() + interval '1 month'
+    );
+
+  SELECT COALESCE(MAX(count), 0)
+  INTO after_trial_count
+  FROM public.count_all_plans_v2()
+  WHERE plan_name = 'Trial';
+
+  RETURN NEXT is(
+    after_trial_count,
+    before_trial_count + 2,
+    'count_all_plans_v2 counts active non-succeeded trials and excludes succeeded subscriptions'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT my_tests();
+
+SELECT * -- noqa: AM04
+FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

**AI-generated by Codex.**

Fixes the admin Users Trend trial-org line by updating `count_all_plans_v2()` to count active future trials whose Stripe status is not `succeeded`, including `created` trial rows. Adds a pgTAP regression covering `created` and `updated` trial rows while confirming `succeeded` rows are excluded from the Trial bucket.

## Motivation

**AI-generated by Codex.**

The chart's orange series comes from `global_stats.trial`, which the nightly `logsnag_insights` snapshot fills from `plans.Trial`. That value came from `count_all_plans_v2()`, but the RPC only counted trials where `stripe_info.status IS NULL`. Current trial rows are created with `status = 'created'`, so new active trials were being dropped from snapshots and the chart fell sharply.

## Business Impact

**AI-generated by Codex.**

Restores accurate internal visibility into active trial organizations, which affects acquisition/onboarding monitoring and business reporting. No customer-facing behavior changes.

## Test Plan

**AI-generated by Codex.**

- [x] `bun run lint:backend`
- [x] `bun lint` passes with one existing warning in `src/services/compatibilityEvents.ts`
- [x] `PGSSLMODE=disable bunx supabase test db --db-url postgresql://postgres:postgres@127.0.0.1:63842/postgres supabase/tests/59_test_count_all_plans_v2.sql`
- [x] `PGSSLMODE=disable bunx supabase test db --db-url postgresql://postgres:postgres@127.0.0.1:63842/postgres supabase/tests`
- [x] `bun run supabase:with-env -- bunx vitest run tests/admin-stats.test.ts`
- [x] `bun run test:backend`
- [x] Commit hook typecheck: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Postgres execution model: this is a `service_role`-only RPC used by the daily admin stats snapshot, not an RLS policy or plugin hot path. The query keeps the existing full `stripe_info` aggregation pattern and indexed lookup on `plans.stripe_id`; local `EXPLAIN (ANALYZE, BUFFERS)` completed in 0.535 ms with 32 shared buffer hits on seeded data.

## Screenshots

**AI-generated by Codex.**

N/A: backend stats snapshot fix.

## Checklist

**AI-generated by Codex.**

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests.
