### PR TITLE
fix(types): restore stripe/global_stats columns to fix backend Typecheck

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1093,6 +1093,7 @@ export type Database = {
       }
       daily_revenue_metrics: {
         Row: {
+          churn_reason: string | null
           churn_mrr: number
           churn_mrr_enterprise: number
           churn_mrr_maker: number
@@ -1112,6 +1113,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          churn_reason?: string | null
           churn_mrr?: number
           churn_mrr_enterprise?: number
           churn_mrr_maker?: number
@@ -1131,6 +1133,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          churn_reason?: string | null
           churn_mrr?: number
           churn_mrr_enterprise?: number
           churn_mrr_maker?: number
@@ -1443,6 +1446,8 @@ export type Database = {
       }
       global_stats: {
         Row: {
+          past_due_orgs: number
+          past_due_orgs_average_days: number
           apps: number
           apps_active: number | null
           average_ltv: number
@@ -1529,6 +1534,8 @@ export type Database = {
           users_active: number | null
         }
         Insert: {
+          past_due_orgs?: number
+          past_due_orgs_average_days?: number
           apps: number
           apps_active?: number | null
           average_ltv?: number
@@ -1615,6 +1622,8 @@ export type Database = {
           users_active?: number | null
         }
         Update: {
+          past_due_orgs?: number
+          past_due_orgs_average_days?: number
           apps?: number
           apps_active?: number | null
           average_ltv?: number
@@ -2510,6 +2519,8 @@ export type Database = {
       }
       stripe_info: {
         Row: {
+          churn_reason: string | null
+          past_due_at: string | null
           bandwidth_exceeded: boolean | null
           build_time_exceeded: boolean | null
           canceled_at: string | null
@@ -2535,6 +2546,8 @@ export type Database = {
           upgraded_at: string | null
         }
         Insert: {
+          churn_reason?: string | null
+          past_due_at?: string | null
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
@@ -2560,6 +2573,8 @@ export type Database = {
           upgraded_at?: string | null
         }
         Update: {
+          churn_reason?: string | null
+          past_due_at?: string | null
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1093,6 +1093,7 @@ export type Database = {
       }
       daily_revenue_metrics: {
         Row: {
+          churn_reason: string | null
           churn_mrr: number
           churn_mrr_enterprise: number
           churn_mrr_maker: number
@@ -1112,6 +1113,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          churn_reason?: string | null
           churn_mrr?: number
           churn_mrr_enterprise?: number
           churn_mrr_maker?: number
@@ -1131,6 +1133,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          churn_reason?: string | null
           churn_mrr?: number
           churn_mrr_enterprise?: number
           churn_mrr_maker?: number
@@ -1443,6 +1446,8 @@ export type Database = {
       }
       global_stats: {
         Row: {
+          past_due_orgs: number
+          past_due_orgs_average_days: number
           apps: number
           apps_active: number | null
           average_ltv: number
@@ -1529,6 +1534,8 @@ export type Database = {
           users_active: number | null
         }
         Insert: {
+          past_due_orgs?: number
+          past_due_orgs_average_days?: number
           apps: number
           apps_active?: number | null
           average_ltv?: number
@@ -1615,6 +1622,8 @@ export type Database = {
           users_active?: number | null
         }
         Update: {
+          past_due_orgs?: number
+          past_due_orgs_average_days?: number
           apps?: number
           apps_active?: number | null
           average_ltv?: number
@@ -2510,6 +2519,8 @@ export type Database = {
       }
       stripe_info: {
         Row: {
+          churn_reason: string | null
+          past_due_at: string | null
           bandwidth_exceeded: boolean | null
           build_time_exceeded: boolean | null
           canceled_at: string | null
@@ -2535,6 +2546,8 @@ export type Database = {
           upgraded_at: string | null
         }
         Insert: {
+          churn_reason?: string | null
+          past_due_at?: string | null
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
@@ -2560,6 +2573,8 @@ export type Database = {
           upgraded_at?: string | null
         }
         Update: {
+          churn_reason?: string | null
+          past_due_at?: string | null
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null


### PR DESCRIPTION
## Problem

`Run tests → Typecheck` is red on `main` (and therefore on every PR branched off it). The **backend** typecheck fails with ~26 errors like:

```
supabase/functions/_backend/triggers/stripe_event.ts: Property 'past_due_at' does not exist on type '{...}'
supabase/functions/_backend/utils/stripe.ts: column 'past_due_at' does not exist on 'stripe_info'
supabase/functions/_backend/triggers/logsnag_insights.ts: 'past_due_orgs' does not exist in type '{...}'
```

These are in untouched backend files — it's a **generated-types drift**: a `chore(auto-sync): update supabase schema and generated types` (`b5ed3750`) regenerated the committed types from a DB that **didn't have migration `20260616173941_add_past_due_global_stats` applied**, so it dropped the columns that migration adds — while the backend code already references them.

## Fix

Restore those columns to both generated type files (`src/types/supabase.types.ts` and `supabase/functions/_backend/utils/supabase.types.ts`), in `Row`/`Insert`/`Update`, exactly matching the migration:

- `stripe_info.past_due_at` (`timestamptz` → `string | null`)
- `stripe_info.churn_reason` (`text` → `string | null`)
- `daily_revenue_metrics.churn_reason` (`text` → `string | null`)
- `global_stats.past_due_orgs` (`int NOT NULL` → `number`)
- `global_stats.past_due_orgs_average_days` (`double NOT NULL` → `number`)

## Verification

- `bun run typecheck` (cli + backend + frontend): **passes** (was 26 backend errors → 0).
- Only the two generated type files change.

> Follow-up: the auto-sync that dropped these should be re-run against a fully-migrated DB so a future sync doesn't re-drop them.
