### PR TITLE
[codex] Add native version stats actions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -121,6 +121,8 @@
   "action-need-plan-upgrade": "Blocked - plan upgrade required",
   "action-no-channel-or-override": "No channel or override configured",
   "action-no-new": "Already has latest version",
+  "action-native-app-version-changed": "Native app version changed",
+  "action-os-version-changed": "OS version changed",
   "action-ping": "Device heartbeat",
   "action-rate-limited": "Request rate limited",
   "action-reset": "Reset to default version",

--- a/src/services/statsActions.ts
+++ b/src/services/statsActions.ts
@@ -47,6 +47,8 @@ export const statsActionFilters = [
   ['action-webview-unclean-restart', 'webview_unclean_restart'],
   ['action-webview-render-process-gone', 'webview_render_process_gone'],
   ['action-webview-content-process-terminated', 'webview_content_process_terminated'],
+  ['action-os-version-changed', 'os_version_changed'],
+  ['action-native-app-version-changed', 'native_app_version_changed'],
   ['action-uninstall', 'uninstall'],
   ['action-need-plan-upgrade', 'needPlanUpgrade'],
   ['action-missing-bundle', 'missingBundle'],

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -4885,6 +4885,8 @@ export type Database = {
         | "webview_unclean_restart"
         | "webview_render_process_gone"
         | "webview_content_process_terminated"
+        | "os_version_changed"
+        | "native_app_version_changed"
       stripe_status:
         | "created"
         | "succeeded"
@@ -5154,6 +5156,8 @@ export const Constants = {
         "webview_unclean_restart",
         "webview_render_process_gone",
         "webview_content_process_terminated",
+        "os_version_changed",
+        "native_app_version_changed",
       ],
       stripe_status: [
         "created",

--- a/supabase/functions/_backend/plugins/stats_actions.ts
+++ b/supabase/functions/_backend/plugins/stats_actions.ts
@@ -80,4 +80,6 @@ export const ALLOWED_STATS_ACTIONS = [
   'webview_unclean_restart',
   'webview_render_process_gone',
   'webview_content_process_terminated',
+  'os_version_changed',
+  'native_app_version_changed',
 ] as const satisfies readonly Database['public']['Enums']['stats_action'][]

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -4885,6 +4885,8 @@ export type Database = {
         | "webview_unclean_restart"
         | "webview_render_process_gone"
         | "webview_content_process_terminated"
+        | "os_version_changed"
+        | "native_app_version_changed"
       stripe_status:
         | "created"
         | "succeeded"
@@ -5154,6 +5156,8 @@ export const Constants = {
         "webview_unclean_restart",
         "webview_render_process_gone",
         "webview_content_process_terminated",
+        "os_version_changed",
+        "native_app_version_changed",
       ],
       stripe_status: [
         "created",

--- a/supabase/migrations/20260611150619_native_version_stats_events.sql
+++ b/supabase/migrations/20260611150619_native_version_stats_events.sql
@@ -1,0 +1,2 @@
+ALTER TYPE public.stats_action ADD VALUE IF NOT EXISTS 'os_version_changed';
+ALTER TYPE public.stats_action ADD VALUE IF NOT EXISTS 'native_app_version_changed';

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -313,7 +313,9 @@ CREATE TYPE "public"."stats_action" AS ENUM (
     'webview_security_policy_violation',
     'webview_unclean_restart',
     'webview_render_process_gone',
-    'webview_content_process_terminated'
+    'webview_content_process_terminated',
+    'os_version_changed',
+    'native_app_version_changed'
 );
 
 

--- a/tests/stats-actions.unit.test.ts
+++ b/tests/stats-actions.unit.test.ts
@@ -19,6 +19,11 @@ const HEALTH_STATS_ACTIONS = [
   'webview_content_process_terminated',
 ] as const
 
+const NATIVE_VERSION_STATS_ACTIONS = [
+  'os_version_changed',
+  'native_app_version_changed',
+] as const
+
 describe('stats action filters', () => {
   it('keeps the frontend action filters in sync with the backend action enum', () => {
     const frontendFilterKeys = statsActionFilters.map(([filterKey]) => filterKey)
@@ -33,6 +38,17 @@ describe('stats action filters', () => {
     expect(ALLOWED_STATS_ACTIONS).toEqual(expect.arrayContaining([...HEALTH_STATS_ACTIONS]))
 
     for (const action of HEALTH_STATS_ACTIONS) {
+      const filterKey = actionToFilter[action]
+
+      expect(filterKey).toBeTruthy()
+      expect(filterToAction[filterKey]).toBe(action)
+    }
+  })
+
+  it('keeps native version change actions accepted and filterable', () => {
+    expect(ALLOWED_STATS_ACTIONS).toEqual(expect.arrayContaining([...NATIVE_VERSION_STATS_ACTIONS]))
+
+    for (const action of NATIVE_VERSION_STATS_ACTIONS) {
       const filterKey = actionToFilter[action]
 
       expect(filterKey).toBeTruthy()


### PR DESCRIPTION
## What
- Add `os_version_changed` and `native_app_version_changed` to backend stats actions.
- Add the Supabase enum migration, generated type/schema snapshots, frontend filters, and English labels.
- Add a focused unit test that keeps the native version change actions accepted and filterable.

## Why
- The capacitor-updater plugin now reports OS version changes and native app version/build changes when the app opens and detects the stored values changed.

## How
- Extended the `stats_action` enum through a migration.
- Added both actions to backend validation and the dashboard action filter mapping.
- Updated generated Supabase type files and schema snapshot to match the enum.

## Testing
- `bunx vitest run tests/stats-actions.unit.test.ts tests/plugin-validation.test.ts`
- `bun run lint:backend`
- `bun run typecheck:backend`
- Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## Not Tested
- Full backend test suite was not run locally.