### PR TITLE
fix(app-list): scope `app list` to the caller's orgs to avoid RBAC RLS timeout

### DIFF
--- a/cli/src/app/list.ts
+++ b/cli/src/app/list.ts
@@ -19,10 +19,17 @@ function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   log.success(table.toString())
 }
 
-async function getActiveApps(supabase: SupabaseClient<Database>, silent: boolean) {
+async function getActiveApps(supabase: SupabaseClient<Database>, silent: boolean, orgIds: string[]) {
+  // Scope the list to the caller's orgs. An unfiltered `apps` select makes Postgres
+  // evaluate the per-row RBAC RLS (a recursive role-closure walk via
+  // get_identity_org_appid → rbac_has_permission) across the ENTIRE apps table, which
+  // hits the statement timeout on large databases and surfaces as "Apps not found"
+  // (the underlying "canceling statement due to statement timeout" is swallowed).
+  // Filtering by owner_org first restricts the rows RLS ever evaluates to the caller's.
   const { data, error } = await withSupabaseSource('apps.list', () => supabase
     .from('apps')
     .select()
+    .in('owner_org', orgIds)
     .order('created_at', { ascending: false }))
 
   if (error) {
@@ -49,7 +56,23 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
   if (!silent)
     log.info('Getting active bundle in Capgo')
 
-  const allApps = await getActiveApps(supabase, silent)
+  // Resolve the orgs this identity can access (RBAC-aware, SECURITY DEFINER — works for
+  // both API keys and logged-in sessions) so the list can be scoped to them. Without
+  // this, the unfiltered apps query times out on large databases (see getActiveApps).
+  const { data: orgs, error: orgsError } = await supabase.rpc('get_orgs_v6')
+  if (orgsError) {
+    if (!silent)
+      log.error('Could not load your organizations')
+    throw new Error(`Could not load organizations: ${orgsError.message}`)
+  }
+  const orgIds = (orgs ?? []).map(org => org.gid).filter(Boolean)
+  if (!orgIds.length) {
+    if (!silent)
+      log.error('No apps found')
+    throw new Error('No apps found')
+  }
+
+  const allApps = await getActiveApps(supabase, silent, orgIds)
 
   void trackEvent({ channel: 'app', event: 'Apps Listed', icon: '📋', tags: { app_count: allApps.length } })
 


### PR DESCRIPTION
## Problem

`capgo app list` returns **`Apps not found`** (an error, not an empty list) for some accounts — even when the user owns all their apps. The same broad query backs `sdk.listApps()` and the `capgo_list_apps` MCP tool.

The real error is swallowed. The Postgres logs show what's actually happening:

```
ERROR: canceling statement due to statement timeout
```

### Root cause

`getActiveApps` ran an **unfiltered** query:

```ts
supabase.from('apps').select().order('created_at', { ascending: false })
```

The `apps` SELECT RLS policy is:

```
check_min_rights('read', get_identity_org_appid(...), owner_org, app_id, NULL)
```

`get_identity_org_appid` → `rbac_has_permission`, which runs a **`WITH RECURSIVE` role-closure walk** (`role_bindings` → `role_hierarchy` → `role_permissions`). On an unfiltered select, Postgres evaluates that **per row across the entire global `apps` table** → O(apps × recursive-RBAC) → **statement timeout** → query errors → swallowed as `Apps not found`.

It's intermittent (right at the timeout boundary) and unrelated to the caller's permissions — a key with `org_super_admin` on its org still hits it.

## Fix

Resolve the caller's orgs first, then scope the apps query to them:

```ts
const { data: orgs } = await supabase.rpc('get_orgs_v6')   // RBAC-aware, SECURITY DEFINER, works for API keys + sessions
const orgIds = (orgs ?? []).map(o => o.gid)
supabase.from('apps').select().in('owner_org', orgIds).order('created_at', { ascending: false })
```

`owner_org` is indexed and the `IN (…)` filter is leakproof, so Postgres restricts the candidate rows via the index **before** evaluating RLS — RLS now runs only on the caller's own apps. No full-table scan, no timeout. This is the same org-scoped pattern the **dashboard already uses** (`get_orgs_v6` + `get_org_apps_with_last_upload`), which is why the dashboard never hit this.

## Scope

- Touches only `cli/src/app/list.ts` (`getActiveApps` + `listAppInternal`).
- `listApp` / `listAppInternal` keep the same return shape, so all callers are unaffected.
- The MCP onboarding's `isAppRegistered` (which surfaced this as a false "app already exists / not in your account") will be ported separately.

## Test plan

- [ ] `npx @capgo/cli app list` with an API key on a large-DB account returns the apps (previously `Apps not found`).
- [ ] Account with no apps still reports `No apps found`.
- [ ] `typecheck` + `lint` green (done locally).

## Follow-up (not in this PR)

The underlying `apps`-list RLS is O(N) per row; the long-term backend fix is to make `rbac_has_permission` non-recursive for the common case (materialized/cached permission set). This PR removes the CLI's exposure to it by not doing unfiltered selects.
