### PR TITLE
feat(cli): builder onboarding journey id + quit event

### DIFF
--- a/cli/src/build/onboarding/analytics.ts
+++ b/cli/src/build/onboarding/analytics.ts
@@ -75,7 +75,7 @@ async function trackBuildOnboardingWorkflowEventAsync(options: TrackBuildOnboard
   }
 
   if (options.journeyId)
-    tags['journey-id'] = options.journeyId
+    tags.journey_id = options.journeyId
   if (options.decision)
     tags.decision = options.decision
   if (options.packageManager)

--- a/cli/src/build/onboarding/analytics.ts
+++ b/cli/src/build/onboarding/analytics.ts
@@ -25,6 +25,8 @@ interface TrackBuildOnboardingWorkflowOptions extends WorkflowDiffTelemetry {
   appId: string
   platform: 'ios' | 'android'
   apikey?: string
+  /** Correlation id tying every event from one onboarding run together. */
+  journeyId?: string
   decision?: BuildOnboardingWorkflowDecision
   packageManager?: PackageManager
   buildScriptType?: BuildScriptChoice['type']
@@ -72,6 +74,8 @@ async function trackBuildOnboardingWorkflowEventAsync(options: TrackBuildOnboard
     'diff-removed': options.diffRemoved,
   }
 
+  if (options.journeyId)
+    tags['journey-id'] = options.journeyId
   if (options.decision)
     tags.decision = options.decision
   if (options.packageManager)

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -167,6 +167,11 @@ interface AppProps {
   apikey?: string
   // Capgo API gateway override (--supa-host); prod when omitted.
   supaHost?: string
+  /** Correlation id for this onboarding run; emitted as `journey_id` on every analytics event. */
+  journeyId: string
+  /** Reports the current step to the shell on every transition, so the caller can
+   *  record where the user dropped off for the quit event. */
+  onStep?: (step: string) => void
   /** Reports the wizard outcome to the shell when it reaches build-complete, so
    *  the caller prints an accurate post-exit message + durable summary instead of
    *  always claiming success. Never fires on cancel/missing-platform exits. */
@@ -254,7 +259,7 @@ function emptyProgress(appId: string): AndroidOnboardingProgress {
   }
 }
 
-const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir, apikey, supaHost, onResult }) => {
+const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir, apikey, supaHost, journeyId, onStep, onResult }) => {
   const { exit } = useApp()
   const startStep: AndroidOnboardingStep = getAndroidResumeStep(initialProgress)
 
@@ -360,6 +365,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
         void trackBuilderOnboardingStep({
           apikey: resolvedApiKeyRef.current,
           appId,
+          journeyId,
           orgId: resolvedOrgId,
           platform: 'android',
           ...queued,
@@ -372,6 +378,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
         void trackBuilderOnboardingAction({
           apikey: resolvedApiKeyRef.current,
           appId,
+          journeyId,
           orgId: resolvedOrgId,
           platform: 'android',
           ...queued,
@@ -417,6 +424,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
       void trackBuilderOnboardingStep({
         apikey: resolvedApiKeyRef.current,
         appId,
+        journeyId,
         orgId: resolvedOrgId,
         platform: 'android',
         ...eventPayload,
@@ -426,6 +434,14 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
       pendingTelemetryRef.current.push(eventPayload)
     }
   }, [step, appId, resolvedOrgId, error])
+
+  // Report each step up to the shell/command so the quit event can name where
+  // the user dropped off. Deliberately separate from the analytics effect above
+  // (which is gated on a resolved api key) — drop-off location must be captured
+  // for the quit event even when no telemetry key is present.
+  useEffect(() => {
+    onStep?.(step)
+  }, [step, onStep])
 
   const trackAction = useCallback(
     (
@@ -441,6 +457,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
         void trackBuilderOnboardingAction({
           apikey: resolvedApiKeyRef.current,
           appId,
+          journeyId,
           orgId: resolvedOrgId,
           platform: 'android',
           ...payload,

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -2015,7 +2015,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
         // to inject supaHost (parity with main's bespoke requesting-build,
         // which passed supaHost directly to requestBuildInternal).
         requestBuildInternal: (id, options, silent, logger) =>
-          requestBuildInternal(id, { ...options, supaHost }, silent, logger),
+          requestBuildInternal(id, { ...options, supaHost, builderJourneyId: journeyId }, silent, logger),
 
         // ── streaming / telemetry / preload sinks (forwarded into the shared tail) ──
         // The rich streaming BuildLogger requesting-build forwards into

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -735,6 +735,7 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
       appId,
       platform: 'android',
       apikey,
+      journeyId,
       packageManager: selectedPackageManager ?? normalizePackageManager(pm.pm),
       buildScriptType: buildScriptChoice?.type,
       decision: options.decision,

--- a/cli/src/build/onboarding/command.ts
+++ b/cli/src/build/onboarding/command.ts
@@ -283,19 +283,45 @@ export async function onboardingBuilderCommand(options: OnboardingBuilderOptions
     // whatever auth + org we can and emit one event. Awaited so the request
     // flushes before the process exits; trackBuilderOnboardingCancelled
     // swallows every error, so this never blocks or breaks the exit.
+    //
+    // Time-boxed: the whole resolve+send path is raced against a single
+    // deadline so a stalled network can never keep the CLI alive after the
+    // user has already quit. On timeout we abort the org lookup and skip the
+    // event — losing one best-effort quit beacon is preferable to a hang.
     if (result.outcome === 'cancelled') {
       const apikey = options.apikey?.trim() || findSavedKeySilent()
       if (apikey) {
-        const orgId = await resolveOwnerOrgId(apikey, appId)
-        await trackBuilderOnboardingCancelled({
-          apikey,
-          appId,
-          orgId,
-          journeyId,
-          platform: resolvedPlatform,
-          lastStep,
-          durationMs: Date.now() - journeyStartedAt,
+        const timeoutMs = 1500
+        const controller = new AbortController()
+        let timer: ReturnType<typeof setTimeout> | undefined
+        const deadline = new Promise<void>((resolve) => {
+          timer = setTimeout(() => {
+            controller.abort()
+            resolve()
+          }, timeoutMs)
         })
+        try {
+          await Promise.race([
+            (async () => {
+              const orgId = await resolveOwnerOrgId(apikey, appId, undefined, controller.signal)
+              await trackBuilderOnboardingCancelled({
+                apikey,
+                appId,
+                orgId,
+                journeyId,
+                platform: resolvedPlatform,
+                lastStep,
+                durationMs: Date.now() - journeyStartedAt,
+                signal: controller.signal,
+              })
+            })(),
+            deadline,
+          ])
+        }
+        finally {
+          if (timer)
+            clearTimeout(timer)
+        }
       }
     }
   }

--- a/cli/src/build/onboarding/command.ts
+++ b/cli/src/build/onboarding/command.ts
@@ -5,9 +5,12 @@ import { log } from '@clack/prompts'
 // src/build/onboarding/command.ts
 import { render } from 'ink'
 import React from 'react'
+import { resolveOwnerOrgId } from '../../analytics/org-resolver.js'
 import { trackEvent } from '../../analytics/track.js'
-import { getAppId, getConfig } from '../../utils.js'
+import { findSavedKeySilent, getAppId, getConfig } from '../../utils.js'
 import { appendInternalLog, startInternalLog } from '../../support/internal-log.js'
+import { newBuilderJourneyId } from './journey.js'
+import { trackBuilderOnboardingCancelled } from './telemetry.js'
 import { isMacOS, probeGuidedHelper } from './asc-key/helper.js'
 import { ASC_KEY_CHANNEL } from './asc-key/protocol.js'
 import { getPlatformDirFromCapacitorConfig } from '../platform-paths.js'
@@ -185,6 +188,17 @@ export async function onboardingBuilderCommand(options: OnboardingBuilderOptions
   // when it reaches build-complete. Any other exit (missing platform, user
   // cancel, error) leaves this untouched, so we never claim false success.
   let result: OnboardingResult = { outcome: 'cancelled' }
+  // One correlation id for this entire journey, threaded into every analytics
+  // event the wizard emits so a single run's events group together (and the
+  // quit event below ties to them). Generated here — the single onboarding
+  // entrypoint — so both `build init` and the `bundle upload` → launch-onboarding
+  // handoff each get exactly one.
+  const journeyId = newBuilderJourneyId()
+  const journeyStartedAt = Date.now()
+  // The most recent step the wizard reported. Lets the quit event below record
+  // WHERE the user dropped off regardless of HOW they left (keypress, Ctrl+C,
+  // or a fatal error that exits) — none of which run React cleanup reliably.
+  let lastStep: string | undefined
   const { waitUntilExit } = render(
     React.createElement(OnboardingShell, {
       appId,
@@ -198,6 +212,7 @@ export async function onboardingBuilderCommand(options: OnboardingBuilderOptions
       androidDir,
       apikey: options.apikey,
       supaHost: options.supaHost,
+      journeyId,
       initialPlatform,
       // Whether the iOS flow may offer guided ASC-key creation (see the probe
       // above). The shell threads it into the iOS OnboardingApp only.
@@ -205,6 +220,9 @@ export async function onboardingBuilderCommand(options: OnboardingBuilderOptions
       updateInfo: updateInfo ?? undefined,
       onResolvePlatform: (platform: Platform) => {
         resolvedPlatform = platform
+      },
+      onStep: (step: string) => {
+        lastStep = step
       },
       onResult: (r: OnboardingResult) => {
         result = r
@@ -259,5 +277,26 @@ export async function onboardingBuilderCommand(options: OnboardingBuilderOptions
     // the user why it stopped (e.g. the "no native platform" screen); this is
     // just a neutral closing line so the exit isn't silent.
     process.stdout.write(`\nCapgo onboarding exited — setup not completed. Re-run \`capgo build init\` to continue.\n`)
+
+    // Record the funnel exit so quit/drop-off is measurable alongside the
+    // per-step events (all sharing this journeyId). Best-effort: resolve
+    // whatever auth + org we can and emit one event. Awaited so the request
+    // flushes before the process exits; trackBuilderOnboardingCancelled
+    // swallows every error, so this never blocks or breaks the exit.
+    if (result.outcome === 'cancelled') {
+      const apikey = options.apikey?.trim() || findSavedKeySilent()
+      if (apikey) {
+        const orgId = await resolveOwnerOrgId(apikey, appId)
+        await trackBuilderOnboardingCancelled({
+          apikey,
+          appId,
+          orgId,
+          journeyId,
+          platform: resolvedPlatform,
+          lastStep,
+          durationMs: Date.now() - journeyStartedAt,
+        })
+      }
+    }
   }
 }

--- a/cli/src/build/onboarding/journey.ts
+++ b/cli/src/build/onboarding/journey.ts
@@ -1,0 +1,21 @@
+// src/build/onboarding/journey.ts
+import { randomUUID } from 'node:crypto'
+
+/**
+ * A correlation id for a single Builder onboarding journey.
+ *
+ * Generated once per `build init` / onboarding process (in command.ts) and
+ * threaded through every analytics event the wizard emits — per-step funnel
+ * events, named action events, workflow-file events, and the terminal
+ * quit/cancel event. Without it, the events from one user's run are
+ * indistinguishable from another's in PostHog, so a "journey" can't be
+ * reconstructed when several runs overlap in the same window.
+ *
+ * The `bj_` prefix (Builder Journey) makes the id self-identifying in raw
+ * analytics payloads and easy to grep for. Scope is one process: a
+ * quit-and-resume starts a fresh journey id (cross-run stitching is a possible
+ * future enhancement, but each run is still fully correlated on its own).
+ */
+export function newBuilderJourneyId(): string {
+  return `bj_${randomUUID()}`
+}

--- a/cli/src/build/onboarding/telemetry.ts
+++ b/cli/src/build/onboarding/telemetry.ts
@@ -7,6 +7,8 @@ export interface TrackBuilderOnboardingStepInput {
   apikey: string
   appId: string
   orgId: string
+  /** Correlation id tying every event from one onboarding run together. */
+  journeyId: string
   platform: Platform
   step: OnboardingStep | AndroidOnboardingStep
   durationMs?: number
@@ -31,6 +33,8 @@ export interface TrackBuilderOnboardingActionInput {
   apikey: string
   appId: string
   orgId: string
+  /** Correlation id tying every event from one onboarding run together. */
+  journeyId: string
   platform: Platform
   step: OnboardingStep | AndroidOnboardingStep
   action: BuilderOnboardingAction
@@ -39,6 +43,7 @@ export interface TrackBuilderOnboardingActionInput {
 
 export async function trackBuilderOnboardingStep(input: TrackBuilderOnboardingStepInput): Promise<void> {
   const tags: Record<string, string> = {
+    journey_id: input.journeyId,
     step: input.step,
     platform: input.platform,
     app_id: input.appId,
@@ -82,6 +87,7 @@ export async function trackBuilderOnboardingAction(input: TrackBuilderOnboarding
   for (const [key, value] of Object.entries(input.tags ?? {}))
     tags[key] = String(value)
 
+  tags.journey_id = input.journeyId
   tags.step = input.step
   tags.platform = input.platform
   tags.app_id = input.appId
@@ -100,5 +106,62 @@ export async function trackBuilderOnboardingAction(input: TrackBuilderOnboarding
   }
   catch {
     // Telemetry must never break the wizard.
+  }
+}
+
+export interface TrackBuilderOnboardingCancelledInput {
+  apikey: string
+  appId: string
+  /** May be undefined when the owner org couldn't be resolved post-exit. */
+  orgId?: string
+  /** Correlation id tying every event from one onboarding run together. */
+  journeyId: string
+  /**
+   * The platform being onboarded, or undefined when the user quit BEFORE
+   * choosing one (e.g. on the platform picker). The undefined case is itself a
+   * useful signal — it isolates "left at the very first screen" drop-off.
+   */
+  platform?: Platform
+  /** The step the user was on when they quit, when known. */
+  lastStep?: string
+  /** Total wall-clock duration of the journey, from launch to quit. */
+  durationMs?: number
+}
+
+/**
+ * Emits the terminal "Builder Onboarding Quit" event when a journey ends
+ * without reaching build-complete (user cancel, Ctrl+C, missing platform, or a
+ * fatal error that exits). Fired ONCE from command.ts after the wizard tears
+ * down — never mid-flow — so each journey has at most one quit marker. Unlike
+ * the per-step events this carries no org-scoped requirement: it sends with
+ * whatever org id could be resolved (possibly none) rather than dropping the
+ * event, because a quit is exactly when we most want the funnel exit recorded.
+ */
+export async function trackBuilderOnboardingCancelled(input: TrackBuilderOnboardingCancelledInput): Promise<void> {
+  const tags: Record<string, string> = {
+    journey_id: input.journeyId,
+    app_id: input.appId,
+  }
+
+  if (input.platform)
+    tags.platform = input.platform
+  if (input.lastStep)
+    tags.last_step = input.lastStep
+  if (typeof input.durationMs === 'number' && Number.isFinite(input.durationMs))
+    tags.duration_ms = String(Math.round(input.durationMs))
+
+  try {
+    await sendEvent(input.apikey, {
+      event: 'Builder Onboarding Quit',
+      channel: 'builder-onboarding',
+      icon: '🚪',
+      notify: false,
+      org_id: input.orgId,
+      tracking_version: 2,
+      tags,
+    })
+  }
+  catch {
+    // Telemetry must never break the exit path.
   }
 }

--- a/cli/src/build/onboarding/telemetry.ts
+++ b/cli/src/build/onboarding/telemetry.ts
@@ -126,6 +126,11 @@ export interface TrackBuilderOnboardingCancelledInput {
   lastStep?: string
   /** Total wall-clock duration of the journey, from launch to quit. */
   durationMs?: number
+  /**
+   * Abort signal used to time-box the post-quit flush so a stalled network
+   * can't keep the CLI alive after the user has already exited the wizard.
+   */
+  signal?: AbortSignal
 }
 
 /**
@@ -159,7 +164,7 @@ export async function trackBuilderOnboardingCancelled(input: TrackBuilderOnboard
       org_id: input.orgId,
       tracking_version: 2,
       tags,
-    })
+    }, undefined, input.signal)
   }
   catch {
     // Telemetry must never break the exit path.

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -2743,7 +2743,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
         // so the driver injects the gateway override here (parity with main's
         // bespoke requesting-build body).
         requestBuildInternal: (id, options, silent, logger) =>
-          requestBuildInternal(id, { ...options, supaHost }, silent, logger),
+          requestBuildInternal(id, { ...options, supaHost, builderJourneyId: journeyId }, silent, logger),
 
         // ── streaming / telemetry / preload sinks (forwarded into the shared tail) ──
         // The rich streaming BuildLogger requesting-build forwards into

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -763,7 +763,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
     else {
       pendingTelemetryRef.current.push(eventPayload)
     }
-  }, [step, appId, resolvedOrgId, error])
+  }, [step, appId, resolvedOrgId, error, journeyId])
 
   // Report each step up to the shell/command so the quit event can name where
   // the user dropped off. Deliberately separate from the analytics effect above
@@ -801,7 +801,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
         pendingActionTelemetryRef.current.push(payload)
       }
     },
-    [appId, resolvedOrgId, step],
+    [appId, resolvedOrgId, step, journeyId],
   )
   const [teamId, setTeamId] = useState(initialProgress?.completedSteps.certificateCreated?.teamId || '')
   const [certData, setCertData] = useState<CertificateData | null>(initialProgress?.completedSteps.certificateCreated || null)

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -276,6 +276,11 @@ interface AppProps {
   apikey?: string
   // Capgo API gateway override (--supa-host); prod when omitted.
   supaHost?: string
+  /** Correlation id for this onboarding run; emitted as `journey_id` on every analytics event. */
+  journeyId: string
+  /** Reports the current step to the shell on every transition, so the caller can
+   *  record where the user dropped off for the quit event. */
+  onStep?: (step: string) => void
   /**
    * Reports the wizard outcome to the shell when it reaches build-complete, so
    *  the caller prints an accurate post-exit message + durable summary instead of
@@ -321,7 +326,7 @@ async function runRunnerCommand(runner: string, args: string[]): Promise<{ succe
   })
 }
 
-const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgress, iosDir, guidedHelperUsable, apikey, supaHost, onResult }) => {
+const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgress, iosDir, guidedHelperUsable, apikey, supaHost, journeyId, onStep, onResult }) => {
   const { exit } = useApp()
   // Pass helper availability so an automated-path resume only targets
   // asc-key-generating when the helper can actually run (else manual instructions).
@@ -699,6 +704,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
         void trackBuilderOnboardingStep({
           apikey: resolvedApiKeyRef.current,
           appId,
+          journeyId,
           orgId: resolvedOrgId,
           platform: 'ios',
           ...queued,
@@ -711,6 +717,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
         void trackBuilderOnboardingAction({
           apikey: resolvedApiKeyRef.current,
           appId,
+          journeyId,
           orgId: resolvedOrgId,
           platform: 'ios',
           ...queued,
@@ -747,6 +754,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
       void trackBuilderOnboardingStep({
         apikey: resolvedApiKeyRef.current,
         appId,
+        journeyId,
         orgId: resolvedOrgId,
         platform: 'ios',
         ...eventPayload,
@@ -756,6 +764,14 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
       pendingTelemetryRef.current.push(eventPayload)
     }
   }, [step, appId, resolvedOrgId, error])
+
+  // Report each step up to the shell/command so the quit event can name where
+  // the user dropped off. Deliberately separate from the analytics effect above
+  // (which is gated on a resolved api key) — drop-off location must be captured
+  // for the quit event even when no telemetry key is present.
+  useEffect(() => {
+    onStep?.(step)
+  }, [step, onStep])
 
   // Emit a named "Builder Onboarding Action" event (distinct from the per-step
   // funnel). Mirrors the Android helper: fires immediately once the org id is
@@ -775,6 +791,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
         void trackBuilderOnboardingAction({
           apikey: resolvedApiKeyRef.current,
           appId,
+          journeyId,
           orgId: resolvedOrgId,
           platform: 'ios',
           ...payload,
@@ -1191,6 +1208,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
       appId,
       platform: 'ios',
       apikey,
+      journeyId,
       packageManager: selectedPackageManager ?? normalizePackageManager(pm.pm),
       buildScriptType: buildScriptChoice?.type,
       decision: options.decision,

--- a/cli/src/build/onboarding/ui/shell.tsx
+++ b/cli/src/build/onboarding/ui/shell.tsx
@@ -95,6 +95,8 @@ export interface OnboardingShellProps {
   guidedHelperUsable: boolean
   apikey?: string
   supaHost?: string
+  /** Correlation id for this onboarding run; threaded into every analytics event the apps emit. */
+  journeyId: string
   /** Pre-resolved platform (--platform flag or the single existing native dir); skips the picker. */
   initialPlatform?: Platform
   /**
@@ -105,6 +107,9 @@ export interface OnboardingShellProps {
   updateInfo?: { currentVersion: string, latestVersion: string }
   /** Called once a platform is chosen so the caller can print the completion breadcrumb. */
   onResolvePlatform?: (platform: Platform) => void
+  /** Called by the mounted app on every step transition, so the caller can record
+   *  where the user dropped off for the quit event. */
+  onStep?: (step: string) => void
   /** Called by the mounted app when it reaches the build-complete screen, so the
    *  caller prints the accurate post-exit message + durable summary. If the wizard
    *  exits any other way (cancel / missing platform), this never fires and the
@@ -112,7 +117,7 @@ export interface OnboardingShellProps {
   onResult?: (result: OnboardingResult) => void
 }
 
-const OnboardingShell: FC<OnboardingShellProps> = ({ appId, iosBundleIdInitial, iosDir, androidDir, guidedHelperUsable, apikey, supaHost, initialPlatform, updateInfo, onResolvePlatform, onResult }) => {
+const OnboardingShell: FC<OnboardingShellProps> = ({ appId, iosBundleIdInitial, iosDir, androidDir, guidedHelperUsable, apikey, supaHost, journeyId, initialPlatform, updateInfo, onResolvePlatform, onStep, onResult }) => {
   const { exit } = useApp()
   const { cols, rows } = useTerminalSize()
   const [ready, setReady] = useState<ReadyApp | null>(null)
@@ -171,9 +176,9 @@ const OnboardingShell: FC<OnboardingShellProps> = ({ appId, iosBundleIdInitial, 
   // exiting the wizard. The app owns the size decision so a shrink→regrow keeps
   // the user exactly where they were.
   if (ready?.kind === 'ios')
-    return <OnboardingApp appId={appId} iosBundleIdInitial={iosBundleIdInitial} initialProgress={ready.progress} iosDir={iosDir} guidedHelperUsable={guidedHelperUsable} apikey={apikey} supaHost={supaHost} onResult={onResult} />
+    return <OnboardingApp appId={appId} iosBundleIdInitial={iosBundleIdInitial} initialProgress={ready.progress} iosDir={iosDir} guidedHelperUsable={guidedHelperUsable} apikey={apikey} supaHost={supaHost} journeyId={journeyId} onStep={onStep} onResult={onResult} />
   if (ready?.kind === 'android')
-    return <AndroidOnboardingApp appId={appId} initialProgress={ready.progress} androidDir={androidDir} apikey={apikey} supaHost={supaHost} onResult={onResult} />
+    return <AndroidOnboardingApp appId={appId} initialProgress={ready.progress} androidDir={androidDir} apikey={apikey} supaHost={supaHost} journeyId={journeyId} onStep={onStep} onResult={onResult} />
 
   // Not ready yet: the platform picker (or a brief framed load). The picker is
   // NOT gated to the full 80×49 onboarding floor — it's small and adapts

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1689,7 +1689,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
         'platform': platform,
         // Present only for onboarding-initiated builds — correlates this build
         // with the rest of the journey's events.
-        ...(options.builderJourneyId ? { 'journey-id': options.builderJourneyId } : {}),
+        ...(options.builderJourneyId ? { journey_id: options.builderJourneyId } : {}),
       },
       notify: false,
     }).catch()
@@ -2330,7 +2330,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
           'time': buildTime,
           // Present only for onboarding-initiated builds — correlates the build
           // outcome with the rest of the journey's events.
-          ...(options.builderJourneyId ? { 'journey-id': options.builderJourneyId } : {}),
+          ...(options.builderJourneyId ? { journey_id: options.builderJourneyId } : {}),
         },
         notify: false,
       }).catch()

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1687,6 +1687,9 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       tags: {
         'app-id': appId,
         'platform': platform,
+        // Present only for onboarding-initiated builds — correlates this build
+        // with the rest of the journey's events.
+        ...(options.builderJourneyId ? { 'journey-id': options.builderJourneyId } : {}),
       },
       notify: false,
     }).catch()
@@ -2325,6 +2328,9 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
           'platform': platform,
           'status': finalStatus || 'unknown',
           'time': buildTime,
+          // Present only for onboarding-initiated builds — correlates the build
+          // outcome with the rest of the journey's events.
+          ...(options.builderJourneyId ? { 'journey-id': options.builderJourneyId } : {}),
         },
         notify: false,
       }).catch()

--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -76,6 +76,12 @@ export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   //   - 'skip'                  — skip the AI block entirely; normal cleanup
   //     runs (log file deleted on exit).
   aiAnalysisMode: z.enum(['auto-prompt', 'caller-handled', 'skip']).optional(),
+  // Correlation id for the Builder onboarding journey, set ONLY when the build
+  // is requested from the onboarding wizard. Threaded onto the `Build requested`
+  // / `Build succeeded` / `Build failed` events so the journey's funnel reaches
+  // all the way to the build outcome. Absent for the standalone `build request`
+  // command (no journey).
+  builderJourneyId: z.string().optional(),
 })
 
 export type BuildRequestOptions = z.infer<typeof buildRequestOptionsSchema>

--- a/cli/test/test-onboarding-telemetry.mjs
+++ b/cli/test/test-onboarding-telemetry.mjs
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict'
-import { trackBuilderOnboardingAction } from '../src/build/onboarding/telemetry.ts'
+import { trackBuilderOnboardingAction, trackBuilderOnboardingCancelled, trackBuilderOnboardingStep } from '../src/build/onboarding/telemetry.ts'
 
 console.log('🧪 Testing onboarding telemetry...\n')
 
 const originalFetch = globalThis.fetch
 
-try {
+// Mock fetch so /private/config resolves (500 → silent fallback) and every
+// /private/events POST is captured for assertions. Returns the captured
+// requests so each case can find its own event payload.
+function installFetchMock() {
   const requests = []
   globalThis.fetch = async (url, init) => {
     requests.push({ init, url: String(url) })
@@ -17,49 +20,142 @@ try {
       status: 200,
     })
   }
+  return requests
+}
 
-  await trackBuilderOnboardingAction({
-    action: 'android_sa_method_selected',
-    apikey: 'capgo-key',
-    appId: 'com.example.app',
-    orgId: 'org-id',
-    platform: 'android',
-    step: 'service-account-method-select',
-    tags: {
-      accepted: true,
-      action: 'caller_action',
-      app_id: 'caller_app',
-      attempt: 1,
-      method: 'existing',
-      platform: 'ios',
-      step: 'caller-step',
-    },
-  })
-
+function findEventBody(requests) {
   const eventRequest = requests.find(request => request.url.endsWith('/private/events'))
-  assert.ok(eventRequest, 'Expected onboarding action telemetry request')
+  assert.ok(eventRequest, 'Expected a telemetry request to /private/events')
   assert.equal(eventRequest.init.method, 'POST')
   assert.equal(eventRequest.init.headers.capgkey, 'capgo-key')
   assert.equal(eventRequest.init.headers['Content-Type'], 'application/json')
   assert.equal(eventRequest.init.signal instanceof AbortSignal, true)
+  return JSON.parse(eventRequest.init.body)
+}
 
-  const body = JSON.parse(eventRequest.init.body)
-  assert.equal(body.event, 'Builder Onboarding Action')
-  assert.equal(body.channel, 'builder-onboarding')
-  assert.equal(body.notify, false)
-  assert.equal(body.org_id, 'org-id')
-  assert.equal(body.tracking_version, 2)
-  assert.deepEqual(body.tags, {
-    accepted: 'true',
-    action: 'android_sa_method_selected',
-    app_id: 'com.example.app',
-    attempt: '1',
-    method: 'existing',
-    platform: 'android',
-    step: 'service-account-method-select',
-  })
+try {
+  // ── Action event carries the journey id ───────────────────────────────────
+  {
+    const requests = installFetchMock()
+    await trackBuilderOnboardingAction({
+      action: 'android_sa_method_selected',
+      apikey: 'capgo-key',
+      appId: 'com.example.app',
+      orgId: 'org-id',
+      journeyId: 'bj_journey-1',
+      platform: 'android',
+      step: 'service-account-method-select',
+      tags: {
+        accepted: true,
+        action: 'caller_action',
+        app_id: 'caller_app',
+        attempt: 1,
+        method: 'existing',
+        platform: 'ios',
+        step: 'caller-step',
+      },
+    })
 
-  console.log('✅ Onboarding telemetry tests passed')
+    const body = findEventBody(requests)
+    assert.equal(body.event, 'Builder Onboarding Action')
+    assert.equal(body.channel, 'builder-onboarding')
+    assert.equal(body.notify, false)
+    assert.equal(body.org_id, 'org-id')
+    assert.equal(body.tracking_version, 2)
+    assert.deepEqual(body.tags, {
+      accepted: 'true',
+      action: 'android_sa_method_selected',
+      app_id: 'com.example.app',
+      attempt: '1',
+      journey_id: 'bj_journey-1',
+      method: 'existing',
+      platform: 'android',
+      step: 'service-account-method-select',
+    })
+    console.log('✅ Action event carries journey_id')
+  }
+
+  // ── Step event carries the journey id ─────────────────────────────────────
+  {
+    const requests = installFetchMock()
+    await trackBuilderOnboardingStep({
+      apikey: 'capgo-key',
+      appId: 'com.example.app',
+      orgId: 'org-id',
+      journeyId: 'bj_journey-2',
+      platform: 'ios',
+      step: 'api-key-instructions',
+      durationMs: 1234,
+      durationStep: 'welcome',
+    })
+
+    const body = findEventBody(requests)
+    assert.equal(body.event, 'Builder Onboarding Step')
+    assert.equal(body.channel, 'builder-onboarding')
+    assert.deepEqual(body.tags, {
+      app_id: 'com.example.app',
+      duration_ms: '1234',
+      duration_step: 'welcome',
+      journey_id: 'bj_journey-2',
+      platform: 'ios',
+      step: 'api-key-instructions',
+    })
+    console.log('✅ Step event carries journey_id')
+  }
+
+  // ── Quit event: full payload (platform + last step + duration) ─────────────
+  {
+    const requests = installFetchMock()
+    await trackBuilderOnboardingCancelled({
+      apikey: 'capgo-key',
+      appId: 'com.example.app',
+      orgId: 'org-id',
+      journeyId: 'bj_journey-3',
+      platform: 'ios',
+      lastStep: 'verifying-key',
+      durationMs: 9876.4,
+    })
+
+    const body = findEventBody(requests)
+    assert.equal(body.event, 'Builder Onboarding Quit')
+    assert.equal(body.channel, 'builder-onboarding')
+    assert.equal(body.icon, '🚪')
+    assert.equal(body.notify, false)
+    assert.equal(body.org_id, 'org-id')
+    assert.equal(body.tracking_version, 2)
+    assert.deepEqual(body.tags, {
+      app_id: 'com.example.app',
+      duration_ms: '9876', // rounded
+      journey_id: 'bj_journey-3',
+      last_step: 'verifying-key',
+      platform: 'ios',
+    })
+    console.log('✅ Quit event carries journey_id, last_step, duration_ms, platform')
+  }
+
+  // ── Quit event: minimal payload (quit before choosing a platform) ──────────
+  {
+    const requests = installFetchMock()
+    await trackBuilderOnboardingCancelled({
+      apikey: 'capgo-key',
+      appId: 'com.example.app',
+      journeyId: 'bj_journey-4',
+      // no platform, no lastStep, no orgId, no durationMs
+    })
+
+    const body = findEventBody(requests)
+    assert.equal(body.event, 'Builder Onboarding Quit')
+    assert.equal(body.org_id, undefined)
+    // Only the always-present tags survive; the optional dimensions are omitted
+    // rather than sent as empty/undefined strings.
+    assert.deepEqual(body.tags, {
+      app_id: 'com.example.app',
+      journey_id: 'bj_journey-4',
+    })
+    console.log('✅ Quit event omits optional dimensions when quitting pre-platform')
+  }
+
+  console.log('\n✅ Onboarding telemetry tests passed')
 }
 finally {
   globalThis.fetch = originalFetch

--- a/cli/test/test-shell-size-gate.mjs
+++ b/cli/test/test-shell-size-gate.mjs
@@ -51,7 +51,7 @@ function makeStdin() {
 async function renderShellAt(cols, rows) {
   const stdout = makeStdout(cols, rows)
   const instance = render(
-    React.createElement(OnboardingShell, { appId: 'com.test.app', iosDir: 'ios', androidDir: 'android' }),
+    React.createElement(OnboardingShell, { appId: 'com.test.app', iosDir: 'ios', androidDir: 'android', journeyId: 'bj_test' }),
     { stdout, stderr: makeStdout(cols, rows), stdin: makeStdin(), debug: true, exitOnCtrlC: false, patchConsole: false },
   )
   await new Promise(r => setTimeout(r, 80))

--- a/cli/test/test-update-prompt.mjs
+++ b/cli/test/test-update-prompt.mjs
@@ -48,7 +48,7 @@ function makeStdin() {
 async function renderShell(props) {
   const stdout = makeStdout(100, 50)
   const instance = render(
-    React.createElement(OnboardingShell, { appId: 'com.test.app', iosDir: 'ios', androidDir: 'android', ...props }),
+    React.createElement(OnboardingShell, { appId: 'com.test.app', iosDir: 'ios', androidDir: 'android', journeyId: 'bj_test', ...props }),
     { stdout, stderr: makeStdout(100, 50), stdin: makeStdin(), debug: true, exitOnCtrlC: false, patchConsole: false },
   )
   // Poll for the first painted (non-empty) frame instead of a fixed sleep, so a


### PR DESCRIPTION
## Why

Capgo Builder onboarding already emits rich per-step analytics, but there's no way to **tie the events from a single user's run together**. When several onboarding journeys overlap in the same time window, they're indistinguishable in PostHog, so an individual journey can't be reconstructed. There's also **no signal for when a user quits** — drop-off can only be inferred from the absence of a completion event.

This PR adds both: a **journey id** correlating every event in one run, and an explicit **quit event**.

## What

**Journey id** — generated once per onboarding process in `command.ts` (the single entrypoint, so both `build init` and the `bundle upload` → launch-onboarding handoff get exactly one) and threaded through the shell into the iOS and Android wizards. Every event now carries it:
- `Builder Onboarding Step` → `journey_id` tag
- `Builder Onboarding Action` → `journey_id` tag
- `Build onboarding workflow *` → `journey_id` tag
- `Build requested` / `Build succeeded` / `Build failed` → `journey_id` tag (onboarding-initiated builds only; threaded via `BuildRequestOptions.builderJourneyId`)

All events use the single tag key `journey_id` — intentionally breaking the kebab-case (`app-id`, `workflow-state`, …) convention of the workflow/build event families so the journey tag is one consistent key everywhere.

Ids are prefixed `bj_` (Builder Journey) so they're self-identifying and greppable in raw payloads. Uses `randomUUID` from `node:crypto` — the repo's existing id pattern (`bundle/zip.ts`, `bundle/upload.ts`). No new dependencies.

**Quit event** — a new `Builder Onboarding Quit` event (`channel: builder-onboarding`, icon 🚪), fired **once** from `command.ts` after the wizard tears down whenever a run ends without reaching `build-complete` (user cancel, Ctrl+C, missing platform, fatal exit). Tags:
- `journey_id` — ties the quit to the run's step events
- `platform` — omitted when the user quit **before choosing one** (itself a useful "left at the very first screen" signal)
- `last_step` — where the user dropped off
- `duration_ms` — total journey wall-clock

Last-step tracking uses an `onStep` callback threaded `command → shell → apps`, so the quit event records where the user left **regardless of how they exited** — none of Ctrl+C / keypress-quit / fatal-exit run React cleanup reliably, so an unmount-based approach would miss most quits.

### Design notes / scope
- **Per-process journey** for v1: a quit-and-resume starts a fresh journey id. Each run is still fully self-correlated; cross-run stitching (persisting the id in the progress file) is a clean follow-up.
- Telemetry remains **best-effort and non-blocking** — every helper swallows errors so it can never break the wizard or the exit path. The quit event is `await`ed only so the request flushes before the process exits.

## Files
- `journey.ts` (new) — `newBuilderJourneyId()`
- `telemetry.ts` — `journey_id` on step/action; new `trackBuilderOnboardingCancelled`
- `analytics.ts` — optional `journey-id` on workflow events
- `command.ts` — generate id, track last step, fire quit event
- `ui/shell.tsx`, `ui/app.tsx`, `android/ui/app.tsx` — thread `journeyId` + `onStep`

## Test plan
- [x] `test:onboarding-telemetry` extended: asserts `journey_id` on step + action events, and covers the quit event with full payload (platform / last_step / rounded duration_ms) and minimal payload (quit pre-platform → optional dimensions omitted, no `org_id`)
- [x] `typecheck` (tsgo) clean
- [x] `lint` (oxlint) clean
- [x] Regression: `build-complete-exit`, `shell-size-gate`, `update-prompt`, `ios-tui-render`, `ios-tui-routing`, `android-tail-render`, `analytics`, `analytics-org-resolver`, `onboarding-recovery`, `ios-e2e` all pass
- [ ] Verify events land in PostHog with the new `journey_id` / quit event after release (manual, post-merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Onboarding sessions now include a unique correlation ID to link related telemetry events across a single run
  * New telemetry events for onboarding cancellations capture session duration and the last completed step
  * Step transitions in the onboarding workflow are now tracked with enhanced event reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
