### PR TITLE
fix(api): avoid false zero app version sizes

### DIFF
--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -199,12 +199,49 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
     cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
 }
 
+function getVersionMetadataBranch(v2Path: string | null, storageProvider: string): 'r2_bundle_size' | 'r2_missing_path' | 'r2_direct_waiting_for_finalize' | 'zero_metadata' {
+  if (storageProvider === 'r2')
+    return v2Path ? 'r2_bundle_size' : 'r2_missing_path'
+  if (storageProvider === 'r2-direct')
+    return 'r2_direct_waiting_for_finalize'
+  return 'zero_metadata'
+}
+
+async function upsertZeroVersionMetadata(c: Context, record: Database['public']['Tables']['app_versions']['Row'], v2Path: string | null): Promise<boolean> {
+  cloudlog({ requestId: c.get('requestId'), message: 'zero metadata branch selected', ...versionUpdateLogFields(record), resolved_r2_path: v2Path })
+  const ownerOrg = await resolveOwnerOrg(c, record)
+  if (!ownerOrg) {
+    cloudlog({ requestId: c.get('requestId'), message: 'missing owner_org for app_versions_meta upsert', id: record.id, app_id: record.app_id })
+    return false
+  }
+
+  const { error: errorUpdate } = await supabaseAdmin(c)
+    .from('app_versions_meta')
+    .upsert({
+      id: record.id,
+      app_id: record.app_id,
+      owner_org: ownerOrg,
+      size: 0,
+      checksum: record.checksum ?? '',
+    }, {
+      onConflict: 'id',
+    })
+    .eq('id', record.id)
+  if (errorUpdate) {
+    cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate, ...versionUpdateLogFields(record), size: 0 })
+  }
+  else {
+    cloudlog({ requestId: c.get('requestId'), message: 'app_versions_meta zero size upserted', ...versionUpdateLogFields(record), owner_org: ownerOrg, size: 0 })
+  }
+  return true
+}
+
 /**
  * Handles app version metadata updates after insert/update trigger execution.
  */
-async function updateIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
+export async function updateIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   const v2Path = await getPath(c, record)
-  const metadataBranch = v2Path && record.storage_provider === 'r2' ? 'r2_bundle_size' : 'zero_metadata'
+  const metadataBranch = getVersionMetadataBranch(v2Path, record.storage_provider)
   cloudlog({
     requestId: c.get('requestId'),
     message: 'on_version_update metadata branch selected',
@@ -218,31 +255,26 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
     if (!shouldContinue)
       return c.json(BRES)
   }
+  else if (record.storage_provider === 'r2') {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'r2 upload finalized without readable object path, skipping app_versions_meta zero size upsert',
+      ...versionUpdateLogFields(record),
+      resolved_r2_path: v2Path,
+    })
+  }
+  else if (record.storage_provider === 'r2-direct') {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'r2-direct upload not finalized, skipping app_versions_meta zero size upsert',
+      ...versionUpdateLogFields(record),
+      resolved_r2_path: v2Path,
+    })
+  }
   else {
-    cloudlog({ requestId: c.get('requestId'), message: 'no v2 path', ...versionUpdateLogFields(record), resolved_r2_path: v2Path })
-    const ownerOrg = await resolveOwnerOrg(c, record)
-    if (!ownerOrg) {
-      cloudlog({ requestId: c.get('requestId'), message: 'missing owner_org for app_versions_meta upsert', id: record.id, app_id: record.app_id })
+    const shouldContinue = await upsertZeroVersionMetadata(c, record, v2Path)
+    if (!shouldContinue)
       return c.json(BRES)
-    }
-    const { error: errorUpdate } = await supabaseAdmin(c)
-      .from('app_versions_meta')
-      .upsert({
-        id: record.id,
-        app_id: record.app_id,
-        owner_org: ownerOrg,
-        size: 0,
-        checksum: record.checksum ?? '',
-      }, {
-        onConflict: 'id',
-      })
-      .eq('id', record.id)
-    if (errorUpdate) {
-      cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate, ...versionUpdateLogFields(record), size: 0 })
-    }
-    else {
-      cloudlog({ requestId: c.get('requestId'), message: 'app_versions_meta zero size upserted', ...versionUpdateLogFields(record), owner_org: ownerOrg, size: 0 })
-    }
   }
 
   // Handle manifest entries

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -2,13 +2,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   appVersionsMetaSelectEq,
+  appVersionsMetaUpsert,
+  appVersionsMetaUpsertEq,
   appVersionsMetaUpdate,
   appVersionsMetaUpdateEq,
   closeClient,
   createStatsMeta,
   deleteObject,
   getDrizzleClient,
