### PR TITLE
fix(types): dedupe duplicate stripe/global_stats type columns (unblock deploy)

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1099,7 +1099,6 @@ export type Database = {
           churn_mrr_maker: number
           churn_mrr_solo: number
           churn_mrr_team: number
-          churn_reason: string | null
           contraction_mrr: number
           contraction_mrr_enterprise: number
           contraction_mrr_maker: number
@@ -1120,7 +1119,6 @@ export type Database = {
           churn_mrr_maker?: number
           churn_mrr_solo?: number
           churn_mrr_team?: number
-          churn_reason?: string | null
           contraction_mrr?: number
           contraction_mrr_enterprise?: number
           contraction_mrr_maker?: number
@@ -1496,8 +1494,6 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
-          past_due_orgs: number
-          past_due_orgs_average_days: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1586,8 +1582,6 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
-          past_due_orgs?: number
-          past_due_orgs_average_days?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -2530,7 +2524,6 @@ export type Database = {
           bandwidth_exceeded: boolean | null
           build_time_exceeded: boolean | null
           canceled_at: string | null
-          churn_reason: string | null
           created_at: string
           customer_country: string | null
           customer_id: string
@@ -2539,7 +2532,6 @@ export type Database = {
           last_stripe_event_at: string | null
           mau_exceeded: boolean | null
           paid_at: string | null
-          past_due_at: string | null
           plan_calculated_at: string | null
           plan_usage: number | null
           price_id: string | null
@@ -2559,7 +2551,6 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
-          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id: string
@@ -2568,7 +2559,6 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
-          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
@@ -2588,7 +2578,6 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
-          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id?: string
@@ -2597,7 +2586,6 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
-          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1099,7 +1099,6 @@ export type Database = {
           churn_mrr_maker: number
           churn_mrr_solo: number
           churn_mrr_team: number
-          churn_reason: string | null
           contraction_mrr: number
           contraction_mrr_enterprise: number
           contraction_mrr_maker: number
@@ -1120,7 +1119,6 @@ export type Database = {
           churn_mrr_maker?: number
           churn_mrr_solo?: number
           churn_mrr_team?: number
-          churn_reason?: string | null
           contraction_mrr?: number
           contraction_mrr_enterprise?: number
           contraction_mrr_maker?: number
@@ -1496,8 +1494,6 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
-          past_due_orgs: number
-          past_due_orgs_average_days: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1586,8 +1582,6 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
-          past_due_orgs?: number
-          past_due_orgs_average_days?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -2530,7 +2524,6 @@ export type Database = {
           bandwidth_exceeded: boolean | null
           build_time_exceeded: boolean | null
           canceled_at: string | null
-          churn_reason: string | null
           created_at: string
           customer_country: string | null
           customer_id: string
@@ -2539,7 +2532,6 @@ export type Database = {
           last_stripe_event_at: string | null
           mau_exceeded: boolean | null
           paid_at: string | null
-          past_due_at: string | null
           plan_calculated_at: string | null
           plan_usage: number | null
           price_id: string | null
@@ -2559,7 +2551,6 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
-          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id: string
@@ -2568,7 +2559,6 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
-          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null
@@ -2588,7 +2578,6 @@ export type Database = {
           bandwidth_exceeded?: boolean | null
           build_time_exceeded?: boolean | null
           canceled_at?: string | null
-          churn_reason?: string | null
           created_at?: string
           customer_country?: string | null
           customer_id?: string
@@ -2597,7 +2586,6 @@ export type Database = {
           last_stripe_event_at?: string | null
           mau_exceeded?: boolean | null
           paid_at?: string | null
-          past_due_at?: string | null
           plan_calculated_at?: string | null
           plan_usage?: number | null
           price_id?: string | null


### PR DESCRIPTION
## Problem

`main` is red on **Typecheck** (~50 `TS2300: Duplicate identifier` errors for `past_due_at`, `churn_reason`, `past_due_orgs`, `past_due_orgs_average_days` in both generated type files). This blocks the **Bump version** test gate → no deploy tag → **prod deploys are stuck again**.

Cause: #2524 and #2526 each restored the same dropped columns. The two PRs merged with no textual conflict, but git applied **both** insertions, so every column landed **twice** in the same `Row`/`Insert`/`Update` block.

## Fix

Dedupe — remove the duplicate copy so each column appears once per block. Per-block (a name may legitimately exist in Row + Insert + Update).

## Verification

`bun run typecheck` (cli + backend + frontend): **0 errors** (was ~50). Only the two generated type files change.

> Urgent: merging this unblocks the version bump → deploy again.