### PR TITLE
chore(observability): trace version size queue processing

### DIFF
--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -37,20 +37,65 @@ async function resolveOwnerOrg(c: Context, record: Database['public']['Tables'][
   return data?.owner_org ?? null
 }
 
+function getManifestEntryCount(value: unknown): number {
+  if (Array.isArray(value))
+    return value.length
+  return value ? 1 : 0
+}
+
+function versionUpdateLogFields(
+  record: Database['public']['Tables']['app_versions']['Row'],
+  oldRecord?: Database['public']['Tables']['app_versions']['Row'] | null,
+) {
+  return {
+    app_id: record.app_id,
+    deleted_at: record.deleted_at,
+    id: record.id,
+    manifest_count: record.manifest_count,
+    manifest_entries: getManifestEntryCount(record.manifest),
+    old_deleted_at: oldRecord?.deleted_at ?? null,
+    old_r2_path: oldRecord?.r2_path ?? null,
+    old_storage_provider: oldRecord?.storage_provider ?? null,
+    old_updated_at: oldRecord?.updated_at ?? null,
+    r2_path: record.r2_path,
+    storage_provider: record.storage_provider,
+    updated_at: record.updated_at,
+    version_name: record.name,
+  }
+}
+
 /**
  * Handles v2 storage metadata updates (size/checksum/stats) for R2-backed bundles.
  *
  * Returns `false` only when processing must stop (e.g. missing owner org).
  */
 async function v2PathSize(c: Context, record: Database['public']['Tables']['app_versions']['Row'], v2Path: string): Promise<boolean> {
-  // pdate size and checksum
-  cloudlog({ requestId: c.get('requestId'), message: 'V2', r2_path: record.r2_path })
-  // set checksum in s3
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'on_version_update reading bundle size',
+    ...versionUpdateLogFields(record),
+    resolved_r2_path: v2Path,
+  })
+
   const size = await s3.getSize(c, v2Path)
   if (!size) {
-    cloudlog({ requestId: c.get('requestId'), message: 'no size found for r2_path', r2_path: record.r2_path })
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'no size found for r2_path',
+      ...versionUpdateLogFields(record),
+      resolved_r2_path: v2Path,
+      size,
+    })
     return true
   }
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'on_version_update resolved bundle size',
+    ...versionUpdateLogFields(record),
+    resolved_r2_path: v2Path,
+    size,
+  })
 
   const ownerOrg = await resolveOwnerOrg(c, record)
   if (!ownerOrg) {
@@ -71,8 +116,12 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
       onConflict: 'id',
     })
     .eq('id', record.id)
-  if (errorUpdate)
-    cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate })
+  if (errorUpdate) {
+    cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate, ...versionUpdateLogFields(record), size })
+  }
+  else {
+    cloudlog({ requestId: c.get('requestId'), message: 'app_versions_meta size upserted', ...versionUpdateLogFields(record), owner_org: ownerOrg, size })
+  }
   const { error } = await createStatsMeta(c, record.app_id, record.id, size)
   if (error)
     cloudlog({ requestId: c.get('requestId'), message: 'error createStatsMeta', error })
@@ -155,6 +204,14 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
  */
 async function updateIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   const v2Path = await getPath(c, record)
+  const metadataBranch = v2Path && record.storage_provider === 'r2' ? 'r2_bundle_size' : 'zero_metadata'
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'on_version_update metadata branch selected',
+    ...versionUpdateLogFields(record),
+    metadataBranch,
+    resolved_r2_path: v2Path,
+  })
 
   if (v2Path && record.storage_provider === 'r2') {
     const shouldContinue = await v2PathSize(c, record, v2Path)
@@ -162,7 +219,7 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
       return c.json(BRES)
   }
   else {
-    cloudlog({ requestId: c.get('requestId'), message: 'no v2 path' })
+    cloudlog({ requestId: c.get('requestId'), message: 'no v2 path', ...versionUpdateLogFields(record), resolved_r2_path: v2Path })
     const ownerOrg = await resolveOwnerOrg(c, record)
     if (!ownerOrg) {
       cloudlog({ requestId: c.get('requestId'), message: 'missing owner_org for app_versions_meta upsert', id: record.id, app_id: record.app_id })
@@ -180,8 +237,12 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
         onConflict: 'id',
       })
       .eq('id', record.id)
