### PR TITLE
feat(cli): track OS + arch + OS version + timezone on all PostHog events (shared send path)

### DIFF
--- a/cli/src/analytics/global-props.ts
+++ b/cli/src/analytics/global-props.ts
@@ -1,0 +1,50 @@
+import { platform, release } from 'node:os'
+import { arch, version as nodeVersion } from 'node:process'
+import { isCI, name as ciName } from 'ci-info'
+import pack from '../../package.json'
+
+export type InvocationSource = 'cli' | 'mcp'
+
+let invocationSource: InvocationSource = 'cli'
+
+export function setInvocationSource(source: InvocationSource): void {
+  invocationSource = source
+}
+
+export function getInvocationSource(): InvocationSource {
+  return invocationSource
+}
+
+export interface GlobalAnalyticsProps {
+  cli_version: string
+  node_version: string
+  os_platform: string
+  os_arch: string
+  os_release: string
+  is_ci: boolean
+  is_tty: boolean
+  invocation_source: InvocationSource
+  ci_provider?: string
+}
+
+/**
+ * Properties attached to every CLI telemetry event. Injected at the shared
+ * sendEvent() send path (see cli/src/utils.ts) so both trackEvent() and the
+ * many direct sendEvent() callers are tagged with the runtime OS, arch, OS
+ * release, CLI/Node versions and CI context.
+ */
+export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
+  const props: GlobalAnalyticsProps = {
+    cli_version: pack.version,
+    node_version: nodeVersion,
+    os_platform: platform(),
+    os_arch: arch,
+    os_release: release(),
+    is_ci: isCI,
+    is_tty: Boolean(process.stdout.isTTY),
+    invocation_source: invocationSource,
+  }
+  if (ciName)
+    props.ci_provider = ciName
+  return props
+}

