### PR TITLE
[codex] support bundle upload to multiple channels

### DIFF
--- a/cli/skills/release-management/SKILL.md
+++ b/cli/skills/release-management/SKILL.md
@@ -36,7 +36,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
 ### `bundle upload [appId]`
 
 - Alias: `u`
-- Example: `npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production`
+- Example: `npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production,beta`
 - Key behavior:
   - Bundle version must be greater than `0.0.0` and unique.
   - Deleted versions cannot be reused.
@@ -44,10 +44,12 @@ Use this skill for OTA update workflows in Capgo Cloud.
   - Encryption is recommended for trustless distribution.
   - Interactive prompts are disabled automatically in CI and other non-interactive sessions so uploads do not block automation.
   - Optional upload prompts can remember the user's answer on the current machine so future uploads can skip the same question.
+  - `--channel` accepts a single channel or a comma-separated list such as `production,beta`.
+  - When multiple channels are provided, channels that already have the uploaded checksum are skipped and the remaining channels are assigned.
   - Use `--qr-preview` to print a terminal QR code for the uploaded bundle after a successful upload. App preview must be enabled first.
 - Important options:
   - `-p, --path <path>`
-  - `-c, --channel <channel>`
+  - `-c, --channel <channel[,channel...]>`
   - `-e, --external <url>`
   - `--iv-session-key <key>`
   - `-b, --bundle <bundle>`
@@ -56,7 +58,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
   - `--min-update-version <minUpdateVersion>`
   - `--auto-min-update-version`
   - `--ignore-metadata-check`