+  getPath,
   getPgClient,
+  getSize,
   manifestDeleteEq,
   manifestReferenceMaybeSingle,
   manifestSelectWhere,
@@ -18,6 +22,8 @@ const {
 } = vi.hoisted(() => {
   const appVersionsMetaSelectEq = vi.fn()
   const appVersionsMetaSelect = vi.fn(() => ({ eq: appVersionsMetaSelectEq }))
+  const appVersionsMetaUpsertEq = vi.fn()
+  const appVersionsMetaUpsert = vi.fn(() => ({ eq: appVersionsMetaUpsertEq }))
   const appVersionsMetaUpdateEq = vi.fn()
   const appVersionsMetaUpdate = vi.fn(() => ({ eq: appVersionsMetaUpdateEq }))
   const manifestDeleteEq = vi.fn()
@@ -32,6 +38,7 @@ const {
       return {
         select: appVersionsMetaSelect,
         update: appVersionsMetaUpdate,
+        upsert: appVersionsMetaUpsert,
       }
     }
     if (table === 'manifest') {
@@ -47,6 +54,8 @@ const {
 
   return {
     appVersionsMetaSelectEq,
+    appVersionsMetaUpsert,
+    appVersionsMetaUpsertEq,
     appVersionsMetaUpdate,
     appVersionsMetaUpdateEq,
     closeClient: vi.fn(),
@@ -59,7 +68,9 @@ const {
         })),
       })),
     })),
+    getPath: vi.fn(),
     getPgClient: vi.fn(() => ({ query: pgQuery })),
+    getSize: vi.fn(),
     manifestDeleteEq,
     manifestReferenceMaybeSingle,
     manifestSelectWhere,
@@ -71,9 +82,10 @@ const {
 })
 
 vi.mock('../supabase/functions/_backend/utils/s3.ts', () => ({
-  getPath: vi.fn(),
+  getPath,
   s3: {
     deleteObject,
+    getSize,
     moveObjectToTrash,
   },
 }))
@@ -97,7 +109,7 @@ vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlogErr: vi.fn(),
 }))
 
