### PR TITLE
fix(dashboard): resolve vue(no-dupe-keys) lint errors blocking CI

### DIFF
--- a/src/components/dashboard/DevicesStats.vue
+++ b/src/components/dashboard/DevicesStats.vue
@@ -109,8 +109,8 @@ const organizationStore = useOrganizationStore()
 const supabase = useSupabase()
 const rawChartData = ref<ChartApiData | null>(null)
 
-const appId = ref('')
-const activeAppId = computed(() => props.appId || appId.value)
+const detectedAppId = ref('')
+const activeAppId = computed(() => props.appId || detectedAppId.value)
 const isNativeUsage = computed(() => props.usageKind === 'native')
 const titleKey = computed(() => isNativeUsage.value ? 'active_users_by_native_version' : 'active_users_by_version')
 
@@ -682,7 +682,7 @@ watch(
     // Check for app route pattern
     if (path.includes('/app/') && packageId) {
       const packageChanged = packageId !== oldPackageId
-      appId.value = packageId
+      detectedAppId.value = packageId
       if (packageChanged) {
         // Clear cache when switching apps
         cachedBillingData.value = null
@@ -695,7 +695,7 @@ watch(
       }
     }
     else {
-      appId.value = ''
+      detectedAppId.value = ''
       requestToken++
       rawChartData.value = null
       isLoading.value = true
@@ -715,7 +715,7 @@ watch(
       return
 
     if (packageId)
-      appId.value = packageId
+      detectedAppId.value = packageId
 
     if (!activeAppId.value)
       return

--- a/src/components/dashboard/StepsBundle.vue
+++ b/src/components/dashboard/StepsBundle.vue
@@ -23,7 +23,7 @@ const displayStore = useDisplayStore()
 const isLoading = ref(false)
 const step = ref(0)
 const clicked = ref(0)
-const appId = ref<string>()
+const detectedAppId = ref<string>()
 const realtimeListener = ref(false)
 const pollTimer = ref<number | null>(null)
 const initialCount = ref<number | null>(null)
@@ -248,7 +248,7 @@ watchEffect(async () => {
         if (initialCount.value !== null && current > initialCount.value) {
           const latestId = await getLatestVersionId()
           step.value += 1
-          appId.value = latestId ?? ''
+          detectedAppId.value = latestId ?? ''
           realtimeListener.value = false
           clearWatchers()
           setLog()


### PR DESCRIPTION
## Problem

`oxlint src` (the 'Run tests' → Lint step) is failing on `main` with 2 errors:

- `src/components/dashboard/StepsBundle.vue:26` — `Duplicate key 'appId'`
- `src/components/dashboard/DevicesStats.vue:112` — `Duplicate key 'appId'`

Each component declares a local `ref` named `appId` that collides with its `appId` **prop**, which `vue(no-dupe-keys)` flags as a script/template name collision. This reds out CI for every open PR (it lints all of `src/`, regardless of diff).

## Fix

Rename the **local refs** to `detectedAppId` (all usages updated); the `appId` **prop** is unchanged. Pure rename, no behavior change.

## Verification

- `bun run lint` → exit 0 (0 errors)
- `bun run typecheck:frontend` → clean

## Why separate

These are pre-existing `main` bugs, unrelated to any feature PR. Merging this first turns the Lint step green for all open PRs (incl. #2519).