-  - `--fail-on-incompatible` (fail the upload instead of uploading when the bundle is incompatible with the channel's current native packages; cannot be combined with `--ignore-metadata-check`)
+  - `--fail-on-incompatible` (fail the upload instead of uploading when the bundle is incompatible with a target channel's current native packages; cannot be combined with `--ignore-metadata-check`)
   - `--ignore-checksum-check`
   - `--force-crc32-checksum`
   - `--timeout <timeout>`

--- a/cli/src/bundle/upload-channels.ts
+++ b/cli/src/bundle/upload-channels.ts
@@ -1,0 +1,35 @@
+export function parseUploadChannels(channel: string | null | undefined): string[] {
+  if (!channel)
+    return []
+
+  const channels = channel
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean)
+
+  return Array.from(new Set(channels))
+}
+
+export function formatUploadChannels(channels: readonly string[]): string {
+  return channels.join(', ')
+}
+
+export function getChannelsToAssignByChecksum(
+  channels: readonly string[],
+  currentChecksum: string,
+  remoteChecksums: ReadonlyMap<string, string | null | undefined>,
+): { channelsAlreadyCurrent: string[], channelsToAssign: string[] } {
+  const channelsAlreadyCurrent: string[] = []
+  const channelsToAssign: string[] = []
+
+  for (const channel of channels) {
+    if (remoteChecksums.get(channel) === currentChecksum) {
+      channelsAlreadyCurrent.push(channel)
+      continue
+    }
+
+    channelsToAssign.push(channel)
+  }
+
+  return { channelsAlreadyCurrent, channelsToAssign }
+}

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -23,12 +23,13 @@ import { confirmWithRememberedChoice } from '../promptPreferences'
 import { showReplicationProgress } from '../replicationProgress'
 import { formatTable } from '../terminal-table'
 import { usesAlwaysDirectUpdate } from '../updaterConfig'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasCliPermission, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { maybePromptBuilderCta, shouldBlockIncompatibleUpload } from './builder-cta'
 import { checkIndexPosition, searchInDirectory } from './check'
 import { summarizeUploadCompatibility } from './compatibility'
 import { prepareBundlePartialFiles, uploadPartial } from './partial'
+import { formatUploadChannels, getChannelsToAssignByChecksum, parseUploadChannels } from './upload-channels'
 
 type SupabaseType = Awaited<ReturnType<typeof createSupabaseClient>>
 type pmType = ReturnType<typeof getPMAndCommand>
@@ -342,6 +343,56 @@ async function checkVersionExists(supabase: SupabaseType, appid: string, bundle:
   }
 
   return false
+}
+
+function pickHighestMinUpdateVersion(results: Array<{ minUpdateVersion?: string }>): string | undefined {
+  let selected: string | undefined
+
+  for (const { minUpdateVersion } of results) {
+    if (!minUpdateVersion)
+      continue
+    if (!selected || greaterOrEqual(parse(minUpdateVersion), parse(selected)))
+      selected = minUpdateVersion
+  }
+
+  return selected
+}
+
+async function getChannelsToAssignAfterChecksumCheck(supabase: SupabaseType, appid: string, channels: string[], currentChecksum: string): Promise<string[]> {
+  const remoteChecksums = new Map<string, string | null>()
+
+  for (const targetChannel of channels) {
+    const s = spinnerC()
+    s.start(`Checking bundle checksum compatibility with channel ${targetChannel}`)
+    const remoteChecksum = await getRemoteChecksums(supabase, appid, targetChannel)
+    remoteChecksums.set(targetChannel, remoteChecksum)
+
+    if (!remoteChecksum) {
+      s.stop(`No checksum found for channel ${targetChannel}, the bundle will be uploaded`)
+      continue
+    }
+
+    if (remoteChecksum === currentChecksum) {
+      s.stop(`Channel ${targetChannel} already has this bundle checksum`)
+      continue
+    }
+
+    s.stop(`Checksum compatible with ${targetChannel} channel`)
+  }
+
+  const { channelsAlreadyCurrent, channelsToAssign } = getChannelsToAssignByChecksum(channels, currentChecksum, remoteChecksums)
+
+  if (channelsToAssign.length === 0) {
+    const channelLabel = formatUploadChannels(channels)
+    log.error(`Cannot upload the same bundle content.\nCurrent bundle checksum matches remote bundle for channel${channels.length > 1 ? 's' : ''} ${channelLabel}\nDid you build your app before uploading?\nPS: You can ignore this check with "--ignore-checksum-check"`)
+    throw new Error('Cannot upload the same bundle content')
+  }
+
+  if (channelsAlreadyCurrent.length > 0) {
+    log.warn(`Skipping channel${channelsAlreadyCurrent.length > 1 ? 's' : ''} ${formatUploadChannels(channelsAlreadyCurrent)} because ${channelsAlreadyCurrent.length > 1 ? 'they already have' : 'it already has'} this bundle content.`)
+  }
+
+  return channelsToAssign
 }
 
 async function prepareBundleFile(path: string, options: OptionsUpload, apikey: string, orgId: string, appid: string, maxUploadLength: number, alertUploadSize: number, publicKeyFromConfig?: string) {
@@ -885,10 +936,19 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   if (options.verbose)
     log.info(`[Verbose] User verified successfully, user_id: ${userId}`)
 
-  const defaultUploadChannel = options.channel ? null : await getDefaultUploadChannel(appid, supabase, localConfig.hostWeb)
-  const channel = options.channel || defaultUploadChannel || 'production'
+  const requestedChannels = parseUploadChannels(options.channel)
+  if (options.channel !== undefined && requestedChannels.length === 0)
+    uploadFail('Missing channel name, pass one channel or a comma-separated list with --channel')
+
+  const defaultUploadChannel = requestedChannels.length > 0 ? null : await getDefaultUploadChannel(appid, supabase, localConfig.hostWeb)
+  const channels = requestedChannels.length > 0 ? requestedChannels : parseUploadChannels(defaultUploadChannel || 'production')
+  if (channels.length === 0)
+    uploadFail('Cannot resolve target channel')
+
+  const channelLabel = formatUploadChannels(channels)
+  let channelsToAssign = channels
   if (options.verbose)
-    log.info(`[Verbose] Target channel: ${channel}`)
+    log.info(`[Verbose] Target channel${channels.length > 1 ? 's' : ''}: ${channelLabel}`)
 
   // Now if it does exist we will fetch the org id
   const orgId = await getOrganizationId(supabase, appid)
@@ -906,16 +966,92 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
     log.info(`[Verbose] Trial check completed`)
 
   if (options.verbose)
-    log.info(`[Verbose] Checking compatibility with channel ${channel}...`)
+    log.info(`[Verbose] Checking if version ${bundle} already exists...`)
 
-  const { nativePackages, minUpdateVersion, incompatibleCount, compatibility } = await verifyCompatibility(supabase, pm, options, channel, appid, bundle, orgId)
-  const incompatible = compatibility.result === 'incompatible'
+  // Enable interactive mode only when TTY is available
+  const versionExistsResult = await checkVersionExists(supabase, appid, bundle, options.versionExistsOk, interactive)
+
+  if (options.verbose)
+    log.info(`[Verbose] Version exists check: ${versionExistsResult ? (typeof versionExistsResult === 'string' ? `retry with ${versionExistsResult}` : 'yes (skipping)') : 'no (continuing)'}`)
+
+  // If version exists and we got a boolean true, skip
+  if (versionExistsResult === true) {
+    return {
+      success: true,
+      skipped: true,
+      reason: 'VERSION_EXISTS',
+      bundle,
+      checksum: null,
+      encryptionMethod,
+      storageProvider: defaultStorageProvider,
+    }
+  }
+
+  // If we got a new version string, retry with that version
+  if (typeof versionExistsResult === 'string') {
+    log.info(`Retrying upload with new version: ${versionExistsResult}`)
+    return uploadBundleInternal(preAppid, { ...options, bundle: versionExistsResult }, silent)
+  }
+
+  if (options.external && !options.external.startsWith('https://')) {
+    uploadFail(`External link should should start with "https://" current is "${options.external}"`)
+  }
+
+  let zipped: Buffer | null = null
+  let finalKeyData = ''
+  let preparedBundle: Awaited<ReturnType<typeof prepareBundleFile>> | undefined
+  if (!options.external) {
+    if (options.verbose)
+      log.info(`[Verbose] Preparing bundle file from path: ${path}`)
+
+    const publicKeyFromConfig = extConfig.config?.plugins?.CapacitorUpdater?.publicKey
+    preparedBundle = await prepareBundleFile(path, options, apikey, orgId, appid, fileConfig.maxUploadLength, fileConfig.alertUploadSize, publicKeyFromConfig)
+    sessionKey = preparedBundle.sessionKey
+    zipped = preparedBundle.zipped
+    encryptionMethod = preparedBundle.encryptionMethod
+    finalKeyData = preparedBundle.finalKeyData
+
+    if (options.verbose) {
+      log.info(`[Verbose] Bundle prepared:`)
+      log.info(`  - Size: ${Math.floor((preparedBundle.zipped?.byteLength ?? 0) / 1024)} KB`)
+      log.info(`  - Checksum: ${preparedBundle.checksum}`)
+      log.info(`  - Encryption: ${preparedBundle.encryptionMethod}`)
+      log.info(`  - IV Session Key: ${preparedBundle.ivSessionKey ? 'present' : 'none'}`)
+      log.info(`  - Key ID: ${preparedBundle.keyId || 'none'}`)
+    }
+
+    if (!options.ignoreChecksumCheck) {
+      if (options.verbose)
+        log.info(`[Verbose] Checking for duplicate checksum...`)
+      channelsToAssign = await getChannelsToAssignAfterChecksumCheck(supabase, appid, channels, preparedBundle.checksum)
+      if (options.verbose)
+        log.info(`[Verbose] Checksum is unique or already satisfied across target channels`)
+    }
+  }
+
+  const assignmentChannelLabel = formatUploadChannels(channelsToAssign)
+  if (options.verbose)
+    log.info(`[Verbose] Checking compatibility with channel${channelsToAssign.length > 1 ? 's' : ''} ${assignmentChannelLabel}...`)
+
+  const compatibilityResults = [] as Array<Awaited<ReturnType<typeof verifyCompatibility>> & { channel: string }>
+  for (const targetChannel of channelsToAssign) {
+    const compatibilityResult = await verifyCompatibility(supabase, pm, options, targetChannel, appid, bundle, orgId)
+    compatibilityResults.push({ channel: targetChannel, ...compatibilityResult })
+  }
+
+  const nativePackages = compatibilityResults.find(result => result.nativePackages)?.nativePackages
+  const minUpdateVersion = pickHighestMinUpdateVersion(compatibilityResults)
+  const incompatibleResults = compatibilityResults.filter(result => result.compatibility.result === 'incompatible')
+  const incompatible = incompatibleResults.length > 0
+  const incompatibleCount = incompatibleResults.reduce((count, result) => Math.max(count, result.incompatibleCount), 0)
+  const incompatibleChannelLabel = formatUploadChannels(incompatibleResults.map(result => result.channel))
 
   // `--fail-on-incompatible`: abort the upload (exit non-zero) instead of shipping
   // an OTA update that cannot take effect without a native build. Emits a single
   // fire-and-forget telemetry event, then throws a dedicated error so the retry
   // prompt in `uploadBundle` is skipped. Closes over the upload context.
   const uploadFailIncompatible = (): never => {
+    const blockedChannelLabel = incompatibleChannelLabel || assignmentChannelLabel
     void trackEvent({
       channel: 'bundle',
       event: 'Bundle Upload Blocked',
@@ -923,9 +1059,10 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
       apikey: options.apikey,
       appId: appid,
       orgId,
-      tags: { reason: 'incompatible', channel, channel_name: channel, incompatible_count: incompatibleCount, interactive },
+      tags: { reason: 'incompatible', channel: blockedChannelLabel, channel_name: blockedChannelLabel, channel_names: blockedChannelLabel, channel_count: incompatibleResults.length || channelsToAssign.length, incompatible_count: incompatibleCount, interactive },
     })
-    const message = `Upload aborted: bundle is incompatible with channel "${channel}" (${incompatibleCount} native package(s) changed). A native build / app-store update is required. Run a native build with Capgo Builder (https://capgo.app/docs/cli/cloud-build/), or remove --fail-on-incompatible to upload anyway.`
+    const channelText = incompatibleResults.length === 1 ? 'channel' : 'channels'
+    const message = `Upload aborted: bundle is incompatible with ${channelText} "${blockedChannelLabel}" (${incompatibleCount} native package(s) changed). A native build / app-store update is required. Run a native build with Capgo Builder (https://capgo.app/docs/cli/cloud-build/), or remove --fail-on-incompatible to upload anyway.`
     log.error(message)
     throw new IncompatibleBundleError(message)
   }
@@ -972,94 +1109,29 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
     log.info(`  - Min update version: ${minUpdateVersion || 'none'}`)
   }
 
