### PR TITLE
fix(cli): allow app_admin keys to create channels (gate write, not admin)

### DIFF
--- a/cli/src/channel/add.ts
+++ b/cli/src/channel/add.ts
@@ -37,7 +37,11 @@ export async function addChannelInternal(channelId: string, appId: string, optio
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon, silent)
   await check2FAComplianceForApp(supabase, appId, silent)
   await resolveUserIdFromApiKey(supabase, options.apikey)
-  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
+  // Creating a channel needs app_admin tier (app.create_channel / the INSERT RLS's app.update_settings),
+  // which get_org_perm_for_apikey reports as perm_write; org_super_admin's app.delete is NOT required.
+  // Gating on admin here was a false-negative that blocked org_admin/app_admin keys. The channels
+  // INSERT RLS remains authoritative, so a non-admin key is still rejected at the DB.
+  await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.write, silent, true)
 
   if (!silent)
     log.info(`Creating channel ${appId}#${channelId} to Capgo`)


### PR DESCRIPTION
## Problem

Org admins with an **admin** API key cannot create a channel via the CLI:

```
■  Insuficcent permissions for app <app>. Current permission: write, required for this action: admin.
```

Same class of bug as #2501 (channel set), on the create path.

## Root cause

`channel add` runs a client-side pre-flight at `OrganizationPerm.admin` (`cli/src/channel/add.ts`). `get_org_perm_for_apikey` only returns `perm_admin` for keys holding **`app.delete`**, which is **org_super_admin-only**. An "admin" API key is bound to `org_admin`/`app_admin`, which hold `app.update_settings` + `app.create_channel` but **not** `app.delete`, so they resolve to **`perm_write`** and are wrongly rejected by the `admin` gate.

Meanwhile the actual create is authorized at app_admin tier:
- `createChannel` does a direct `from('channels').insert()`, governed by the channels **INSERT RLS**, which requires `app.update_settings` (app_admin) — held by `org_admin`/`app_admin`.

So the CLI gate is stricter than the DB.

## Fix

Lower the `channel add` pre-flight gate from `OrganizationPerm.admin` to `OrganizationPerm.write`. In the current RBAC model `perm_write` == app_admin tier, which is exactly what creating a channel requires. The INSERT RLS remains authoritative, so an under-privileged key (e.g. a real upload/developer key → `perm_upload`, no `app.update_settings`) is still rejected at the DB — no over-permit.

## Scope

Band-aid only, mirroring #2501. `channel delete` still gates on `admin`. The proper fix (channel-scope permission enforcement: `channel.promote_bundle` / `channel.update_settings` / `app.create_channel` honored across RLS + backend + CLI) is tracked separately.

## Test plan

- [ ] An `org_admin`/`app_admin`-bound API key can run `channel add <name> <app>` successfully.
- [ ] A read/upload key is still rejected (gate + RLS).