### PR TITLE
fix(frontend): use updater 8.49.1

### DIFF
--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -258,7 +258,7 @@ include ':capgo-capacitor-textinteraction'
 project(':capgo-capacitor-textinteraction').projectDir = new File('../node_modules/.bun/@capgo+capacitor-textinteraction@8.0.25+1b808583819c2ac6/node_modules/@capgo/capacitor-textinteraction/android')
 
 include ':capgo-capacitor-updater'
-project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.bun/@capgo+capacitor-updater@8.49.0+1b808583819c2ac6/node_modules/@capgo/capacitor-updater/android')
+project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.bun/@capgo+capacitor-updater@8.49.1+1b808583819c2ac6/node_modules/@capgo/capacitor-updater/android')
 
 include ':capgo-capacitor-uploader'
 project(':capgo-capacitor-uploader').projectDir = new File('../node_modules/.bun/@capgo+capacitor-uploader@8.2.1+1b808583819c2ac6/node_modules/@capgo/capacitor-uploader/android')

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
         "@capgo/capacitor-speech-synthesis": "^8.0.15",
         "@capgo/capacitor-textinteraction": "^8.0.25",
         "@capgo/capacitor-transitions": "^8.1.8",
-        "@capgo/capacitor-updater": "8.49.0",
+        "@capgo/capacitor-updater": "8.49.1",
         "@capgo/capacitor-uploader": "^8.2.1",
         "@capgo/capacitor-video-player": "^8.1.13",
         "@capgo/capacitor-video-thumbnails": "^8.1.12",
@@ -588,7 +588,7 @@
 
     "@capgo/capacitor-transitions": ["@capgo/capacitor-transitions@8.1.8", "", { "peerDependencies": { "@angular/core": ">=17.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "solid-js": ">=1.0.0", "svelte": ">=4.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@angular/core", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-tgCVvuljFWx9+gX28AYin7j7ygufdvJNzV2uP6AbkhaF7nvAvM7GmwhewBTFlomdrpQUQ9Xu6amUDdQ7v0SGpQ=="],
 
-    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.49.0", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-1s2+JvVGKMa20hctJkkmhVEdEHQ+sMnxJIgjZbHNJwEBOIqjA2Hh9YWINc+IUp7qAEYX+cVWmLxqRSNPBzThIQ=="],
+    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.49.1", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-cFAfOAeySj7hoQ3NsxZ5Tn5O6CRNYgJiqghTmG7XoVtatzU8WhhGO9vWe/qEaHTOL4sgXHkHB8joaOt9V0barw=="],
 
     "@capgo/capacitor-uploader": ["@capgo/capacitor-uploader@8.2.1", "", { "dependencies": { "idb": "^8.0.2" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-jkOew7h10Auwusu+w0TVGMKXx3wIfj3ipIvX7mZlPdDpgw9RFAEqrOqmTsMfM/h9pbOgooJF5iO0I7346KOfwA=="],
 

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -98,7 +98,7 @@ let package = Package(
         .package(name: "CapgoCapacitorSpeechRecognition", path: "../../../node_modules/.bun/@capgo+capacitor-speech-recognition@8.1.3+1b808583819c2ac6/node_modules/@capgo/capacitor-speech-recognition"),
         .package(name: "CapgoCapacitorSpeechSynthesis", path: "../../../node_modules/.bun/@capgo+capacitor-speech-synthesis@8.0.15+1b808583819c2ac6/node_modules/@capgo/capacitor-speech-synthesis"),
         .package(name: "CapgoCapacitorTextinteraction", path: "../../../node_modules/.bun/@capgo+capacitor-textinteraction@8.0.25+1b808583819c2ac6/node_modules/@capgo/capacitor-textinteraction"),
-        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.bun/@capgo+capacitor-updater@8.49.0+1b808583819c2ac6/node_modules/@capgo/capacitor-updater"),
+        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.bun/@capgo+capacitor-updater@8.49.1+1b808583819c2ac6/node_modules/@capgo/capacitor-updater"),
         .package(name: "CapgoCapacitorUploader", path: "../../../node_modules/.bun/@capgo+capacitor-uploader@8.2.1+1b808583819c2ac6/node_modules/@capgo/capacitor-uploader"),
         .package(name: "CapgoCapacitorVideoPlayer", path: "../../../node_modules/.bun/@capgo+capacitor-video-player@8.1.13+e0c29ead8bde6eb5/node_modules/@capgo/capacitor-video-player"),
         .package(name: "CapgoCapacitorVideoThumbnails", path: "../../../node_modules/.bun/@capgo+capacitor-video-thumbnails@8.1.12+1b808583819c2ac6/node_modules/@capgo/capacitor-video-thumbnails"),

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@capgo/capacitor-speech-synthesis": "^8.0.15",
     "@capgo/capacitor-textinteraction": "^8.0.25",
     "@capgo/capacitor-transitions": "^8.1.8",
-    "@capgo/capacitor-updater": "8.49.0",
+    "@capgo/capacitor-updater": "8.49.1",
     "@capgo/capacitor-uploader": "^8.2.1",
     "@capgo/capacitor-video-player": "^8.1.13",
     "@capgo/capacitor-video-thumbnails": "^8.1.12",


### PR DESCRIPTION
## Summary (AI generated)

- Bump `@capgo/capacitor-updater` from `8.49.0` to `8.49.1`.
- Regenerate Android and iOS Capacitor native package references for the new updater package path.

## Motivation (AI generated)

Capgo should consume the released updater version that includes the native preview and three-finger pinch fixes instead of relying on the previous pinned version.

## Business Impact (AI generated)

This lets the Capgo app use the released preview-session updater behavior, improving preview recovery and native shake-menu access for internal and customer testing flows.

## Test Plan (AI generated)

- [x] `bunx cap sync`
- [x] `bun run typecheck:frontend`
- [x] `bun run lint`
- [x] `bun run build`
- [x] Commit hook full typecheck

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the capacitor updater dependency to patch version 8.49.1 across Android, iOS, and project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->