-  if (options.verbose)
-    log.info(`[Verbose] Checking if version ${bundle} already exists...`)
-
-  // Enable interactive mode only when TTY is available
-  const versionExistsResult = await checkVersionExists(supabase, appid, bundle, options.versionExistsOk, interactive)
-
-  if (options.verbose)
-    log.info(`[Verbose] Version exists check: ${versionExistsResult ? (typeof versionExistsResult === 'string' ? `retry with ${versionExistsResult}` : 'yes (skipping)') : 'no (continuing)'}`)
-
-  // If version exists and we got a boolean true, skip
-  if (versionExistsResult === true) {
-    return {
-      success: true,
-      skipped: true,
-      reason: 'VERSION_EXISTS',
-      bundle,
-      checksum: null,
-      encryptionMethod,
-      storageProvider: defaultStorageProvider,
-    }
-  }
-
-  // If we got a new version string, retry with that version
-  if (typeof versionExistsResult === 'string') {
-    log.info(`Retrying upload with new version: ${versionExistsResult}`)
-    return uploadBundleInternal(preAppid, { ...options, bundle: versionExistsResult }, silent)
-  }
-
-  if (options.external && !options.external.startsWith('https://')) {
-    uploadFail(`External link should should start with "https://" current is "${options.external}"`)
-  }
-
   if (options.deleteLinkedBundleOnUpload) {
-    log.warn('Deleting linked bundle on upload is destructive, it will delete the currently linked bundle in the channel you are trying to upload to.')
+    log.warn(`Deleting linked bundle on upload is destructive, it will delete the currently linked bundle in the target channel${channelsToAssign.length > 1 ? 's' : ''}: ${assignmentChannelLabel}.`)
     log.warn('Please make sure you want to do this, if you are not sure, please do not use this option.')
   }
 
   const versionData = {
     name: bundle,
     app_id: appid,
-    session_key: undefined as undefined | string,
+    session_key: options.external ? options.ivSessionKey : preparedBundle?.ivSessionKey,
     external_url: options.external,
     storage_provider: defaultStorageProvider,
     min_update_version: minUpdateVersion,
     native_packages: nativePackages,
     owner_org: orgId,
     user_id: userId,
-    checksum: undefined as undefined | string,
+    checksum: options.external ? options.encryptedChecksum : preparedBundle?.checksum,
     link: options.link || null,
     comment: options.comment || null,
-    key_id: undefined as undefined | string,
+    key_id: preparedBundle?.keyId || undefined,
     cli_version: pack.version,
   } as Database['public']['Tables']['app_versions']['Insert']
 
