### PR TITLE
chore(api): log R2 size lookup diagnostics

### DIFF
--- a/supabase/functions/_backend/triggers/on_manifest_create.ts
+++ b/supabase/functions/_backend/triggers/on_manifest_create.ts
@@ -29,18 +29,17 @@ function getQueueLogMetadata(c: Context): QueueLogMetadata {
     cfId: c.req.header('x-capgo-cf-id') ?? null,
   }
 }
-
-async function getManifestSizeWithRetry(c: Context, s3Path: string): Promise<{ size: number, lastError?: unknown, attempts: number }> {
+async function getManifestSizeWithRetry(c: Context, s3Path: string): Promise<{ diagnostics?: Awaited<ReturnType<typeof s3.getSizeDiagnostics>>, lastError?: unknown, attempts: number }> {
   const { result, lastError, attempts } = await retryWithBackoff(
-    () => s3.getSize(c, s3Path),
+    () => s3.getSizeDiagnostics(c, s3Path),
     {
       attempts: SIZE_RETRY_ATTEMPTS,
       baseDelayMs: SIZE_RETRY_DELAY_MS,
-      shouldRetry: size => size <= 0,
+      shouldRetry: diagnostics => diagnostics.size <= 0,
     },
   )
 
-  return { attempts, size: typeof result === 'number' ? result : 0, lastError }
+  return { attempts, diagnostics: result, lastError }
 }
 
 function shouldRetryManifestSizeLookup(size: number, currentFileSize: number | null | undefined): boolean {
@@ -92,17 +91,18 @@ export async function updateManifestSize(c: Context, record: Database['public'][
     throw simpleError('no_s3_path', 'No s3 path', { record })
   }
 
-  const { size, lastError, attempts } = await getManifestSizeWithRetry(c, record.s3_path)
+  const { diagnostics, lastError, attempts } = await getManifestSizeWithRetry(c, record.s3_path)
+  const size = diagnostics?.size ?? 0
   if (lastError) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'getSize failed after retries', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, attempts, queue, error: lastError })
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getSize failed after retries', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, attempts, queue, error: lastError, storageDiagnostics: diagnostics })
   }
   if (shouldRetryManifestSizeLookup(size, record.file_size)) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'getSize returned 0 after retries', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, attempts, queue })
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getSize returned 0 after retries', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, attempts, queue, storageDiagnostics: diagnostics })
     // Return non-2xx so queue_consumer keeps the message and applies its 5-read retry budget.
-    throw quickError(503, 'manifest_size_not_found', 'Manifest file size metadata was not found', { attempts, file_name: record.file_name, id: record.id, queue, s3_path: record.s3_path }, lastError, { alert: false })
+    throw quickError(503, 'manifest_size_not_found', 'Manifest file size metadata was not found', { attempts, file_name: record.file_name, id: record.id, queue, s3_path: record.s3_path, storageDiagnostics: diagnostics }, lastError, { alert: false })
   }
   if (size <= 0) {
-    cloudlog({ requestId: c.get('requestId'), message: 'getSize returned 0, keeping existing file_size', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, file_size: record.file_size, attempts, queue })
+    cloudlog({ requestId: c.get('requestId'), message: 'getSize returned 0, keeping existing file_size', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, file_size: record.file_size, attempts, queue, storageDiagnostics: diagnostics })
     return c.json(BRES)
   }
 
@@ -111,10 +111,10 @@ export async function updateManifestSize(c: Context, record: Database['public'][
       .from('manifest')
       .update({ file_size: size })
       .eq('id', record.id))
-    cloudlog({ requestId: c.get('requestId'), message: 'manifest file_size updated', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, size, attempts, queue })
+    cloudlog({ requestId: c.get('requestId'), message: 'manifest file_size updated', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, size, attempts, queue, selectedCandidateKey: diagnostics?.selectedCandidateKey })
   }
   catch (updateError) {
-    cloudlog({ requestId: c.get('requestId'), message: 'error update manifest size', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, size, attempts, queue, error: updateError })
+    cloudlog({ requestId: c.get('requestId'), message: 'error update manifest size', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, size, attempts, queue, error: updateError, storageDiagnostics: diagnostics })
     throw simpleError('manifest_update_failed', 'Failed to update manifest file_size', { record, updateError })
   }
 

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -64,6 +64,16 @@ function versionUpdateLogFields(
   }
 }
 
