### PR TITLE
[codex] Fix bundle size metadata queue

### DIFF
--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -3,14 +3,18 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
-import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { BRES, middlewareAPISecret, quickError, simpleError, triggerValidator } from '../utils/hono.ts'
+import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { normalizeLegacyEncodedManifestFileName } from '../utils/manifest_encoding.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { manifest } from '../utils/postgres_schema.ts'
-import { getPath, s3 } from '../utils/s3.ts'
+import { retryWithBackoff } from '../utils/retry.ts'
+import { s3 } from '../utils/s3.ts'
 import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+
+const BUNDLE_SIZE_RETRY_ATTEMPTS = 3
+const BUNDLE_SIZE_RETRY_DELAY_MS = 500
 
 /**
  * Resolves `owner_org` for an app version row.
@@ -37,19 +41,35 @@ async function resolveOwnerOrg(c: Context, record: Database['public']['Tables'][
   return data?.owner_org ?? null
 }
 
+async function getBundleSizeWithRetry(c: Context, r2Path: string): Promise<{ size: number, lastError?: unknown, attempts: number }> {
+  const { result, lastError, attempts } = await retryWithBackoff(
+    () => s3.getSize(c, r2Path),
+    {
+      attempts: BUNDLE_SIZE_RETRY_ATTEMPTS,
+      baseDelayMs: BUNDLE_SIZE_RETRY_DELAY_MS,
+      shouldRetry: size => size <= 0,
+    },
+  )
+
+  return { attempts, size: typeof result === 'number' ? result : 0, lastError }
+}
+
 /**
  * Handles v2 storage metadata updates (size/checksum/stats) for R2-backed bundles.
  *
  * Returns `false` only when processing must stop (e.g. missing owner org).
  */
 async function v2PathSize(c: Context, record: Database['public']['Tables']['app_versions']['Row'], v2Path: string): Promise<boolean> {
-  // pdate size and checksum
+  // Update size and checksum.
   cloudlog({ requestId: c.get('requestId'), message: 'V2', r2_path: record.r2_path })
-  // set checksum in s3
-  const size = await s3.getSize(c, v2Path)
-  if (!size) {
-    cloudlog({ requestId: c.get('requestId'), message: 'no size found for r2_path', r2_path: record.r2_path })
-    return true
+  const { size, lastError, attempts } = await getBundleSizeWithRetry(c, v2Path)
+  if (lastError) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getSize failed after retries', id: record.id, app_id: record.app_id, r2_path: record.r2_path, attempts, error: lastError })
+  }
+  if (size <= 0) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getSize returned 0 after retries', id: record.id, app_id: record.app_id, r2_path: record.r2_path, storage_provider: record.storage_provider, attempts })
+    // Return non-2xx so queue_consumer keeps the message and applies its 5-read retry budget.
+    throw quickError(503, 'bundle_size_not_found', 'Bundle file size metadata was not found', { attempts, app_id: record.app_id, id: record.id, r2_path: record.r2_path }, lastError, { alert: false })
   }
 
   const ownerOrg = await resolveOwnerOrg(c, record)
@@ -150,38 +170,56 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
 }
 
+async function upsertZeroVersionMetadata(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
+  cloudlog({ requestId: c.get('requestId'), message: 'no v2 path' })
+  const ownerOrg = await resolveOwnerOrg(c, record)
+  if (!ownerOrg) {
+    cloudlog({ requestId: c.get('requestId'), message: 'missing owner_org for app_versions_meta upsert', id: record.id, app_id: record.app_id })
+    return false
+  }
+  const { error: errorUpdate } = await supabaseAdmin(c)
+    .from('app_versions_meta')
+    .upsert({
+      id: record.id,
+      app_id: record.app_id,
+      owner_org: ownerOrg,
+      size: 0,
+      checksum: record.checksum ?? '',
+    }, {
+      onConflict: 'id',
+    })
+    .eq('id', record.id)
+  if (errorUpdate)
+    cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate })
+  return true
+}
+
 /**
  * Handles app version metadata updates after insert/update trigger execution.
  */
 async function updateIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