-  let zipped: Buffer | null = null
-  let finalKeyData = ''
-  if (!options.external) {
-    if (options.verbose)
-      log.info(`[Verbose] Preparing bundle file from path: ${path}`)
-
-    const publicKeyFromConfig = extConfig.config?.plugins?.CapacitorUpdater?.publicKey
-    const { zipped: _zipped, ivSessionKey, checksum, sessionKey: sk, encryptionMethod: em, finalKeyData: fkd, keyId } = await prepareBundleFile(path, options, apikey, orgId, appid, fileConfig.maxUploadLength, fileConfig.alertUploadSize, publicKeyFromConfig)
-    versionData.session_key = ivSessionKey
-    versionData.checksum = checksum
-    versionData.key_id = keyId || undefined
-    sessionKey = sk
-    zipped = _zipped
-    encryptionMethod = em
-    finalKeyData = fkd
-
-    if (options.verbose) {
-      log.info(`[Verbose] Bundle prepared:`)
-      log.info(`  - Size: ${Math.floor((_zipped?.byteLength ?? 0) / 1024)} KB`)
-      log.info(`  - Checksum: ${checksum}`)
-      log.info(`  - Encryption: ${em}`)
-      log.info(`  - IV Session Key: ${ivSessionKey ? 'present' : 'none'}`)
-      log.info(`  - Key ID: ${keyId || 'none'}`)
-    }
-
-    if (!options.ignoreChecksumCheck) {
-      if (options.verbose)
-        log.info(`[Verbose] Checking for duplicate checksum...`)
-      await checkChecksum(supabase, appid, channel, checksum)
-      if (options.verbose)
-        log.info(`[Verbose] Checksum is unique`)
-    }
-  }
-  else {
+  if (options.external) {
     if (options.verbose)
       log.info(`[Verbose] Using external URL: ${options.external}`)
 
@@ -1074,8 +1146,6 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
       },
       notify: false,
     }, options.verbose)
