### PR TITLE
[codex] Hide external purchase flows in native app

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1651,6 +1651,7 @@
   "plan-distribution-trend": "Plan Distribution Trend",
   "plan-failed": "Plan failed, please verify your card details",
   "plan-failed-description": "Your Capgo subscription is inactive or has expired. To resume updates and dashboard access, please upgrade your plan.",
+  "plan-failed-native-description": "Your Capgo subscription is inactive or has expired. Some dashboard features are unavailable until billing is resolved.",
   "plan-feature-community-support-discord": "Community support (Discord)",
   "plan-feature-custom-domain": "Custom domain",
   "plan-feature-direct-chat-support": "Direct chat support",

--- a/src/components/Banner.vue
+++ b/src/components/Banner.vue
@@ -46,6 +46,7 @@ watchEffect(async () => {
 })
 
 const isMobile = Capacitor.isNativePlatform()
+const billingCtaHref = computed(() => isMobile ? '/settings/organization/usage' : '/settings/organization/plans')
 
 // Check if user lacks security compliance (2FA or password) - data is unreliable in this case
 const lacksSecurityAccess = computed(() => {
@@ -143,7 +144,7 @@ const bannerColor = computed(() => {
     <span class="text-xs font-semibold sm:text-sm text-slate-800 dark:text-slate-200">
       {{ bannerText }}
     </span>
-    <a href="/settings/organization/plans" class="border-none d-btn d-btn-xs sm:d-btn-sm" :class="bannerColor">
+    <a :href="billingCtaHref" class="border-none d-btn d-btn-xs sm:d-btn-sm" :class="bannerColor">
       {{ isMobile ? t('see-usage') : t('upgrade') }}
     </a>
   </div>
@@ -154,6 +155,6 @@ const bannerColor = computed(() => {
       {{ bannerLeftText }}:
     </span>
     <span class="text-xs font-medium text-black sm:text-base dark:text-white">{{ bannerText }}</span>
-    <a href="/settings/organization/plans" class="ml-2 whitespace-nowrap border-none d-btn d-btn-xs sm:d-btn-sm" :class="bannerColor">{{ isMobile ? t('see-usage') : t('upgrade') }}</a>
+    <a :href="billingCtaHref" class="ml-2 whitespace-nowrap border-none d-btn d-btn-xs sm:d-btn-sm" :class="bannerColor">{{ isMobile ? t('see-usage') : t('upgrade') }}</a>
   </div>
 </template>

--- a/src/components/FailedCard.vue
+++ b/src/components/FailedCard.vue
@@ -3,12 +3,14 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { useOrganizationStore } from '~/stores/organization'
 
 const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const organizationStore = useOrganizationStore()
+const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 // Password policy takes priority over subscription
 const needsPasswordUpdate = computed(() => {
@@ -137,9 +139,9 @@ async function copyOrgId() {
           {{ t('subscription-required') }}
         </h3>
         <div class="mt-3 text-base text-red-700">
-          <p>{{ t('plan-failed-description') }}</p>
+          <p>{{ t(hideExternalPurchaseFlows ? 'plan-failed-native-description' : 'plan-failed-description') }}</p>
         </div>
-        <div class="mt-6">
+        <div v-if="!hideExternalPurchaseFlows" class="mt-6">
           <button
             class="py-3 px-8 text-base font-semibold text-white bg-red-600 rounded-lg shadow-md transition-colors duration-200 hover:bg-red-700 hover:shadow-lg focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:outline-none"
             @click="goToPlans"

--- a/src/components/PaymentRequiredModal.vue
+++ b/src/components/PaymentRequiredModal.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 
 const { t } = useI18n()
 const router = useRouter()
+const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 function goToPlans() {
   router.push('/settings/organization/plans')
@@ -28,9 +30,10 @@ function goToPlans() {
         {{ t('subscription-required') }}
       </h2>
       <p class="mb-6 max-w-sm text-gray-600 dark:text-gray-400">
-        {{ t('plan-failed-description') }}
+        {{ t(hideExternalPurchaseFlows ? 'plan-failed-native-description' : 'plan-failed-description') }}
       </p>
       <button
+        v-if="!hideExternalPurchaseFlows"
         class="inline-flex gap-2 items-center px-6 py-3 text-white bg-amber-500 rounded-lg transition-colors cursor-pointer hover:bg-amber-600 focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:outline-none"
         @click="goToPlans"
       >

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import IconSettings from '~icons/lucide/settings'
 import IconDown from '~icons/material-symbols/keyboard-arrow-down-rounded'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { resolveImagePath } from '~/services/storage'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -26,6 +27,7 @@ const dropdown = useTemplateRef('dropdown')
 const hasVisibleOrganizations = computed(() => organizationStore.organizations.length > 0)
 const currentLabel = computed(() => currentOrganization.value?.name ?? t('select-organization'))
 const invitationCount = computed(() => organizationStore.organizations.filter(org => org.role.startsWith('invite')).length)
+const canCreateOrganizationInContext = !isNativeAppStoreContext()
 const ORGANIZATION_LOGO_REFRESH_INTERVAL_MS = 10 * 60 * 1000
 const isRefreshingBrokenLogos = ref(false)
 const lastOrganizationLogoRefreshAt = ref(0)
@@ -237,6 +239,9 @@ function onOrganizationClick(org: Organization) {
 }
 
 async function createNewOrg() {
+  if (!canCreateOrganizationInContext)
+    return
+
   closeDropdown()
   await router.push({
     path: '/onboarding/organization',
@@ -426,7 +431,7 @@ watch(
             </div>
           </li>
         </ul>
-        <div class="p-2 border-t border-gray-700">
+        <div v-if="canCreateOrganizationInContext" class="p-2 border-t border-gray-700">
           <div class="block p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
             <a
               class="flex justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
@@ -437,10 +442,13 @@ watch(
         </div>
       </div>
     </details>
-    <div v-else class="p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
+    <div v-else-if="canCreateOrganizationInContext" class="p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
       <button class="block w-full text-white d-btn d-btn-outline bg-slate-800 d-btn-sm" @click="createNewOrg">
         {{ t('create-new-org') }}
       </button>
+    </div>
+    <div v-else class="rounded-lg border border-gray-700 bg-[#1a1d24] px-3 py-2 text-sm text-slate-300">
+      {{ t('select-organization') }}
     </div>
   </div>
 </template>

--- a/src/components/dashboard/TrialBanner.vue
+++ b/src/components/dashboard/TrialBanner.vue
@@ -15,6 +15,7 @@
 import type { ComponentPublicInstance } from 'vue'
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { pushEvent } from '~/services/posthog'
 import { getLocalConfig } from '~/services/supabase'
 import { useOrganizationStore } from '~/stores/organization'
@@ -32,6 +33,7 @@ const rightPupil = ref({ x: 0, y: 0 })
 
 const currentOrg = computed(() => organizationStore.currentOrganization)
 const config = getLocalConfig()
+const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 function trackBannerEvent(eventName: string) {
   const org = currentOrg.value
@@ -73,7 +75,7 @@ const hasApps = computed(() => {
 })
 
 const showBanner = computed(() => {
-  return isTrial.value && isAccountOldEnough.value && hasApps.value
+  return !hideExternalPurchaseFlows && isTrial.value && isAccountOldEnough.value && hasApps.value
 })
 
 // Whether we need the time tick running — true when the account-age check

--- a/src/layouts/settings.vue
+++ b/src/layouts/settings.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import type { Tab } from '~/components/comp_def'
-import { Capacitor } from '@capacitor/core'
 import { computedAsync } from '@vueuse/core'
 import { computed, ref, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -13,6 +12,7 @@ import Tabs from '~/components/Tabs.vue'
 import { accountTabs } from '~/constants/accountTabs'
 import { organizationTabs as baseOrgTabs } from '~/constants/organizationTabs'
 import { settingsTabs } from '~/constants/settingsTabs'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { checkPermissions } from '~/services/permissions'
 import { openPortal } from '~/services/stripe'
 import { stripeEnabled } from '~/services/supabase'
@@ -22,6 +22,7 @@ const { t } = useI18n()
 const organizationStore = useOrganizationStore()
 const router = useRouter()
 const route = useRoute()
+const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 // Modal state for non-admin billing access (triggered by billing tab click)
 const showBillingModal = ref(false)
@@ -40,7 +41,19 @@ const shouldBlockContent = computed(() => {
 })
 
 // keep Tab icon typing (including ShallowRef) instead of Vue's UnwrapRef narrowing
-const organizationTabs = ref<Tab[]>([...baseOrgTabs]) as Ref<Tab[]>
+function withoutExternalPurchaseTabs(tabs: Tab[]) {
+  if (!hideExternalPurchaseFlows)
+    return tabs
+
+  const restrictedKeys = new Set([
+    '/billing',
+    '/settings/organization/credits',
+    '/settings/organization/plans',
+  ])
+  return tabs.filter(tab => !restrictedKeys.has(tab.key))
+}
+
+const organizationTabs = ref<Tab[]>(withoutExternalPurchaseTabs([...baseOrgTabs])) as Ref<Tab[]>
 
 const canReadBilling = computedAsync(async () => {
   const orgId = organizationStore.currentOrganization?.gid
@@ -93,16 +106,16 @@ const showAdminOnlyModal = computed(() => {
 })
 
 watchEffect(() => {
-  if (!stripeEnabled.value) {
+  if (!stripeEnabled.value || hideExternalPurchaseFlows) {
     const path = route.path.replace(/\/$/, '')
     const billingPaths = [
-      '/settings/organization/usage',
+      ...(hideExternalPurchaseFlows ? [] : ['/settings/organization/usage']),
       '/settings/organization/credits',
       '/settings/organization/plans',
       '/billing',
     ]
     if (billingPaths.some(p => path === p || path.startsWith(`${p}/`)))
-      router.replace('/settings/organization')
+      router.replace(hideExternalPurchaseFlows ? '/settings/organization/usage' : '/settings/organization')
   }
 })
 
@@ -132,7 +145,7 @@ watchEffect(() => {
   if (!needsUsage && hasUsage)
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/usage')
 
-  const needsCredits = billingEnabled && canUpdateBilling.value
+  const needsCredits = billingEnabled && canUpdateBilling.value && !hideExternalPurchaseFlows
   const hasCredits = organizationTabs.value.find(tab => tab.key === '/settings/organization/credits')
 
   if (needsCredits && !hasCredits) {
@@ -144,7 +157,7 @@ watchEffect(() => {
   if (!needsCredits && hasCredits)
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/credits')
 
-  const needsPlans = billingEnabled && canUpdateBilling.value
+  const needsPlans = billingEnabled && canUpdateBilling.value && !hideExternalPurchaseFlows
   const hasPlans = organizationTabs.value.find(tab => tab.key === '/settings/organization/plans')
   if (needsPlans && !hasPlans) {
     const base = baseOrgTabs.find(t => t.key === '/settings/organization/plans')
@@ -190,7 +203,7 @@ watchEffect(() => {
   })
 
   // Check billing access - users with org.read_billing permission can access billing
-  if (!Capacitor.isNativePlatform()
+  if (!hideExternalPurchaseFlows
     && billingEnabled
     && canReadBilling.value
     && !organizationTabs.value.find(tab => tab.key === '/billing')) {
@@ -209,7 +222,7 @@ watchEffect(() => {
       },
     })
   }
-  else if (!canReadBilling.value || !billingEnabled) {
+  else if (hideExternalPurchaseFlows || !canReadBilling.value || !billingEnabled) {
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/billing')
   }
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import { routes } from 'vue-router/auto-routes'
 import { installDeepLinkHandler } from '~/services/deepLinks'
+import { getNativeExternalPurchaseRedirect, isNativeAppStoreContext, isNativeExternalPurchaseRestrictedPath } from '~/services/nativeCompliance'
 import { posthogLoader } from '~/services/posthog'
 import { getErrorMessage, isKnownCrawlerNoiseErrorMessage, isStaleAssetErrorMessage } from '~/services/staleAssetErrors'
 import { getLocalConfig } from '~/services/supabase'
@@ -176,6 +177,10 @@ const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
 })
 router.beforeEach((to, from, next) => {
+  if (isNativeAppStoreContext() && isNativeExternalPurchaseRestrictedPath(to.path)) {
+    return next(getNativeExternalPurchaseRedirect(to.path))
+  }
+
   if (to.path.startsWith('/app/') && to.query.tab) {
     const tab = to.query.tab as string
     const newPath = to.path.endsWith('/') ? `${to.path}${tab}` : `${to.path}/${tab}`

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type { NavigationGuardNext, RouteLocationNormalized } from 'vue-router'
 import type { UserModule } from '~/types'
 import { hideLoader } from '~/services/loader'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { setUser } from '~/services/posthog'
 import { isSsoUser, provisionSsoUser } from '~/services/ssoProvisioning'
 import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
@@ -215,6 +216,8 @@ async function guard(
 
   function shouldRedirectToPendingInviteOnboarding(organizationsLoaded: boolean) {
     if (!organizationsLoaded)
+      return false
+    if (isNativeAppStoreContext())
       return false
     if (to.path.startsWith('/onboarding/invitation'))
       return false

--- a/src/pages/ApiKeys.vue
+++ b/src/pages/ApiKeys.vue
@@ -24,6 +24,7 @@ import {
   sortApiKeyRows,
 } from '~/services/apikeys'
 import { formatLocalDate } from '~/services/date'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { checkPermissions } from '~/services/permissions'
 import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -122,6 +123,7 @@ const expirationDate = ref<Date | null>(null)
 // RBAC creation state
 const selectedOrgRole = ref('org_member')
 const allowOrgCreation = ref(false)
+const hideOrgCreationPermission = isNativeAppStoreContext()
 const selectedOrgsForCreation = ref<string[]>([])
 const selectedOrgRolesById = ref<Record<string, string>>({})
 const isHydratingApiKeyEdit = ref(false)
@@ -734,7 +736,7 @@ function getOrgRoleForBinding(orgId: string) {
 }
 
 const canEnableOrgCreation = computed(() =>
-  selectedOrgsForCreation.value.some(orgId => rolesWithOrgCreateAccess.has(getOrgRoleForBinding(orgId))),
+  !hideOrgCreationPermission && selectedOrgsForCreation.value.some(orgId => rolesWithOrgCreateAccess.has(getOrgRoleForBinding(orgId))),
 )
 const selectedAppIds = computed(() => Object.keys(pendingAppBindings.value))
 const selectedChannelPermissionApp = computed(() =>
@@ -1082,11 +1084,14 @@ function buildApiKeyBindingsFromForm(): ApiKeyBindingInput[] {
   return bindings
 }
 
-function buildApiKeyGlobalPermissionsFromForm() {
-  if (!allowOrgCreation.value || !canEnableOrgCreation.value)
-    return []
+function buildApiKeyGlobalPermissionsFromForm(currentKey?: ApiKeyRow | null) {
+  if (allowOrgCreation.value && canEnableOrgCreation.value)
+    return [apiKeyOrgCreatePermission]
 
-  return [apiKeyOrgCreatePermission]
+  if (hideOrgCreationPermission && currentKey && hasOrgCreatePermission(currentKey))
+    return [apiKeyOrgCreatePermission]
+
+  return []
 }
 
 function hasOrgCreatePermission(key: ApiKeyRow) {
@@ -1223,7 +1228,7 @@ async function updateApiKey() {
       ...(nameChanged ? { name: trimmedName } : {}),
       expires_at: expiresAt,
       bindings: buildApiKeyBindingsFromForm(),
-      global_permissions: buildApiKeyGlobalPermissionsFromForm(),
+      global_permissions: buildApiKeyGlobalPermissionsFromForm(key),
     },
   })
 
@@ -1821,7 +1826,7 @@ getKeys()
           </div>
 
           <!-- Global organization permissions -->
-          <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+          <div v-if="!hideOrgCreationPermission" class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40">
             <label class="flex items-start gap-3" :class="canEnableOrgCreation ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'">
               <input
                 v-model="allowOrgCreation"

--- a/src/pages/onboarding/invitation.vue
+++ b/src/pages/onboarding/invitation.vue
@@ -9,6 +9,7 @@ import IconCheck from '~icons/lucide/check'
 import IconLoader from '~icons/lucide/loader-2'
 import IconUserPlus from '~icons/lucide/user-plus'
 import IconX from '~icons/lucide/x'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
@@ -60,6 +61,11 @@ async function continueAfterInvitationsResolved() {
 
   if (organizationStore.hasOrganizations) {
     await router.replace(targetPath.value)
+    return
+  }
+
+  if (isNativeAppStoreContext()) {
+    await router.replace('/scan')
     return
   }
 

--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -17,6 +17,7 @@ import UserGroupIcon from '~icons/heroicons/user-group'
 import RbacPermissionOnlyModal from '~/components/RbacPermissionOnlyModal.vue'
 import { creditPricingMetricOrder, formatCreditPricingPrice, formatCreditPricingTierLabel } from '~/services/creditPricing'
 import { formatLocalDate } from '~/services/date'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { checkPermissions } from '~/services/permissions'
 import { completeCreditTopUp, startCreditTopUp } from '~/services/stripe'
 import { getCreditPricingSteps, useSupabase } from '~/services/supabase'
@@ -64,6 +65,7 @@ const supabase = useSupabase()
 const organizationStore = useOrganizationStore()
 const { currentOrganization } = storeToRefs(organizationStore)
 const displayStore = useDisplayStore()
+const isMobile = isNativeAppStoreContext()
 
 // Modal state for non-admin access
 const showAdminModal = ref(false)
@@ -483,6 +485,11 @@ watch(() => route.hash, (hash) => {
 })
 
 onMounted(async () => {
+  if (isMobile) {
+    await router.replace('/settings/organization/usage')
+    return
+  }
+
   displayStore.NavTitle = t('credits')
   await organizationStore.awaitInitialLoad()
   if (!(await ensureBillingAccess()))
@@ -492,6 +499,9 @@ onMounted(async () => {
 })
 
 watch(() => currentOrganization.value?.gid, async (newOrgId: string | undefined, oldOrgId: string | undefined) => {
+  if (isMobile)
+    return
+
   if (!newOrgId || newOrgId === oldOrgId)
     return
   if (!(await ensureBillingAccess()))

--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -9,6 +9,7 @@ import { toast } from 'vue-sonner'
 import CreditsCta from '~/components/CreditsCta.vue'
 import RbacPermissionOnlyModal from '~/components/RbacPermissionOnlyModal.vue'
 import { formatIncludedThenPrice } from '~/services/creditPricing'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { checkPermissions } from '~/services/permissions'
 import { getDatafastAttribution, openCheckout } from '~/services/stripe'
 import { getCreditUnitPricing, getCurrentPlanNameOrg, useSupabase } from '~/services/supabase'
@@ -34,7 +35,7 @@ const router = useRouter()
 const main = useMainStore()
 const organizationStore = useOrganizationStore()
 const dialogStore = useDialogV2Store()
-const isMobile = Capacitor.isNativePlatform()
+const isMobile = isNativeAppStoreContext()
 
 // Modal state for non-admin access
 const showAdminModal = ref(false)
@@ -326,6 +327,11 @@ watch(currentOrganization, async (newOrg, prevOrg) => {
 
 watchEffect(async () => {
   if (route.path === '/settings/organization/plans') {
+    if (isMobile) {
+      router.replace('/settings/organization/usage')
+      return
+    }
+
     // if success is in url params show modal success plan setup
     if (route.query.success) {
       // toast.success(t('usage-success'))
@@ -422,6 +428,7 @@ function buttonStyle(p: Database['public']['Tables']['plans']['Row']) {
             </h1>
             <!-- Custom Plan Trigger -->
             <button
+              v-if="!isMobile"
               class="items-center hidden px-3 py-1 text-xs font-medium text-blue-700 transition-colors rounded-full bg-blue-50 lg:inline-flex dark:text-blue-300 hover:bg-blue-100 dark:bg-blue-900/30"
               @click="openSupport()"
             >
@@ -431,7 +438,7 @@ function buttonStyle(p: Database['public']['Tables']['plans']['Row']) {
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
             {{ t('plan-desc') }}
           </p>
-          <p class="mt-2 text-sm">
+          <p v-if="!isMobile" class="mt-2 text-sm">
             <a class="font-medium text-blue-600 hover:underline dark:text-blue-300" href="https://capgo.app/pricing/#compare-plans">
               {{ t('plan-full-comparison-link') }}
             </a>
@@ -464,10 +471,10 @@ function buttonStyle(p: Database['public']['Tables']['plans']['Row']) {
       </div>
 
       <!-- Credits CTA: shows info banner for credits-only orgs, upsell CTA for others -->
-      <CreditsCta class="mb-6 shrink-0" :credits-only="isCreditsOnly" />
+      <CreditsCta v-if="!isMobile" class="mb-6 shrink-0" :credits-only="isCreditsOnly" />
 
       <!-- Expert as a Service CTA -->
-      <div class="mb-6 shrink-0">
+      <div v-if="!isMobile" class="mb-6 shrink-0">
         <div class="flex flex-col gap-3 p-4 border border-amber-200 bg-amber-50 rounded-2xl text-amber-900 dark:border-amber-800/50 dark:bg-amber-900/20 dark:text-amber-100 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <p class="text-sm font-semibold">

--- a/src/pages/settings/organization/Security.vue
+++ b/src/pages/settings/organization/Security.vue
@@ -14,6 +14,7 @@ import IconLock from '~icons/heroicons/lock-closed'
 import IconShield from '~icons/heroicons/shield-check'
 import IconUser from '~icons/heroicons/user'
 import SsoConfiguration from '~/components/organizations/SsoConfiguration.vue'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { checkPermissions } from '~/services/permissions'
 import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getCurrentPlanNameOrg, useSupabase } from '~/services/supabase'
@@ -49,6 +50,7 @@ const router = useRouter()
 const supabase = useSupabase()
 const isLoading = ref(true)
 const isSaving = ref(false)
+const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 displayStore.NavTitle = t('security')
 
@@ -1520,7 +1522,7 @@ onMounted(async () => {
           </section>
 
           <!-- SSO Configuration Section -->
-          <section v-if="hasOrgPerm" class="p-6 border rounded-lg border-slate-200 dark:border-slate-700">
+          <section v-if="hasOrgPerm && (isEnterprisePlan || !hideExternalPurchaseFlows)" class="p-6 border rounded-lg border-slate-200 dark:border-slate-700">
             <!-- Enterprise Plan: Show SSO Configuration -->
             <template v-if="isEnterprisePlan">
               <div class="flex items-start gap-4 mb-6">

--- a/src/pages/settings/organization/Usage.vue
+++ b/src/pages/settings/organization/Usage.vue
@@ -11,6 +11,7 @@ import CreditsCta from '~/components/CreditsCta.vue'
 import Spinner from '~/components/Spinner.vue'
 import { bytesToGb } from '~/services/conversion'
 import { formatLocalDate, formatLocalDateTime, formatUtcDateTimeAsLocal } from '~/services/date'
+import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { calculateCreditCost, getCurrentPlanNameOrg, getPlans, getPlanUsagePercent, getTotalStorage, getUsageCreditDeductions } from '~/services/supabase'
 import { sendEvent } from '~/services/tracking'
 import { useDialogV2Store } from '~/stores/dialogv2'
@@ -29,6 +30,7 @@ const router = useRouter()
 const dialogStore = useDialogV2Store()
 const displayStore = useDisplayStore()
 displayStore.NavTitle = t('usage')
+const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 const { currentOrganization } = storeToRefs(organizationStore)
 
@@ -285,6 +287,9 @@ function formatBuildTime(seconds: number): string {
 }
 
 const shouldShowUpgrade = computed(() => {
+  if (hideExternalPurchaseFlows)
+    return false
+
   if (!currentPlanSuggest.value || !currentPlan.value) {
     return false
   }
@@ -385,7 +390,7 @@ function nextRunDate() {
                 {{ currentPlan?.name || t('loading') }}
               </div>
             </div>
-            <div class="flex flex-col">
+            <div v-if="!hideExternalPurchaseFlows" class="flex flex-col">
               <div class="mb-1 text-sm text-gray-500 dark:text-gray-400">
                 {{ t('base') }}
               </div>
@@ -393,7 +398,7 @@ function nextRunDate() {
                 {{ formatMonthlyPrice(currentPlan?.price_m) }}
               </div>
             </div>
-            <div class="flex flex-col">
+            <div v-if="!hideExternalPurchaseFlows" class="flex flex-col">
               <div class="mb-1 text-sm text-gray-500 dark:text-gray-400">
                 {{ t('credits-used-in-period') }}
               </div>
@@ -402,7 +407,7 @@ function nextRunDate() {
               </div>
             </div>
           </div>
-          <div class="flex items-end justify-between pt-4 mt-4 border-t border-gray-100 dark:border-gray-700">
+          <div v-if="!hideExternalPurchaseFlows" class="flex items-end justify-between pt-4 mt-4 border-t border-gray-100 dark:border-gray-700">
             <div class="text-sm text-gray-500 dark:text-gray-400">
               {{ t('total') }}
             </div>
@@ -440,7 +445,7 @@ function nextRunDate() {
       </div>
 
       <!-- Credits CTA -->
-      <CreditsCta class="mb-8 shrink-0" />
+      <CreditsCta v-if="!hideExternalPurchaseFlows" class="mb-8 shrink-0" />
 
       <!-- Usage Metrics Grid -->
       <h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white shrink-0">

--- a/src/services/nativeCompliance.ts
+++ b/src/services/nativeCompliance.ts
@@ -1,0 +1,64 @@
+import { Capacitor } from '@capacitor/core'
+
+const nativeExternalPurchaseRestrictedPaths = [
+  '/billing',
+  '/invitation',
+  '/onboarding/invitation',
+  '/onboarding/organization',
+  '/register',
+  '/settings/organization/credits',
+  '/settings/organization/plans',
+]
+
+function normalizePath(path: string) {
+  let normalized = path
+  while (normalized.length > 1 && normalized.endsWith('/'))
+    normalized = normalized.slice(0, -1)
+  return normalized || '/'
+}
+
+export function isNativeAppStoreContext() {
+  return Capacitor.isNativePlatform()
+}
+
+export function isNativeExternalPurchaseRestrictedPath(path: string) {
+  const normalizedPath = normalizePath(path)
+  return nativeExternalPurchaseRestrictedPaths.some((restrictedPath) => {
+    return normalizedPath === restrictedPath || normalizedPath.startsWith(`${restrictedPath}/`)
+  })
+}
+
+export function getNativeExternalPurchaseRedirect(path: string) {
+  const normalizedPath = normalizePath(path)
+  if (
+    normalizedPath === '/register'
+    || normalizedPath.startsWith('/register/')
+    || normalizedPath === '/invitation'
+    || normalizedPath.startsWith('/invitation/')
+  ) {
+    return '/login'
+  }
+
+  if (
+    normalizedPath === '/onboarding/invitation'
+    || normalizedPath.startsWith('/onboarding/invitation/')
+    || normalizedPath === '/onboarding/organization'
+    || normalizedPath.startsWith('/onboarding/organization/')
+  ) {
+    return '/scan'
+  }
+
+  if (
+    normalizedPath === '/settings/organization/credits'
+    || normalizedPath.startsWith('/settings/organization/credits/')
+    || normalizedPath === '/settings/organization/plans'
+    || normalizedPath.startsWith('/settings/organization/plans/')
+    || normalizedPath === '/billing'
+    || normalizedPath.startsWith('/billing/')
+  ) {
+    return '/settings/organization/usage'
+  }
+
+  // Fallback for future restricted paths that are not explicitly mapped above.
+  return '/dashboard'
+}


### PR DESCRIPTION
## Summary (AI generated)

- Added a shared native compliance guard for Capacitor/App Store contexts.
- Blocks native access to account registration, invitation-based registration, organization onboarding, billing, plans, and credits routes.
- Hides native-visible organization creation, org-create API key permission, Stripe upgrade/credits CTAs, trial upsells, premium support links, and plan comparison links.
- Keeps native billing/status surfaces informational by routing to usage and using non-purchase copy.

## Motivation (AI generated)

Apple rejected the app under Guidelines 3.1.1 and 3.1.3(c) because the native app exposed organization/business registration and external purchase or paid-support mechanisms. The native Capacitor app needs to avoid those flows while keeping the web console behavior unchanged.

## Business Impact (AI generated)

This reduces App Store review risk and helps restore native app availability without removing web monetization flows. Existing users can still view usage/status in native, while purchases, subscriptions, org creation, and paid support remain web-only.

## Test Plan (AI generated)

- [x] `bun lint`
- [x] `bun run lint:backend`
- [x] `bun run typecheck:frontend`
- [x] `bun run build`
- [x] Full `bun run typecheck` ran successfully through the commit hook.

## Screenshots (AI generated)

Not included. This change gates existing flows by native context and redirects restricted routes.

## Checklist (AI generated)

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce my tests.

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native app store support with platform-specific experience

* **Changes**
  * Native app users now see specialized subscription and billing messaging
  * Organization creation is restricted in native app context
  * External purchase options are hidden for native app users
  * Updated navigation and pricing display for native app platform users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->