### PR TITLE
Add credit usage PostHog ledger events

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "test:cloudflare:updates": "vitest run tests/updates* --config vitest.config.cloudflare.ts",
     "bench": "vitest bench --config vitest.config.bench.ts --run",
     "admin:backfill-paid-product-activity": "bun scripts/backfill_paid_product_activity.ts",
+    "admin:backfill-credit-usage-posthog": "bun scripts/backfill_credit_usage_posthog_events.ts",
     "admin:backfill-plugin-version-ladder": "bun scripts/backfill_plugin_version_ladder.ts",
     "admin:backfill-missing-app-icons": "bun scripts/backfill_missing_app_icons.ts",
     "admin:backfill-missing-store-urls": "bun scripts/backfill_missing_store_urls.ts",

--- a/scripts/backfill_credit_usage_posthog_events.ts
+++ b/scripts/backfill_credit_usage_posthog_events.ts
@@ -1,0 +1,210 @@
+/*
+ * Backfill usage credit ledger PostHog events from public.usage_credit_transactions.
+ *
+ * Dry-run the past 90 days:
+ *   bun run admin:backfill-credit-usage-posthog
+ *
+ * Send events for the past 90 days:
+ *   bun run admin:backfill-credit-usage-posthog --apply
+ *
+ * Send a specific range:
+ *   bun run admin:backfill-credit-usage-posthog --apply --from=2026-03-01 --to=2026-06-01
+ */
+import process from 'node:process'
+import type { UsageOverageEventRow } from '../supabase/functions/_backend/utils/credit_usage_posthog.ts'
+import { buildCreditUsagePosthogEventInput, getCreditUsageSourceRefOverageEventId } from '../supabase/functions/_backend/utils/credit_usage_posthog.ts'
+import { DEFAULT_ENV_FILE, createSupabaseServiceClient, getArgValue, getRequiredEnv, loadEnv, parsePositiveInteger } from './admin_stripe_backfill_utils.ts'
+
+const DEFAULT_DAYS = 90
+const DEFAULT_BATCH_SIZE = 500
+const DEFAULT_POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
+
+function printHelp() {
+  console.log(`Backfill usage credit ledger events into PostHog.
+
+Usage:
+  bun run admin:backfill-credit-usage-posthog [options]
+
+Options:
+  --apply              Send events to PostHog. Without this, dry-run only.
+  --days=N             Look back N days when --from is not supplied. Default: ${DEFAULT_DAYS}.
+  --from=YYYY-MM-DD    Start occurred_at date, inclusive.
+  --to=YYYY-MM-DD      End occurred_at date, exclusive. Default: now.
+  --org-id=UUID        Limit to one organization.
+  --limit=N            Stop after N transactions.
+  --batch-size=N       Supabase page size. Default: ${DEFAULT_BATCH_SIZE}.
+  --env-file=PATH      Env file to load. Default: ${DEFAULT_ENV_FILE}.
+  --help               Show this help.
+
+Required env:
+  SUPABASE_URL
+  SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SERVICE_KEY
+
+Required for --apply:
+  POSTHOG_API_KEY
+
+Optional env:
+  POSTHOG_API_HOST     Defaults to ${DEFAULT_POSTHOG_CAPTURE_URL}
+`)
+}
+
+function parseDate(value: string, label: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime()))
+    throw new Error(`${label} must be a valid date`)
+  return date
+}
+
+function normalizePosthogCaptureUrl(host: string | undefined) {
+  const resolvedHost = host?.trim() || DEFAULT_POSTHOG_CAPTURE_URL
+  return resolvedHost.endsWith('/capture/')
+    ? resolvedHost
+    : new URL('capture/', resolvedHost.endsWith('/') ? resolvedHost : `${resolvedHost}/`).toString()
+}
+
+async function sendPosthogEvent(posthogUrl: string, apiKey: string, input: ReturnType<typeof buildCreditUsagePosthogEventInput>) {
+  const response = await fetch(posthogUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: apiKey,
+      distinct_id: input.distinctId,
+      event: input.event,
+      properties: {
+        ...input.tags,
+        $groups: input.groups,
+        channel: input.channel,
+        description: input.description,
+      },
+      timestamp: input.timestamp,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`PostHog capture failed: ${response.status} ${body}`)
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.includes('--help')) {
+    printHelp()
+    return
+  }
+
+  const envFile = getArgValue(args, '--env-file') ?? DEFAULT_ENV_FILE
+  const fileEnv = await loadEnv(envFile)
+  const env: Record<string, string | undefined> = { ...fileEnv, ...process.env }
+  const apply = args.includes('--apply')
+  const days = parsePositiveInteger(getArgValue(args, '--days'), '--days', DEFAULT_DAYS)
+  const batchSize = parsePositiveInteger(getArgValue(args, '--batch-size'), '--batch-size', DEFAULT_BATCH_SIZE)
+  const limit = getArgValue(args, '--limit') ? parsePositiveInteger(getArgValue(args, '--limit'), '--limit', 0) : null
+  const orgId = getArgValue(args, '--org-id')
+  const to = getArgValue(args, '--to') ? parseDate(getArgValue(args, '--to')!, '--to') : new Date()
+  const from = getArgValue(args, '--from')
+    ? parseDate(getArgValue(args, '--from')!, '--from')
+    : new Date(to.getTime() - days * 24 * 60 * 60 * 1000)
+
+  if (from >= to)
+    throw new Error('--from must be before --to')
+
+  const supabase = createSupabaseServiceClient(env)
+  const posthogApiKey = apply ? getRequiredEnv(env, 'POSTHOG_API_KEY') : ''
+  const posthogUrl = normalizePosthogCaptureUrl(env.POSTHOG_API_HOST)
+  const fromIso = from.toISOString()
+  const toIso = to.toISOString()
+
+  console.log(`${apply ? 'Applying' : 'Dry-running'} usage credit PostHog backfill`)
+  console.log(`Range: ${fromIso} <= occurred_at < ${toIso}`)
+  if (orgId)
+    console.log(`Org: ${orgId}`)
+  console.log(`Batch size: ${batchSize}`)
+
+  let offset = 0
+  let seen = 0
+  let sent = 0
+  let skipped = 0
+  const byType = new Map<string, number>()
+  const byMetric = new Map<string, number>()
+
+  while (limit === null || seen < limit) {
+    const remaining = limit === null ? batchSize : Math.min(batchSize, limit - seen)
+    let query = supabase
+      .from('usage_credit_transactions')
+      .select('*')
+      .gte('occurred_at', fromIso)
+      .lt('occurred_at', toIso)
+      .order('occurred_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(offset, offset + remaining - 1)
+
+    if (orgId)
+      query = query.eq('org_id', orgId)
+
+    const { data: transactions, error } = await query
+    if (error)
+      throw new Error(`Failed to fetch usage credit transactions: ${error.message}`)
+
+    if (!transactions || transactions.length === 0)
+      break
+
+    const overageIds = Array.from(new Set(
+      transactions
+        .map(transaction => getCreditUsageSourceRefOverageEventId(transaction.source_ref))
+        .filter((id): id is string => !!id),
+    ))
+
+    const overageById = new Map<string, UsageOverageEventRow>()
+    for (let index = 0; index < overageIds.length; index += batchSize) {
+      const ids = overageIds.slice(index, index + batchSize)
+      const { data: overageEvents, error: overageError } = await supabase
+        .from('usage_overage_events')
+        .select('*')
+        .in('id', ids)
+
+      if (overageError)
+        throw new Error(`Failed to fetch usage overage events: ${overageError.message}`)
+
+      for (const overageEvent of overageEvents ?? [])
+        overageById.set(overageEvent.id, overageEvent)
+    }
+
+    for (const transaction of transactions) {
+      const overageId = getCreditUsageSourceRefOverageEventId(transaction.source_ref)
+      const input = buildCreditUsagePosthogEventInput(transaction, overageId ? overageById.get(overageId) ?? null : null, 'backfill')
+      seen += 1
+      byType.set(String(input.tags.transaction_type), (byType.get(String(input.tags.transaction_type)) ?? 0) + 1)
+      byMetric.set(String(input.tags.metric ?? 'none'), (byMetric.get(String(input.tags.metric ?? 'none')) ?? 0) + 1)
+
+      if (!apply) {
+        if (seen <= 5)
+          console.log('dry-run sample', JSON.stringify({ distinctId: input.distinctId, event: input.event, tags: input.tags, timestamp: input.timestamp }))
+        skipped += 1
+        continue
+      }
+
+      await sendPosthogEvent(posthogUrl, posthogApiKey, input)
+      sent += 1
+    }
+
+    if (transactions.length < remaining)
+      break
+
+    offset += transactions.length
+  }
+
+  console.log(JSON.stringify({
+    apply,
+    by_metric: Object.fromEntries(byMetric.entries()),
+    by_type: Object.fromEntries(byType.entries()),
+    seen,
+    sent,
+    skipped,
+  }, null, 2))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/backfill_credit_usage_posthog_events.ts
+++ b/scripts/backfill_credit_usage_posthog_events.ts
@@ -9,6 +9,9 @@
  *
  * Send a specific range:
  *   bun run admin:backfill-credit-usage-posthog --apply --from=2026-03-01 --to=2026-06-01
+ *
+ * Reuse a run marker across retries:
+ *   bun run admin:backfill-credit-usage-posthog --apply --backfill-run-id=credits-2026-q2
  */
 import process from 'node:process'
 import type { UsageOverageEventRow } from '../supabase/functions/_backend/utils/credit_usage_posthog.ts'
@@ -33,6 +36,7 @@ Options:
   --org-id=UUID        Limit to one organization.
   --limit=N            Stop after N transactions.
   --batch-size=N       Supabase page size. Default: ${DEFAULT_BATCH_SIZE}.
+  --backfill-run-id=ID Mark all emitted events with this run id. Defaults to a generated id.
   --env-file=PATH      Env file to load. Default: ${DEFAULT_ENV_FILE}.
   --help               Show this help.
 
@@ -101,6 +105,9 @@ async function main() {
   const batchSize = parsePositiveInteger(getArgValue(args, '--batch-size'), '--batch-size', DEFAULT_BATCH_SIZE)
   const limit = getArgValue(args, '--limit') ? parsePositiveInteger(getArgValue(args, '--limit'), '--limit', 0) : null
   const orgId = getArgValue(args, '--org-id')
+  const backfillStartedAt = new Date().toISOString()
+  const backfillRunId = getArgValue(args, '--backfill-run-id')?.trim()
+    || `credit-usage-posthog-${backfillStartedAt.replace(/[:.]/g, '-')}`
   const to = getArgValue(args, '--to') ? parseDate(getArgValue(args, '--to')!, '--to') : new Date()
   const from = getArgValue(args, '--from')
     ? parseDate(getArgValue(args, '--from')!, '--from')
@@ -116,6 +123,7 @@ async function main() {
   const toIso = to.toISOString()
 
   console.log(`${apply ? 'Applying' : 'Dry-running'} usage credit PostHog backfill`)
+  console.log(`Backfill run id: ${backfillRunId}`)
   console.log(`Range: ${fromIso} <= occurred_at < ${toIso}`)
   if (orgId)
     console.log(`Org: ${orgId}`)
@@ -173,6 +181,10 @@ async function main() {
     for (const transaction of transactions) {
       const overageId = getCreditUsageSourceRefOverageEventId(transaction.source_ref)
       const input = buildCreditUsagePosthogEventInput(transaction, overageId ? overageById.get(overageId) ?? null : null, 'backfill')
+      input.tags.backfill_range_from = fromIso
+      input.tags.backfill_range_to = toIso
+      input.tags.backfill_run_id = backfillRunId
+      input.tags.backfill_started_at = backfillStartedAt
       seen += 1
       byType.set(String(input.tags.transaction_type), (byType.get(String(input.tags.transaction_type)) ?? 0) + 1)
       byMetric.set(String(input.tags.metric ?? 'none'), (byMetric.get(String(input.tags.metric ?? 'none')) ?? 0) + 1)

--- a/scripts/backfill_credit_usage_posthog_events.ts
+++ b/scripts/backfill_credit_usage_posthog_events.ts
@@ -8,7 +8,7 @@
  *   bun run admin:backfill-credit-usage-posthog --apply
  *
  * Send a specific range:
- *   bun run admin:backfill-credit-usage-posthog --apply --from=2026-03-01 --to=2026-06-01
+ *   bun run admin:backfill-credit-usage-posthog --apply --from=2026-03-01 --cutover=2026-06-01T00:00:00Z
  *
  * Reuse a run marker across retries:
  *   bun run admin:backfill-credit-usage-posthog --apply --backfill-run-id=credits-2026-q2
@@ -21,6 +21,22 @@ import { DEFAULT_ENV_FILE, createSupabaseServiceClient, getArgValue, getRequired
 const DEFAULT_DAYS = 90
 const DEFAULT_BATCH_SIZE = 500
 const DEFAULT_POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
+export const CREDIT_USAGE_BACKFILL_JOB_NAME = 'credit_usage_posthog_events'
+
+export interface BackfillProgressRow {
+  cutover_at: string
+  job_name: string
+  last_processed_id: number | null
+  last_processed_occurred_at: string | null
+  scope_key: string
+}
+
+interface BackfillRunTagOptions {
+  backfillRangeFrom: string
+  backfillRangeTo: string
+  backfillRunId: string
+  backfillStartedAt: string
+}
 
 function printHelp() {
   console.log(`Backfill usage credit ledger events into PostHog.
@@ -33,6 +49,7 @@ Options:
   --days=N             Look back N days when --from is not supplied. Default: ${DEFAULT_DAYS}.
   --from=YYYY-MM-DD    Start occurred_at date, inclusive.
   --to=YYYY-MM-DD      End occurred_at date, exclusive. Default: now.
+  --cutover=TIMESTAMP  Exclude transactions at or after this timestamp. Required for first --apply run.
   --org-id=UUID        Limit to one organization.
   --limit=N            Stop after N transactions.
   --batch-size=N       Supabase page size. Default: ${DEFAULT_BATCH_SIZE}.
@@ -48,6 +65,7 @@ Required for --apply:
   POSTHOG_API_KEY
 
 Optional env:
+  CREDIT_USAGE_POSTHOG_BACKFILL_CUTOVER_AT
   POSTHOG_API_HOST     Defaults to ${DEFAULT_POSTHOG_CAPTURE_URL}
 `)
 }
@@ -64,6 +82,83 @@ function normalizePosthogCaptureUrl(host: string | undefined) {
   return resolvedHost.endsWith('/capture/')
     ? resolvedHost
     : new URL('capture/', resolvedHost.endsWith('/') ? resolvedHost : `${resolvedHost}/`).toString()
+}
+
+export function getBackfillProgressScopeKey(orgId: string | null | undefined) {
+  return orgId?.trim() ? `org:${orgId.trim()}` : 'all_orgs'
+}
+
+export function buildCheckpointResumeFilter(lastProcessedOccurredAt: string, lastProcessedId: number) {
+  return `occurred_at.gt.${lastProcessedOccurredAt},and(occurred_at.eq.${lastProcessedOccurredAt},id.gt.${lastProcessedId})`
+}
+
+export function addBackfillRunTags(input: ReturnType<typeof buildCreditUsagePosthogEventInput>, options: BackfillRunTagOptions) {
+  input.tags.backfill_range_from = options.backfillRangeFrom
+  input.tags.backfill_range_to = options.backfillRangeTo
+  input.tags.backfill_run_id = options.backfillRunId
+  input.tags.backfill_started_at = options.backfillStartedAt
+  return input
+}
+
+function normalizeIsoDate(value: string, label: string) {
+  return parseDate(value, label).toISOString()
+}
+
+function isSameInstant(left: string, right: string) {
+  return normalizeIsoDate(left, 'checkpoint cutover_at') === normalizeIsoDate(right, 'configured cutover')
+}
+
+export function resolveCutoverIso(options: {
+  apply: boolean
+  configuredCutover: string | null
+  progress: BackfillProgressRow | null
+  to: Date
+}) {
+  if (options.configuredCutover)
+    return normalizeIsoDate(options.configuredCutover, '--cutover')
+
+  if (options.progress?.cutover_at)
+    return normalizeIsoDate(options.progress.cutover_at, 'checkpoint cutover_at')
+
+  if (options.apply) {
+    throw new Error(
+      'Missing cutover timestamp. Pass --cutover=<timestamp> or set CREDIT_USAGE_POSTHOG_BACKFILL_CUTOVER_AT for the first --apply run.',
+    )
+  }
+
+  return options.to.toISOString()
+}
+
+async function loadBackfillProgress(supabase: any, jobName: string, scopeKey: string): Promise<BackfillProgressRow | null> {
+  const { data, error } = await supabase
+    .from('backfill_progress')
+    .select('job_name, scope_key, cutover_at, last_processed_occurred_at, last_processed_id')
+    .eq('job_name', jobName)
+    .eq('scope_key', scopeKey)
+    .maybeSingle()
+
+  if (error)
+    throw new Error(`Failed to load backfill checkpoint: ${error.message}`)
+
+  return data ?? null
+}
+
+async function saveBackfillProgress(supabase: any, progress: BackfillProgressRow) {
+  const { error } = await supabase
+    .from('backfill_progress')
+    .upsert({
+      cutover_at: progress.cutover_at,
+      job_name: progress.job_name,
+      last_processed_id: progress.last_processed_id,
+      last_processed_occurred_at: progress.last_processed_occurred_at,
+      scope_key: progress.scope_key,
+      updated_at: new Date().toISOString(),
+    }, {
+      onConflict: 'job_name,scope_key',
+    })
+
+  if (error)
+    throw new Error(`Failed to save backfill checkpoint: ${error.message}`)
 }
 
 async function sendPosthogEvent(posthogUrl: string, apiKey: string, input: ReturnType<typeof buildCreditUsagePosthogEventInput>) {
@@ -105,6 +200,7 @@ async function main() {
   const batchSize = parsePositiveInteger(getArgValue(args, '--batch-size'), '--batch-size', DEFAULT_BATCH_SIZE)
   const limit = getArgValue(args, '--limit') ? parsePositiveInteger(getArgValue(args, '--limit'), '--limit', 0) : null
   const orgId = getArgValue(args, '--org-id')
+  const scopeKey = getBackfillProgressScopeKey(orgId)
   const backfillStartedAt = new Date().toISOString()
   const backfillRunId = getArgValue(args, '--backfill-run-id')?.trim()
     || `credit-usage-posthog-${backfillStartedAt.replace(/[:.]/g, '-')}`
@@ -113,23 +209,42 @@ async function main() {
     ? parseDate(getArgValue(args, '--from')!, '--from')
     : new Date(to.getTime() - days * 24 * 60 * 60 * 1000)
 
-  if (from >= to)
-    throw new Error('--from must be before --to')
-
   const supabase = createSupabaseServiceClient(env)
+  const supabaseAny = supabase as any
+  const progress = await loadBackfillProgress(supabaseAny, CREDIT_USAGE_BACKFILL_JOB_NAME, scopeKey)
+  const configuredCutover = getArgValue(args, '--cutover') ?? env.CREDIT_USAGE_POSTHOG_BACKFILL_CUTOVER_AT?.trim() ?? null
+  const cutoverIso = resolveCutoverIso({ apply, configuredCutover, progress, to })
+
+  if (progress?.cutover_at && !isSameInstant(progress.cutover_at, cutoverIso)) {
+    throw new Error(
+      `Checkpoint cutover_at (${progress.cutover_at}) does not match configured cutover (${cutoverIso}) for ${CREDIT_USAGE_BACKFILL_JOB_NAME}/${scopeKey}.`,
+    )
+  }
+
+  const upperBound = to < parseDate(cutoverIso, '--cutover') ? to : parseDate(cutoverIso, '--cutover')
+
+  if (from >= upperBound)
+    throw new Error('--from must be before the earlier of --to and --cutover')
+
   const posthogApiKey = apply ? getRequiredEnv(env, 'POSTHOG_API_KEY') : ''
   const posthogUrl = normalizePosthogCaptureUrl(env.POSTHOG_API_HOST)
   const fromIso = from.toISOString()
-  const toIso = to.toISOString()
+  const toIso = upperBound.toISOString()
+
+  let resumeOccurredAt = progress?.last_processed_occurred_at ? normalizeIsoDate(progress.last_processed_occurred_at, 'checkpoint last_processed_occurred_at') : null
+  let resumeId = progress?.last_processed_id ?? null
 
   console.log(`${apply ? 'Applying' : 'Dry-running'} usage credit PostHog backfill`)
   console.log(`Backfill run id: ${backfillRunId}`)
+  console.log(`Checkpoint scope: ${CREDIT_USAGE_BACKFILL_JOB_NAME}/${scopeKey}`)
+  console.log(`Cutover: ${cutoverIso}`)
+  if (resumeOccurredAt && resumeId !== null)
+    console.log(`Resuming after: (${resumeOccurredAt}, ${resumeId})`)
   console.log(`Range: ${fromIso} <= occurred_at < ${toIso}`)
   if (orgId)
     console.log(`Org: ${orgId}`)
   console.log(`Batch size: ${batchSize}`)
 
-  let offset = 0
   let seen = 0
   let sent = 0
   let skipped = 0
@@ -145,10 +260,13 @@ async function main() {
       .lt('occurred_at', toIso)
       .order('occurred_at', { ascending: true })
       .order('id', { ascending: true })
-      .range(offset, offset + remaining - 1)
+      .range(0, remaining - 1)
 
     if (orgId)
       query = query.eq('org_id', orgId)
+
+    if (resumeOccurredAt && resumeId !== null)
+      query = query.or(buildCheckpointResumeFilter(resumeOccurredAt, resumeId))
 
     const { data: transactions, error } = await query
     if (error)
@@ -180,11 +298,15 @@ async function main() {
 
     for (const transaction of transactions) {
       const overageId = getCreditUsageSourceRefOverageEventId(transaction.source_ref)
-      const input = buildCreditUsagePosthogEventInput(transaction, overageId ? overageById.get(overageId) ?? null : null, 'backfill')
-      input.tags.backfill_range_from = fromIso
-      input.tags.backfill_range_to = toIso
-      input.tags.backfill_run_id = backfillRunId
-      input.tags.backfill_started_at = backfillStartedAt
+      const input = addBackfillRunTags(
+        buildCreditUsagePosthogEventInput(transaction, overageId ? overageById.get(overageId) ?? null : null, 'backfill'),
+        {
+          backfillRangeFrom: fromIso,
+          backfillRangeTo: toIso,
+          backfillRunId,
+          backfillStartedAt,
+        },
+      )
       seen += 1
       byType.set(String(input.tags.transaction_type), (byType.get(String(input.tags.transaction_type)) ?? 0) + 1)
       byMetric.set(String(input.tags.metric ?? 'none'), (byMetric.get(String(input.tags.metric ?? 'none')) ?? 0) + 1)
@@ -200,10 +322,22 @@ async function main() {
       sent += 1
     }
 
+    const lastTransaction = transactions[transactions.length - 1]
+    resumeOccurredAt = normalizeIsoDate(lastTransaction.occurred_at, 'transaction occurred_at')
+    resumeId = Number(lastTransaction.id)
+
+    if (apply) {
+      await saveBackfillProgress(supabaseAny, {
+        cutover_at: cutoverIso,
+        job_name: CREDIT_USAGE_BACKFILL_JOB_NAME,
+        last_processed_id: resumeId,
+        last_processed_occurred_at: resumeOccurredAt,
+        scope_key: scopeKey,
+      })
+    }
+
     if (transactions.length < remaining)
       break
-
-    offset += transactions.length
   }
 
   console.log(JSON.stringify({
@@ -216,7 +350,9 @@ async function main() {
   }, null, 2))
 }
 
-main().catch((error) => {
-  console.error(error)
-  process.exit(1)
-})
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/supabase/functions/_backend/triggers/credit_usage_posthog.ts
+++ b/supabase/functions/_backend/triggers/credit_usage_posthog.ts
@@ -1,0 +1,73 @@
+import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import { Hono } from 'hono/tiny'
+import type { UsageOverageEventRow } from '../utils/credit_usage_posthog.ts'
+import { buildCreditUsagePosthogEventInput, getCreditUsageSourceRefOverageEventId } from '../utils/credit_usage_posthog.ts'
+import { BRES, middlewareAPISecret, parseBody, simpleError } from '../utils/hono.ts'
+import { cloudlog } from '../utils/logging.ts'
+import { trackPosthogEvent } from '../utils/posthog.ts'
+import { supabaseAdmin } from '../utils/supabase.ts'
+
+interface CreditUsagePosthogPayload {
+  transaction_id?: number | string
+}
+
+export const app = new Hono<MiddlewareKeyVariables>()
+
+app.post('/', middlewareAPISecret, async (c) => {
+  const payload = await parseBody<CreditUsagePosthogPayload>(c)
+  const transactionId = Number(payload.transaction_id)
+
+  if (!Number.isInteger(transactionId) || transactionId <= 0)
+    throw simpleError('invalid_payload', 'Missing transaction_id in credit usage PostHog payload', { payload })
+
+  const supabase = supabaseAdmin(c)
+  const { data: transaction, error: transactionError } = await supabase
+    .from('usage_credit_transactions')
+    .select('*')
+    .eq('id', transactionId)
+    .maybeSingle()
+
+  if (transactionError)
+    throw simpleError('transaction_lookup_failed', 'Failed to load usage credit transaction', { transactionId, error: transactionError })
+
+  if (!transaction) {
+    cloudlog({ requestId: c.get('requestId'), message: 'usage credit transaction not found, skipping PostHog event', transactionId })
+    return c.json(BRES)
+  }
+
+  let overageEvent: UsageOverageEventRow | null = null
+  const overageEventId = getCreditUsageSourceRefOverageEventId(transaction.source_ref)
+  if (overageEventId) {
+    const { data, error } = await supabase
+      .from('usage_overage_events')
+      .select('*')
+      .eq('id', overageEventId)
+      .maybeSingle()
+
+    if (error)
+      throw simpleError('overage_lookup_failed', 'Failed to load usage overage event', { transactionId, overageEventId, error })
+
+    overageEvent = data
+  }
+
+  const eventInput = buildCreditUsagePosthogEventInput(transaction, overageEvent, 'backend')
+  const sent = await trackPosthogEvent(c, {
+    channel: eventInput.channel,
+    description: eventInput.description,
+    event: eventInput.event,
+    groups: eventInput.groups,
+    setPersonProperties: false,
+    tags: eventInput.tags,
+    timestamp: eventInput.timestamp,
+    user_id: eventInput.distinctId,
+  })
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: sent ? 'credit usage PostHog event sent' : 'credit usage PostHog event skipped',
+    transactionId,
+    orgId: transaction.org_id,
+  })
+
+  return c.json(BRES)
+})

--- a/supabase/functions/_backend/utils/credit_usage_posthog.ts
+++ b/supabase/functions/_backend/utils/credit_usage_posthog.ts
@@ -1,0 +1,112 @@
+import type { Database, Json } from './supabase.types.ts'
+import type { PostHogGroups } from './posthog.ts'
+
+export const CREDIT_USAGE_POSTHOG_EVENT = 'Credit Usage Ledger Entry'
+
+export type CreditUsagePosthogSource = 'backend' | 'backfill'
+export type UsageCreditTransactionRow = Database['public']['Tables']['usage_credit_transactions']['Row']
+export type UsageOverageEventRow = Database['public']['Tables']['usage_overage_events']['Row']
+
+export interface CreditUsagePosthogEventInput {
+  channel: string
+  description: string
+  distinctId: string
+  event: string
+  groups: PostHogGroups
+  tags: Record<string, string | number | boolean | null>
+  timestamp: string
+}
+
+function jsonObject(value: Json | null | undefined): Record<string, Json | undefined> {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    return {}
+
+  return value
+}
+
+function jsonString(value: Json | undefined) {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function jsonNumber(value: Json | undefined) {
+  if (value === null || value === undefined || value === '')
+    return null
+
+  const numberValue = Number(value)
+  return Number.isFinite(numberValue) ? numberValue : null
+}
+
+function nullableNumber(value: number | string | null | undefined) {
+  if (value === null || value === undefined)
+    return null
+
+  const numberValue = Number(value)
+  return Number.isFinite(numberValue) ? numberValue : null
+}
+
+function compactTags(tags: Record<string, string | number | boolean | null | undefined>) {
+  const output: Record<string, string | number | boolean | null> = {}
+  for (const [key, value] of Object.entries(tags)) {
+    if (value !== undefined)
+      output[key] = value
+  }
+  return output
+}
+
+export function getCreditUsageSourceRefOverageEventId(sourceRef: Json | null | undefined) {
+  return jsonString(jsonObject(sourceRef).overage_event_id)
+}
+
+export function buildCreditUsagePosthogEventInput(
+  transaction: UsageCreditTransactionRow,
+  overageEvent: UsageOverageEventRow | null,
+  captureSource: CreditUsagePosthogSource,
+): CreditUsagePosthogEventInput {
+  const sourceRef = jsonObject(transaction.source_ref)
+  const details = jsonObject(overageEvent?.details)
+  const amount = nullableNumber(transaction.amount) ?? 0
+  const balanceAfter = nullableNumber(transaction.balance_after)
+  const overageAmount = nullableNumber(overageEvent?.overage_amount)
+  const usage = jsonNumber(details.usage)
+  const limit = jsonNumber(details.limit)
+  const metric = overageEvent?.metric ?? jsonString(sourceRef.metric)
+  const overageEventId = overageEvent?.id ?? getCreditUsageSourceRefOverageEventId(transaction.source_ref)
+  const creditUsageKind = amount < 0 ? 'debit' : amount > 0 ? 'credit' : 'zero'
+
+  return {
+    channel: 'usage',
+    description: transaction.description ?? `Usage credit ${transaction.transaction_type}`,
+    distinctId: transaction.org_id,
+    event: CREDIT_USAGE_POSTHOG_EVENT,
+    groups: { organization: transaction.org_id },
+    tags: compactTags({
+      $insert_id: `usage_credit_transaction:${transaction.id}`,
+      balance_after: balanceAfter,
+      billing_cycle_end: overageEvent?.billing_cycle_end ?? null,
+      billing_cycle_start: overageEvent?.billing_cycle_start ?? null,
+      capture_source: captureSource,
+      credit_usage_kind: creditUsageKind,
+      credits_abs: Math.abs(amount),
+      credits_delta: amount,
+      credits_granted: amount > 0 ? amount : 0,
+      credits_spent: amount < 0 ? Math.abs(amount) : 0,
+      grant_id: transaction.grant_id,
+      is_build_time_credit_usage: amount < 0 && metric === 'build_time',
+      is_credit_debit: amount < 0,
+      limit,
+      metric,
+      occurred_at: transaction.occurred_at,
+      org_id: transaction.org_id,
+      overage_amount: overageAmount,
+      overage_event_id: overageEventId,
+      source_record: 'usage_credit_transactions',
+      source_record_id: String(transaction.id),
+      source_ref_payment_intent_id: jsonString(sourceRef.paymentIntentId),
+      source_ref_session_id: jsonString(sourceRef.sessionId),
+      transaction_id: transaction.id,
+      transaction_type: transaction.transaction_type,
+      usage,
+    }),
+    timestamp: transaction.occurred_at ?? new Date().toISOString(),
+  }
+}

--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -14,6 +14,7 @@ interface PostHogCapturePayload extends Pick<TrackOptions, 'event'>, Pick<TrackO
   ip?: string
   setPersonProperties?: boolean
   tags?: Record<string, any>
+  timestamp?: string
   user_id?: string
 }
 
@@ -47,7 +48,7 @@ export async function trackPosthogEvent(c: Context, payload: PostHogCapturePaylo
     distinct_id: distinctId,
     properties,
     ip: payload.ip,
-    timestamp: new Date().toISOString(),
+    timestamp: payload.timestamp ?? new Date().toISOString(),
   }
 
   try {

--- a/supabase/functions/triggers/index.ts
+++ b/supabase/functions/triggers/index.ts
@@ -1,4 +1,5 @@
 import { app as credit_usage_alerts } from '../_backend/triggers/credit_usage_alerts.ts'
+import { app as credit_usage_posthog } from '../_backend/triggers/credit_usage_posthog.ts'
 import { app as cron_clean_orphan_images } from '../_backend/triggers/cron_clean_orphan_images.ts'
 import { app as cron_clear_versions } from '../_backend/triggers/cron_clear_versions.ts'
 import { app as cron_email } from '../_backend/triggers/cron_email.ts'
@@ -55,6 +56,7 @@ appGlobal.route('/cron_clear_versions', cron_clear_versions)
 appGlobal.route('/cron_clean_orphan_images', cron_clean_orphan_images)
 appGlobal.route('/cron_reconcile_build_status', cron_reconcile_build_status)
 appGlobal.route('/credit_usage_alerts', credit_usage_alerts)
+appGlobal.route('/credit_usage_posthog', credit_usage_posthog)
 appGlobal.route('/on_organization_delete', on_organization_delete)
 appGlobal.route('/on_deploy_history_create', on_deploy_history_create)
 appGlobal.route('/queue_consumer', queue_consumer)

--- a/supabase/migrations/20260612092702_credit_usage_posthog_events.sql
+++ b/supabase/migrations/20260612092702_credit_usage_posthog_events.sql
@@ -1,5 +1,30 @@
 SELECT pgmq.create('credit_usage_posthog');
 
+CREATE TABLE IF NOT EXISTS public.backfill_progress (
+  job_name text NOT NULL,
+  scope_key text NOT NULL,
+  cutover_at timestamp with time zone NOT NULL,
+  last_processed_occurred_at timestamp with time zone,
+  last_processed_id bigint,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL,
+  PRIMARY KEY (job_name, scope_key)
+);
+
+ALTER TABLE public.backfill_progress OWNER TO postgres;
+ALTER TABLE public.backfill_progress ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Deny all access" ON public.backfill_progress;
+
+CREATE POLICY "Deny all access" ON public.backfill_progress
+USING (false)
+WITH CHECK (false);
+
+REVOKE ALL ON TABLE public.backfill_progress FROM PUBLIC;
+REVOKE ALL ON TABLE public.backfill_progress FROM anon;
+REVOKE ALL ON TABLE public.backfill_progress FROM authenticated;
+GRANT ALL ON TABLE public.backfill_progress TO service_role;
+
 CREATE OR REPLACE FUNCTION public.enqueue_credit_usage_posthog_event() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
     SET search_path TO ''
@@ -9,19 +34,23 @@ BEGIN
     RETURN COALESCE(NEW, OLD);
   END IF;
 
-  PERFORM pgmq.send(
-    'credit_usage_posthog',
-    jsonb_build_object(
-      'function_name', 'credit_usage_posthog',
-      'function_type', NULL,
-      'payload', jsonb_build_object(
-        'transaction_id', NEW.id,
-        'org_id', NEW.org_id,
-        'transaction_type', NEW.transaction_type,
-        'occurred_at', NEW.occurred_at
+  BEGIN
+    PERFORM pgmq.send(
+      'credit_usage_posthog',
+      jsonb_build_object(
+        'function_name', 'credit_usage_posthog',
+        'function_type', NULL,
+        'payload', jsonb_build_object(
+          'transaction_id', NEW.id,
+          'org_id', NEW.org_id,
+          'transaction_type', NEW.transaction_type,
+          'occurred_at', NEW.occurred_at
+        )
       )
-    )
-  );
+    );
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'Failed to enqueue credit usage PostHog event for transaction %: %', NEW.id, SQLERRM;
+  END;
 
   RETURN NEW;
 END;

--- a/supabase/migrations/20260612092702_credit_usage_posthog_events.sql
+++ b/supabase/migrations/20260612092702_credit_usage_posthog_events.sql
@@ -1,0 +1,49 @@
+SELECT pgmq.create('credit_usage_posthog');
+
+CREATE OR REPLACE FUNCTION public.enqueue_credit_usage_posthog_event() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+BEGIN
+  IF TG_OP <> 'INSERT' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  PERFORM pgmq.send(
+    'credit_usage_posthog',
+    jsonb_build_object(
+      'function_name', 'credit_usage_posthog',
+      'function_type', NULL,
+      'payload', jsonb_build_object(
+        'transaction_id', NEW.id,
+        'org_id', NEW.org_id,
+        'transaction_type', NEW.transaction_type,
+        'occurred_at', NEW.occurred_at
+      )
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.enqueue_credit_usage_posthog_event() OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.enqueue_credit_usage_posthog_event() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.enqueue_credit_usage_posthog_event() FROM anon;
+REVOKE ALL ON FUNCTION public.enqueue_credit_usage_posthog_event() FROM authenticated;
+REVOKE ALL ON FUNCTION public.enqueue_credit_usage_posthog_event() FROM service_role;
+
+DROP TRIGGER IF EXISTS credit_usage_posthog_on_transactions ON public.usage_credit_transactions;
+
+CREATE TRIGGER credit_usage_posthog_on_transactions
+AFTER INSERT ON public.usage_credit_transactions
+FOR EACH ROW EXECUTE FUNCTION public.enqueue_credit_usage_posthog_event();
+
+UPDATE public.cron_tasks
+SET target = CASE
+  WHEN target::jsonb ? 'credit_usage_posthog' THEN target
+  ELSE (target::jsonb || '["credit_usage_posthog"]'::jsonb)::text
+END
+WHERE name = 'high_frequency_queues'
+  AND task_type = 'function_queue';

--- a/tests/credit-usage-posthog.unit.test.ts
+++ b/tests/credit-usage-posthog.unit.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { addBackfillRunTags, buildCheckpointResumeFilter, getBackfillProgressScopeKey, resolveCutoverIso } from '../scripts/backfill_credit_usage_posthog_events.ts'
 import { buildCreditUsagePosthogEventInput } from '../supabase/functions/_backend/utils/credit_usage_posthog.ts'
 
 const {
@@ -119,6 +120,63 @@ describe('credit usage PostHog event builder', () => {
       transaction_type: 'deduction',
       usage: 5400,
       limit: 1800,
+    })
+  })
+})
+
+describe('credit usage PostHog backfill helpers', () => {
+  it('builds stable checkpoint scope keys', () => {
+    expect(getBackfillProgressScopeKey(null)).toBe('all_orgs')
+    expect(getBackfillProgressScopeKey(undefined)).toBe('all_orgs')
+    expect(getBackfillProgressScopeKey(' org-1 ')).toBe('org:org-1')
+  })
+
+  it('builds a resume filter after the last processed occurred_at and id pair', () => {
+    expect(buildCheckpointResumeFilter('2026-03-01T10:00:00.000Z', 123))
+      .toBe('occurred_at.gt.2026-03-01T10:00:00.000Z,and(occurred_at.eq.2026-03-01T10:00:00.000Z,id.gt.123)')
+  })
+
+  it('normalizes explicit cutovers before they are used as query bounds', () => {
+    expect(resolveCutoverIso({
+      apply: true,
+      configuredCutover: '2026-06-01',
+      progress: null,
+      to: new Date('2026-06-12T00:00:00.000Z'),
+    })).toBe('2026-06-01T00:00:00.000Z')
+  })
+
+  it('requires a cutover before the first applying run', () => {
+    expect(() => resolveCutoverIso({
+      apply: true,
+      configuredCutover: null,
+      progress: null,
+      to: new Date('2026-06-12T00:00:00.000Z'),
+    })).toThrow('Missing cutover timestamp')
+  })
+
+  it('marks backfilled events with a run id without changing event identity', () => {
+    const input = buildCreditUsagePosthogEventInput(transaction as any, overageEvent as any, 'backfill')
+
+    const tagged = addBackfillRunTags(input, {
+      backfillRangeFrom: '2026-03-01T00:00:00.000Z',
+      backfillRangeTo: '2026-06-01T00:00:00.000Z',
+      backfillRunId: 'credits-q2',
+      backfillStartedAt: '2026-06-12T09:30:00.000Z',
+    })
+
+    expect(tagged).toBe(input)
+    expect(tagged).toMatchObject({
+      distinctId: 'org-1',
+      event: 'Credit Usage Ledger Entry',
+      timestamp: '2026-03-01T10:00:00.000Z',
+    })
+    expect(tagged.tags).toMatchObject({
+      $insert_id: 'usage_credit_transaction:123',
+      backfill_range_from: '2026-03-01T00:00:00.000Z',
+      backfill_range_to: '2026-06-01T00:00:00.000Z',
+      backfill_run_id: 'credits-q2',
+      backfill_started_at: '2026-06-12T09:30:00.000Z',
+      capture_source: 'backfill',
     })
   })
 })

--- a/tests/credit-usage-posthog.unit.test.ts
+++ b/tests/credit-usage-posthog.unit.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildCreditUsagePosthogEventInput } from '../supabase/functions/_backend/utils/credit_usage_posthog.ts'
+
+const {
+  supabaseAdminMock,
+  trackPosthogEventMock,
+} = vi.hoisted(() => ({
+  supabaseAdminMock: vi.fn(),
+  trackPosthogEventMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
+  BRES: { status: 'ok' },
+  middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => next(),
+  parseBody: async (c: { req: { json: () => Promise<unknown> } }) => await c.req.json(),
+  simpleError: (code: string, message: string, info?: unknown) => {
+    const error = new Error(`${code}: ${message}`)
+    Object.assign(error, { info })
+    return error
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/posthog.ts', () => ({
+  trackPosthogEvent: trackPosthogEventMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin: supabaseAdminMock,
+}))
+
+const transaction = {
+  amount: -10,
+  balance_after: 90,
+  description: 'Overage deduction for build_time usage',
+  grant_id: 'grant-1',
+  id: 123,
+  occurred_at: '2026-03-01T10:00:00.000Z',
+  org_id: 'org-1',
+  source_ref: { metric: 'build_time', overage_event_id: 'overage-1' },
+  transaction_type: 'deduction',
+}
+
+const overageEvent = {
+  billing_cycle_end: '2026-04-01',
+  billing_cycle_start: '2026-03-01',
+  created_at: '2026-03-01T10:00:00.000Z',
+  credit_step_id: 7,
+  credits_debited: 10,
+  credits_estimated: 10,
+  details: { limit: 1800, usage: 5400 },
+  id: 'overage-1',
+  metric: 'build_time',
+  org_id: 'org-1',
+  overage_amount: 3600,
+}
+
+function queryResponse(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        maybeSingle: vi.fn(async () => ({ data, error })),
+      })),
+    })),
+  }
+}
+
+function post(body: unknown) {
+  return app.request(new Request('http://local/', {
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  }))
+}
+
+const { app } = await import('../supabase/functions/_backend/triggers/credit_usage_posthog.ts')
+
+beforeEach(() => {
+  trackPosthogEventMock.mockResolvedValue(true)
+  supabaseAdminMock.mockImplementation(() => ({
+    from: (table: string) => {
+      if (table === 'usage_credit_transactions')
+        return queryResponse(transaction)
+      if (table === 'usage_overage_events')
+        return queryResponse(overageEvent)
+      throw new Error(`Unexpected table ${table}`)
+    },
+  }))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  supabaseAdminMock.mockReset()
+  trackPosthogEventMock.mockReset()
+})
+
+describe('credit usage PostHog event builder', () => {
+  it('marks build-time deductions as credit spend linked to builds', () => {
+    const input = buildCreditUsagePosthogEventInput(transaction as any, overageEvent as any, 'backfill')
+
+    expect(input).toMatchObject({
+      channel: 'usage',
+      distinctId: 'org-1',
+      event: 'Credit Usage Ledger Entry',
+      groups: { organization: 'org-1' },
+      timestamp: '2026-03-01T10:00:00.000Z',
+    })
+    expect(input.tags).toMatchObject({
+      $insert_id: 'usage_credit_transaction:123',
+      capture_source: 'backfill',
+      credits_delta: -10,
+      credits_spent: 10,
+      is_build_time_credit_usage: true,
+      metric: 'build_time',
+      overage_event_id: 'overage-1',
+      transaction_type: 'deduction',
+      usage: 5400,
+      limit: 1800,
+    })
+  })
+})
+
+describe('credit usage PostHog trigger', () => {
+  it('loads the transaction context and sends a PostHog-only event', async () => {
+    const response = await post({ transaction_id: 123 })
+
+    expect(response.status).toBe(200)
+    expect(trackPosthogEventMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: 'Credit Usage Ledger Entry',
+      groups: { organization: 'org-1' },
+      setPersonProperties: false,
+      timestamp: '2026-03-01T10:00:00.000Z',
+      user_id: 'org-1',
+      tags: expect.objectContaining({
+        capture_source: 'backend',
+        credits_spent: 10,
+        is_build_time_credit_usage: true,
+        metric: 'build_time',
+        source_record_id: '123',
+      }),
+    }))
+  })
+})

--- a/tests/posthog.unit.test.ts
+++ b/tests/posthog.unit.test.ts
@@ -83,6 +83,27 @@ describe('posthog helper', () => {
     expect(body.properties.$set).toEqual({ app_id: 'app-id' })
   })
 
+  it('can send historical events without updating person properties', async () => {
+    const { trackPosthogEvent } = await import('../supabase/functions/_backend/utils/posthog.ts')
+
+    await trackPosthogEvent(createContext(), {
+      event: 'Historical Event',
+      channel: 'usage',
+      description: 'tracked',
+      setPersonProperties: false,
+      tags: { source_record_id: '123' },
+      timestamp: '2026-03-01T00:00:00.000Z',
+      user_id: 'org-id',
+    })
+
+    const request = fetchMock.mock.calls[0]
+    const body = JSON.parse(request?.[1]?.body as string)
+
+    expect(body.timestamp).toBe('2026-03-01T00:00:00.000Z')
+    expect(body.properties.source_record_id).toBe('123')
+    expect(body.properties).not.toHaveProperty('$set')
+  })
+
   it('uses the full exception endpoint host and only sends the request path for exceptions', async () => {
     const { capturePosthogException } = await import('../supabase/functions/_backend/utils/posthog.ts')
     envState.posthogApiHost = 'https://eu.i.posthog.com/i/v0/e'

--- a/tests/security-definer-execute-hardening.test.ts
+++ b/tests/security-definer-execute-hardening.test.ts
@@ -28,6 +28,7 @@ const SERVICE_ONLY_PROCS = [
   'public.check_org_hashed_key_enforcement(uuid, public.apikeys)',
   'public.cleanup_onboarding_app_data_on_complete()',
   'public.delete_old_deleted_versions()',
+  'public.enqueue_credit_usage_posthog_event()',
   'public.generate_org_user_stripe_info_on_org_create()',
   'public.get_apikey()',
   'public.noupdate()',


### PR DESCRIPTION
## Summary
- enqueue a backend PostHog capture whenever `usage_credit_transactions` gets a new ledger row
- add the `Credit Usage Ledger Entry` event payload with org group, transaction id, credit delta/spend, overage metric, and build-time linkage
- add a dry-run-by-default 90-day backfill script: `bun run admin:backfill-credit-usage-posthog --apply`

## Notes
- I did not run the backfill script with `--apply`.
- Build-linked credit usage can be charted with `event = Credit Usage Ledger Entry`, `transaction_type = deduction`, and `metric = build_time`, summing `credits_spent` per day.

## Validation
- `bunx vitest run tests/posthog.unit.test.ts tests/credit-usage-posthog.unit.test.ts`
- `bun run typecheck:backend`
- `bun run lint:backend`
- `bun scripts/backfill_credit_usage_posthog_events.ts --help`
- `bunx oxlint scripts/backfill_credit_usage_posthog_events.ts tests/credit-usage-posthog.unit.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credit usage transactions are now tracked in the analytics platform in real-time.

* **Chores**
  * Added an admin script to backfill historical credit usage event data.
  * Updated database infrastructure to support automated credit usage event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->