-const { deleteIt } = await import('../supabase/functions/_backend/triggers/on_version_update.ts')
+const { deleteIt, updateIt } = await import('../supabase/functions/_backend/triggers/on_version_update.ts')
 
 function createContext() {
   return {
@@ -112,6 +124,7 @@ function createVersion(overrides: Record<string, unknown> = {}) {
     id: 123,
     manifest: null,
     name: '1.0.0',
+    owner_org: 'org-1',
     r2_path: 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
     storage_provider: 'r2',
     ...overrides,
@@ -127,11 +140,64 @@ describe('on_version_update deleted version cleanup', () => {
     manifestSelectWhere.mockResolvedValue([])
     manifestDeleteEq.mockResolvedValue({ error: null })
     manifestReferenceMaybeSingle.mockResolvedValue({ data: null, error: null })
+    getPath.mockResolvedValue('orgs/org-1/apps/com.cleanup.test/1.0.0.zip')
+    getSize.mockResolvedValue(9876)
     pgQuery.mockResolvedValue({ rows: [] })
     appVersionsMetaSelectEq.mockReturnValue({
       single: vi.fn(async () => ({ data: { size: 1234 }, error: null })),
     })
     appVersionsMetaUpdateEq.mockResolvedValue({ error: null })
+    appVersionsMetaUpsertEq.mockResolvedValue({ error: null })
+  })
+
+  it('does not write zero metadata while an r2-direct upload is still finalizing', async () => {
+    const response = await updateIt(createContext(), createVersion({ storage_provider: 'r2-direct' }))
+
+    expect(response.status).toBe(200)
+    expect(getPath).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ storage_provider: 'r2-direct' }))
+    expect(getSize).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not write zero metadata when an r2-direct upload has no object yet', async () => {
+    getPath.mockResolvedValue(null)
+
+    const response = await updateIt(createContext(), createVersion({ storage_provider: 'r2-direct' }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not write zero metadata when a finalized r2 upload has no readable object path', async () => {
+    getPath.mockResolvedValue(null)
+
+    const response = await updateIt(createContext(), createVersion({ storage_provider: 'r2' }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).not.toHaveBeenCalled()
+    expect(appVersionsMetaUpsert).not.toHaveBeenCalled()
+    expect(createStatsMeta).not.toHaveBeenCalled()
+  })
+
+  it('stores the real R2 size once the upload is finalized', async () => {
+    const response = await updateIt(createContext(), createVersion({ storage_provider: 'r2' }))
+
+    expect(response.status).toBe(200)
+    expect(getSize).toHaveBeenCalledWith(expect.anything(), 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip')
+    expect(appVersionsMetaUpsert).toHaveBeenCalledWith({
+      app_id: 'com.cleanup.test',
+      checksum: '',
+      id: 123,
+      owner_org: 'org-1',
+      size: 9876,
+    }, {
+      onConflict: 'id',
+    })
+    expect(appVersionsMetaUpsertEq).toHaveBeenCalledWith('id', 123)
+    expect(createStatsMeta).toHaveBeenCalledWith(expect.anything(), 'com.cleanup.test', 123, 9876)
   })
 
   it('moves the bundle to trash and clears stored size for soft-deleted versions', async () => {


### PR DESCRIPTION
## Summary
- Stop `on_version_update` from writing `app_versions_meta.size = 0` while an upload is still in `r2-direct`.
- Stop finalized `storage_provider = 'r2'` rows from falling through to zero metadata when `getPath()` cannot read the R2 object path.
- Keep real size writes limited to the branch where `storage_provider = 'r2'` and R2 returns a readable object path, with logs for every branch.
- Add focused unit coverage for `r2-direct`, finalized `r2` with no readable object path, and finalized `r2` real-size writes.

## Motivation
I checked Cloudflare Workers Observability logs in account `9ee3d7479a3c359681e3fab2c8cb22c0` for the last 7 days. The exact production failure is **not identifiable from the retained Cloudflare logs**:

- `getSize returned 0 after retries`: 0 events
- `manifest_size_not_found`: 0 events
- `getSize failed all manifest storage candidates`: 0 events
- `getSize head failed`: 0 events
- `getSize final`: 0 events
- `manifest file_size updated`: 0 events
- `function_name = on_manifest_create`: 0 events across services
- `function_name = on_version_update`: not observable from the indexed fields

So this PR does **not** claim the non-TUS upload-link path is the production root cause. Prod uses TUS, and the previous wording was too strong.

The exact code issue fixed here is still real: before this change, `on_version_update` treated a missing readable R2 path as a reason to fall through into `upsertZeroVersionMetadata()`. That can happen for both `r2-direct` and already-finalized `r2` rows because `getPath()` returns `null` when the object cannot be verified. Missing object metadata is not proof that the bundle size is zero, so we must not persist zero in that path. The handler now logs the branch and skips zero writes until a real R2 size is readable.

## Business Impact
This prevents false zero-byte app version metadata from being persisted when R2 metadata is unavailable. That keeps storage accounting closer to object storage truth and makes the next occurrence diagnosable from explicit branch logs instead of silently writing zero.

## Test Plan
- [x] `bunx vitest run tests/on-version-update-cleanup.unit.test.ts`
- [x] `bun lint:backend`
- [x] `bun run typecheck:backend`
- [x] Commit hook ran `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- [x] GitHub CI passed on the amended PR

AI-generated-by: Codex