+function getMetadataBranch(storageProvider: string | null, resolvedR2Path: string | null) {
+  if (storageProvider === 'r2' && resolvedR2Path)
+    return 'r2_bundle_size'
+  if (storageProvider === 'r2')
+    return 'zero_metadata_r2_path_unavailable'
+  if (storageProvider === 'r2-direct')
+    return 'zero_metadata_r2_direct_not_finalized'
+  return 'zero_metadata_non_r2_storage'
+}
+
 /**
  * Handles v2 storage metadata updates (size/checksum/stats) for R2-backed bundles.
  *
@@ -77,7 +87,8 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
     resolved_r2_path: v2Path,
   })
 
-  const size = await s3.getSize(c, v2Path)
+  const diagnostics = await s3.getSizeDiagnostics(c, v2Path)
+  const size = diagnostics.size
   if (!size) {
     cloudlog({
       requestId: c.get('requestId'),
@@ -85,6 +96,7 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
       ...versionUpdateLogFields(record),
       resolved_r2_path: v2Path,
       size,
+      storageDiagnostics: diagnostics,
     })
     return true
   }
@@ -94,6 +106,7 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
     message: 'on_version_update resolved bundle size',
     ...versionUpdateLogFields(record),
     resolved_r2_path: v2Path,
+    selectedCandidateKey: diagnostics.selectedCandidateKey,
     size,
   })
 
@@ -204,7 +217,7 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
  */
 async function updateIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   const v2Path = await getPath(c, record)
-  const metadataBranch = v2Path && record.storage_provider === 'r2' ? 'r2_bundle_size' : 'zero_metadata'
+  const metadataBranch = getMetadataBranch(record.storage_provider, v2Path)
   cloudlog({
     requestId: c.get('requestId'),
     message: 'on_version_update metadata branch selected',
@@ -213,13 +226,13 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
     resolved_r2_path: v2Path,
   })
 
-  if (v2Path && record.storage_provider === 'r2') {
+  if (metadataBranch === 'r2_bundle_size' && v2Path) {
     const shouldContinue = await v2PathSize(c, record, v2Path)
     if (!shouldContinue)
       return c.json(BRES)
   }
   else {
-    cloudlog({ requestId: c.get('requestId'), message: 'no v2 path', ...versionUpdateLogFields(record), resolved_r2_path: v2Path })
+    cloudlog({ requestId: c.get('requestId'), message: 'on_version_update zero metadata branch selected', ...versionUpdateLogFields(record), metadataBranch, resolved_r2_path: v2Path })
     const ownerOrg = await resolveOwnerOrg(c, record)
     if (!ownerOrg) {
       cloudlog({ requestId: c.get('requestId'), message: 'missing owner_org for app_versions_meta upsert', id: record.id, app_id: record.app_id })
@@ -238,10 +251,10 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
       })
       .eq('id', record.id)
     if (errorUpdate) {
-      cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate, ...versionUpdateLogFields(record), size: 0 })
+      cloudlog({ requestId: c.get('requestId'), message: 'errorUpdate', error: errorUpdate, ...versionUpdateLogFields(record), metadataBranch, size: 0 })
     }
     else {
-      cloudlog({ requestId: c.get('requestId'), message: 'app_versions_meta zero size upserted', ...versionUpdateLogFields(record), owner_org: ownerOrg, size: 0 })
+      cloudlog({ requestId: c.get('requestId'), message: 'app_versions_meta zero size upserted', ...versionUpdateLogFields(record), metadataBranch, owner_org: ownerOrg, size: 0 })
     }
   }
 

--- a/supabase/functions/_backend/utils/s3.ts
+++ b/supabase/functions/_backend/utils/s3.ts
@@ -273,12 +273,45 @@ function serializeStorageError(error: unknown) {
   }
 }
 
