### PR TITLE
fix(cli): reword ASC key helper consent copy to "receive"

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,7 +207,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "8.4.1",
+      "version": "8.5.1",
       "bin": {
         "capgo": "dist/index.js",
       },
@@ -263,8 +263,8 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "@capgo/cli-helper-darwin-arm64": "^1.1.0",
-        "@capgo/cli-helper-darwin-x64": "^1.1.0",
+        "@capgo/cli-helper-darwin-arm64": "^1.1.1",
+        "@capgo/cli-helper-darwin-x64": "^1.1.1",
       },
     },
   },
@@ -616,9 +616,9 @@
 
     "@capgo/cli": ["@capgo/cli@workspace:cli"],
 
-    "@capgo/cli-helper-darwin-arm64": ["@capgo/cli-helper-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3KxpDm4CQ1Z3VUlgZ2NwRdG73PE/A5C2ujhYlP+Q+nh1NLaVBeYwc+F2asyhr4Vb4oPqvJYIaqhCx9SootZYoQ=="],
+    "@capgo/cli-helper-darwin-arm64": ["@capgo/cli-helper-darwin-arm64@1.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yHatsJ6KkltSRsSw8/UF4+fYFZGlbHPLw+mIdqlhTirWGAxwEaE+wFh/u3eSqXqxclSG4wQg4kcykYmtu2/r4Q=="],
 
-    "@capgo/cli-helper-darwin-x64": ["@capgo/cli-helper-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-pL8Vvp+La2DNpL6nIEv5OpsvLWFJycZ4n7wjJ/WJBB7gOWUwtR8j/YVMjUDyz5Z7GiX5j4q8kApuDU/ntqQXsg=="],
+    "@capgo/cli-helper-darwin-x64": ["@capgo/cli-helper-darwin-x64@1.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-OI5uiobvMBLOiOMdloDA1Lq2bwrzSj9sFCJv+CyZpiRa6rygP7DNa5F3yvamo9oqJ1vbUCiuVp/6e4U4PcSzMw=="],
 
     "@capgo/find-package-manager": ["@capgo/find-package-manager@0.0.18", "", {}, "sha512-YTajLnUJYYOqHWH59l6Umlqq1PmdUReWY5HLgfHfVHJk/xyWzfQ8Kzo5dLd1vxqNWZV8zvGHLk9mCxMAxt/q1A=="],
 

--- a/cli/native/asc-key-helper/Sources/UI/ConsentView.swift
+++ b/cli/native/asc-key-helper/Sources/UI/ConsentView.swift
@@ -64,7 +64,7 @@ struct ConsentView: View {
             )
             point(
                 icon: "doc.badge.gearshape.fill",
-                title: "We only read the key you generate",
+                title: "We only receive the key you generate",
                 detail: "Capgo captures just the new API key (Key ID, Issuer ID, and the .p8) so Capgo Builder can upload your app."
             )
         }

--- a/cli/package.json
+++ b/cli/package.json
@@ -176,8 +176,8 @@
     "string-width": "^8.2.1"
   },
   "optionalDependencies": {
-    "@capgo/cli-helper-darwin-arm64": "^1.1.0",
-    "@capgo/cli-helper-darwin-x64": "^1.1.0"
+    "@capgo/cli-helper-darwin-arm64": "^1.1.1",
+    "@capgo/cli-helper-darwin-x64": "^1.1.1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^9.0.0",


### PR DESCRIPTION
## What

Rewords one line of user-facing copy on the App Store Connect API key helper's consent screen:

- **Before:** "We only **read** the key you generate"
- **After:** "We only **receive** the key you generate"

File: `cli/native/asc-key-helper/Sources/UI/ConsentView.swift` (the `reassurances` section).

## Why

"receive" is more accurate than "read" — the helper *captures* (receives) the freshly generated API key (Key ID, Issuer ID, and the `.p8`) so Capgo Builder can upload the app. The supporting detail line already says "Capgo captures just the new API key…", so this aligns the title with it.

## Scope

Copy-only change. No logic, no behavior change. The old wording appeared only here (no test goldens or duplicate strings reference it).

## Release

A prerelease tag `cli-helper-1.1.1-rc.1` is pushed on this branch's commit to exercise the `publish_cli_helper` pipeline (builds + signs + notarizes the helpers, publishes under the npm `rc` dist-tag) without merging first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified consent screen messaging regarding key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->