-  const v2Path = await getPath(c, record)
-
-  if (v2Path && record.storage_provider === 'r2') {
-    const shouldContinue = await v2PathSize(c, record, v2Path)
-    if (!shouldContinue)
-      return c.json(BRES)
-  }
-  else {
-    cloudlog({ requestId: c.get('requestId'), message: 'no v2 path' })
-    const ownerOrg = await resolveOwnerOrg(c, record)
-    if (!ownerOrg) {
-      cloudlog({ requestId: c.get('requestId'), message: 'missing owner_org for app_versions_meta upsert', id: record.id, app_id: record.app_id })
+  if (record.storage_provider === 'r2') {
+    if (record.r2_path) {
+      const shouldContinue = await v2PathSize(c, record, record.r2_path)
+      if (!shouldContinue)
+        return c.json(BRES)
+    }
+    else if (isPersistedManifestOnlyVersion(record)) {
+      cloudlog({ requestId: c.get('requestId'), message: 'manifest-only r2 version already persisted, skipping bundle metadata retry', id: record.id, app_id: record.app_id, manifest_count: record.manifest_count })
+    }
+    else if (!record.manifest) {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'r2 version missing r2_path', id: record.id, app_id: record.app_id, storage_provider: record.storage_provider })
+      throw quickError(503, 'bundle_r2_path_missing', 'Bundle R2 path is not ready', { app_id: record.app_id, id: record.id }, undefined, { alert: false })
+    }
+    else if (!await upsertZeroVersionMetadata(c, record)) {
       return c.json(BRES)
     }
-    const { error: errorUpdate } = await supabaseAdmin(c)
-      .from('app_versions_meta')
-      .upsert({
-        id: record.id,
-        app_id: record.app_id,
-        owner_org: ownerOrg,
-        size: 0,
-        checksum: record.checksum ?? '',
-      }, {
-        onConflict: 'id',
-      })
-      .eq('id', record.id)
-    if (errorUpdate)
-      cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate })
+  }
+  else if (record.r2_path) {
+    cloudlog({ requestId: c.get('requestId'), message: 'bundle metadata skipped for non-r2 storage provider', id: record.id, app_id: record.app_id, r2_path: record.r2_path, storage_provider: record.storage_provider })
+  }
+  else if (!await upsertZeroVersionMetadata(c, record)) {
+    return c.json(BRES)
   }
 
   // Handle manifest entries
@@ -190,6 +228,25 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
   }
 
   return c.json(BRES)
