### PR TITLE
feat(dashboard): surface guided P8 key creation in builder promo (macOS-gated)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -492,6 +492,8 @@
   "build-step-wait-subtitle": "This page will self-refresh when the build is detected",
   "build-time": "Build Time",
   "build-timeout-help": "Native cloud builds are stopped after this many minutes. The default is 15 minutes.",
+  "builder-promo-s2-lead-macos": "A guided setup configures signing for iOS & Android — and if you don't have an App Store Connect key yet, it opens a guided window and creates one for you, step by step. The rest — build machines, Xcode, Fastlane, CI — is already running, nothing to manage.",
+  "builder-promo-s2-item4-macos": "No Apple key yet? A guided window creates it for you",
   "build-timeout-invalid": "Build timeout must be between 5 and 360 minutes",
   "build-timeout-label": "Build timeout (minutes)",
   "build-time-usage": "Build time usage: ",

--- a/src/components/dashboard/BuilderPresentationModal.vue
+++ b/src/components/dashboard/BuilderPresentationModal.vue
@@ -26,6 +26,15 @@ const router = useRouter()
 const config = getLocalConfig()
 const reduce = typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches
 
+// Guided App Store Connect key creation is a macOS-only desktop helper, so the
+// explicit "we create your Apple key for you" copy on slide 2 is gated to macOS
+// visitors. iPadOS reports a "Macintosh" UA but exposes touch points — exclude it.
+const isMacOS = typeof navigator !== 'undefined'
+  && /Macintosh|Mac OS X/.test(navigator.userAgent || '')
+  && (navigator.maxTouchPoints ?? 0) <= 1
+const s2Lead = computed(() => (isMacOS ? t('builder-promo-s2-lead-macos') : t('builder-promo-s2-lead')))
+const s2Item4 = computed(() => (isMacOS ? t('builder-promo-s2-item4-macos') : t('builder-promo-s2-item4')))
+
 const SLIDE_COUNT = 5
 const cur = ref(0)
 const launched = ref(false)
@@ -475,7 +484,7 @@ onUnmounted(() => {
               <div class="bp-right">
                 <h2>{{ t('builder-promo-s2-title') }}</h2>
                 <p class="bp-lead">
-                  {{ t('builder-promo-s2-lead') }}
+                  {{ s2Lead }}
                 </p>
                 <div class="bp-list">
                   <div class="bp-item g">
@@ -488,7 +497,7 @@ onUnmounted(() => {
                     <span class="bp-c">✓</span> {{ t('builder-promo-s2-item3') }}
                   </div>
                   <div class="bp-item g">
-                    <span class="bp-c">✓</span> {{ t('builder-promo-s2-item4') }}
+                    <span class="bp-c">✓</span> {{ s2Item4 }}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## What & why

The Capgo Builder promo modal on the dashboard assumed users already had an App Store Connect API key (`.p8`). It never told them about the recently-merged **guided key-creation** flow — where, on macOS, `capgo build init` opens a window, walks you through App Store Connect, and captures the key for you.

This adds that beat to **Slide 2 ("Set up once, in minutes")** — but only for macOS visitors, since the guided helper is a macOS-only desktop app. Non-macOS visitors keep the existing generic "guided signing" copy, so we never imply a capability that isn't there for them.

## Changes

- **`BuilderPresentationModal.vue`** — `isMacOS` user-agent check (excludes iPadOS, which reports a "Macintosh" UA but exposes touch points). Slide 2's lead + 4th checklist item route through `computed` wrappers that pick the macOS or generic string.
- **`messages/en.json`** — two new macOS-only keys; originals left untouched:
  - `builder-promo-s2-lead-macos`
  - `builder-promo-s2-item4-macos`

## Test plan

- [x] `oxlint` + `eslint` on the changed component — clean
- [x] App boots against prod (`bun run dev`, Branch main) with 0 console errors
- [ ] On macOS: open an app with no native builds → **Learn more** → Slide 2 shows the guided-key-creation copy
- [ ] On non-macOS (or iPad): Slide 2 shows the original generic copy

## Follow-up (separate PR, `website` repo)

Marketing page (`native-build.astro`) + docs (`ios.mdx`, `build.mdx`) get the same "no key? we create it for you, guided" angle, with a macOS-only footnote on the marketing page.