+interface SizeRangeDiagnostic {
+  contentLength?: string | null
+  contentRange?: string | null
+  error?: ReturnType<typeof serializeStorageError>
+  reason: 'head_error' | 'missing_head_size'
+  size: number
+  status?: number
+  statusText?: string
+}
+
+interface SizeKeyDiagnostic {
+  fileId: string
+  finalSize: number
+  head: {
+    error?: ReturnType<typeof serializeStorageError>
+    rawSize?: unknown
+    size: number
+    success: boolean
+  }
+  range?: SizeRangeDiagnostic
+  usedFallback: boolean
+}
+
+export interface StorageSizeDiagnostics {
+  bucket: string
+  candidateKeys: string[]
+  candidates: SizeKeyDiagnostic[]
+  endpoint: string
+  fileId: string
+  selectedCandidateKey: string | null
+  size: number
+}
+
 async function getSizeFromRangeFallback(
   c: Context,
   client: ReturnType<typeof initS3>,
   fileId: string,
   reason: 'head_error' | 'missing_head_size',
-): Promise<number> {
+): Promise<SizeRangeDiagnostic> {
   try {
     const url = await client.getPresignedUrl('GET', fileId, {
       parameters: { 'x-id': 'GetObject' },
@@ -295,18 +328,14 @@ async function getSizeFromRangeFallback(
     const contentLength = res.headers.get('content-length') || res.headers.get('Content-Length')
     if (!res.ok) {
       await res.body?.cancel()
+      const diagnostic = { contentLength, contentRange, reason, size: 0, status: res.status, statusText: res.statusText }
       cloudlog({
         requestId: c.get('requestId'),
         message: 'getSize range fallback returned non-success response',
         fileId,
-        reason,
-        status: res.status,
-        statusText: res.statusText,
-        contentRange,
-        contentLength,
-        size: 0,
+        ...diagnostic,
       })
-      return 0
+      return diagnostic
     }
 
     const size = res.status === 206 && contentRange
@@ -316,43 +345,46 @@ async function getSizeFromRangeFallback(
         : 0
     await res.body?.cancel()
 
+    const diagnostic = { contentLength, contentRange, reason, size, status: res.status, statusText: res.statusText }
     cloudlog({
       requestId: c.get('requestId'),
       message: 'getSize range fallback result',
       fileId,
-      reason,
-      status: res.status,
-      statusText: res.statusText,
-      contentRange,
-      contentLength,
-      size,
+      ...diagnostic,
     })
-    return size
+    return diagnostic
   }
   catch (fallbackError) {
+    const diagnostic = { error: serializeStorageError(fallbackError), reason, size: 0 }
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'getSize range fallback failed',
       fileId,
-      reason,
-      error: serializeStorageError(fallbackError),
+      ...diagnostic,
       bucket: getEnv(c, 'S3_BUCKET'),
       endpoint: getEnv(c, 'S3_ENDPOINT'),
     })
-    return 0
+    return diagnostic
   }
 }
 
-async function getSizeForKey(c: Context, client: ReturnType<typeof initS3>, fileId: string) {
+async function getSizeForKey(c: Context, client: ReturnType<typeof initS3>, fileId: string): Promise<SizeKeyDiagnostic> {
   let size = 0
   let headError: unknown
-  let usedFallback = false
+  const diagnostic: SizeKeyDiagnostic = {
+    fileId,
+    finalSize: 0,
+    head: { size: 0, success: false },
+    usedFallback: false,
+  }
+
   try {
     // Ask Cloudflare/R2 for the raw object (no brotli/gzip) so Content-Length is preserved.
     const file = await client.statObject(fileId, {
       headers: { 'Accept-Encoding': 'identity' },
     })
     size = Number.isFinite(file.size) ? file.size : 0
+    diagnostic.head = { rawSize: file.size, size, success: true }
     cloudlog({
       requestId: c.get('requestId'),
       message: 'getSize head result',
@@ -365,21 +397,24 @@ async function getSizeForKey(c: Context, client: ReturnType<typeof initS3>, file
   }
   catch (error) {
     headError = error
+    diagnostic.head = { error: serializeStorageError(error), size: 0, success: false }
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'getSize head failed',
       fileId,
-      error: serializeStorageError(error),
+      error: diagnostic.head.error,
       bucket: getEnv(c, 'S3_BUCKET'),
       endpoint: getEnv(c, 'S3_ENDPOINT'),
     })
   }
 
   if (!size) {
-    usedFallback = true
-    size = await getSizeFromRangeFallback(c, client, fileId, headError ? 'head_error' : 'missing_head_size')
+    diagnostic.usedFallback = true
+    diagnostic.range = await getSizeFromRangeFallback(c, client, fileId, headError ? 'head_error' : 'missing_head_size')
+    size = diagnostic.range.size
   }
 
+  diagnostic.finalSize = size
   cloudlog({
     requestId: c.get('requestId'),
     message: 'getSize final',
@@ -387,18 +422,32 @@ async function getSizeForKey(c: Context, client: ReturnType<typeof initS3>, file
     bucket: getEnv(c, 'S3_BUCKET'),
     endpoint: getEnv(c, 'S3_ENDPOINT'),
     finalSize: size,
-    usedFallback,
+    usedFallback: diagnostic.usedFallback,
+    head: diagnostic.head,
+    range: diagnostic.range,
   })
-  return size
+  return diagnostic
 }
 
-async function getSize(c: Context, fileId: string) {
+async function getSizeDiagnostics(c: Context, fileId: string): Promise<StorageSizeDiagnostics> {
   const client = initS3(c)
   const candidateKeys = getManifestStorageCandidateKeys(fileId)
+  const diagnostics: StorageSizeDiagnostics = {
+    bucket: getEnv(c, 'S3_BUCKET'),
+    candidateKeys,
+    candidates: [],
+    endpoint: getEnv(c, 'S3_ENDPOINT'),
+    fileId,
+    selectedCandidateKey: null,
+    size: 0,
+  }
 
   for (const candidateKey of candidateKeys) {
-    const size = await getSizeForKey(c, client, candidateKey)
-    if (size > 0) {
+    const candidate = await getSizeForKey(c, client, candidateKey)
+    diagnostics.candidates.push(candidate)
+    if (candidate.finalSize > 0) {
+      diagnostics.selectedCandidateKey = candidateKey
+      diagnostics.size = candidate.finalSize
       if (candidateKey !== fileId) {
         cloudlog({
           requestId: c.get('requestId'),
@@ -406,25 +455,25 @@ async function getSize(c: Context, fileId: string) {
           fileId,
           candidateKey,
           candidateKeys,
-          size,
+          size: candidate.finalSize,
         })
       }
-      return size
+      return diagnostics
     }
   }
 
-  if (candidateKeys.length > 1) {
-    cloudlogErr({
-      requestId: c.get('requestId'),
-      message: 'getSize failed all manifest storage candidates',
-      fileId,
-      candidateKeys,
-      bucket: getEnv(c, 'S3_BUCKET'),
-      endpoint: getEnv(c, 'S3_ENDPOINT'),
-    })
-  }
+  cloudlogErr({
+    requestId: c.get('requestId'),
+    message: 'getSize exhausted storage candidates',
+    ...diagnostics,
+  })
 
-  return 0
+  return diagnostics
+}
+
+async function getSize(c: Context, fileId: string) {
+  const diagnostics = await getSizeDiagnostics(c, fileId)
+  return diagnostics.size
 }
 
 async function getObject(c: Context, fileId: string): Promise<Response | null> {
@@ -449,6 +498,7 @@ async function getObject(c: Context, fileId: string): Promise<Response | null> {
 export const s3 = {
   getSize,
   deleteObject,
+  getSizeDiagnostics,
   moveObjectToTrash,
   deleteObjectsWithPrefix,
   checkIfExist,


### PR DESCRIPTION
## Summary
- Adds structured R2 size lookup diagnostics that record every candidate key, HEAD result, range fallback result, selected key, and final size.
- Includes those diagnostics in manifest queue retry logs and `manifest_size_not_found` responses.
- Adds explicit app-version metadata branch logs so zero-size metadata records say whether the trigger saw `r2`, `r2-direct`, missing/unavailable R2 path, or non-R2 storage.

## Motivation
Cloudflare Workers Observability was queried for the current production failure strings over the last 7 days on June 11, 2026. The queries returned 0 matches for `getSize returned 0 after retries`, `manifest_size_not_found`, `getSize failed all manifest storage candidates`, `getSize head failed`, `no size found for r2_path`, and `app_versions_meta zero size upserted`.

That means the exact production cause is not identifiable from retained logs right now. This PR deliberately does not guess at a root-cause fix. It makes the next occurrence identifiable from the logs.

## Business Impact
This prevents another ambiguous storage-size incident. Support and engineering will be able to distinguish missing R2 object, encoded-key mismatch, HEAD metadata anomaly, range fallback failure, `r2-direct` not finalized, or unavailable `r2_path` from one log payload instead of relying on inference.

## Test Plan
- [x] `bun lint:backend`
- [x] `bun run typecheck:backend`
- [x] pre-commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- [x] `bunx vitest run tests/backend-alert-resilience.unit.test.ts --reporter=verbose --pool=forks`
- [ ] CI

## AI-generated-by
Codex