--- a/cli/src/analytics/global-props.ts
+++ b/cli/src/analytics/global-props.ts
@@ -21,6 +21,7 @@ export interface GlobalAnalyticsProps {
   os_platform: string
   os_arch: string
   os_release: string
+  timezone: string
   is_ci: boolean
   is_tty: boolean
   invocation_source: InvocationSource
@@ -31,7 +32,7 @@ export interface GlobalAnalyticsProps {
  * Properties attached to every CLI telemetry event. Injected at the shared
  * sendEvent() send path (see cli/src/utils.ts) so both trackEvent() and the
  * many direct sendEvent() callers are tagged with the runtime OS, arch, OS
- * release, CLI/Node versions and CI context.
+ * release, timezone, CLI/Node versions and CI context.
  */
 export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
   const props: GlobalAnalyticsProps = {
@@ -40,6 +41,7 @@ export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
     os_platform: platform(),
     os_arch: arch,
     os_release: release(),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     is_ci: isCI,
     is_tty: Boolean(process.stdout.isTTY),
     invocation_source: invocationSource,

--- a/cli/src/analytics/global-props.ts
+++ b/cli/src/analytics/global-props.ts
@@ -41,7 +41,7 @@ export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
     os_platform: platform(),
     os_arch: arch,
     os_release: release(),
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'undefined',
     is_ci: isCI,
     is_tty: Boolean(process.stdout.isTTY),
     invocation_source: invocationSource,

--- a/cli/src/analytics/track.ts
+++ b/cli/src/analytics/track.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { platform } from 'node:os'
+import { platform, release } from 'node:os'
 import { arch, env, version as nodeVersion } from 'node:process'
 import { isCI, name as ciName } from 'ci-info'
 import pack from '../../package.json'
@@ -31,6 +31,7 @@ export interface GlobalAnalyticsProps {
   node_version: string
   os_platform: string
   os_arch: string
+  os_release: string
   is_ci: boolean
   is_tty: boolean
   invocation_source: InvocationSource
@@ -43,6 +44,7 @@ export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
     node_version: nodeVersion,
     os_platform: platform(),
     os_arch: arch,
+    os_release: release(),
     is_ci: isCI,
     is_tty: Boolean(process.stdout.isTTY),
     invocation_source: invocationSource,

--- a/cli/src/analytics/track.ts
+++ b/cli/src/analytics/track.ts
@@ -1,7 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { platform, release } from 'node:os'
-import { arch, env, version as nodeVersion } from 'node:process'
-import { isCI, name as ciName } from 'ci-info'
+import { env } from 'node:process'
 import pack from '../../package.json'
 import { isTruthyEnvValue } from '../posthog'
 import { findSavedKeySilent, getAppId, getConfig, sendEvent } from '../utils'
@@ -10,48 +8,14 @@ import { categorizeCliError, categorizeHttpStatus } from './error-category'
 import { deriveSupabaseOperation, setSupabaseCallRecorder, SLOW_THRESHOLD_MS, withSupabaseSource } from './supabase-perf'
 import type { SupabaseCallInfo } from './supabase-perf'
 
-type InvocationSource = 'cli' | 'mcp'
-
-let invocationSource: InvocationSource = 'cli'
-
-export function setInvocationSource(source: InvocationSource): void {
-  invocationSource = source
-}
-
-export function getInvocationSource(): InvocationSource {
-  return invocationSource
-}
+// Global analytics props + invocation source live in ./global-props so the
+// shared sendEvent() path (cli/src/utils.ts) can inject them on every event
+// without a circular import. Re-exported here for existing import sites.
+export { getGlobalAnalyticsProps, getInvocationSource, setInvocationSource } from './global-props'
+export type { GlobalAnalyticsProps, InvocationSource } from './global-props'
 
 export function isTelemetryDisabled(): boolean {
   return isTruthyEnvValue(env.CAPGO_DISABLE_TELEMETRY) || isTruthyEnvValue(env.CAPGO_DISABLE_POSTHOG)
-}
-
-export interface GlobalAnalyticsProps {
-  cli_version: string
-  node_version: string
-  os_platform: string
-  os_arch: string
-  os_release: string
-  is_ci: boolean
-  is_tty: boolean
-  invocation_source: InvocationSource
-  ci_provider?: string
-}
-
-export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
-  const props: GlobalAnalyticsProps = {
-    cli_version: pack.version,
-    node_version: nodeVersion,
-    os_platform: platform(),
-    os_arch: arch,
-    os_release: release(),
-    is_ci: isCI,
-    is_tty: Boolean(process.stdout.isTTY),
-    invocation_source: invocationSource,
-  }
-  if (ciName)
-    props.ci_provider = ciName
-  return props
 }
 
 // --- flush registry: keep in-flight telemetry alive until the process drains ---
@@ -152,7 +116,6 @@ export function trackEvent(input: TrackEventInput): Promise<void> {
       }
 
       const tags: Record<string, string | number | boolean> = {
-        ...getGlobalAnalyticsProps(),
         ...(appId ? { app_id: appId } : {}),
         ...(input.tags ?? {}),
       }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1435,6 +1435,23 @@ export async function updateOrCreateChannel(supabase: SupabaseClient<Database>, 
 
 export async function sendEvent(capgkey: string, payload: TrackOptions & { notifyConsole?: boolean }, verbose?: boolean, signal?: AbortSignal): Promise<void> {
   try {
+    // Build the enriched payload first and DEFENSIVELY: a fault while reading
+    // the global analytics props must degrade to the caller's own tags and must
+    // never drop the event. sendEvent is the single send path that trackEvent()
+    // and every direct caller funnel through, so OS/version segmentation stays
+    // complete. Caller-supplied tags win on key conflict.
+    let globalProps = {}
+    try {
+      globalProps = getGlobalAnalyticsProps()
+    }
+    catch (enrichError) {
+      if (verbose)
+        log.error(`Failed to enrich event tags, sending caller tags only: ${formatError(enrichError)}`)
+    }
+    const enrichedPayload = {
+      ...payload,
+      tags: { ...globalProps, ...(payload.tags ?? {}) },
+    }
     if (verbose) {
       log.info(`Get remove config: for ${payload.event}`)
     }
@@ -1442,7 +1459,7 @@ export async function sendEvent(capgkey: string, payload: TrackOptions & { notif
     // not bypass an Ink-controlled stdout (e.g. during `capgo init`).
     const config = await getRemoteConfig(true, signal)
     if (verbose) {
-      log.info(`Sending LogSnag event: ${JSON.stringify(payload)}`)
+      log.info(`Sending LogSnag event: ${JSON.stringify(enrichedPayload)}`)
     }
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 seconds timeout
@@ -1451,15 +1468,6 @@ export async function sendEvent(capgkey: string, payload: TrackOptions & { notif
     const eventSignal = signal
       ? (typeof AbortSignal.any === 'function' ? AbortSignal.any([controller.signal, signal]) : signal)
       : controller.signal
-
-    // Inject the shared global analytics props (OS, arch, OS release, CLI/Node
-    // versions, CI context) on every event. sendEvent is the single send path
-    // that trackEvent() and all direct callers funnel through, so segmentation
-    // by OS/version stays complete. Caller-supplied tags win on conflict.
-    const enrichedPayload = {
-      ...payload,
-      tags: { ...getGlobalAnalyticsProps(), ...(payload.tags ?? {}) },
-    }
 
     try {
       const fetchResponse = await fetch(`${config.hostApi}/private/events`, {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -28,6 +28,7 @@ import { loadConfig, writeConfig } from './config'
 import { nativePackageSchema } from './schemas/common'
 import { formatApiErrorForCli, parseSecurityPolicyError } from './utils/security_policy_errors'
 import { createTimedFetch, isSupabaseInstrumentationEnabled } from './analytics/supabase-perf'
+import { getGlobalAnalyticsProps } from './analytics/global-props'
 
 export const baseKey = '.capgo_key'
 export const baseKeyV2 = '.capgo_key_v2'
@@ -1451,10 +1452,19 @@ export async function sendEvent(capgkey: string, payload: TrackOptions & { notif
       ? (typeof AbortSignal.any === 'function' ? AbortSignal.any([controller.signal, signal]) : signal)
       : controller.signal
 
+    // Inject the shared global analytics props (OS, arch, OS release, CLI/Node
+    // versions, CI context) on every event. sendEvent is the single send path
+    // that trackEvent() and all direct callers funnel through, so segmentation
+    // by OS/version stays complete. Caller-supplied tags win on conflict.
+    const enrichedPayload = {
+      ...payload,
+      tags: { ...getGlobalAnalyticsProps(), ...(payload.tags ?? {}) },
+    }
+
     try {
       const fetchResponse = await fetch(`${config.hostApi}/private/events`, {
         method: 'POST',
-        body: JSON.stringify(payload),
+        body: JSON.stringify(enrichedPayload),
         headers: {
           'Content-Type': 'application/json',
           'capgkey': capgkey,

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1433,13 +1433,14 @@ export async function updateOrCreateChannel(supabase: SupabaseClient<Database>, 
     .single()
 }
 
-export async function sendEvent(capgkey: string, payload: TrackOptions & { notifyConsole?: boolean }, verbose?: boolean, signal?: AbortSignal): Promise<void> {
+export async function sendEvent(capgkey: string, payload: TrackOptions & { notifyConsole?: boolean, nonPersonTags?: Record<string, string | number | boolean> }, verbose?: boolean, signal?: AbortSignal): Promise<void> {
   try {
-    // Build the enriched payload first and DEFENSIVELY: a fault while reading
-    // the global analytics props must degrade to the caller's own tags and must
-    // never drop the event. sendEvent is the single send path that trackEvent()
-    // and every direct caller funnel through, so OS/version segmentation stays
-    // complete. Caller-supplied tags win on key conflict.
+    // Attach the global analytics props as nonPersonTags — event properties the
+    // backend never writes as PostHog person properties ($set) — built
+    // DEFENSIVELY: a fault while reading them degrades to the caller's tags and
+    // must never drop the event. sendEvent is the single send path that
+    // trackEvent() and every direct caller funnel through, so OS/version
+    // segmentation stays complete. Caller-supplied nonPersonTags win on conflict.
     let globalProps = {}
     try {
       globalProps = getGlobalAnalyticsProps()
@@ -1450,7 +1451,7 @@ export async function sendEvent(capgkey: string, payload: TrackOptions & { notif
     }
     const enrichedPayload = {
       ...payload,
-      tags: { ...globalProps, ...(payload.tags ?? {}) },
+      nonPersonTags: { ...globalProps, ...(payload.nonPersonTags ?? {}) },
     }
     if (verbose) {
       log.info(`Get remove config: for ${payload.event}`)

--- a/cli/test/test-analytics.mjs
+++ b/cli/test/test-analytics.mjs
@@ -56,8 +56,8 @@ try {
   assert.equal(body.tags.foo, 'bar')
   assert.equal(body.tags.count, 3)
   assert.equal(body.tags.flag, true)
-  assert.equal(body.tags.invocation_source, 'cli')
-  assert.equal(typeof body.tags.cli_version, 'string')
+  assert.equal(body.nonPersonTags.invocation_source, 'cli')
+  assert.equal(typeof body.nonPersonTags.cli_version, 'string')
 
   // 3. opt-out suppresses the send
   process.env.CAPGO_DISABLE_TELEMETRY = '1'

--- a/cli/test/test-analytics.mjs
+++ b/cli/test/test-analytics.mjs
@@ -30,6 +30,7 @@ try {
   assert.equal(typeof props.os_platform, 'string')
   assert.equal(typeof props.os_arch, 'string')
   assert.equal(typeof props.os_release, 'string')
+  assert.equal(typeof props.timezone, 'string')
   assert.equal(typeof props.is_ci, 'boolean')
   assert.equal(typeof props.is_tty, 'boolean')
   assert.equal(props.invocation_source, 'cli')

--- a/cli/test/test-analytics.mjs
+++ b/cli/test/test-analytics.mjs
@@ -29,6 +29,7 @@ try {
   assert.equal(typeof props.node_version, 'string')
   assert.equal(typeof props.os_platform, 'string')
   assert.equal(typeof props.os_arch, 'string')
+  assert.equal(typeof props.os_release, 'string')
   assert.equal(typeof props.is_ci, 'boolean')
   assert.equal(typeof props.is_tty, 'boolean')
   assert.equal(props.invocation_source, 'cli')

--- a/cli/test/test-mcp-analytics.mjs
+++ b/cli/test/test-mcp-analytics.mjs
@@ -38,7 +38,7 @@ try {
   assert.equal(body.channel, 'mcp')
   assert.equal(body.tags.tool_name, 'capgo_list_apps')
   assert.equal(body.tags.success, true)
-  assert.equal(body.tags.invocation_source, 'mcp')
+  assert.equal(body.nonPersonTags.invocation_source, 'mcp')
   assert.equal(typeof body.tags.duration_ms, 'number')
 
   // isError result path

--- a/cli/test/test-onboarding-telemetry.mjs
+++ b/cli/test/test-onboarding-telemetry.mjs
@@ -5,7 +5,7 @@ import { trackBuilderOnboardingAction, trackBuilderOnboardingCancelled, trackBui
 // sendEvent() now injects the shared global analytics props (OS, arch, OS
 // release, CLI/Node versions, CI context) on every event. Strip them so the
 // caller-tag assertions below stay focused on event-specific dimensions.
-const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider']
+const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider', 'timezone']
 function callerTags(tags) {
   const rest = { ...tags }
   for (const key of GLOBAL_TAG_KEYS)

--- a/cli/test/test-onboarding-telemetry.mjs
+++ b/cli/test/test-onboarding-telemetry.mjs
@@ -2,6 +2,17 @@
 import assert from 'node:assert/strict'
 import { trackBuilderOnboardingAction, trackBuilderOnboardingCancelled, trackBuilderOnboardingStep } from '../src/build/onboarding/telemetry.ts'
 
+// sendEvent() now injects the shared global analytics props (OS, arch, OS
+// release, CLI/Node versions, CI context) on every event. Strip them so the
+// caller-tag assertions below stay focused on event-specific dimensions.
+const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider']
+function callerTags(tags) {
+  const rest = { ...tags }
+  for (const key of GLOBAL_TAG_KEYS)
+    delete rest[key]
+  return rest
+}
+
 console.log('🧪 Testing onboarding telemetry...\n')
 
 const originalFetch = globalThis.fetch
@@ -30,7 +41,13 @@ function findEventBody(requests) {
   assert.equal(eventRequest.init.headers.capgkey, 'capgo-key')
   assert.equal(eventRequest.init.headers['Content-Type'], 'application/json')
   assert.equal(eventRequest.init.signal instanceof AbortSignal, true)
-  return JSON.parse(eventRequest.init.body)
+  const body = JSON.parse(eventRequest.init.body)
+  // sendEvent() injects the shared global analytics props on every event.
+  assert.equal(typeof body.tags.os_release, 'string', 'global os_release tag present')
+  assert.equal(typeof body.tags.os_platform, 'string', 'global os_platform tag present')
+  assert.equal(typeof body.tags.os_arch, 'string', 'global os_arch tag present')
+  assert.equal(typeof body.tags.cli_version, 'string', 'global cli_version tag present')
+  return body
 }
 
 try {
@@ -62,7 +79,7 @@ try {
     assert.equal(body.notify, false)
     assert.equal(body.org_id, 'org-id')
     assert.equal(body.tracking_version, 2)
-    assert.deepEqual(body.tags, {
+    assert.deepEqual(callerTags(body.tags), {
       accepted: 'true',
       action: 'android_sa_method_selected',
       app_id: 'com.example.app',
@@ -92,7 +109,7 @@ try {
     const body = findEventBody(requests)
     assert.equal(body.event, 'Builder Onboarding Step')
     assert.equal(body.channel, 'builder-onboarding')
-    assert.deepEqual(body.tags, {
+    assert.deepEqual(callerTags(body.tags), {
       app_id: 'com.example.app',
       duration_ms: '1234',
       duration_step: 'welcome',
@@ -123,7 +140,7 @@ try {
     assert.equal(body.notify, false)
     assert.equal(body.org_id, 'org-id')
     assert.equal(body.tracking_version, 2)
-    assert.deepEqual(body.tags, {
+    assert.deepEqual(callerTags(body.tags), {
       app_id: 'com.example.app',
       duration_ms: '9876', // rounded
       journey_id: 'bj_journey-3',
@@ -148,7 +165,7 @@ try {
     assert.equal(body.org_id, undefined)
     // Only the always-present tags survive; the optional dimensions are omitted
     // rather than sent as empty/undefined strings.
-    assert.deepEqual(body.tags, {
+    assert.deepEqual(callerTags(body.tags), {
       app_id: 'com.example.app',
       journey_id: 'bj_journey-4',
     })

--- a/cli/test/test-onboarding-telemetry.mjs
+++ b/cli/test/test-onboarding-telemetry.mjs
@@ -2,16 +2,6 @@
 import assert from 'node:assert/strict'
 import { trackBuilderOnboardingAction, trackBuilderOnboardingCancelled, trackBuilderOnboardingStep } from '../src/build/onboarding/telemetry.ts'
 
-// sendEvent() now injects the shared global analytics props (OS, arch, OS
-// release, CLI/Node versions, CI context) on every event. Strip them so the
-// caller-tag assertions below stay focused on event-specific dimensions.
-const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider', 'timezone']
-function callerTags(tags) {
-  const rest = { ...tags }
-  for (const key of GLOBAL_TAG_KEYS)
-    delete rest[key]
-  return rest
-}
 
 console.log('🧪 Testing onboarding telemetry...\n')
 
@@ -42,11 +32,11 @@ function findEventBody(requests) {
   assert.equal(eventRequest.init.headers['Content-Type'], 'application/json')
   assert.equal(eventRequest.init.signal instanceof AbortSignal, true)
   const body = JSON.parse(eventRequest.init.body)
-  // sendEvent() injects the shared global analytics props on every event.
-  assert.equal(typeof body.tags.os_release, 'string', 'global os_release tag present')
-  assert.equal(typeof body.tags.os_platform, 'string', 'global os_platform tag present')
-  assert.equal(typeof body.tags.os_arch, 'string', 'global os_arch tag present')
-  assert.equal(typeof body.tags.cli_version, 'string', 'global cli_version tag present')
+  // The shared global analytics props ride in nonPersonTags on every event.
+  assert.equal(typeof body.nonPersonTags.os_release, 'string', 'global os_release tag present')
+  assert.equal(typeof body.nonPersonTags.os_platform, 'string', 'global os_platform tag present')
+  assert.equal(typeof body.nonPersonTags.os_arch, 'string', 'global os_arch tag present')
+  assert.equal(typeof body.nonPersonTags.cli_version, 'string', 'global cli_version tag present')
   return body
 }
 
@@ -79,7 +69,7 @@ try {
     assert.equal(body.notify, false)
     assert.equal(body.org_id, 'org-id')
     assert.equal(body.tracking_version, 2)
-    assert.deepEqual(callerTags(body.tags), {
+    assert.deepEqual(body.tags, {
       accepted: 'true',
       action: 'android_sa_method_selected',
       app_id: 'com.example.app',
@@ -109,7 +99,7 @@ try {
     const body = findEventBody(requests)
     assert.equal(body.event, 'Builder Onboarding Step')
     assert.equal(body.channel, 'builder-onboarding')
-    assert.deepEqual(callerTags(body.tags), {
+    assert.deepEqual(body.tags, {
       app_id: 'com.example.app',
       duration_ms: '1234',
       duration_step: 'welcome',
@@ -140,7 +130,7 @@ try {
     assert.equal(body.notify, false)
     assert.equal(body.org_id, 'org-id')
     assert.equal(body.tracking_version, 2)
-    assert.deepEqual(callerTags(body.tags), {
+    assert.deepEqual(body.tags, {
       app_id: 'com.example.app',
       duration_ms: '9876', // rounded
       journey_id: 'bj_journey-3',
@@ -165,7 +155,7 @@ try {
     assert.equal(body.org_id, undefined)
     // Only the always-present tags survive; the optional dimensions are omitted
     // rather than sent as empty/undefined strings.
-    assert.deepEqual(callerTags(body.tags), {
+    assert.deepEqual(body.tags, {
       app_id: 'com.example.app',
       journey_id: 'bj_journey-4',
     })

--- a/cli/test/test-v2-event-migration.mjs
+++ b/cli/test/test-v2-event-migration.mjs
@@ -33,7 +33,19 @@ try {
   assert.equal(body.org_id, 'org-123', 'org is now sent as org_id (not user_id)')
   assert.equal(body.tracking_version, 2, 'event opts into the v2 actor-scoped contract')
   assert.equal(body.user_id, undefined, 'CLI must not send user_id (backend derives the actor from the key)')
-  assert.deepEqual(body.tags, { 'app-id': 'com.example.app' })
+  // sendEvent() injects the shared global analytics props (OS, arch, OS
+  // release, CLI/Node versions, CI context) on every event — including
+  // markSnag's direct (non-trackEvent) send path. Assert they ride along...
+  assert.equal(typeof body.tags.os_release, 'string', 'OS release rides on the shared send path')
+  assert.equal(typeof body.tags.os_platform, 'string')
+  assert.equal(typeof body.tags.os_arch, 'string')
+  assert.equal(typeof body.tags.cli_version, 'string')
+  // ...then assert the caller-specific tags exactly, ignoring the globals.
+  const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider']
+  const callerTags = { ...body.tags }
+  for (const key of GLOBAL_TAG_KEYS)
+    delete callerTags[key]
+  assert.deepEqual(callerTags, { 'app-id': 'com.example.app' })
 
   console.log('✅ v2 event migration tests passed')
 }

--- a/cli/test/test-v2-event-migration.mjs
+++ b/cli/test/test-v2-event-migration.mjs
@@ -41,7 +41,7 @@ try {
   assert.equal(typeof body.tags.os_arch, 'string')
   assert.equal(typeof body.tags.cli_version, 'string')
   // ...then assert the caller-specific tags exactly, ignoring the globals.
-  const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider']
+  const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider', 'timezone']
   const callerTags = { ...body.tags }
   for (const key of GLOBAL_TAG_KEYS)
     delete callerTags[key]

--- a/cli/test/test-v2-event-migration.mjs
+++ b/cli/test/test-v2-event-migration.mjs
@@ -33,19 +33,15 @@ try {
   assert.equal(body.org_id, 'org-123', 'org is now sent as org_id (not user_id)')
   assert.equal(body.tracking_version, 2, 'event opts into the v2 actor-scoped contract')
   assert.equal(body.user_id, undefined, 'CLI must not send user_id (backend derives the actor from the key)')
-  // sendEvent() injects the shared global analytics props (OS, arch, OS
-  // release, CLI/Node versions, CI context) on every event — including
-  // markSnag's direct (non-trackEvent) send path. Assert they ride along...
-  assert.equal(typeof body.tags.os_release, 'string', 'OS release rides on the shared send path')
-  assert.equal(typeof body.tags.os_platform, 'string')
-  assert.equal(typeof body.tags.os_arch, 'string')
-  assert.equal(typeof body.tags.cli_version, 'string')
-  // ...then assert the caller-specific tags exactly, ignoring the globals.
-  const GLOBAL_TAG_KEYS = ['cli_version', 'node_version', 'os_platform', 'os_arch', 'os_release', 'is_ci', 'is_tty', 'invocation_source', 'ci_provider', 'timezone']
-  const callerTags = { ...body.tags }
-  for (const key of GLOBAL_TAG_KEYS)
-    delete callerTags[key]
-  assert.deepEqual(callerTags, { 'app-id': 'com.example.app' })
+  // Global analytics props now ride in nonPersonTags (event-only; the backend
+  // never writes them as PostHog person properties / $set). Caller tags stay in
+  // tags — markSnag's direct (non-trackEvent) send path included.
+  assert.equal(typeof body.nonPersonTags.os_release, 'string', 'OS release rides on the shared send path')
+  assert.equal(typeof body.nonPersonTags.os_platform, 'string')
+  assert.equal(typeof body.nonPersonTags.os_arch, 'string')
+  assert.equal(typeof body.nonPersonTags.timezone, 'string')
+  assert.equal(typeof body.nonPersonTags.cli_version, 'string')
+  assert.deepEqual(body.tags, { 'app-id': 'com.example.app' })
 
   console.log('✅ v2 event migration tests passed')
 }

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -36,6 +36,7 @@ interface TrackEventBody extends TrackOptions {
   notifyConsole?: boolean
   org_id?: string
   tracking_version?: number | string
+  nonPersonTags?: Record<string, string | number | boolean>
 }
 
 function isTrackingV2(version: unknown) {

--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -6,6 +6,36 @@ import { existInEnv, getEnv } from './utils.ts'
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
 const POSTHOG_EXCEPTION_URL = 'https://eu.i.posthog.com/i/v0/e/'
 
+// Global analytics props the CLI attaches to EVERY event (see
+// cli/src/analytics/global-props.ts). They describe the event's runtime
+// environment, not stable identity traits, so they must NOT be written as
+// PostHog person properties ($set): volatile dimensions like is_tty and
+// invocation_source would otherwise become last-write-wins per actor. They
+// still ride along as regular event properties (the tags spread, not $set).
+const NON_PERSON_PROPERTY_TAG_KEYS = new Set([
+  'cli_version',
+  'node_version',
+  'os_platform',
+  'os_arch',
+  'os_release',
+  'timezone',
+  'is_ci',
+  'is_tty',
+  'invocation_source',
+  'ci_provider',
+])
+
+function toPersonProperties(tags?: Record<string, any>): Record<string, any> | undefined {
+  if (!tags)
+    return tags
+  const personProps: Record<string, any> = {}
+  for (const [key, value] of Object.entries(tags)) {
+    if (!NON_PERSON_PROPERTY_TAG_KEYS.has(key))
+      personProps[key] = value
+  }
+  return personProps
+}
+
 export type PostHogGroups = Record<string, string>
 
 interface PostHogCapturePayload extends Pick<TrackOptions, 'event'>, Pick<TrackOptions, 'channel' | 'description'> {
@@ -38,7 +68,7 @@ export async function trackPosthogEvent(c: Context, payload: PostHogCapturePaylo
     ...(payload.tags || {}),
     channel: payload.channel,
     description: payload.description,
-    ...(payload.setPersonProperties === false ? {} : { $set: payload.tags }),
+    ...(payload.setPersonProperties === false ? {} : { $set: toPersonProperties(payload.tags) }),
     ...(hasGroups ? { $groups: payload.groups } : {}),
   }
 

--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -6,36 +6,6 @@ import { existInEnv, getEnv } from './utils.ts'
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
 const POSTHOG_EXCEPTION_URL = 'https://eu.i.posthog.com/i/v0/e/'
 
-// Global analytics props the CLI attaches to EVERY event (see
-// cli/src/analytics/global-props.ts). They describe the event's runtime
-// environment, not stable identity traits, so they must NOT be written as
-// PostHog person properties ($set): volatile dimensions like is_tty and
-// invocation_source would otherwise become last-write-wins per actor. They
-// still ride along as regular event properties (the tags spread, not $set).
-const NON_PERSON_PROPERTY_TAG_KEYS = new Set([
-  'cli_version',
-  'node_version',
-  'os_platform',
-  'os_arch',
-  'os_release',
-  'timezone',
-  'is_ci',
-  'is_tty',
-  'invocation_source',
-  'ci_provider',
-])
-
-function toPersonProperties(tags?: Record<string, any>): Record<string, any> | undefined {
-  if (!tags)
-    return tags
-  const personProps: Record<string, any> = {}
-  for (const [key, value] of Object.entries(tags)) {
-    if (!NON_PERSON_PROPERTY_TAG_KEYS.has(key))
-      personProps[key] = value
-  }
-  return personProps
-}
-
 export type PostHogGroups = Record<string, string>
 
 interface PostHogCapturePayload extends Pick<TrackOptions, 'event'>, Pick<TrackOptions, 'channel' | 'description'> {
@@ -44,6 +14,7 @@ interface PostHogCapturePayload extends Pick<TrackOptions, 'event'>, Pick<TrackO
   ip?: string
   setPersonProperties?: boolean
   tags?: Record<string, any>
+  nonPersonTags?: Record<string, any>
   timestamp?: string
   user_id?: string
 }
@@ -64,11 +35,16 @@ export async function trackPosthogEvent(c: Context, payload: PostHogCapturePaylo
 
   const hasGroups = payload.groups && Object.keys(payload.groups).length > 0
 
+  // `tags` become BOTH event properties and PostHog person properties ($set).
+  // `nonPersonTags` are event properties ONLY — never $set — for volatile
+  // per-event context (e.g. the CLI's global runtime props) that must not
+  // become last-write-wins identity traits on the actor.
   const properties = {
+    ...(payload.nonPersonTags || {}),
     ...(payload.tags || {}),
     channel: payload.channel,
     description: payload.description,
-    ...(payload.setPersonProperties === false ? {} : { $set: toPersonProperties(payload.tags) }),
+    ...(payload.setPersonProperties === false ? {} : { $set: payload.tags }),
     ...(hasGroups ? { $groups: payload.groups } : {}),
   }
 

--- a/supabase/functions/_backend/utils/tracking.ts
+++ b/supabase/functions/_backend/utils/tracking.ts
@@ -30,6 +30,7 @@ export interface SendEventToTrackingPayload extends TrackOptions {
   bento?: BentoTrackingPayload
   groups?: PostHogGroups
   sentToBento?: boolean
+  nonPersonTags?: Record<string, string | number | boolean>
 }
 
 export interface SendEventToTrackingOptions {
@@ -65,6 +66,7 @@ async function executeTracking(c: Context, payload: SendEventToTrackingPayload, 
       event: payload.event,
       user_id: payload.user_id,
       tags: payload.tags,
+      nonPersonTags: payload.nonPersonTags,
       channel: payload.channel,
       description: payload.description,
       groups: payload.groups,


### PR DESCRIPTION
## What

Ensures **every** PostHog event sent by the CLI carries the runtime **OS, arch, and OS version** (plus CLI/Node versions and CI context) — not just events that went through `trackEvent()`.

## Why

`getGlobalAnalyticsProps()` already supplied:
- `os_platform` (e.g. `darwin`, `linux`, `win32`)
- `os_arch` (e.g. `arm64`, `x64`)

…but it was **only spread by `trackEvent()`**. The CLI has ~40 **direct `sendEvent()` callers** (login, org, app, bundle, channel, build, onboarding/debug — e.g. `markSnag`) that forward straight to `/private/events`. Those events carried **none** of the global props, so OS/arch/version segmentation was incomplete. The OS *version* was missing everywhere except the separate PostHog exception path.

## Approach

1. **Add `os_release`** (`node:os` `release()`) to the global props — named to match the existing exception payload.
2. **Inject the global props at the shared `sendEvent()` choke point** (`cli/src/utils.ts`) that both `trackEvent()` and all direct callers funnel through. Caller-supplied tags win on key conflicts.
3. **Extract** the props + invocation-source state into a standalone `cli/src/analytics/global-props.ts` so `utils.ts` can import them without a `utils ⇄ track` circular import. `track.ts` re-exports the symbols for existing import sites and drops its now-redundant spread.

Net effect: OS + arch + OS version (and cli_version, node_version, is_ci, is_tty, invocation_source, ci_provider) now ride on **all** CLI PostHog events. The exception path (`cli/src/posthog.ts`) already had `os_release` and is unchanged.

## Changes

- `cli/src/analytics/global-props.ts` (new) — `getGlobalAnalyticsProps()` (incl. `os_release`), invocation-source state, types.
- `cli/src/analytics/track.ts` — re-export from `global-props`; remove the local definitions and the redundant per-event spread.
- `cli/src/utils.ts` — `sendEvent()` now merges global props into every event payload's tags.
- `cli/test/test-analytics.mjs` — asserts `os_release` on the global props.
- `cli/test/test-v2-event-migration.mjs` — asserts globals ride on the direct `markSnag` path; exact caller-tag match strips globals.
- `cli/test/test-onboarding-telemetry.mjs` — asserts globals present per event; caller-tag deep-equals strip globals.

## Test plan

- [x] `test:analytics`, `test:v2-event-migration`, `test:onboarding-telemetry`, `test:mcp-analytics`, `test:supabase-perf`, `test:app-created-source`, `test:doctor-analytics`, `test:posthog-exception` — all pass
- [x] `bun run typecheck` — clean (exit 0)
- [x] `oxlint` on changed source — clean