### PR TITLE
fix(cli): allow app_admin keys to set channels (gate write, not admin)

### DIFF
--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -76,8 +76,11 @@ export async function setChannelInternal(channel: string, appId: string, options
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
   const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
-
-  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
+  // Setting an existing channel (bundle promotion / settings) needs app_admin tier, which
+  // get_org_perm_for_apikey reports as perm_write; org_super_admin's app.delete is NOT required.
+  // Gating on admin here was a false-negative that blocked app_admin/org_admin keys. The backend
+  // (POST /channel/) and the channels RLS already authorize this at write/app_admin level.
+  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.write, silent, true)
   const orgId = await getOrganizationId(supabase, appId)
 
   const {


### PR DESCRIPTION
## Problem

`channel set <channel> <appId> --bundle <version>` fails with a false-negative permission error even for keys that are fully authorized:

```
■  Insuficcent permissions for app <app>. Current permission: write, required for this action: admin.
```

The same key + same operation succeeds via the backend (`POST https://api.capgo.app/channel/`) and via the web console.

## Root cause

`channel set` runs a client-side pre-flight check at `OrganizationPerm.admin` (`cli/src/channel/set.ts`). The DB RPC `get_org_perm_for_apikey` only returns `perm_admin` for keys holding **`app.delete`**, which is held **exclusively by `org_super_admin`**.

Keys bound to `app_admin` / `org_admin` (which is what a normal "admin"/"all" key is) hold `app.update_settings` + `app.update_user_roles` but **not** `app.delete`, so they resolve to **`perm_write`** and are wrongly rejected by the `admin` gate.

Meanwhile the operation is genuinely authorized at the write/app_admin tier:
- Backend `POST /channel/` checks `app.create_channel` (app_admin tier), not org_super_admin.
- The `channels` table RLS authorizes the update for app_admin-tier keys.

So the CLI gate was stricter than both the backend and the database.

## Fix

Lower the `channel set` pre-flight gate from `OrganizationPerm.admin` to `OrganizationPerm.write`. In the current RBAC model `perm_write` == app_admin tier, so this exactly matches what the backend and RLS already require. The channels RLS remains authoritative, so there is no over-permit (an under-privileged key is still rejected at the DB).

## Scope / follow-up

This is a targeted unblock for `channel set` only. `channel add` and `channel delete` still gate on `admin`.

The deeper, correct fix — gating *modification of an existing channel* (bundle promotion / settings) on the channel-scope permissions RBAC already defines (`channel.promote_bundle` / `channel.update_settings`, both held by `app_developer`) instead of app-scope admin perms — spans the backend `post.ts`, the channels UPDATE RLS, and the CLI, and is tracked separately. That work is what restores true write/developer keys.

## Test plan

- [ ] An `app_admin`/`org_admin`-bound API key can run `channel set <channel> <app> --bundle <ver>` successfully.
- [ ] An `app_reader` key is still rejected (gate + RLS).
- [ ] Behavior matches `POST /channel/` for the same key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission authorization for channel settings to allow administrators with `app_admin` and `org_admin` permission levels to properly access and configure channel settings without unnecessary restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->