-    if (errorUpdate)
-      cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate })
+    if (errorUpdate) {
+      cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate, ...versionUpdateLogFields(record), size: 0 })
+    }
+    else {
+      cloudlog({ requestId: c.get('requestId'), message: 'app_versions_meta zero size upserted', ...versionUpdateLogFields(record), owner_org: ownerOrg, size: 0 })
+    }
   }
 
   // Handle manifest entries
@@ -347,6 +408,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['app_versions']['Row']
   const oldRecord = c.get('oldRecord') as Database['public']['Tables']['app_versions']['Row']
+  cloudlog({ requestId: c.get('requestId'), message: 'on_version_update received', ...versionUpdateLogFields(record, oldRecord) })
   cloudlog({ requestId: c.get('requestId'), message: 'record', record })
 
   if (!record.app_id) {
@@ -358,10 +420,10 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
     return deleteIt(c, record)
 
   if (!record.r2_path && !record.manifest) {
-    cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', record })
+    cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', ...versionUpdateLogFields(record, oldRecord) })
     return c.json(BRES)
   }
 
-  cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted' })
+  cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted', ...versionUpdateLogFields(record, oldRecord) })
   return updateIt(c, record)
 })

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -97,6 +97,35 @@ function extractMessageBody(message: Message): Record<string, unknown> {
   return legacyBody
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function getQueueMessageTrace(functionName: string, body: Record<string, unknown>): Record<string, unknown> | null {
+  if (functionName !== 'on_version_update' || body.table !== 'app_versions' || body.type !== 'UPDATE')
+    return null
+
+  const record = isRecord(body.record) ? body.record : {}
+  const oldRecord = isRecord(body.old_record) ? body.old_record : {}
+  const manifest = record.manifest
+
+  return {
+    app_id: record.app_id ?? null,
+    deleted_at: record.deleted_at ?? null,
+    id: record.id ?? null,
+    manifest_count: record.manifest_count ?? null,
+    manifest_entries: Array.isArray(manifest) ? manifest.length : (manifest ? 1 : 0),
+    old_deleted_at: oldRecord.deleted_at ?? null,
+    old_r2_path: oldRecord.r2_path ?? null,
+    old_storage_provider: oldRecord.storage_provider ?? null,
+    old_updated_at: oldRecord.updated_at ?? null,
+    r2_path: record.r2_path ?? null,
+    storage_provider: record.storage_provider ?? null,
+    updated_at: record.updated_at ?? null,
+    version_name: record.name ?? null,
+  }
+}
+
 function getActionableQueueFailures(failureDetails: FailureDetail[]): FailureDetail[] {
   return failureDetails.filter((detail) => {
     if (detail.read_count < MAX_QUEUE_READS)
@@ -321,22 +350,54 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
   const payloadSize = JSON.stringify(body).length
   const start = Date.now()
   const targetUrl = function_name === 'on_manifest_create' ? 'direct:on_manifest_create' : resolveFunctionUrl(c, function_name, function_type)
+  const trace = getQueueMessageTrace(function_name, body)
 
   try {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Queue message dispatching.`,
+      body_trace: trace,
+      cfId,
+      function_name,
+      function_type,
+      msgId: message.msg_id,
+      payloadSize,
+      readCount: message.read_ct,
+      targetUrl,
+    })
     const result = await dispatchQueueMessage(c, function_name, function_type, body, cfId, {
       msgId: message.msg_id,
       queueName,
       readCount: message.read_ct,
     }, targetUrl)
     const errorDetails = await extractErrorDetails(result.response)
+    const durationMs = Date.now() - start
+
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Queue message processed.`,
+      body_trace: trace,
+      cfId,
+      durationMs,
+      errorCode: errorDetails.errorCode,
+      errorMessage: errorDetails.errorMessage,
+      function_name,
+      function_type,
+      msgId: message.msg_id,
+      payloadSize,
+      readCount: message.read_ct,
+      responseOk: result.response.status >= 200 && result.response.status < 300,
+      responseStatus: result.response.status,
+      targetUrl: result.targetUrl,
+    })
 
     return {
       httpResponse: result.response,
       errorDetails,
       cfId,
       payloadSize,
-      durationMs: Date.now() - start,
-      targetUrl,
+      durationMs,
+      targetUrl: result.targetUrl,
       ...message,
     }
   }
@@ -361,6 +422,7 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
       durationMs,
       error: serializedError,
       responseStatus: httpResponse.status,
+      body_trace: trace,
       function_name,
       function_type,
       msgId: message.msg_id,
@@ -368,6 +430,22 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
       targetUrl,
     })
     const errorDetails = await extractErrorDetails(httpResponse)
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Queue message processed as failure response.`,
+      body_trace: trace,
+      cfId,
+      durationMs,
+      errorCode: errorDetails.errorCode,
+      errorMessage: errorDetails.errorMessage,
+      function_name,
+      function_type,
+      msgId: message.msg_id,
+      payloadSize,
+      readCount: message.read_ct,
+      responseStatus: httpResponse.status,
+      targetUrl,
+    })
 
     return {
       httpResponse,
@@ -979,6 +1057,7 @@ app.post('/sync', async (c) => {
 export const __queueConsumerTestUtils__ = {
   extractErrorDetails,
   extractMessageBody,
+  getQueueMessageTrace,
   getActionableQueueFailures,
   getCronHealthcheckStartUrl,
   getQueueBatchSize,

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -108,13 +108,18 @@ function getQueueMessageTrace(functionName: string, body: Record<string, unknown
   const record = isRecord(body.record) ? body.record : {}
   const oldRecord = isRecord(body.old_record) ? body.old_record : {}
   const manifest = record.manifest
+  let manifestEntries = 0
+  if (Array.isArray(manifest))
+    manifestEntries = manifest.length
+  else if (manifest)
+    manifestEntries = 1
 
   return {
     app_id: record.app_id ?? null,
     deleted_at: record.deleted_at ?? null,
     id: record.id ?? null,
     manifest_count: record.manifest_count ?? null,
-    manifest_entries: Array.isArray(manifest) ? manifest.length : (manifest ? 1 : 0),
+    manifest_entries: manifestEntries,
     old_deleted_at: oldRecord.deleted_at ?? null,
     old_r2_path: oldRecord.r2_path ?? null,
     old_storage_provider: oldRecord.storage_provider ?? null,

--- a/supabase/functions/_backend/utils/s3.ts
+++ b/supabase/functions/_backend/utils/s3.ts
@@ -184,19 +184,49 @@ async function deleteObjectsWithPrefix(c: Context, prefix: string): Promise<numb
 
 async function checkIfExist(c: Context, fileId: string | null) {
   if (!fileId) {
+    cloudlog({ requestId: c.get('requestId'), message: 'checkIfExist skipped empty fileId' })
     return false
   }
+
+  const bucket = getEnv(c, 'S3_BUCKET')
+  const endpoint = getEnv(c, 'S3_ENDPOINT')
+
   try {
     const client = initS3(c)
     const url = await client.getPresignedUrl('HEAD', fileId)
     const response = await fetch(url, {
       method: 'HEAD',
     })
-    const contentLength = Number.parseInt(response.headers.get('content-length') || '0')
-    return response.status === 200 && contentLength > 0
+    const contentLengthHeader = response.headers.get('content-length')
+    const contentLength = Number.parseInt(contentLengthHeader || '0')
+    const exists = response.status === 200 && contentLength > 0
+    await response.body?.cancel()
+
+    if (!exists) {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'checkIfExist returned false',
+        bucket,
+        contentLength,
+        contentLengthHeader,
+        endpoint,
+        fileId,
+        status: response.status,
+        statusText: response.statusText,
+      })
+    }
+
+    return exists
   }
-  catch {
-    // cloudlog({ requestId: c.get('requestId'), message: 'checkIfExist', fileId, error  })
+  catch (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'checkIfExist failed',
+      bucket,
+      endpoint,
+      error: serializeStorageError(error),
+      fileId,
+    })
     return false
   }
 }

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -59,6 +59,51 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(__queueConsumerTestUtils__.extractMessageBody(message!)).toEqual({})
   })
 
+  it.concurrent('summarizes app version update queue payloads for logs', () => {
+    expect(__queueConsumerTestUtils__.getQueueMessageTrace('on_version_update', {
+      old_record: {
+        deleted_at: null,
+        r2_path: null,
+        storage_provider: 'r2-direct',
+        updated_at: '2026-06-10T17:33:48.108Z',
+      },
+      record: {
+        app_id: 'at.pulserunning.rny',
+        deleted_at: null,
+        id: 181090948,
+        manifest: [{ file_name: 'index.html' }, { file_name: 'assets/app.js' }],
+        manifest_count: 0,
+        name: '1.7.0',
+        r2_path: 'orgs/org-id/apps/at.pulserunning.rny/1.7.0.zip',
+        storage_provider: 'r2',
+        updated_at: '2026-06-10T17:33:48.559Z',
+      },
+      table: 'app_versions',
+      type: 'UPDATE',
+    })).toEqual({
+      app_id: 'at.pulserunning.rny',
+      deleted_at: null,
+      id: 181090948,
+      manifest_count: 0,
+      manifest_entries: 2,
+      old_deleted_at: null,
+      old_r2_path: null,
+      old_storage_provider: 'r2-direct',
+      old_updated_at: '2026-06-10T17:33:48.108Z',
+      r2_path: 'orgs/org-id/apps/at.pulserunning.rny/1.7.0.zip',
+      storage_provider: 'r2',
+      updated_at: '2026-06-10T17:33:48.559Z',
+      version_name: '1.7.0',
+    })
+  })
+
+  it.concurrent('does not summarize unrelated queue payloads', () => {
+    expect(__queueConsumerTestUtils__.getQueueMessageTrace('cron_sync_sub', {
+      customerId: 'cus_1',
+      orgId: 'org-1',
+    })).toBeNull()
+  })
+
   it.concurrent('does not alert Discord while failed messages still have retries left', () => {
     expect(__queueConsumerTestUtils__.getActionableQueueFailures([
       {


### PR DESCRIPTION
## Summary
- Add per-message queue logs for app version update dispatch/results, including msg id, CF id, status, target URL, and sanitized version fields.
- Add structured on_version_update logs for received payloads, branch selection, R2 size resolution, and app_versions_meta upsert results.
- Add R2 existence-check logs when HEAD returns false or throws, plus unit coverage for the queue payload trace summary.

## Motivation
Recent production investigation proved fresh app_versions rows can remain with app_versions_meta.size = 0 even when the R2 object exists with a real size. The exact final failure path is not identifiable from current evidence because queue_consumer deletes successful pgmq messages and only logs aggregate success counts. This PR does not change behavior; it adds the missing proof points so the next occurrence shows whether the final r2 update message was dispatched, skipped, failed storage existence, failed size lookup, or failed DB upsert.

## Business Impact
Accurate bundle size metadata controls storage reporting and billing confidence. These logs reduce time-to-root-cause for production size drift without changing upload/download behavior.

## Test Plan
- [x] bun test tests/queue-consumer-message-shape.unit.test.ts
- [x] bun lint:backend
- [x] bun run typecheck:backend
- [x] commit hook ran bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend

AI-generated-by: Codex