### PR TITLE
[codex] Retry transient files upload network failures

### DIFF
--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -60,7 +60,7 @@ import { copyToClipboard, revealInFinder } from '../support/clipboard.js'
 import { contactSupport } from '../support/contact-support.js'
 import { appendInternalLog, getInternalLogPath, startInternalLog } from '../support/internal-log.js'
 import { uploadSupportLogs } from '../support/support-upload.js'
-import { assertCliPermission, canPromptInteractively, createSupabaseClient, findSavedKey, getConfig, getOrganizationId, sendEvent } from '../utils'
+import { assertCliPermission, canPromptInteractively, createSupabaseClient, findSavedKey, getConfig, getOrganizationId, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
 import { mergeCredentials, MIN_OUTPUT_RETENTION_SECONDS, parseInAppUpdatePriority, parseOptionalBoolean, parseOutputRetentionSeconds } from './credentials'
 import { buildProvisioningMap } from './credentials-command'
 import { writeBuildOutputRecord } from './output-record'
@@ -1740,6 +1740,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
         const upload = new tus.Upload(zipBuffer as any, {
           endpoint: buildRequest.upload_url,
           chunkSize: 5 * 1024 * 1024, // 5MB chunks
+          retryDelays: [...TUS_UPLOAD_RETRY_DELAYS],
           metadata: {
             filename: basename(zipPath),
             filetype: 'application/zip',

--- a/cli/src/bundle/partial.ts
+++ b/cli/src/bundle/partial.ts
@@ -14,7 +14,7 @@ import { parse } from '@std/semver'
 import * as micromatch from 'micromatch'
 import * as tus from 'tus-js-client'
 import { encryptChecksum, encryptChecksumV3, encryptSource } from '../api/crypto'
-import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, sendEvent } from '../utils'
+import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
 
 // Check if file already exists on server (bypass cache and force storage lookup)
 async function fileExists(localConfig: any, filename: string): Promise<boolean> {
@@ -293,7 +293,7 @@ export async function uploadPartial(
         const upload = new tus.Upload(finalBuffer as any, {
           endpoint: `${localConfig.hostFilesApi}/files/upload/attachments/`,
           chunkSize: options.tusChunkSize,
-          retryDelays: [0, 1000, 3000, 5000, 10000],
+          retryDelays: [...TUS_UPLOAD_RETRY_DELAYS],
           removeFingerprintOnSuccess: true,
           metadata: {
             filename,

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -317,7 +317,7 @@ async function checkVersionExists(supabase: SupabaseType, appid: string, bundle:
         ],
       })
 
-      if (pIsCancel(choice) || choice === 'cancel') {
+      if (pIsCancel(choice) || typeof choice !== 'string' || choice === 'cancel') {
         uploadFail('Upload cancelled by user')
       }
 

--- a/cli/src/promptPreferences.ts
+++ b/cli/src/promptPreferences.ts
@@ -71,6 +71,7 @@ export async function confirmWithRememberedChoice({
 
   if (pIsCancel(choice))
     return false
+  const confirmedChoice = choice === true
 
   const shouldRememberChoice = await pConfirm({
     message: rememberMessage,
@@ -78,7 +79,7 @@ export async function confirmWithRememberedChoice({
   })
 
   if (!pIsCancel(shouldRememberChoice) && shouldRememberChoice)
-    await rememberPromptPreferenceSafely(preferenceKey, choice)
+    await rememberPromptPreferenceSafely(preferenceKey, confirmedChoice)
 
-  return choice
+  return confirmedChoice
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -41,6 +41,7 @@ export const UPLOAD_TIMEOUT = 120000
 export const ALERT_UPLOAD_SIZE_BYTES = 1024 * 1024 * 20 // 20MB
 export const MAX_UPLOAD_LENGTH_BYTES = 1024 * 1024 * 1024 // 1GB
 export const MAX_CHUNK_SIZE_BYTES = 1024 * 1024 * 99 // 99MB
+export const TUS_UPLOAD_RETRY_DELAYS = [0, 1000, 3000, 5000, 10000]
 
 export const PACKNAME = 'package.json'
 
@@ -1317,6 +1318,7 @@ export async function uploadTUS(apikey: string, data: Buffer, orgId: string, app
       endpoint: `${localConfig.hostFilesApi}/files/upload/attachments/`,
       // parallelUploads: multipart,
       chunkSize,
+      retryDelays: [...TUS_UPLOAD_RETRY_DELAYS],
       metadataForPartialUploads: {
         filename: `orgs/${orgId}/apps/${appId}/${name}.zip`,
         filetype: 'application/gzip',

--- a/cli/src/versionHelpers.ts
+++ b/cli/src/versionHelpers.ts
@@ -55,7 +55,7 @@ export async function interactiveVersionBump(
   // Manual version input
   const userVersion = await pText({
     message: `Current version is ${currentVersion}. Enter new version:`,
-    validate: (value) => {
+    validate: (value: string | undefined) => {
       if (!value)
         return 'Version is required'
       if (!/^\d+\.\d+\.\d+/.test(value))

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -159,7 +159,7 @@ async function recoverUploadOffsetFromDurableObject(
 function retryableUploadUnavailableResponse(): Response {
   return new Response(JSON.stringify({
     error: 'upload_retryable',
-    message: 'Upload worker moved during this request. Retry the upload request.',
+    message: 'Upload temporarily unavailable. Retry the upload request.',
   }), {
     status: 503,
     headers: {
@@ -233,10 +233,12 @@ async function fetchUploadHandlerWithRetry(
       })
 
       if (!shouldRetry) {
-        if (!canRetryRequest && isRetryableDurableObjectError) {
+        if (isRetryableDurableObjectError) {
           cloudlog({
             requestId: c.get('requestId'),
-            message: 'upload handler - durable object fetch failed for streaming request, returning retryable response',
+            message: canRetryRequest
+              ? 'upload handler - exhausted retryable durable object fetch attempts, returning retryable response'
+              : 'upload handler - durable object fetch failed for streaming request, returning retryable response',
             attempt,
             fileId: c.get('fileId'),
           })

--- a/tests/backend-alert-resilience.unit.test.ts
+++ b/tests/backend-alert-resilience.unit.test.ts
@@ -113,6 +113,40 @@ describe('backend alert resilience helpers', () => {
     expect(handler.fetch).toHaveBeenCalledTimes(2)
   })
 
+  it.concurrent('returns retryable response after exhausting replayable network upload creation failures', async () => {
+    const { filesTestUtils } = await import('../supabase/functions/_backend/files/files.ts')
+
+    const handler = {
+      fetch: vi.fn(async () => {
+        throw Object.assign(new Error('Network connection lost.'), {
+          retryable: true,
+        })
+      }),
+    } as any
+
+    const response = await filesTestUtils.fetchUploadHandlerWithRetry(
+      createTestContext(),
+      handler,
+      new Request('http://localhost/files/upload/attachments/test.zip', {
+        method: 'POST',
+        headers: {
+          'Content-Length': '0',
+          'Tus-Resumable': '1.0.0',
+          'Upload-Length': '2500',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get('Retry-After')).toBe('1')
+    expect(response.headers.get('Tus-Resumable')).toBe('1.0.0')
+    await expect(response.json()).resolves.toEqual({
+      error: 'upload_retryable',
+      message: 'Upload temporarily unavailable. Retry the upload request.',
+    })
+    expect(handler.fetch).toHaveBeenCalledTimes(3)
+  })
+
   it.concurrent('forwards a replayable zero-byte TUS creation-with-upload body', async () => {
     const { filesTestUtils } = await import('../supabase/functions/_backend/files/files.ts')
 
@@ -273,7 +307,7 @@ describe('backend alert resilience helpers', () => {
     expect(response.headers.get('Tus-Resumable')).toBe('1.0.0')
     await expect(response.json()).resolves.toEqual({
       error: 'upload_retryable',
-      message: 'Upload worker moved during this request. Retry the upload request.',
+      message: 'Upload temporarily unavailable. Retry the upload request.',
     })
     expect(handler.fetch).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary (AI generated)

- Return a TUS-compatible retryable `503` after exhausted transient upload Durable Object/network failures instead of throwing into global alerting.
- Add CLI TUS retry delays consistently across bundle, partial, and builder upload paths.
- Fix small CLI prompt type narrowing issues surfaced by `cli:typecheck`.

## Motivation (AI generated)

Transient `Network connection lost.` errors from the files upload Durable Object path are retryable. The backend already retries replayable upload requests, but after attempts were exhausted it still threw, producing Discord function-failed alerts for recoverable upload creation failures. Returning a retryable TUS response lets clients continue their normal retry flow and keeps alerting focused on actionable failures.

## Business Impact (AI generated)

This should reduce noisy files upload alerts and make small transient upload failures less visible to users. More consistent CLI retries also improves release reliability for customers uploading bundles or partial update assets.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/backend-alert-resilience.unit.test.ts`
- [x] `bun run lint:backend`
- [x] `bun run typecheck:backend`
- [x] `bun run cli:check`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized retry behavior for uploads, improving consistency across different upload types.
  * Enhanced error messaging for temporary upload unavailability to better inform users when retrying.
  * Strengthened handling of edge cases in upload cancellation and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->