+}
+
+export const onVersionUpdateTestUtils = {
+  getBundleSizeWithRetry,
+  updateIt,
+}
+
+function isManifestCleanupUpdate(record: Database['public']['Tables']['app_versions']['Row'], oldRecord: Database['public']['Tables']['app_versions']['Row']) {
+  return record.storage_provider === 'r2'
+    && !record.r2_path
+    && !record.manifest
+    && Boolean(oldRecord.manifest)
+}
+
+function isPersistedManifestOnlyVersion(record: Database['public']['Tables']['app_versions']['Row']) {
+  return record.storage_provider === 'r2'
+    && !record.r2_path
+    && !record.manifest
+    && Number(record.manifest_count ?? 0) > 0
 }
 
 /**
@@ -357,7 +414,17 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
   if (record.deleted_at && record.deleted_at !== oldRecord.deleted_at)
     return deleteIt(c, record)
 
-  if (!record.r2_path && !record.manifest) {
+  if (isManifestCleanupUpdate(record, oldRecord)) {
+    cloudlog({ requestId: c.get('requestId'), message: 'manifest cleanup update, skipping bundle metadata retry', record })
+    return c.json(BRES)
+  }
+
+  if (isPersistedManifestOnlyVersion(record)) {
+    cloudlog({ requestId: c.get('requestId'), message: 'persisted manifest-only update, skipping bundle metadata retry', record })
+    return c.json(BRES)
+  }
+
+  if (!record.r2_path && !record.manifest && record.storage_provider !== 'r2') {
     cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', record })
     return c.json(BRES)
   }

--- a/tests/log-as.test.ts
+++ b/tests/log-as.test.ts
@@ -35,6 +35,12 @@ async function seedStaleCreatedByOrg() {
     .eq('id', STALE_CREATED_BY_ORG_ID)
   expect(cleanupError).toBeNull()
 
+  const { error: stripeCleanupError } = await supabase
+    .from('stripe_info')
+    .delete()
+    .eq('customer_id', `pending_${STALE_CREATED_BY_ORG_ID}`)
+  expect(stripeCleanupError).toBeNull()
+
   const { error: orgError } = await supabase
     .from('orgs')
     .insert({

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -1,16 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  appVersionsUpdate,
+  appVersionsUpdateEq,
   appVersionsMetaSelectEq,
+  appVersionsMetaUpsert,
+  appVersionsMetaUpsertEq,
   appVersionsMetaUpdate,
   appVersionsMetaUpdateEq,
   closeClient,
   createStatsMeta,
   deleteObject,
+  getSize,
   getDrizzleClient,
   getPgClient,
   manifestDeleteEq,
+  manifestInsert,
   manifestReferenceMaybeSingle,
+  manifestSelectLimit,
   manifestSelectWhere,
   moveObjectToTrash,
   pgQuery,
@@ -18,25 +25,42 @@ const {
 } = vi.hoisted(() => {
   const appVersionsMetaSelectEq = vi.fn()
   const appVersionsMetaSelect = vi.fn(() => ({ eq: appVersionsMetaSelectEq }))
+  const appVersionsMetaUpsertEq = vi.fn()
+  const appVersionsMetaUpsert = vi.fn(() => ({ eq: appVersionsMetaUpsertEq }))
   const appVersionsMetaUpdateEq = vi.fn()
   const appVersionsMetaUpdate = vi.fn(() => ({ eq: appVersionsMetaUpdateEq }))
+  const appVersionsUpdateEq = vi.fn()
+  const appVersionsUpdate = vi.fn(() => ({ eq: appVersionsUpdateEq }))
   const manifestDeleteEq = vi.fn()
   const manifestDelete = vi.fn(() => ({ eq: manifestDeleteEq }))
+  const manifestInsert = vi.fn()
+  const manifestSelectLimit = vi.fn()
   const manifestReferenceMaybeSingle = vi.fn()
   const manifestReferenceLimit = vi.fn(() => ({ maybeSingle: manifestReferenceMaybeSingle }))
   const manifestReferenceEqFileName = vi.fn(() => ({ limit: manifestReferenceLimit }))
-  const manifestReferenceEqFileHash = vi.fn(() => ({ eq: manifestReferenceEqFileName }))
+  const manifestReferenceEqFileHash = vi.fn((column: string) => {
+    if (column === 'app_version_id')
+      return { limit: manifestSelectLimit }
+    return { eq: manifestReferenceEqFileName }
+  })
   const manifestSelect = vi.fn(() => ({ eq: manifestReferenceEqFileHash }))
   const supabaseFrom = vi.fn((table: string) => {
+    if (table === 'app_versions') {
+      return {
+        update: appVersionsUpdate,
+      }
+    }
     if (table === 'app_versions_meta') {
       return {
         select: appVersionsMetaSelect,
+        upsert: appVersionsMetaUpsert,
         update: appVersionsMetaUpdate,
       }
     }
     if (table === 'manifest') {
       return {
         delete: manifestDelete,
+        insert: manifestInsert,
         select: manifestSelect,
       }
     }
@@ -46,12 +70,17 @@ const {
   const pgQuery = vi.fn(async () => ({ rows: [] }))
 
   return {
+    appVersionsUpdate,
+    appVersionsUpdateEq,
     appVersionsMetaSelectEq,
+    appVersionsMetaUpsert,
+    appVersionsMetaUpsertEq,
     appVersionsMetaUpdate,
     appVersionsMetaUpdateEq,
     closeClient: vi.fn(),
     createStatsMeta: vi.fn(),
     deleteObject: vi.fn(),
+    getSize: vi.fn(),
     getDrizzleClient: vi.fn(() => ({
       select: vi.fn(() => ({
         from: vi.fn(() => ({
@@ -61,7 +90,9 @@ const {
     })),
     getPgClient: vi.fn(() => ({ query: pgQuery })),
     manifestDeleteEq,
+    manifestInsert,
     manifestReferenceMaybeSingle,
+    manifestSelectLimit,
     manifestSelectWhere,
     moveObjectToTrash: vi.fn(),
     pgQuery,
@@ -71,9 +102,9 @@ const {
 })
 
 vi.mock('../supabase/functions/_backend/utils/s3.ts', () => ({
-  getPath: vi.fn(),
   s3: {
     deleteObject,
+    getSize,
     moveObjectToTrash,
   },
 }))
@@ -97,7 +128,9 @@ vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlogErr: vi.fn(),
 }))
 
-const { deleteIt } = await import('../supabase/functions/_backend/triggers/on_version_update.ts')
+const { app, deleteIt, onVersionUpdateTestUtils } = await import('../supabase/functions/_backend/triggers/on_version_update.ts')
+
+const API_SECRET = 'testsecret'
 
 function createContext() {
   return {
@@ -111,6 +144,7 @@ function createVersion(overrides: Record<string, unknown> = {}) {
     app_id: 'com.cleanup.test',
     id: 123,
     manifest: null,
+    manifest_count: 0,
     name: '1.0.0',
     r2_path: 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
     storage_provider: 'r2',
@@ -126,11 +160,16 @@ describe('on_version_update deleted version cleanup', () => {
     createStatsMeta.mockResolvedValue({ error: null })
     manifestSelectWhere.mockResolvedValue([])
     manifestDeleteEq.mockResolvedValue({ error: null })
+    manifestInsert.mockResolvedValue({ error: null })
     manifestReferenceMaybeSingle.mockResolvedValue({ data: null, error: null })
+    manifestSelectLimit.mockResolvedValue({ data: [], error: null })
     pgQuery.mockResolvedValue({ rows: [] })
+    getSize.mockResolvedValue(1234)
+    appVersionsUpdateEq.mockResolvedValue({ error: null })
     appVersionsMetaSelectEq.mockReturnValue({
       single: vi.fn(async () => ({ data: { size: 1234 }, error: null })),
     })
+    appVersionsMetaUpsertEq.mockResolvedValue({ error: null })
     appVersionsMetaUpdateEq.mockResolvedValue({ error: null })
   })
 
@@ -178,5 +217,238 @@ describe('on_version_update deleted version cleanup', () => {
     await expect(deleteIt(createContext(), createVersion())).rejects.toThrow('Cannot move S3 object for deleted version to trash')
     expect(appVersionsMetaUpdate).not.toHaveBeenCalled()
     expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+})
+
+describe('on_version_update bundle size metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createStatsMeta.mockResolvedValue({ error: null })
+    getSize.mockResolvedValue(4321)
+    manifestInsert.mockResolvedValue({ error: null })
+    manifestSelectLimit.mockResolvedValue({ data: [], error: null })
+    pgQuery.mockResolvedValue({ rows: [] })
+    appVersionsUpdateEq.mockResolvedValue({ error: null })
+    appVersionsMetaUpsertEq.mockResolvedValue({ error: null })
+  })
+
+  it('does not write zero metadata for r2-direct upload snapshots', async () => {
+    const response = await onVersionUpdateTestUtils.updateIt(createContext(), createVersion({
+      owner_org: 'org-1',
+      storage_provider: 'r2-direct',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+
+  it('persists manifest-only R2 updates without requiring a bundle path', async () => {
+    const response = await onVersionUpdateTestUtils.updateIt(createContext(), createVersion({
+      manifest: [{
+        file_hash: 'manifest-hash',
+        file_name: 'assets/signup%402x.png',
+        s3_path: 'orgs/org-1/apps/com.cleanup.test/delta/hash_assets/signup%402x.png',
+      }],
+      owner_org: 'org-1',
+      r2_path: null,
+      storage_provider: 'r2',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpsert).toHaveBeenCalledWith({
+      app_id: 'com.cleanup.test',
+      checksum: '',
+      id: 123,
+      owner_org: 'org-1',
+      size: 0,
+    }, {
+      onConflict: 'id',
+    })
+    expect(manifestInsert).toHaveBeenCalledWith([expect.objectContaining({
+      app_version_id: 123,
+      file_hash: 'manifest-hash',
+      file_name: 'assets/signup@2x.png',
+      file_size: 0,
+      s3_path: 'orgs/org-1/apps/com.cleanup.test/delta/hash_assets/signup%402x.png',
+    })])
+    expect(appVersionsUpdate).toHaveBeenCalledWith({ manifest_count: 1 })
+    expect(appVersionsUpdate).toHaveBeenCalledWith({ manifest: null })
+  })
+
+  it('writes positive R2 bundle size metadata for completed uploads', async () => {
+    const response = await onVersionUpdateTestUtils.updateIt(createContext(), createVersion({
+      checksum: 'checksum-1',
+      owner_org: 'org-1',
+      storage_provider: 'r2',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).toHaveBeenCalledWith(expect.anything(), 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip')
+    expect(appVersionsMetaUpsert).toHaveBeenCalledWith({
+      app_id: 'com.cleanup.test',
+      checksum: 'checksum-1',
+      id: 123,
+      owner_org: 'org-1',
+      size: 4321,
+    }, {
+      onConflict: 'id',
+    })
+    expect(appVersionsMetaUpsertEq).toHaveBeenCalledWith('id', 123)
+    expect(createStatsMeta).toHaveBeenCalledWith(expect.anything(), 'com.cleanup.test', 123, 4321)
+  })
+
+  it('keeps completed R2 uploads retryable when object size is not available yet', async () => {
+    getSize.mockResolvedValue(0)
+
+    await expect(onVersionUpdateTestUtils.updateIt(createContext(), createVersion({
+      owner_org: 'org-1',
+      storage_provider: 'r2',
+    }))).rejects.toThrow('Bundle file size metadata was not found')
+
+    expect(getSize).toHaveBeenCalledTimes(3)
+    expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+
+  it('keeps the webhook retryable for R2 updates that have no bundle path or manifest yet', async () => {
+    const previousApiSecret = process.env.API_SECRET
+    process.env.API_SECRET = API_SECRET
+
+    try {
+      const response = await app.request('http://local/', {
+        body: JSON.stringify({
+          old_record: createVersion({
+            manifest: null,
+            r2_path: null,
+            storage_provider: 'r2',
+          }),
+          record: createVersion({
+            manifest: null,
+            owner_org: 'org-1',
+            r2_path: null,
+            storage_provider: 'r2',
+          }),
+          table: 'app_versions',
+          type: 'UPDATE',
+        }),
+        headers: {
+          'apisecret': API_SECRET,
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+
+      expect(response.status).toBe(503)
+      expect(await response.text()).toContain('Bundle R2 path is not ready')
+    }
+    finally {
+      if (previousApiSecret === undefined)
+        delete process.env.API_SECRET
+      else
+        process.env.API_SECRET = previousApiSecret
+    }
+  })
+
+  it('does not retry persisted manifest-only R2 versions on later metadata edits', async () => {
+    const response = await onVersionUpdateTestUtils.updateIt(createContext(), createVersion({
+      manifest_count: 3,
+      owner_org: 'org-1',
+      r2_path: null,
+      storage_provider: 'r2',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not retry the manifest cleanup update after manifest rows are persisted', async () => {
+    const previousApiSecret = process.env.API_SECRET
+    process.env.API_SECRET = API_SECRET
+
+    try {
+      const response = await app.request('http://local/', {
+        body: JSON.stringify({
+          old_record: createVersion({
+            manifest: [{
+              file_hash: 'manifest-hash',
+              file_name: 'assets/signup%402x.png',
+              s3_path: 'orgs/org-1/apps/com.cleanup.test/delta/hash_assets/signup%402x.png',
+            }],
+            r2_path: null,
+            storage_provider: 'r2',
+          }),
+          record: createVersion({
+            manifest: null,
+            owner_org: 'org-1',
+            r2_path: null,
+            storage_provider: 'r2',
+          }),
+          table: 'app_versions',
+          type: 'UPDATE',
+        }),
+        headers: {
+          'apisecret': API_SECRET,
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+
+      expect(response.status).toBe(200)
+      expect(getSize).not.toHaveBeenCalled()
+      expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    }
+    finally {
+      if (previousApiSecret === undefined)
+        delete process.env.API_SECRET
+      else
+        process.env.API_SECRET = previousApiSecret
+    }
+  })
+
+  it('does not retry the webhook for later metadata edits on persisted manifest-only versions', async () => {
+    const previousApiSecret = process.env.API_SECRET
+    process.env.API_SECRET = API_SECRET
+
+    try {
+      const response = await app.request('http://local/', {
+        body: JSON.stringify({
+          old_record: createVersion({
+            manifest: null,
+            manifest_count: 3,
+            r2_path: null,
+            storage_provider: 'r2',
+          }),
+          record: createVersion({
+            manifest: null,
+            manifest_count: 3,
+            owner_org: 'org-1',
+            r2_path: null,
+            storage_provider: 'r2',
+          }),
+          table: 'app_versions',
+          type: 'UPDATE',
+        }),
+        headers: {
+          'apisecret': API_SECRET,
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+
+      expect(response.status).toBe(200)
+      expect(getSize).not.toHaveBeenCalled()
+      expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    }
+    finally {
+      if (previousApiSecret === undefined)
+        delete process.env.API_SECRET
+      else
+        process.env.API_SECRET = previousApiSecret
+    }
   })
 })


### PR DESCRIPTION
## Summary

Fixes `on_version_update` so app version size metadata is only written from a completed R2 bundle state.

- Skip zero-size metadata writes for intermediate `r2-direct` upload snapshots that already have an `r2_path`.
- Retry R2 bundle size lookup before writing metadata.
- Return a retryable `503` when a completed `r2` bundle still has no readable object size, so the queue keeps the message and applies its retry budget instead of deleting it as successful.
- Add unit coverage for pending `r2-direct`, successful completed `r2`, and retryable missing-size cases.

## Motivation

The exact production failure path was: CLI creates the version as `r2-direct`, upload-link updates `r2_path` while the row is still `r2-direct`, then the final upload update flips the row to `r2`. The old trigger treated the intermediate snapshot as `no v2 path` and upserted `app_versions_meta.size = 0`. If the final size lookup later returned `0`, it logged and returned success, so the queue deleted the message and the zero remained.

## Business Impact

Bundle storage accounting becomes consistent again for new uploads. Failed or delayed R2 metadata reads are observable and retryable instead of silently creating wrong zero-byte metadata, which reduces undercounted storage and bad admin/debug data.

## Test Plan

- [x] `bunx vitest run tests/on-version-update-cleanup.unit.test.ts`
- [x] `bun run lint:backend`
- [x] `bun run typecheck:backend`
- [x] `bun run test:backend`
- [x] `bun run typecheck`
- [x] `bun run lint` (passes with one existing frontend JSDoc warning in `src/services/compatibilityEvents.ts`)

## AI-Generated Content

This PR was generated by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retry for bundle-size retrieval from cloud object storage to improve reliability.

* **Bug Fixes**
  * Improved handling when bundle size or path is missing: retryable errors are returned so processing can be retried; manifest-only updates persist zero-size metadata; manifest-cleanup updates are not retried.
  
* **Tests**
  * Expanded tests for bundle size metadata, retry behavior, manifest cleanup, and updated test setup cleanup for impersonation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->