### PR TITLE
[codex] fix secure SSO bypass for impersonation

### DIFF
--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -60,8 +60,8 @@ async function openLogAsDialog() {
   }
 }
 
-function resetSpoofedUser() {
-  if (unspoofUser()) {
+async function resetSpoofedUser() {
+  if (await unspoofUser()) {
     toast.error('Stop Spoofed, will reload')
     setTimeout(() => {
       router.replace('/dashboard').then(() => {

--- a/src/modules/sso-enforcement.ts
+++ b/src/modules/sso-enforcement.ts
@@ -1,5 +1,5 @@
 import type { UserModule } from '~/types'
-import { defaultApiHost, useSupabase } from '~/services/supabase'
+import { defaultApiHost, getSpoofedAdminJwt, useSupabase } from '~/services/supabase'
 
 interface SsoEnforcementResponse {
   allowed: boolean
@@ -8,6 +8,7 @@ interface SsoEnforcementResponse {
 
 const SSO_CHECK_CACHE_KEY = 'sso_enforcement_checked'
 const SSO_CHECK_CACHE_TTL = 5 * 60 * 1000
+const SPOOF_ADMIN_AUTHORIZATION_HEADER = 'X-Capgo-Spoof-Admin-Authorization'
 
 const PUBLIC_ROUTES = [
   '/login',
@@ -74,12 +75,17 @@ export const install: UserModule = ({ router }) => {
       return next()
 
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${session.access_token}`,
+      }
+      const spoofedAdminJwt = getSpoofedAdminJwt()
+      if (spoofedAdminJwt)
+        headers[SPOOF_ADMIN_AUTHORIZATION_HEADER] = `Bearer ${spoofedAdminJwt}`
+
       const response = await fetch(`${defaultApiHost}/private/sso/check-enforcement`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${session.access_token}`,
-        },
+        headers,
         body: JSON.stringify({
           email: session.user.email,
           auth_type: 'password',

--- a/src/modules/sso-enforcement.ts
+++ b/src/modules/sso-enforcement.ts
@@ -6,7 +6,7 @@ interface SsoEnforcementResponse {
   reason?: string
 }
 
-const SSO_CHECK_CACHE_KEY = 'sso_enforcement_checked'
+const SSO_CHECK_CACHE_KEY = 'sso_enforcement_checked_v2'
 const SSO_CHECK_CACHE_TTL = 5 * 60 * 1000
 const SPOOF_ADMIN_AUTHORIZATION_HEADER = 'X-Capgo-Spoof-Admin-Authorization'
 
@@ -71,15 +71,15 @@ export const install: UserModule = ({ router }) => {
     if (!userId)
       return next()
 
-    if (isCacheValid(userId))
-      return next()
-
     try {
+      const spoofedAdminJwt = await getSpoofedAdminJwt()
+      if (!spoofedAdminJwt && isCacheValid(userId))
+        return next()
+
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${session.access_token}`,
       }
-      const spoofedAdminJwt = await getSpoofedAdminJwt()
       if (spoofedAdminJwt)
         headers[SPOOF_ADMIN_AUTHORIZATION_HEADER] = `Bearer ${spoofedAdminJwt}`
 
@@ -106,7 +106,8 @@ export const install: UserModule = ({ router }) => {
         return next('/login?sso_required=true')
       }
 
-      setCacheValid(userId)
+      if (!spoofedAdminJwt)
+        setCacheValid(userId)
     }
     catch (e) {
       // Fail closed: if enforcement check is unreachable, sign user out for safety

--- a/src/modules/sso-enforcement.ts
+++ b/src/modules/sso-enforcement.ts
@@ -79,7 +79,7 @@ export const install: UserModule = ({ router }) => {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${session.access_token}`,
       }
-      const spoofedAdminJwt = getSpoofedAdminJwt()
+      const spoofedAdminJwt = await getSpoofedAdminJwt()
       if (spoofedAdminJwt)
         headers[SPOOF_ADMIN_AUTHORIZATION_HEADER] = `Bearer ${spoofedAdminJwt}`
 

--- a/src/services/logAs.ts
+++ b/src/services/logAs.ts
@@ -19,7 +19,7 @@ export async function logAsUser(identifier: string, router: Router) {
       throw new Error('Missing user id, email, or org id')
 
     if (isSpoofed())
-      unspoofUser()
+      await unspoofUser()
 
     const supabase = useSupabase()
     const { data, error } = await supabase.functions.invoke('private/log_as', {

--- a/src/services/logAs.ts
+++ b/src/services/logAs.ts
@@ -18,8 +18,8 @@ export async function logAsUser(identifier: string, router: Router) {
     if (!identifier)
       throw new Error('Missing user id, email, or org id')
 
-    if (isSpoofed())
-      await unspoofUser()
+    if (isSpoofed() && !(await unspoofUser()))
+      throw new Error('Cannot restore admin session, please sign in again')
 
     const supabase = useSupabase()
     const { data, error } = await supabase.functions.invoke('private/log_as', {

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -40,6 +40,33 @@ export function getLocalConfig() {
 let config: CapgoConfig = getLocalConfig()
 export const stripeEnabled = ref<boolean>(config.stripeEnabled ?? true)
 
+interface SpoofedAdminSession {
+  jwt: string
+  refreshToken: string
+}
+
+function getSpoofedAdminStorageKey() {
+  return `supabase-${config.supbaseId}.spoof_admin_jwt`
+}
+
+function getSpoofedAdminSession(): SpoofedAdminSession | null {
+  const textData = localStorage.getItem(getSpoofedAdminStorageKey())
+  if (!textData)
+    return null
+
+  try {
+    const parsed = JSON.parse(textData) as Partial<SpoofedAdminSession>
+    if (typeof parsed.jwt !== 'string' || !parsed.jwt)
+      return null
+    if (typeof parsed.refreshToken !== 'string' || !parsed.refreshToken)
+      return null
+    return { jwt: parsed.jwt, refreshToken: parsed.refreshToken }
+  }
+  catch {
+    return null
+  }
+}
+
 export function mergeRemoteConfig(localConfig: CapgoConfig, remoteConfig: Partial<CapgoConfig> | null | undefined): CapgoConfig {
   return {
     ...localConfig,
@@ -97,10 +124,14 @@ export function useSupabase() {
 }
 
 export function isSpoofed() {
-  return !!localStorage.getItem(`supabase-${config.supbaseId}.spoof_admin_jwt`)
+  return !!getSpoofedAdminSession()
 }
 export function saveSpoof(jwt: string, refreshToken: string) {
-  return localStorage.setItem(`supabase-${config.supbaseId}.spoof_admin_jwt`, JSON.stringify({ jwt, refreshToken }))
+  return localStorage.setItem(getSpoofedAdminStorageKey(), JSON.stringify({ jwt, refreshToken }))
+}
+
+export function getSpoofedAdminJwt() {
+  return getSpoofedAdminSession()?.jwt ?? null
 }
 
 export async function hashEmail(email: string) {
@@ -114,17 +145,13 @@ export async function hashEmail(email: string) {
 }
 
 export function unspoofUser() {
-  const textData: string | null = localStorage.getItem(`supabase-${config.supbaseId}.spoof_admin_jwt`)
-  if (!textData || !isSpoofed())
-    return false
-
-  const { jwt, refreshToken } = JSON.parse(textData)
-  if (!jwt || !refreshToken)
+  const spoofedAdminSession = getSpoofedAdminSession()
+  if (!spoofedAdminSession)
     return false
 
   const supabase = useSupabase()
-  supabase.auth.setSession({ access_token: jwt, refresh_token: refreshToken })
-  localStorage.removeItem(`supabase-${config.supbaseId}.spoof_admin_jwt`)
+  supabase.auth.setSession({ access_token: spoofedAdminSession.jwt, refresh_token: spoofedAdminSession.refreshToken })
+  localStorage.removeItem(getSpoofedAdminStorageKey())
   return true
 }
 

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -181,6 +181,10 @@ export function saveSpoof(jwt: string, refreshToken: string) {
   return saveSpoofedAdminSession({ jwt, refreshToken })
 }
 
+export function clearSpoof() {
+  localStorage.removeItem(getSpoofedAdminStorageKey())
+}
+
 export async function getSpoofedAdminJwt() {
   const spoofedAdminSession = getSpoofedAdminSession()
   if (!spoofedAdminSession)
@@ -189,10 +193,15 @@ export async function getSpoofedAdminJwt() {
   if (!shouldRefreshSpoofedAdminJwt(spoofedAdminSession.jwt))
     return spoofedAdminSession.jwt
 
-  const refreshedSession = await refreshSpoofedAdminSession(spoofedAdminSession)
-  if (refreshedSession) {
-    saveSpoofedAdminSession(refreshedSession)
-    return refreshedSession.jwt
+  try {
+    const refreshedSession = await refreshSpoofedAdminSession(spoofedAdminSession)
+    if (refreshedSession) {
+      saveSpoofedAdminSession(refreshedSession)
+      return refreshedSession.jwt
+    }
+  }
+  catch {
+    console.error('Failed to refresh spoofed admin session')
   }
 
   const expiresAt = getJwtExpiresAt(spoofedAdminSession.jwt)

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -45,8 +45,14 @@ interface SpoofedAdminSession {
   refreshToken: string
 }
 
+const SPOOF_ADMIN_TOKEN_REFRESH_WINDOW_SECONDS = 60
+
 function getSpoofedAdminStorageKey() {
   return `supabase-${config.supbaseId}.spoof_admin_jwt`
+}
+
+function saveSpoofedAdminSession(session: SpoofedAdminSession) {
+  return localStorage.setItem(getSpoofedAdminStorageKey(), JSON.stringify({ jwt: session.jwt, refreshToken: session.refreshToken }))
 }
 
 function getSpoofedAdminSession(): SpoofedAdminSession | null {
@@ -65,6 +71,51 @@ function getSpoofedAdminSession(): SpoofedAdminSession | null {
   catch {
     return null
   }
+}
+
+function decodeBase64Url(value: string) {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  return globalThis.atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, '='))
+}
+
+function getJwtExpiresAt(jwt: string) {
+  const payload = jwt.split('.')[1]
+  if (!payload)
+    return null
+
+  try {
+    const parsed = JSON.parse(decodeBase64Url(payload)) as { exp?: unknown }
+    return typeof parsed.exp === 'number' ? parsed.exp : null
+  }
+  catch {
+    return null
+  }
+}
+
+function shouldRefreshSpoofedAdminJwt(jwt: string) {
+  const expiresAt = getJwtExpiresAt(jwt)
+  if (!expiresAt)
+    return true
+
+  return expiresAt - Date.now() / 1000 <= SPOOF_ADMIN_TOKEN_REFRESH_WINDOW_SECONDS
+}
+
+function createSpoofAdminSupabase() {
+  return createClient<Database>(getSupabaseHost(), config.supaKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  })
+}
+
+async function refreshSpoofedAdminSession(session: SpoofedAdminSession): Promise<SpoofedAdminSession | null> {
+  const { data, error } = await createSpoofAdminSupabase().auth.refreshSession({ refresh_token: session.refreshToken })
+  if (error || !data.session?.access_token || !data.session.refresh_token)
+    return null
+
+  return { jwt: data.session.access_token, refreshToken: data.session.refresh_token }
 }
 
 export function mergeRemoteConfig(localConfig: CapgoConfig, remoteConfig: Partial<CapgoConfig> | null | undefined): CapgoConfig {
@@ -127,11 +178,25 @@ export function isSpoofed() {
   return !!getSpoofedAdminSession()
 }
 export function saveSpoof(jwt: string, refreshToken: string) {
-  return localStorage.setItem(getSpoofedAdminStorageKey(), JSON.stringify({ jwt, refreshToken }))
+  return saveSpoofedAdminSession({ jwt, refreshToken })
 }
 
-export function getSpoofedAdminJwt() {
-  return getSpoofedAdminSession()?.jwt ?? null
+export async function getSpoofedAdminJwt() {
+  const spoofedAdminSession = getSpoofedAdminSession()
+  if (!spoofedAdminSession)
+    return null
+
+  if (!shouldRefreshSpoofedAdminJwt(spoofedAdminSession.jwt))
+    return spoofedAdminSession.jwt
+
+  const refreshedSession = await refreshSpoofedAdminSession(spoofedAdminSession)
+  if (refreshedSession) {
+    saveSpoofedAdminSession(refreshedSession)
+    return refreshedSession.jwt
+  }
+
+  const expiresAt = getJwtExpiresAt(spoofedAdminSession.jwt)
+  return expiresAt && expiresAt > Date.now() / 1000 ? spoofedAdminSession.jwt : null
 }
 
 export async function hashEmail(email: string) {
@@ -144,13 +209,16 @@ export async function hashEmail(email: string) {
   return hashHex
 }
 
-export function unspoofUser() {
+export async function unspoofUser() {
   const spoofedAdminSession = getSpoofedAdminSession()
   if (!spoofedAdminSession)
     return false
 
   const supabase = useSupabase()
-  supabase.auth.setSession({ access_token: spoofedAdminSession.jwt, refresh_token: spoofedAdminSession.refreshToken })
+  const { data, error } = await supabase.auth.setSession({ access_token: spoofedAdminSession.jwt, refresh_token: spoofedAdminSession.refreshToken })
+  if (error || !data.session)
+    return false
+
   localStorage.removeItem(getSpoofedAdminStorageKey())
   return true
 }

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -49,18 +49,17 @@ export const useMainStore = defineStore('main', () => {
 
   const totalDownload = ref<number>(0)
 
-  const logout = () => {
-    return new Promise<void>((resolve) => {
-      const supabase = useSupabase()
-      const config = getLocalConfig()
-      const listener = supabase.auth.onAuthStateChange(async (event: any) => {
+  const logout = async () => {
+    const supabase = useSupabase()
+    const config = getLocalConfig()
+    await new Promise<void>((resolve) => {
+      const listener = supabase.auth.onAuthStateChange((event: any) => {
         if (event === 'SIGNED_OUT') {
           listener.data.subscription.unsubscribe()
           auth.value = undefined
           user.value = undefined
           isAdmin.value = false
           reset(config.supaHost)
-          await unspoofUser()
           resolve()
         }
       })
@@ -69,6 +68,7 @@ export const useMainStore = defineStore('main', () => {
         supabase.auth.signOut()
       }, 300)
     })
+    await unspoofUser()
   }
 
   const getTotalStats: () => TotalStats = () => {

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -6,12 +6,12 @@ import { ref } from 'vue'
 import { getDaysBetweenDates } from '~/services/conversion'
 import { reset } from '~/services/posthog'
 import {
+  clearSpoof,
   findBestPlan,
   getAllDashboard,
   getLocalConfig,
   getTotalStorage,
   normalizeDashboardDateRange,
-  unspoofUser,
   useSupabase,
 } from '~/services/supabase'
 import { createDeferredPromise } from '../utils/promise'
@@ -68,7 +68,7 @@ export const useMainStore = defineStore('main', () => {
         supabase.auth.signOut()
       }, 300)
     })
-    await unspoofUser()
+    clearSpoof()
   }
 
   const getTotalStats: () => TotalStats = () => {

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -53,14 +53,14 @@ export const useMainStore = defineStore('main', () => {
     return new Promise<void>((resolve) => {
       const supabase = useSupabase()
       const config = getLocalConfig()
-      const listener = supabase.auth.onAuthStateChange((event: any) => {
+      const listener = supabase.auth.onAuthStateChange(async (event: any) => {
         if (event === 'SIGNED_OUT') {
           listener.data.subscription.unsubscribe()
           auth.value = undefined
           user.value = undefined
           isAdmin.value = false
           reset(config.supaHost)
-          unspoofUser()
+          await unspoofUser()
           resolve()
         }
       })

--- a/supabase/functions/_backend/private/sso/check-enforcement.ts
+++ b/supabase/functions/_backend/private/sso/check-enforcement.ts
@@ -1,7 +1,13 @@
 import { createHono, getClaimsFromJWT, middlewareAuth, parseBody, quickError, useCors } from '../../utils/hono.ts'
 import { cloudlog } from '../../utils/logging.ts'
-import { supabaseWithAuth } from '../../utils/supabase.ts'
+import { supabaseClient, supabaseWithAuth } from '../../utils/supabase.ts'
 import { version } from '../../utils/version.ts'
+
+const SPOOF_ADMIN_AUTHORIZATION_HEADER = 'x-capgo-spoof-admin-authorization'
+
+function toBearerAuthorization(authorization: string) {
+  return authorization.startsWith('Bearer ') ? authorization : `Bearer ${authorization}`
+}
 
 export const app = createHono('', version)
 
@@ -86,6 +92,33 @@ app.post('/', middlewareAuth, async (c) => {
     if (!enforcementRow.enforce_sso) {
       cloudlog({ requestId, context: 'check_enforcement - SSO not enforced', domain })
       return c.json({ allowed: true })
+    }
+    // Support impersonation may bypass SSO only when a separate non-target JWT still validates as a platform admin.
+
+    const spoofAdminAuthorization = c.req.header(SPOOF_ADMIN_AUTHORIZATION_HEADER)
+    if (spoofAdminAuthorization) {
+      const adminAuthorization = toBearerAuthorization(spoofAdminAuthorization)
+      const adminClaims = await getClaimsFromJWT(c, adminAuthorization)
+      const adminUserId = adminClaims?.sub
+
+      if (!adminUserId) {
+        cloudlog({ requestId, context: 'check_enforcement - invalid spoof admin token', orgId, userId })
+      }
+      else if (adminUserId === userId) {
+        cloudlog({ requestId, context: 'check_enforcement - spoof admin token matches target user', orgId, userId })
+      }
+      else {
+        const adminSupabase = supabaseClient(c, adminAuthorization)
+        const { data: isPlatformAdmin, error: platformAdminError } = await (adminSupabase.rpc as any)('is_platform_admin')
+
+        if (platformAdminError) {
+          cloudlog({ requestId, context: 'check_enforcement - spoof admin check error', error: platformAdminError.message, orgId, userId, adminUserId })
+        }
+        else if (isPlatformAdmin) {
+          cloudlog({ requestId, context: 'check_enforcement - platform admin impersonation bypass', email, orgId, adminUserId })
+          return c.json({ allowed: true })
+        }
+      }
     }
 
     // SSO is enforced - check RBAC super-admin-only permission for break-glass bypass

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -103,7 +103,7 @@ export interface MiddlewareKeyVariables {
 
 export const useCors = cors({
   origin: '*',
-  allowHeaders: ['Content-Type', 'Authorization', 'capgkey', 'capgo_api', 'x-api-key', 'x-limited-key-id', 'apisecret', 'apikey', 'x-client-info'],
+  allowHeaders: ['Content-Type', 'Authorization', 'X-Capgo-Spoof-Admin-Authorization', 'capgkey', 'capgo_api', 'x-api-key', 'x-limited-key-id', 'apisecret', 'apikey', 'x-client-info'],
   allowMethods: ['POST', 'GET', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 })
 

--- a/tests/main-dashboard-range.unit.test.ts
+++ b/tests/main-dashboard-range.unit.test.ts
@@ -16,7 +16,7 @@ vi.mock('~/services/supabase', () => ({
   getLocalConfig: () => ({ supaHost: 'https://supabase.capgo.test' }),
   getTotalStorage: mockGetTotalStorage,
   normalizeDashboardDateRange: mockNormalizeDashboardDateRange,
-  unspoofUser: vi.fn(),
+  clearSpoof: vi.fn(),
   useSupabase: () => ({
     auth: {
       onAuthStateChange: vi.fn(() => ({

--- a/tests/sso-enforcement-redirect.unit.test.ts
+++ b/tests/sso-enforcement-redirect.unit.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetSession = vi.fn()
 const mockSignOut = vi.fn()
+const mockGetSpoofedAdminJwt = vi.fn()
 
 vi.mock('~/services/supabase', () => ({
   defaultApiHost: 'https://api.capgo.test',
+  getSpoofedAdminJwt: mockGetSpoofedAdminJwt,
   useSupabase: () => ({
     auth: {
       getSession: mockGetSession,
@@ -67,6 +69,7 @@ describe('sso enforcement redirect handling', () => {
         },
       },
     })
+    mockGetSpoofedAdminJwt.mockReturnValue(null)
     mockSignOut.mockResolvedValue({ error: null })
   })
 
@@ -98,5 +101,27 @@ describe('sso enforcement redirect handling', () => {
 
     expect(mockSignOut).toHaveBeenCalledOnce()
     expect(next).toHaveBeenCalledWith('/login?sso_required=true')
+  })
+
+  it('sends the stored admin token for backend-verified impersonation bypass', async () => {
+    mockGetSpoofedAdminJwt.mockReturnValue('admin-token-456')
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ allowed: true }),
+    } as unknown as Response)
+
+    const guard = await getGuard()
+    const next = vi.fn()
+
+    await guard({ path: '/dashboard' }, { path: '/login' }, next)
+
+    expect(fetch).toHaveBeenCalledWith('https://api.capgo.test/private/sso/check-enforcement', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Authorization': 'Bearer token-123',
+        'X-Capgo-Spoof-Admin-Authorization': 'Bearer admin-token-456',
+      }),
+    }))
+    expect(mockSignOut).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith()
   })
 })

--- a/tests/sso-enforcement-redirect.unit.test.ts
+++ b/tests/sso-enforcement-redirect.unit.test.ts
@@ -124,4 +124,29 @@ describe('sso enforcement redirect handling', () => {
     expect(mockSignOut).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalledWith()
   })
+
+  it('does not cache allow decisions from impersonation proof for later password checks', async () => {
+    mockGetSpoofedAdminJwt.mockReturnValueOnce('admin-token-456').mockReturnValueOnce(null)
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ allowed: true }),
+    } as unknown as Response)
+
+    const guard = await getGuard()
+
+    await guard({ path: '/dashboard' }, { path: '/login' }, vi.fn())
+    await guard({ path: '/dashboard' }, { path: '/login' }, vi.fn())
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenNthCalledWith(1, 'https://api.capgo.test/private/sso/check-enforcement', expect.objectContaining({
+      headers: expect.objectContaining({
+        'X-Capgo-Spoof-Admin-Authorization': 'Bearer admin-token-456',
+      }),
+    }))
+    expect(fetch).toHaveBeenNthCalledWith(2, 'https://api.capgo.test/private/sso/check-enforcement', expect.objectContaining({
+      headers: expect.not.objectContaining({
+        'X-Capgo-Spoof-Admin-Authorization': expect.any(String),
+      }),
+    }))
+  })
 })

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { fetchWithRetry, getAuthHeaders, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, USER_ADMIN_EMAIL, USER_ID } from './test-utils.ts'
+import { fetchWithRetry, getAuthHeaders, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, USER_ADMIN_EMAIL, USER_EMAIL_NONMEMBER, USER_ID, USER_PASSWORD_NONMEMBER } from './test-utils.ts'
 
 const SSO_TEST_ORG_ID = randomUUID()
 const SSO_TEST_CUSTOMER_ID = `cus_sso_test_${randomUUID()}`
@@ -317,6 +317,28 @@ describe('[POST] /private/sso/check-enforcement', () => {
         headers: {
           ...targetAuthHeaders,
           'X-Capgo-Spoof-Admin-Authorization': targetAuthHeaders.Authorization,
+        },
+        body: JSON.stringify({
+          email: 'ignored@example.com',
+          auth_type: 'password',
+        }),
+      })
+
+      expect(response.status).toBe(200)
+      const data = await response.json() as { allowed: boolean, reason?: string }
+      expect(data).toEqual({ allowed: false, reason: 'sso_enforced' })
+    })
+  })
+
+  it.concurrent('should not allow a different non-admin token to bypass SSO enforcement as spoof proof', async () => {
+    await withEnforcedSsoPasswordUser(async ({ targetAuthHeaders }) => {
+      const nonAdminHeaders = await getAuthHeadersForCredentials(USER_EMAIL_NONMEMBER, USER_PASSWORD_NONMEMBER)
+
+      const response = await fetchWithRetry(getEndpointUrl('/private/sso/check-enforcement'), {
+        method: 'POST',
+        headers: {
+          ...targetAuthHeaders,
+          'X-Capgo-Spoof-Admin-Authorization': nonAdminHeaders.Authorization,
         },
         body: JSON.stringify({
           email: 'ignored@example.com',

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { fetchWithRetry, getAuthHeaders, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, USER_ID } from './test-utils.ts'
+import { fetchWithRetry, getAuthHeaders, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, USER_ADMIN_EMAIL, USER_ID } from './test-utils.ts'
 
 const SSO_TEST_ORG_ID = randomUUID()
 const SSO_TEST_CUSTOMER_ID = `cus_sso_test_${randomUUID()}`
@@ -42,6 +42,71 @@ beforeAll(async () => {
     throw orgUserError
 })
 
+async function withEnforcedSsoPasswordUser(callback: (context: { targetAuthHeaders: Record<string, string>, email: string }) => Promise<void>) {
+  const enforcementOrgId = randomUUID()
+  const enforcementCustomerId = `cus_sso_impersonation_${randomUUID()}`
+  const providerId = randomUUID()
+  const externalProviderId = randomUUID()
+  const domain = `${randomUUID()}.sso.test`
+  const email = `impersonated-user@${domain}`
+  const password = 'testtest'
+
+  const { data: createdUser, error: createUserError } = await getSupabaseClient().auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  })
+  if (createUserError || !createdUser.user)
+    throw createUserError ?? new Error('Failed to create dedicated SSO impersonation auth user')
+
+  try {
+    const { error: stripeError } = await getSupabaseClient().from('stripe_info').insert({
+      customer_id: enforcementCustomerId,
+      status: 'succeeded',
+      product_id: 'prod_LQIregjtNduh4q',
+      subscription_id: `sub_sso_impersonation_${randomUUID()}`,
+      trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+      is_good_plan: true,
+    })
+    if (stripeError)
+      throw stripeError
+
+    const { error: orgError } = await getSupabaseClient().from('orgs').insert({
+      id: enforcementOrgId,
+      name: `SSO Impersonation Org ${enforcementOrgId}`,
+      management_email: `sso-impersonation-${enforcementOrgId}@capgo.app`,
+      created_by: USER_ID,
+      customer_id: enforcementCustomerId,
+    })
+    if (orgError)
+      throw orgError
+
+    const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+      id: providerId,
+      org_id: enforcementOrgId,
+      domain,
+      provider_id: externalProviderId,
+      status: 'active',
+      enforce_sso: true,
+      dns_verification_token: `dns-${randomUUID()}`,
+    })
+    if (providerError)
+      throw providerError
+
+    const targetAuthHeaders = await getAuthHeadersForCredentials(email, password)
+    await callback({ targetAuthHeaders, email })
+  }
+  finally {
+    await Promise.allSettled([
+      (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
+      getSupabaseClient().from('orgs').delete().eq('id', enforcementOrgId),
+      getSupabaseClient().from('stripe_info').delete().eq('customer_id', enforcementCustomerId),
+      getSupabaseClient().auth.admin.deleteUser(createdUser.user.id),
+    ])
+  }
+}
+
+// Keep shared SSO suite fixture cleanup separate from per-test random SSO fixtures.
 afterAll(async () => {
   await getSupabaseClient().from('org_users').delete().eq('org_id', SSO_TEST_ORG_ID)
   await getSupabaseClient().from('orgs').delete().eq('id', SSO_TEST_ORG_ID)
@@ -221,6 +286,48 @@ describe('[POST] /private/sso/check-enforcement', () => {
     expect(response.status).toBe(200)
     const data = await response.json() as { allowed: boolean }
     expect(data.allowed).toBe(true)
+  })
+
+  it.concurrent('should allow platform admin impersonation when SSO is enforced', async () => {
+    await withEnforcedSsoPasswordUser(async ({ targetAuthHeaders }) => {
+      const adminHeaders = await getAuthHeadersForCredentials(USER_ADMIN_EMAIL, 'adminadmin')
+
+      const response = await fetchWithRetry(getEndpointUrl('/private/sso/check-enforcement'), {
+        method: 'POST',
+        headers: {
+          ...targetAuthHeaders,
+          'X-Capgo-Spoof-Admin-Authorization': adminHeaders.Authorization,
+        },
+        body: JSON.stringify({
+          email: 'ignored@example.com',
+          auth_type: 'password',
+        }),
+      })
+
+      expect(response.status).toBe(200)
+      const data = await response.json() as { allowed: boolean }
+      expect(data.allowed).toBe(true)
+    })
+  })
+
+  it.concurrent('should not allow a user token to bypass SSO enforcement as spoof proof', async () => {
+    await withEnforcedSsoPasswordUser(async ({ targetAuthHeaders }) => {
+      const response = await fetchWithRetry(getEndpointUrl('/private/sso/check-enforcement'), {
+        method: 'POST',
+        headers: {
+          ...targetAuthHeaders,
+          'X-Capgo-Spoof-Admin-Authorization': targetAuthHeaders.Authorization,
+        },
+        body: JSON.stringify({
+          email: 'ignored@example.com',
+          auth_type: 'password',
+        }),
+      })
+
+      expect(response.status).toBe(200)
+      const data = await response.json() as { allowed: boolean, reason?: string }
+      expect(data).toEqual({ allowed: false, reason: 'sso_enforced' })
+    })
   })
 
   it.concurrent('should ignore malformed provider entries in JWT app metadata', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Forward the stored platform-admin session token during spoofed SSO enforcement checks.
- Validate that token server-side with `is_platform_admin()` before allowing an impersonated password session through SSO enforcement.
- Add CORS support and regression coverage for platform-admin impersonation and forged user-token bypass attempts.

## Motivation (AI generated)

Platform-admin impersonation currently receives a normal target-user Supabase session. When the target belongs to an org with SSO enforcement, the route guard treats that session as a password login and signs it out. A frontend-only skip would be forgeable, so the bypass has to be proven by the backend.

## Business Impact (AI generated)

Support/admin users can safely impersonate users in SSO-enforced orgs without being logged out, preserving support workflows for enterprise customers while keeping normal SSO enforcement intact for non-admin sessions.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun run lint:backend`
- [x] `bunx vitest run tests/sso-enforcement-redirect.unit.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/sso.test.ts`
- [x] `bun run typecheck:frontend`
- [x] Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin impersonation for SSO enforcement: platform admins can present an authorized header to perform validated impersonation checks.

* **Improvements**
  * Extended allowed API request headers for authentication flows.
  * More reliable sign-out/unspoof sequencing to ensure session state is consistent.

* **Tests**
  * Added end-to-end and unit tests covering admin impersonation and SSO enforcement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->