-    versionData.session_key = options.ivSessionKey
-    versionData.checksum = options.encryptedChecksum
 
     if (options.verbose) {
       log.info(`[Verbose] External bundle configured:`)
@@ -1339,25 +1409,38 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   }
 
   const shouldDeleteLinkedBundle = options.deleteLinkedBundleOnUpload && hasOrganizationPerm(permissions, OrganizationPerm.write)
-  const linkedBundleToDelete = shouldDeleteLinkedBundle
-    ? await getLinkedBundleOnChannel(supabase, appid, channel)
-    : null
+  const linkedBundlesToDelete = shouldDeleteLinkedBundle
+    ? await Promise.all(channelsToAssign.map(async targetChannel => ({
+        channel: targetChannel,
+        version: await getLinkedBundleOnChannel(supabase, appid, targetChannel),
+      })))
+    : []
   if (options.deleteLinkedBundleOnUpload && !shouldDeleteLinkedBundle) {
     log.warn('Cannot delete linked bundle on upload as a upload organization member')
   }
 
-  let channelVersionSet = false
+  const channelVersionSet = new Set<string>()
   if (hasOrganizationPerm(permissions, OrganizationPerm.write)) {
-    if (options.verbose)
-      log.info(`[Verbose] Setting bundle ${bundle} to channel ${channel}...`)
-    channelVersionSet = await setVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, channel, userId, orgId, appid, localConfig, options.selfAssign)
-    if (options.verbose)
-      log.info(`[Verbose] Channel updated successfully`)
+    for (const targetChannel of channelsToAssign) {
+      if (options.verbose)
+        log.info(`[Verbose] Setting bundle ${bundle} to channel ${targetChannel}...`)
+      const targetChannelVersionSet = await setVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, userId, orgId, appid, localConfig, options.selfAssign)
+      if (targetChannelVersionSet)
+        channelVersionSet.add(targetChannel)
+      if (options.verbose)
+        log.info(`[Verbose] Channel ${targetChannel} updated successfully`)
+    }
 
     if (shouldDeleteLinkedBundle) {
-      if (options.verbose)
-        log.info(`[Verbose] Deleting previously linked bundle in channel ${channel}...`)
-      await deleteLinkedBundleOnUpload(supabase, linkedBundleToDelete)
+      const deletedVersionIds = new Set<number>()
+      for (const linkedBundle of linkedBundlesToDelete) {
+        if (!linkedBundle.version || deletedVersionIds.has(linkedBundle.version.id))
+          continue
+        if (options.verbose)
+          log.info(`[Verbose] Deleting previously linked bundle in channel ${linkedBundle.channel}...`)
+        await deleteLinkedBundleOnUpload(supabase, linkedBundle.version)
+        deletedVersionIds.add(linkedBundle.version.id)
+      }
     }
   }
   else {
@@ -1397,7 +1480,10 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   // Record every incompatible upload in PostHog (`Bundle Incompatible`). The
   // channel_overwritten flag lets the backend gate the org-member email to
   // uploads that actually went live (i.e. overwrote the channel's version).
-  if (compatibility?.result === 'incompatible') {
+  for (const compatibilityResult of compatibilityResults) {
+    if (compatibilityResult.compatibility.result !== 'incompatible')
+      continue
+
     void trackEvent({
       channel: 'bundle',
       event: 'Bundle Incompatible',
@@ -1409,12 +1495,12 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
         source: 'upload',
         // `channel` is overwritten by the event category ('bundle') in PostHog
         // (the backend still reads tags.channel); channel_name keeps it queryable.
-        channel,
-        channel_name: channel,
-        channel_overwritten: channelVersionSet,
+        channel: compatibilityResult.channel,
+        channel_name: compatibilityResult.channel,
+        channel_overwritten: channelVersionSet.has(compatibilityResult.channel),
         version_new_name: bundle,
-        ...(compatibility.versionOldId ? { version_old_id: compatibility.versionOldId } : {}),
-        ...(compatibility.versionOldName ? { version_old_name: compatibility.versionOldName } : {}),
+        ...(compatibilityResult.compatibility.versionOldId ? { version_old_id: compatibilityResult.compatibility.versionOldId } : {}),
+        ...(compatibilityResult.compatibility.versionOldName ? { version_old_name: compatibilityResult.compatibility.versionOldName } : {}),
       },
     })
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -192,11 +192,11 @@ Version must be > 0.0.0 and unique. Deleted versions cannot be reused for securi
 External option: Store only a URL link (useful for apps >200MB or privacy requirements).
 Capgo never inspects external content. Add encryption for trustless security.
 
-Example: npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production`)
+Example: npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production,beta`)
   .action(handleBundleUploadCommand)
   .option('-a, --apikey <apikey>', optionDescriptions.apikey)
   .option('-p, --path <path>', `Path of the folder to upload, if not provided it will use the webDir set in capacitor.config`)
-  .option('-c, --channel <channel>', `Channel to link to`)
+  .option('-c, --channel <channel>', `Channel to link to. Use commas for multiple channels, for example production,beta`)
   .option('-e, --external <url>', `Link to external URL instead of upload to Capgo Cloud`)
   .option('--iv-session-key <key>', `Set the IV and session key for bundle URL external`)
   .option('--s3-region <region>', `Region for your S3 bucket`)

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -2020,23 +2020,6 @@ export async function getRemoteDependencies(supabase: SupabaseClient<Database>, 
   return convertNativePackages(((remoteNativePackages.version as any)?.native_packages as any) ?? [])
 }
 
-export async function checkChecksum(supabase: SupabaseClient<Database>, appId: string, channel: string, currentChecksum: string) {
-  const s = spinnerC()
-  s.start(`Checking bundle checksum compatibility with channel ${channel}`)
-  const remoteChecksum = await getRemoteChecksums(supabase, appId, channel)
-
-  if (!remoteChecksum) {
-    s.stop(`No checksum found for channel ${channel}, the bundle will be uploaded`)
-    return
-  }
-  if (remoteChecksum && remoteChecksum === currentChecksum) {
-    // cannot upload the same bundle - stop spinner before throwing
-    s.stop(`Checksum check failed`)
-    log.error(`Cannot upload the same bundle content.\nCurrent bundle checksum matches remote bundle for channel ${channel}\nDid you build your app before uploading?\nPS: You can ignore this check with "--ignore-checksum-check"`)
-    throw new Error('Cannot upload the same bundle content')
-  }
-  s.stop(`Checksum compatible with ${channel} channel`)
-}
 
 export type { Compatibility, CompatibilityDetails, IncompatibilityReason } from './schemas/common'
 

--- a/cli/webdocs/bundle.mdx
+++ b/cli/webdocs/bundle.mdx
@@ -25,8 +25,10 @@ Capgo never inspects external content. Add encryption for trustless security.
 **Example:**
 
 ```bash
-npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production
+npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production,beta
 ```
+
+Use a comma-separated `--channel` value to assign one upload to multiple channels. Channels that already have the uploaded checksum are skipped while the remaining requested channels are assigned.
 
 **Options:**
 
@@ -34,7 +36,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | -------------- | ------------- | -------------------- |
 | **-a** | <code>string</code> | API key to link to your account |
 | **-p** | <code>string</code> | Path of the folder to upload, if not provided it will use the webDir set in capacitor.config |
-| **-c** | <code>string</code> | Channel to link to |
+| **-c** | <code>string</code> | Channel to link to. Use comma-separated names, for example <code>production,beta</code>, to assign the upload to multiple channels |
 | **-e** | <code>string</code> | Link to external URL instead of upload to Capgo Cloud |
 | **--iv-session-key** | <code>string</code> | Set the IV and session key for bundle URL external |
 | **--s3-region** | <code>string</code> | Region for your S3 bucket |
@@ -75,11 +77,11 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **--package-json** | <code>string</code> | Paths to package.json files for monorepos (comma-separated) |
 | **--node-modules** | <code>string</code> | Paths to node_modules directories for monorepos (comma-separated) |
 | **--encrypt-partial** | <code>boolean</code> | Encrypt delta update files (auto-enabled for updater > 6.14.4) |
-| **--delete-linked-bundle-on-upload** | <code>boolean</code> | Locates the currently linked bundle in the channel you are trying to upload to, and deletes it |
+| **--delete-linked-bundle-on-upload** | <code>boolean</code> | Locates the currently linked bundles in the target channel(s), and deletes them |
 | **--no-brotli-patterns** | <code>string</code> | Files to exclude from Brotli compression (comma-separated globs, e.g., "*.jpg,*.png") |
 | **--disable-brotli** | <code>boolean</code> | Completely disable brotli compression even if updater version supports it |
 | **--version-exists-ok** | <code>boolean</code> | Exit successfully if bundle version already exists, useful for CI/CD workflows with monorepos |
-| **--self-assign** | <code>boolean</code> | Allow devices to auto-join this channel (updates channel setting) |
+| **--self-assign** | <code>boolean</code> | Allow devices to auto-join the target channel(s) (updates channel setting) |
 | **--qr-preview** | <code>boolean</code> | Print a terminal QR code for this bundle preview after upload |
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |

--- a/tests/cli-sdk-utils.ts
+++ b/tests/cli-sdk-utils.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import { chdir, cwd, env } from 'node:process'
 import { CapgoSDK } from '@capgo/cli/sdk'
 import AdmZip from 'adm-zip'
+import { getChannelsToAssignByChecksum, parseUploadChannels } from '../cli/src/bundle/upload-channels'
 import { BASE_DEPENDENCIES, BASE_DEPENDENCIES_OLD, BASE_PACKAGE_JSON, TEMP_DIR_NAME } from './cli-utils'
 import { APIKEY_TEST_ALL, getSupabaseClient, USER_ID } from './test-utils'
 
@@ -837,8 +838,18 @@ export function createTestSDK(apikey: string = APIKEY_TEST_ALL) {
       if ('error' in uploadPayload)
         return { success: false, error: uploadPayload.error }
 
-      const currentChannelVersion = options.channel ? await getChannelVersionRecord(options.appId, options.channel) : null
-      if (currentChannelVersion?.checksum === uploadPayload.checksum) {
+      const targetChannels = parseUploadChannels(options.channel)
+      if (options.channel !== undefined && targetChannels.length === 0)
+        return { success: false, error: 'Missing channel name' }
+
+      const remoteChecksums = new Map<string, string | null>()
+      for (const targetChannel of targetChannels) {
+        const currentChannelVersion = await getChannelVersionRecord(options.appId, targetChannel)
+        remoteChecksums.set(targetChannel, currentChannelVersion?.checksum ?? null)
+      }
+      const { channelsToAssign } = getChannelsToAssignByChecksum(targetChannels, uploadPayload.checksum, remoteChecksums)
+
+      if (targetChannels.length > 0 && channelsToAssign.length === 0) {
         return {
           success: false,
           error: 'Cannot upload the same bundle content',
@@ -847,7 +858,7 @@ export function createTestSDK(apikey: string = APIKEY_TEST_ALL) {
 
       const minUpdateVersion = await resolveUploadMinUpdateVersion(
         options.appId,
-        options.channel,
+        channelsToAssign[0] ?? targetChannels[0],
         options.autoMinUpdateVersion,
         options.minUpdateVersion,
       )
@@ -879,10 +890,10 @@ export function createTestSDK(apikey: string = APIKEY_TEST_ALL) {
         throw uploadError
       }
 
-      if (options.channel) {
-        const channelRecord = await getChannelRecord(options.appId, options.channel)
+      for (const targetChannel of channelsToAssign) {
+        const channelRecord = await getChannelRecord(options.appId, targetChannel)
         if (!channelRecord)
-          return { success: false, error: `Channel ${options.channel} not found for app ${options.appId}` }
+          return { success: false, error: `Channel ${targetChannel} not found for app ${options.appId}` }
 
         const { error } = await getSupabaseClient()
           .from('channels')

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -98,6 +98,74 @@ describe('tests CLI upload', () => {
     expect(result.success).toBe(true)
   }, 60000)
 
+  it('should link uploaded bundle to multiple comma-separated channels', async () => {
+    const appName = `com.cli_multi_channel_${randomUUID()}`
+    const extraChannel = `multi-${randomUUID().slice(0, 8)}`
+    await Promise.all([
+      resetAndSeedAppData(appName),
+      prepareCli(appName),
+    ])
+
+    try {
+      const supabase = getSupabaseClient()
+      const { data: versionData, error: versionError } = await supabase
+        .from('app_versions')
+        .select('id')
+        .eq('app_id', appName)
+        .limit(1)
+        .single()
+
+      expect(versionError).toBeNull()
+      if (!versionData)
+        throw new Error('Missing seeded app version')
+
+      const { error: channelError } = await supabase
+        .from('channels')
+        .insert({
+          name: extraChannel,
+          app_id: appName,
+          version: versionData.id,
+          owner_org: ORG_ID,
+          created_by: USER_ID,
+          public: false,
+          disable_auto_update_under_native: true,
+          disable_auto_update: 'major' as const,
+          allow_device_self_set: false,
+          allow_emulator: false,
+          allow_device: false,
+          allow_dev: false,
+          allow_prod: false,
+          ios: false,
+          android: false,
+        })
+
+      expect(channelError).toBeNull()
+
+      const { result, version } = await uploadWithFreshVersionRetry(appName, `production,${extraChannel}`, {
+        ignoreCompatibilityCheck: true,
+      })
+      expect(result.success).toBe(true)
+
+      const { data: channels, error } = await supabase
+        .from('channels')
+        .select('name, version(name)')
+        .eq('app_id', appName)
+        .in('name', ['production', extraChannel])
+
+      expect(error).toBeNull()
+      const versionsByChannel = new Map((channels ?? []).map(row => [row.name, (row.version as any)?.name]))
+      expect(versionsByChannel.get('production')).toBe(version)
+      expect(versionsByChannel.get(extraChannel)).toBe(version)
+    }
+    finally {
+      await Promise.all([
+        cleanupCli(appName),
+        resetAppData(appName),
+        resetAppDataStats(appName),
+      ])
+    }
+  }, 60000)
+
   it('should not upload same hash twice', async () => {
     const appName = `com.cli_duplicate_${randomUUID()}`
     await Promise.all([

--- a/tests/upload-channels.unit.test.ts
+++ b/tests/upload-channels.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { formatUploadChannels, getChannelsToAssignByChecksum, parseUploadChannels } from '../cli/src/bundle/upload-channels'
+
+describe('bundle upload channel parsing', () => {
+  it.concurrent('parses comma-separated channels with trimming and dedupe', () => {
+    expect(parseUploadChannels(' production, beta ,, production,staging ')).toEqual(['production', 'beta', 'staging'])
+  })
+
+  it.concurrent('returns an empty list for missing or blank channels', () => {
+    expect(parseUploadChannels(undefined)).toEqual([])
+    expect(parseUploadChannels(' , , ')).toEqual([])
+  })
+
+  it.concurrent('formats channel lists for logs', () => {
+    expect(formatUploadChannels(['production', 'beta'])).toBe('production, beta')
+  })
+
+  it.concurrent('selects only channels that need the uploaded checksum', () => {
+    const result = getChannelsToAssignByChecksum(
+      ['production', 'beta', 'staging'],
+      'new-checksum',
+      new Map([
+        ['production', 'old-checksum'],
+        ['beta', 'new-checksum'],
+        ['staging', null],
+      ]),
+    )
+
+    expect(result).toEqual({
+      channelsAlreadyCurrent: ['beta'],
+      channelsToAssign: ['production', 'staging'],
+    })
+  })
+
+  it.concurrent('returns no assignable channels when every target already has the checksum', () => {
+    const result = getChannelsToAssignByChecksum(
+      ['production', 'beta'],
+      'new-checksum',
+      new Map([
+        ['production', 'new-checksum'],
+        ['beta', 'new-checksum'],
+      ]),
+    )
+
+    expect(result).toEqual({
+      channelsAlreadyCurrent: ['production', 'beta'],
+      channelsToAssign: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
AI-generated by Codex.

- Adds comma-separated `--channel` parsing for `bundle upload`, so one upload can assign the new bundle to multiple channels.
- Runs compatibility checks, checksum checks, channel updates, linked-bundle cleanup, and incompatible telemetry per target channel.
- Adds parser coverage and a DB-backed CLI regression test for `production,<extra-channel>` uploads.

## Motivation
AI-generated by Codex.

Users need to publish the same uploaded bundle to more than one channel in a single CLI upload command instead of uploading once and then manually setting additional channels.

## Business Impact
AI-generated by Codex.

This reduces release friction for teams managing multiple rollout channels and lowers the chance of inconsistent channel assignment after a bundle upload.

## Test Plan
AI-generated by Codex.

- [x] `bun test tests/upload-channels.unit.test.ts tests/cli.test.ts -t "bundle upload channel parsing|multiple comma-separated"`
- [x] `bun run cli:check`
- [x] `bun lint` (passes with existing warning in `src/services/compatibilityEvents.ts`)
