### PR TITLE
[codex] Fix spoof session failure handling

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1804,6 +1804,8 @@
   "attempted-destination": "Attempted destination:",
   "reset-password": "Reset Password",
   "reset-spoofed-user": "Stop spoofing",
+  "spoof-session-cleared": "Stale spoof session cleared",
+  "spoof-stopped-reload": "Stopped spoofing, will reload",
   "reset-your-password": "Reset your password",
   "resource": "Resource",
   "response-body": "Response Body",

--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -26,6 +26,7 @@ const acronym = computed(() => {
   return res.toUpperCase()
 })
 const isLoading = ref(false)
+const spoofed = ref(isSpoofed())
 const logAsInput = ref('')
 
 async function openLogAsDialog() {
@@ -61,13 +62,25 @@ async function openLogAsDialog() {
 }
 
 async function resetSpoofedUser() {
-  if (await unspoofUser()) {
-    toast.error('Stop Spoofed, will reload')
+  isLoading.value = true
+  try {
+    const restored = await unspoofUser()
+    spoofed.value = isSpoofed()
+
+    if (!restored) {
+      toast.error(t('spoof-session-cleared'))
+      return
+    }
+
+    toast.success(t('spoof-stopped-reload'))
     setTimeout(() => {
       router.replace('/dashboard').then(() => {
         globalThis.location.reload()
       })
     }, 1000)
+  }
+  finally {
+    isLoading.value = false
   }
 }
 
@@ -125,14 +138,14 @@ async function logOut() {
         <div class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" @click="openSupport">
           {{ t('support') }}
         </div>
-        <div v-if="main.isAdmin && !isSpoofed()" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="openLogAsDialog">
+        <div v-if="main.isAdmin && !spoofed" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="openLogAsDialog">
           <span v-if="!isLoading">{{ t('log-as') }}</span>
           <span v-else class="flex items-center">
             <Spinner size="w-4 h-4" class="mr-2" />
             {{ t('loading') }}
           </span>
         </div>
-        <div v-if="isSpoofed()" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" @click="resetSpoofedUser">
+        <div v-if="spoofed" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="resetSpoofedUser">
           {{ t('reset-spoofed-user') }}
         </div>
         <div class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" @click="logOut">

--- a/src/services/logAs.ts
+++ b/src/services/logAs.ts
@@ -1,8 +1,22 @@
 import type { Router } from 'vue-router'
+import { FunctionsHttpError } from '@supabase/supabase-js'
 import { toast } from 'vue-sonner'
-import { isSpoofed, saveSpoof, unspoofUser, useSupabase } from './supabase'
+import { getSpoofedAdminJwt, isSpoofed, saveSpoof, useSupabase } from './supabase'
 
-function getErrorMessage(error: unknown) {
+async function getErrorMessage(error: unknown) {
+  if (error instanceof FunctionsHttpError && error.context instanceof Response) {
+    try {
+      const json = await error.context.clone().json() as { error?: string, message?: string }
+      if (json.message)
+        return json.message
+      if (json.error)
+        return json.error
+    }
+    catch {
+      // Fall back to the SDK error message below.
+    }
+  }
+
   if (error instanceof Error)
     return error.message
   if (typeof error === 'string')
@@ -18,33 +32,45 @@ export async function logAsUser(identifier: string, router: Router) {
     if (!identifier)
       throw new Error('Missing user id, email, or org id')
 
-    if (isSpoofed() && !(await unspoofUser()))
+    const wasSpoofed = isSpoofed()
+    const spoofedAdminJwt = wasSpoofed ? await getSpoofedAdminJwt() : null
+    if (wasSpoofed && !spoofedAdminJwt)
       throw new Error('Cannot restore admin session, please sign in again')
 
     const supabase = useSupabase()
-    const { data, error } = await supabase.functions.invoke('private/log_as', {
+    const invokeOptions: { body: { identifier: string }, headers?: Record<string, string> } = {
       body: { identifier },
-    })
+    }
+    if (spoofedAdminJwt)
+      invokeOptions.headers = { Authorization: `Bearer ${spoofedAdminJwt}` }
+
+    const { data, error } = await supabase.functions.invoke('private/log_as', invokeOptions)
 
     if (error)
-      throw new Error(getErrorMessage(error))
+      throw new Error(await getErrorMessage(error))
 
     const { jwt: newJwt, refreshToken: newRefreshToken } = data ?? {}
 
     if (!newJwt || !newRefreshToken)
       throw new Error('Cannot log in, see console')
 
-    const { data: currentSession, error: sessionError } = await supabase.auth.getSession()
-    if (sessionError || !currentSession?.session)
-      throw new Error('No current session')
+    let adminSession: { jwt: string, refreshToken: string } | null = null
+    if (!wasSpoofed) {
+      const { data: currentSession, error: sessionError } = await supabase.auth.getSession()
+      if (sessionError || !currentSession?.session)
+        throw new Error('No current session')
 
-    const { access_token: currentJwt, refresh_token: currentRefreshToken } = currentSession.session
+      const { access_token: currentJwt, refresh_token: currentRefreshToken } = currentSession.session
+      adminSession = { jwt: currentJwt, refreshToken: currentRefreshToken }
+    }
 
     const { error: authError } = await supabase.auth.setSession({ access_token: newJwt, refresh_token: newRefreshToken })
     if (authError)
       throw authError
 
-    saveSpoof(currentJwt, currentRefreshToken)
+    if (adminSession)
+      saveSpoof(adminSession.jwt, adminSession.refreshToken)
+
     toast.dismiss(toastId)
     toast.success('Spoofed, will reload')
     setTimeout(() => {
@@ -55,7 +81,7 @@ export async function logAsUser(identifier: string, router: Router) {
   }
   catch (error) {
     toast.dismiss(toastId)
-    const message = getErrorMessage(error)
+    const message = await getErrorMessage(error)
     toast.error(message)
     console.error(error)
     throw error

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -205,7 +205,11 @@ export async function getSpoofedAdminJwt() {
   }
 
   const expiresAt = getJwtExpiresAt(spoofedAdminSession.jwt)
-  return expiresAt && expiresAt > Date.now() / 1000 ? spoofedAdminSession.jwt : null
+  if (expiresAt && expiresAt > Date.now() / 1000)
+    return spoofedAdminSession.jwt
+
+  clearSpoof()
+  return null
 }
 
 export async function hashEmail(email: string) {
@@ -223,12 +227,19 @@ export async function unspoofUser() {
   if (!spoofedAdminSession)
     return false
 
+  const restoredAdminSession = await refreshSpoofedAdminSession(spoofedAdminSession).catch(() => null)
+  if (!restoredAdminSession) {
+    clearSpoof()
+    return false
+  }
+
   const supabase = useSupabase()
-  const { data, error } = await supabase.auth.setSession({ access_token: spoofedAdminSession.jwt, refresh_token: spoofedAdminSession.refreshToken })
+  const { data, error } = await supabase.auth.setSession({ access_token: restoredAdminSession.jwt, refresh_token: restoredAdminSession.refreshToken })
+  clearSpoof()
+
   if (error || !data.session)
     return false
 
-  localStorage.removeItem(getSpoofedAdminStorageKey())
   return true
 }
 

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1098,6 +1098,7 @@ export type Database = {
           churn_mrr_maker: number
           churn_mrr_solo: number
           churn_mrr_team: number
+          churn_reason: string | null
           contraction_mrr: number
           contraction_mrr_enterprise: number
           contraction_mrr_maker: number
@@ -1117,6 +1118,7 @@ export type Database = {
           churn_mrr_maker?: number
           churn_mrr_solo?: number
           churn_mrr_team?: number
+          churn_reason?: string | null
           contraction_mrr?: number
           contraction_mrr_enterprise?: number
           contraction_mrr_maker?: number
@@ -1489,6 +1491,8 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          past_due_orgs: number
+          past_due_orgs_average_days: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1575,6 +1579,8 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          past_due_orgs?: number
+          past_due_orgs_average_days?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -2513,6 +2519,7 @@ export type Database = {
           bandwidth_exceeded: boolean | null
           build_time_exceeded: boolean | null
           canceled_at: string | null
+          churn_reason: string | null
           created_at: string
           customer_country: string | null
           customer_id: string
@@ -2521,6 +2528,7 @@ export type Database = {
           last_stripe_event_at: string | null
           mau_exceeded: boolean | null
           paid_at: string | null
+          past_due_at: string | null
           plan_calculated_at: string | null
           plan_usage: number | null
           price_id: string | null
@@ -2538,6 +2546,7 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
+          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id: string
@@ -2546,6 +2555,7 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
+          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
@@ -2563,6 +2573,7 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
+          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id?: string
@@ -2571,6 +2582,7 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
+          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1098,6 +1098,7 @@ export type Database = {
           churn_mrr_maker: number
           churn_mrr_solo: number
           churn_mrr_team: number
+          churn_reason: string | null
           contraction_mrr: number
           contraction_mrr_enterprise: number
           contraction_mrr_maker: number
@@ -1117,6 +1118,7 @@ export type Database = {
           churn_mrr_maker?: number
           churn_mrr_solo?: number
           churn_mrr_team?: number
+          churn_reason?: string | null
           contraction_mrr?: number
           contraction_mrr_enterprise?: number
           contraction_mrr_maker?: number
@@ -1489,6 +1491,8 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          past_due_orgs: number
+          past_due_orgs_average_days: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1575,6 +1579,8 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          past_due_orgs?: number
+          past_due_orgs_average_days?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -2513,6 +2519,7 @@ export type Database = {
           bandwidth_exceeded: boolean | null
           build_time_exceeded: boolean | null
           canceled_at: string | null
+          churn_reason: string | null
           created_at: string
           customer_country: string | null
           customer_id: string
@@ -2521,6 +2528,7 @@ export type Database = {
           last_stripe_event_at: string | null
           mau_exceeded: boolean | null
           paid_at: string | null
+          past_due_at: string | null
           plan_calculated_at: string | null
           plan_usage: number | null
           price_id: string | null
@@ -2538,6 +2546,7 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
+          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id: string
@@ -2546,6 +2555,7 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
+          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
@@ -2563,6 +2573,7 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
+          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id?: string
@@ -2571,6 +2582,7 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
+          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null

--- a/tests/log-as-service.unit.test.ts
+++ b/tests/log-as-service.unit.test.ts
@@ -1,0 +1,133 @@
+import type { Router } from 'vue-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getSpoofedAdminJwt: vi.fn(),
+  isSpoofed: vi.fn(),
+  saveSpoof: vi.fn(),
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(() => 'toast-id'),
+    success: vi.fn(),
+  },
+  useSupabase: vi.fn(),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: mocks.toast,
+}))
+
+vi.mock('../src/services/supabase.ts', () => ({
+  getSpoofedAdminJwt: mocks.getSpoofedAdminJwt,
+  isSpoofed: mocks.isSpoofed,
+  saveSpoof: mocks.saveSpoof,
+  useSupabase: mocks.useSupabase,
+}))
+
+function createRouter() {
+  return {
+    replace: vi.fn(() => Promise.resolve()),
+  } as unknown as Router
+}
+
+function useSupabaseMock() {
+  const invoke = vi.fn()
+  const getSession = vi.fn()
+  const setSession = vi.fn()
+
+  mocks.useSupabase.mockReturnValue({
+    auth: {
+      getSession,
+      setSession,
+    },
+    functions: {
+      invoke,
+    },
+  })
+
+  return { getSession, invoke, setSession }
+}
+
+describe('logAsUser', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mocks.toast.loading.mockReturnValue('toast-id')
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleError.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('keeps the current spoofed session untouched when the next spoof request fails', async () => {
+    const { getSession, invoke, setSession } = useSupabaseMock()
+    mocks.isSpoofed.mockReturnValue(true)
+    mocks.getSpoofedAdminJwt.mockResolvedValue('admin-jwt')
+    invoke.mockResolvedValue({ data: null, error: new Error('User does not exist') })
+
+    const { logAsUser } = await import('../src/services/logAs.ts')
+
+    await expect(logAsUser('missing-target', createRouter())).rejects.toThrow('User does not exist')
+
+    expect(mocks.getSpoofedAdminJwt).toHaveBeenCalledOnce()
+    expect(invoke).toHaveBeenCalledWith('private/log_as', {
+      body: { identifier: 'missing-target' },
+      headers: { Authorization: 'Bearer admin-jwt' },
+    })
+    expect(getSession).not.toHaveBeenCalled()
+    expect(setSession).not.toHaveBeenCalled()
+    expect(mocks.saveSpoof).not.toHaveBeenCalled()
+  })
+
+  it('switches between spoofed users without replacing the stored admin backup', async () => {
+    const { getSession, invoke, setSession } = useSupabaseMock()
+    mocks.isSpoofed.mockReturnValue(true)
+    mocks.getSpoofedAdminJwt.mockResolvedValue('admin-jwt')
+    invoke.mockResolvedValue({ data: { jwt: 'new-user-jwt', refreshToken: 'new-user-refresh' }, error: null })
+    setSession.mockResolvedValue({ data: { session: {} }, error: null })
+
+    const { logAsUser } = await import('../src/services/logAs.ts')
+
+    await logAsUser('next-target', createRouter())
+
+    expect(invoke).toHaveBeenCalledWith('private/log_as', {
+      body: { identifier: 'next-target' },
+      headers: { Authorization: 'Bearer admin-jwt' },
+    })
+    expect(getSession).not.toHaveBeenCalled()
+    expect(setSession).toHaveBeenCalledWith({ access_token: 'new-user-jwt', refresh_token: 'new-user-refresh' })
+    expect(mocks.saveSpoof).not.toHaveBeenCalled()
+  })
+
+  it('stores the current admin session when starting a spoof from the admin account', async () => {
+    const { getSession, invoke, setSession } = useSupabaseMock()
+    mocks.isSpoofed.mockReturnValue(false)
+    invoke.mockResolvedValue({ data: { jwt: 'user-jwt', refreshToken: 'user-refresh' }, error: null })
+    getSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'admin-jwt',
+          refresh_token: 'admin-refresh',
+        },
+      },
+      error: null,
+    })
+    setSession.mockResolvedValue({ data: { session: {} }, error: null })
+
+    const { logAsUser } = await import('../src/services/logAs.ts')
+
+    await logAsUser('target-user', createRouter())
+
+    expect(mocks.getSpoofedAdminJwt).not.toHaveBeenCalled()
+    expect(invoke).toHaveBeenCalledWith('private/log_as', {
+      body: { identifier: 'target-user' },
+    })
+    expect(mocks.saveSpoof).toHaveBeenCalledWith('admin-jwt', 'admin-refresh')
+    expect(setSession).toHaveBeenCalledWith({ access_token: 'user-jwt', refresh_token: 'user-refresh' })
+  })
+})

--- a/tests/supabase-spoof.unit.test.ts
+++ b/tests/supabase-spoof.unit.test.ts
@@ -1,0 +1,99 @@
+import { Buffer } from 'node:buffer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mocks.createClient,
+}))
+
+function createJwt(exp: number) {
+  return `header.${Buffer.from(JSON.stringify({ exp })).toString('base64url')}.signature`
+}
+
+function stubLocalStorage() {
+  const storage = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    removeItem: vi.fn((key: string) => storage.delete(key)),
+    setItem: vi.fn((key: string, value: string) => storage.set(key, value)),
+  })
+  vi.stubGlobal('atob', (value: string) => Buffer.from(value, 'base64').toString('binary'))
+}
+
+describe('spoof session storage', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mocks.createClient.mockReset()
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co')
+    stubLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+  it('clears stale spoof storage without touching the active session when unspoof cannot restore admin', async () => {
+    const refreshSession = vi.fn().mockResolvedValue({ data: { session: null }, error: new Error('invalid refresh token') })
+    const setSession = vi.fn()
+    mocks.createClient
+      .mockReturnValueOnce({ auth: { refreshSession } })
+      .mockReturnValueOnce({ auth: { setSession } })
+
+    const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(1), 'stale-refresh-token')
+    expect(isSpoofed()).toBe(true)
+
+    await expect(unspoofUser()).resolves.toBe(false)
+
+    expect(refreshSession).toHaveBeenCalledWith({ refresh_token: 'stale-refresh-token' })
+    expect(setSession).not.toHaveBeenCalled()
+    expect(isSpoofed()).toBe(false)
+  })
+
+  it('restores admin with a refreshed stored session before clearing spoof storage', async () => {
+    const refreshSession = vi.fn().mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'fresh-admin-jwt',
+          refresh_token: 'fresh-admin-refresh-token',
+        },
+      },
+      error: null,
+    })
+    const setSession = vi.fn().mockResolvedValue({ data: { session: {} }, error: null })
+    mocks.createClient
+      .mockReturnValueOnce({ auth: { refreshSession } })
+      .mockReturnValueOnce({ auth: { setSession } })
+
+    const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(1), 'admin-refresh-token')
+    expect(isSpoofed()).toBe(true)
+
+    await expect(unspoofUser()).resolves.toBe(true)
+
+    expect(setSession).toHaveBeenCalledWith({
+      access_token: 'fresh-admin-jwt',
+      refresh_token: 'fresh-admin-refresh-token',
+    })
+    expect(isSpoofed()).toBe(false)
+  })
+
+  it('clears expired spoof storage when the stored admin jwt cannot be refreshed', async () => {
+    const refreshSession = vi.fn().mockResolvedValue({ data: { session: null }, error: new Error('invalid refresh token') })
+    mocks.createClient.mockReturnValueOnce({ auth: { refreshSession } })
+
+    const { getSpoofedAdminJwt, isSpoofed, saveSpoof } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(1), 'stale-refresh-token')
+
+    await expect(getSpoofedAdminJwt()).resolves.toBeNull()
+
+    expect(isSpoofed()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- preserve the active session when log-as fails from an already spoofed account
- clear stale spoof storage when admin restore tokens cannot be refreshed
- make the profile menu react to spoof storage cleanup immediately
- add focused unit coverage for failed log-as and stale unspoof paths

## Root cause
The frontend trusted the spoof marker in localStorage. Failed log-as attempts restored or validated spoof state before proving the next impersonation could succeed, and unspoof tried to set the live Supabase session with stale stored admin tokens. That could clear the active browser session while leaving the stale spoof key behind.

## Validation
- bun lint
- bunx eslint tests/supabase-spoof.unit.test.ts tests/log-as-service.unit.test.ts
- bunx vitest run tests/supabase-spoof.unit.test.ts tests/log-as-service.unit.test.ts
- bun run typecheck:frontend
- commit hook: bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend