### PR TITLE
[codex] Adjust native build minutes and credit pricing

### DIFF
--- a/supabase/migrations/20260617124855_double_native_build_minutes_credit_prices.sql
+++ b/supabase/migrations/20260617124855_double_native_build_minutes_credit_prices.sql
@@ -1,0 +1,301 @@
+UPDATE public.plans
+SET
+  build_time_unit = CASE id
+    WHEN '526e11d8-3c51-4581-ac92-4770c602f47c'::uuid THEN 3600::bigint
+    WHEN '440cfd69-0cfd-486e-b59b-cb99f7ae76a0'::uuid THEN 7200::bigint
+    WHEN 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77'::uuid THEN 36000::bigint
+    WHEN '745d7ab3-6cd6-4d65-b257-de6782d5ba50'::uuid THEN 1200000::bigint
+    ELSE build_time_unit
+  END,
+  updated_at = now()
+WHERE id IN (
+  '526e11d8-3c51-4581-ac92-4770c602f47c'::uuid,
+  '440cfd69-0cfd-486e-b59b-cb99f7ae76a0'::uuid,
+  'abd76414-8f90-49a5-b3a4-8ff4d2e12c77'::uuid,
+  '745d7ab3-6cd6-4d65-b257-de6782d5ba50'::uuid
+);
+
+
+WITH desired_steps (step_min, step_max, price_per_unit, unit_factor) AS (
+  VALUES
+    (0::bigint, 6000::bigint, 0.08::double precision, 60::bigint),
+    (6000::bigint, 30000::bigint, 0.07::double precision, 60::bigint),
+    (30000::bigint, 60000::bigint, 0.06::double precision, 60::bigint),
+    (60000::bigint, 300000::bigint, 0.05::double precision, 60::bigint),
+    (300000::bigint, 600000::bigint, 0.045::double precision, 60::bigint),
+    (600000::bigint, 9223372036854775807::bigint, 0.04::double precision, 60::bigint)
+),
+updated_steps AS (
+  UPDATE public.capgo_credits_steps AS existing
+  SET
+    price_per_unit = desired_steps.price_per_unit,
+    unit_factor = desired_steps.unit_factor
+  FROM desired_steps
+  WHERE existing.type = 'build_time'
+    AND existing.org_id IS NULL
+    AND existing.step_min = desired_steps.step_min
+    AND existing.step_max = desired_steps.step_max
+  RETURNING existing.step_min, existing.step_max
+)
+INSERT INTO public.capgo_credits_steps (
+  type,
+  step_min,
+  step_max,
+  price_per_unit,
+  unit_factor,
+  org_id
+)
+SELECT
+  'build_time',
+  desired_steps.step_min,
+  desired_steps.step_max,
+  desired_steps.price_per_unit,
+  desired_steps.unit_factor,
+  NULL
+FROM desired_steps
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM updated_steps
+  WHERE updated_steps.step_min = desired_steps.step_min
+    AND updated_steps.step_max = desired_steps.step_max
+);
+
+WITH affected_orgs AS (
+  SELECT
+    o.id AS org_id,
+    si.customer_id,
+    p.name AS plan_name,
+    (
+      o.has_usage_credits IS TRUE
+      AND NOT (
+        si.trial_at > now()
+        OR (
+          si.status = 'succeeded'::public.stripe_status
+          AND (
+            si.subscription_anchor_end IS NULL
+            OR si.subscription_anchor_end > now()
+          )
+        )
+      )
+    ) AS is_credit_only,
+    CASE
+      WHEN o.has_usage_credits IS TRUE
+        AND NOT (
+          si.trial_at > now()
+          OR (
+            si.status = 'succeeded'::public.stripe_status
+            AND (
+              si.subscription_anchor_end IS NULL
+              OR si.subscription_anchor_end > now()
+            )
+          )
+        )
+        THEN 0::bigint
+      ELSE p.build_time_unit
+    END AS plan_build_time_unit
+  FROM public.orgs AS o
+  JOIN public.stripe_info AS si ON si.customer_id = o.customer_id
+  JOIN public.plans AS p ON p.stripe_id = si.product_id
+  WHERE si.build_time_exceeded IS TRUE
+    AND p.id IN (
+      '526e11d8-3c51-4581-ac92-4770c602f47c'::uuid,
+      '440cfd69-0cfd-486e-b59b-cb99f7ae76a0'::uuid,
+      'abd76414-8f90-49a5-b3a4-8ff4d2e12c77'::uuid,
+      '745d7ab3-6cd6-4d65-b257-de6782d5ba50'::uuid
+    )
+),
+org_cycle AS (
+  SELECT
+    affected_orgs.org_id,
+    affected_orgs.customer_id,
+    affected_orgs.plan_name,
+    affected_orgs.is_credit_only,
+    affected_orgs.plan_build_time_unit,
+    cycle.subscription_anchor_start::date AS cycle_start,
+    cycle.subscription_anchor_end::date AS cycle_end
+  FROM affected_orgs
+  CROSS JOIN LATERAL public.get_cycle_info_org(affected_orgs.org_id) AS cycle
+),
+org_usage AS (
+  SELECT
+    org_cycle.org_id,
+    org_cycle.customer_id,
+    org_cycle.plan_name,
+    org_cycle.is_credit_only,
+    org_cycle.plan_build_time_unit,
+    org_cycle.cycle_start,
+    org_cycle.cycle_end,
+    GREATEST(
+      COALESCE(metrics.build_time_unit, 0)::numeric - COALESCE(org_cycle.plan_build_time_unit, 0)::numeric,
+      0::numeric
+    ) AS build_time_overage
+  FROM org_cycle
+  CROSS JOIN LATERAL public.get_total_metrics(
+    org_cycle.org_id,
+    org_cycle.cycle_start,
+    org_cycle.cycle_end
+  ) AS metrics
+),
+org_plan_status AS (
+  SELECT
+    org_usage.org_id,
+    org_usage.customer_id,
+    org_usage.plan_name,
+    org_usage.is_credit_only,
+    org_usage.plan_build_time_unit,
+    org_usage.cycle_start,
+    org_usage.cycle_end,
+    org_usage.build_time_overage,
+    plan_fit.is_good_plan,
+    plan_fit.mau_percent,
+    plan_fit.bandwidth_percent,
+    plan_fit.storage_percent,
+    plan_fit.build_time_percent
+  FROM org_usage
+  CROSS JOIN LATERAL public.get_plan_usage_and_fit_uncached(org_usage.org_id) AS plan_fit
+),
+org_credit_cost AS (
+  SELECT
+    org_plan_status.org_id,
+    org_plan_status.customer_id,
+    org_plan_status.plan_name,
+    org_plan_status.plan_build_time_unit,
+    org_plan_status.is_credit_only,
+    org_plan_status.cycle_start,
+    org_plan_status.cycle_end,
+    org_plan_status.build_time_overage,
+    org_plan_status.is_good_plan,
+    org_plan_status.mau_percent,
+    org_plan_status.bandwidth_percent,
+    org_plan_status.storage_percent,
+    org_plan_status.build_time_percent,
+    credit_cost.credit_cost_per_unit
+  FROM org_plan_status
+  CROSS JOIN LATERAL public.calculate_credit_cost(
+    'build_time'::public.credit_metric_type,
+    org_plan_status.build_time_overage
+  ) AS credit_cost
+),
+org_credit_debits AS (
+  SELECT
+    org_credit_cost.org_id,
+    org_credit_cost.customer_id,
+    org_credit_cost.plan_name,
+    org_credit_cost.is_credit_only,
+    org_credit_cost.plan_build_time_unit,
+    org_credit_cost.build_time_overage,
+    org_credit_cost.is_good_plan,
+    org_credit_cost.mau_percent,
+    org_credit_cost.bandwidth_percent,
+    org_credit_cost.storage_percent,
+    org_credit_cost.build_time_percent,
+    org_credit_cost.credit_cost_per_unit,
+    COALESCE(SUM(uoe.credits_debited), 0::numeric) AS existing_credits_debited
+  FROM org_credit_cost
+  LEFT JOIN public.usage_overage_events AS uoe
+    ON uoe.org_id = org_credit_cost.org_id
+    AND uoe.metric = 'build_time'::public.credit_metric_type
+    AND uoe.billing_cycle_start IS NOT DISTINCT FROM org_credit_cost.cycle_start
+    AND uoe.billing_cycle_end IS NOT DISTINCT FROM org_credit_cost.cycle_end
+  GROUP BY
+    org_credit_cost.org_id,
+    org_credit_cost.customer_id,
+    org_credit_cost.plan_name,
+    org_credit_cost.is_credit_only,
+    org_credit_cost.plan_build_time_unit,
+    org_credit_cost.build_time_overage,
+    org_credit_cost.is_good_plan,
+    org_credit_cost.mau_percent,
+    org_credit_cost.bandwidth_percent,
+    org_credit_cost.storage_percent,
+    org_credit_cost.build_time_percent,
+    org_credit_cost.credit_cost_per_unit
+),
+org_credit_status AS (
+  SELECT
+    org_credit_debits.customer_id,
+    org_credit_debits.is_credit_only,
+    org_credit_debits.plan_name,
+    org_credit_debits.plan_build_time_unit,
+    org_credit_debits.build_time_overage,
+    org_credit_debits.is_good_plan,
+    org_credit_debits.mau_percent,
+    org_credit_debits.bandwidth_percent,
+    org_credit_debits.storage_percent,
+    org_credit_debits.build_time_percent,
+    CASE
+      WHEN org_credit_debits.build_time_overage <= 0 THEN 0::numeric
+      WHEN COALESCE(org_credit_debits.credit_cost_per_unit, 0::numeric) > 0 THEN GREATEST(
+        org_credit_debits.build_time_overage - LEAST(
+          org_credit_debits.build_time_overage,
+          org_credit_debits.existing_credits_debited / org_credit_debits.credit_cost_per_unit
+        ),
+        0::numeric
+      )
+      ELSE org_credit_debits.build_time_overage
+    END AS build_time_unpaid_overage
+  FROM org_credit_debits
+),
+org_final_status AS (
+  SELECT
+    org_credit_status.customer_id,
+    org_credit_status.plan_name,
+    org_credit_status.is_credit_only,
+    org_credit_status.build_time_unpaid_overage,
+    CASE
+      WHEN org_credit_status.plan_name = 'Enterprise'
+        AND NOT org_credit_status.is_credit_only
+        THEN true
+      WHEN org_credit_status.is_good_plan
+        AND NOT org_credit_status.is_credit_only
+        THEN true
+      WHEN NOT org_credit_status.is_credit_only
+        AND org_credit_status.build_time_unpaid_overage <= 0
+        AND COALESCE(org_credit_status.mau_percent, 0::double precision) <= 100
+        AND COALESCE(org_credit_status.bandwidth_percent, 0::double precision) <= 100
+        AND COALESCE(org_credit_status.storage_percent, 0::double precision) <= 100
+        THEN true
+      WHEN org_credit_status.is_credit_only
+        AND org_credit_status.build_time_unpaid_overage <= 0
+        AND COALESCE(org_credit_status.mau_percent, 0::double precision) = 0
+        AND COALESCE(org_credit_status.bandwidth_percent, 0::double precision) = 0
+        AND COALESCE(org_credit_status.storage_percent, 0::double precision) = 0
+        THEN true
+      ELSE false
+    END AS is_good_plan,
+    GREATEST(
+      COALESCE(org_credit_status.mau_percent, 0::double precision),
+      COALESCE(org_credit_status.bandwidth_percent, 0::double precision),
+      COALESCE(org_credit_status.storage_percent, 0::double precision),
+      COALESCE(
+        CASE
+          WHEN COALESCE(org_credit_status.plan_build_time_unit, 0) > 0
+            AND org_credit_status.build_time_overage > 0
+            THEN (
+              (
+                org_credit_status.plan_build_time_unit::numeric
+                + org_credit_status.build_time_unpaid_overage
+              ) * 100::numeric / org_credit_status.plan_build_time_unit::numeric
+            )::double precision
+          ELSE org_credit_status.build_time_percent
+        END,
+        0::double precision
+      )
+    ) AS total_percent
+  FROM org_credit_status
+)
+UPDATE public.stripe_info AS si
+SET
+  build_time_exceeded = CASE
+    WHEN (
+      org_final_status.plan_name = 'Enterprise'
+      AND NOT org_final_status.is_credit_only
+    ) OR org_final_status.build_time_unpaid_overage <= 0
+      THEN false
+    ELSE si.build_time_exceeded
+  END,
+  is_good_plan = org_final_status.is_good_plan,
+  plan_usage = COALESCE(ROUND(org_final_status.total_percent)::bigint, si.plan_usage),
+  updated_at = now()
+FROM org_final_status
+WHERE si.customer_id = org_final_status.customer_id;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -81,10 +81,10 @@ BEGIN
     (NOW(), encode(extensions.digest('deleted@capgo.app'::bytea, 'sha256'::text)::bytea, 'hex'::text), '00000000-0000-0000-0000-000000000001');
 
     INSERT INTO "public"."plans" ("created_at", "updated_at", "name", "description", "price_m", "price_y", "stripe_id", "credit_id", "id", "price_m_id", "price_y_id", "storage", "bandwidth", "mau", "market_desc", "build_time_unit", "native_build_concurrency") VALUES
-    (NOW(), NOW(), 'Maker', 'plan.maker.desc', 39, 396, 'prod_LQIs1Yucml9ChU', 'prod_TJRd2hFHZsBIPK', '440cfd69-0cfd-486e-b59b-cb99f7ae76a0', 'price_1KjSGyGH46eYKnWwL4h14DsK', 'price_1KjSKIGH46eYKnWwFG9u4tNi', 3221225472, 268435456000, 10000, 'Best for small business owners', 3600, 3),
-    (NOW(), NOW(), 'Enterprise', 'plan.payasyougo.desc', 239, 4799, 'prod_MH5Jh6ajC9e7ZH', 'prod_TJRd2hFHZsBIPK', '745d7ab3-6cd6-4d65-b257-de6782d5ba50', 'price_1LYX8yGH46eYKnWwzeBjISvW', 'price_1LYX8yGH46eYKnWwzeBjISvW', 12884901888, 3221225472000, 1000000, 'Best for scalling enterprises', 600000, 6),
-    (NOW(), NOW(), 'Solo', 'plan.solo.desc', 14, 146, 'prod_LQIregjtNduh4q', 'prod_TJRd2hFHZsBIPK', '526e11d8-3c51-4581-ac92-4770c602f47c', 'price_1LVvuZGH46eYKnWwuGKOf4DK', 'price_1LVvuIGH46eYKnWwHMDCrxcH', 1073741824, 13958643712, 2000, 'Best for independent developers', 1800, 2),
-    (NOW(), NOW(), 'Team', 'plan.team.desc', 99, 998, 'prod_LQIugvJcPrxhda', 'prod_TJRd2hFHZsBIPK', 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77', 'price_1KjSIUGH46eYKnWwWHvg8XYs', 'price_1KjSLlGH46eYKnWwAwMW2wiW', 6442450944, 536870912000, 100000, 'Best for medium enterprises', 18000, 4);
+    (NOW(), NOW(), 'Maker', 'plan.maker.desc', 39, 396, 'prod_LQIs1Yucml9ChU', 'prod_TJRd2hFHZsBIPK', '440cfd69-0cfd-486e-b59b-cb99f7ae76a0', 'price_1KjSGyGH46eYKnWwL4h14DsK', 'price_1KjSKIGH46eYKnWwFG9u4tNi', 3221225472, 268435456000, 10000, 'Best for small business owners', 7200, 3),
+    (NOW(), NOW(), 'Enterprise', 'plan.payasyougo.desc', 239, 4799, 'prod_MH5Jh6ajC9e7ZH', 'prod_TJRd2hFHZsBIPK', '745d7ab3-6cd6-4d65-b257-de6782d5ba50', 'price_1LYX8yGH46eYKnWwzeBjISvW', 'price_1LYX8yGH46eYKnWwzeBjISvW', 12884901888, 3221225472000, 1000000, 'Best for scalling enterprises', 1200000, 6),
+    (NOW(), NOW(), 'Solo', 'plan.solo.desc', 14, 146, 'prod_LQIregjtNduh4q', 'prod_TJRd2hFHZsBIPK', '526e11d8-3c51-4581-ac92-4770c602f47c', 'price_1LVvuZGH46eYKnWwuGKOf4DK', 'price_1LVvuIGH46eYKnWwHMDCrxcH', 1073741824, 13958643712, 2000, 'Best for independent developers', 3600, 2),
+    (NOW(), NOW(), 'Team', 'plan.team.desc', 99, 998, 'prod_LQIugvJcPrxhda', 'prod_TJRd2hFHZsBIPK', 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77', 'price_1KjSIUGH46eYKnWwWHvg8XYs', 'price_1KjSLlGH46eYKnWwAwMW2wiW', 6442450944, 536870912000, 100000, 'Best for medium enterprises', 36000, 4);
 
     INSERT INTO
       "public"."capgo_credits_steps" (
@@ -218,12 +218,12 @@ BEGIN
         1073741824,
         NULL
       ), -- 1280+ GiB
-      ('build_time', 0, 6000, 0.16, 60, NULL), -- 0-100 minutes (in seconds, displayed as minutes)
-      ('build_time', 6000, 30000, 0.14, 60, NULL), -- 100-500 minutes (in seconds, displayed as minutes)
-      ('build_time', 30000, 60000, 0.12, 60, NULL), -- 500-1000 minutes (in seconds, displayed as minutes)
-      ('build_time', 60000, 300000, 0.10, 60, NULL), -- 1000-5000 minutes (in seconds, displayed as minutes)
-      ('build_time', 300000, 600000, 0.09, 60, NULL), -- 5000-10000 minutes (in seconds, displayed as minutes)
-      ('build_time', 600000, 9223372036854775807, 0.08, 60, NULL); -- 10000+ minutes (in seconds, displayed as minutes)
+      ('build_time', 0, 6000, 0.08, 60, NULL), -- 0-100 minutes (in seconds, displayed as minutes)
+      ('build_time', 6000, 30000, 0.07, 60, NULL), -- 100-500 minutes (in seconds, displayed as minutes)
+      ('build_time', 30000, 60000, 0.06, 60, NULL), -- 500-1000 minutes (in seconds, displayed as minutes)
+      ('build_time', 60000, 300000, 0.05, 60, NULL), -- 1000-5000 minutes (in seconds, displayed as minutes)
+      ('build_time', 300000, 600000, 0.045, 60, NULL), -- 5000-10000 minutes (in seconds, displayed as minutes)
+      ('build_time', 600000, 9223372036854775807, 0.04, 60, NULL); -- 10000+ minutes (in seconds, displayed as minutes)
 
     INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public") VALUES
     ('capgo', 'capgo', NULL, NOW(), NOW(), 't'),

--- a/supabase/tests/08_plan_functions.sql
+++ b/supabase/tests/08_plan_functions.sql
@@ -29,7 +29,7 @@ SELECT
 SELECT
     results_eq(
         'SELECT (get_current_plan_max_org(''22dbad8a-b885-4309-9b3b-a09f8460fb6d'')).build_time_unit',
-        $$VALUES (1800::bigint)$$,
+        $$VALUES (3600::bigint)$$,
         'get_current_plan_max_org test - correct build_time_unit'
     );
 

--- a/supabase/tests/32_test_usage_credits.sql
+++ b/supabase/tests/32_test_usage_credits.sql
@@ -50,8 +50,8 @@ SELECT
            AND step_min = 0
          ORDER BY step_max ASC
          LIMIT 1$$,
-        $$VALUES (0.16::double precision)$$,
-        'build_time credit pricing starts at $0.16 per minute'
+        $$VALUES (0.08::double precision)$$,
+        'build_time credit pricing starts at $0.08 per minute'
     );
 
 SELECT
@@ -62,14 +62,14 @@ SELECT
            AND org_id IS NULL
          ORDER BY step_max DESC, step_min DESC
          LIMIT 1$$,
-        $$VALUES (0.08::double precision)$$,
-        'build_time credit pricing floors at $0.08 per minute'
+        $$VALUES (0.04::double precision)$$,
+        'build_time credit pricing floors at $0.04 per minute'
     );
 
 SELECT
     results_eq(
         $$SELECT credits_required FROM public.calculate_credit_cost('build_time', 6000)$$,
-        $$VALUES (16.0::numeric)$$,
+        $$VALUES (8.0::numeric)$$,
         'calculate_credit_cost prices build_time through the shared credit ladder'
     );
 
@@ -239,7 +239,7 @@ FROM repricing_overage;
 
 UPDATE public.capgo_credits_steps
 SET
-    price_per_unit = 0.16,
+    price_per_unit = 0.08,
     unit_factor = 60
 WHERE id = (SELECT credit_step_id FROM test_repricing_context);
 

--- a/tests/build_time_tracking.test.ts
+++ b/tests/build_time_tracking.test.ts
@@ -205,14 +205,14 @@ describe('build Time Tracking System', () => {
     const supabase = getSupabaseClient()
 
     // Insert high build time usage directly into daily_build_time
-    // Solo plan limit is 1800 seconds (30 min), so we insert way over that
+    // Solo plan limit is 3600 seconds (60 min), so we insert way over that
     const today = new Date().toISOString().split('T')[0]
     const { error: buildTimeInsertError } = await supabase
       .from('daily_build_time')
       .insert({
         app_id: APPNAME,
         date: today,
-        build_time_unit: 36000, // 10 hours in seconds (way over Solo plan limit of 1800 seconds)
+        build_time_unit: 36000, // 10 hours in seconds (way over Solo plan limit of 3600 seconds)
         build_count: 10,
       })
     expect(buildTimeInsertError).toBeFalsy()

--- a/tests/credit-pricing-ui.unit.test.ts
+++ b/tests/credit-pricing-ui.unit.test.ts
@@ -28,7 +28,7 @@ describe('credit pricing UI helpers', () => {
       unit_factor: 60,
     }, t)).toBe('Up to 100m')
 
-    expect(formatCreditPricingPrice('build_time', 0.16, t)).toBe('$0.16 per minute')
+    expect(formatCreditPricingPrice('build_time', 0.08, t)).toBe('$0.08 per minute')
   })
 
   it.concurrent('falls back to generic tier copy for custom org-scoped ranges', () => {
@@ -62,7 +62,7 @@ describe('credit pricing UI helpers', () => {
         type: 'build_time',
         step_min: 6000,
         step_max: 30000,
-        price_per_unit: 0.14,
+        price_per_unit: 0.07,
         unit_factor: 60,
       },
       {
@@ -76,16 +76,16 @@ describe('credit pricing UI helpers', () => {
         type: 'build_time',
         step_min: 0,
         step_max: 6000,
-        price_per_unit: 0.16,
+        price_per_unit: 0.08,
         unit_factor: 60,
       },
     ])).toEqual({
       bandwidth: 0.12,
-      build_time: 0.16,
+      build_time: 0.08,
     })
   })
 
   it.concurrent('formats plan overage copy from the shared price formatter', () => {
-    expect(formatIncludedThenPrice('build_time', 0.08, t)).toBe('Included in plan, then $0.08 per minute')
+    expect(formatIncludedThenPrice('build_time', 0.04, t)).toBe('Included in plan, then $0.04 per minute')
   })
 })

--- a/tests/credit-usage-posthog.unit.test.ts
+++ b/tests/credit-usage-posthog.unit.test.ts
@@ -52,7 +52,7 @@ const overageEvent = {
   credit_step_id: 7,
   credits_debited: 10,
   credits_estimated: 10,
-  details: { limit: 1800, usage: 5400 },
+  details: { limit: 3600, usage: 7200 },
   id: 'overage-1',
   metric: 'build_time',
   org_id: 'org-1',
@@ -118,8 +118,8 @@ describe('credit usage PostHog event builder', () => {
       metric: 'build_time',
       overage_event_id: 'overage-1',
       transaction_type: 'deduction',
-      usage: 5400,
-      limit: 1800,
+      usage: 7200,
+      limit: 3600,
     })
   })
 })

--- a/tests/credits-pricing.test.ts
+++ b/tests/credits-pricing.test.ts
@@ -18,7 +18,7 @@ describe('credits pricing API', () => {
       .filter(step => step.type === 'build_time')
       .sort((a, b) => a.step_min - b.step_min)
 
-    expect(buildSteps.map(step => step.price_per_unit)).toEqual([0.16, 0.14, 0.12, 0.10, 0.09, 0.08])
+    expect(buildSteps.map(step => step.price_per_unit)).toEqual([0.08, 0.07, 0.06, 0.05, 0.045, 0.04])
   })
 
   it.concurrent('preserves not_authorized for org-scoped pricing queries without auth', async () => {
@@ -76,8 +76,8 @@ describe('credits pricing API', () => {
     }
 
     expect(data.usage.build_time).toBe(6000)
-    expect(data.breakdown.build_time.cost).toBe(16)
-    expect(data.total_cost).toBe(16)
+    expect(data.breakdown.build_time.cost).toBe(8)
+    expect(data.total_cost).toBe(8)
   })
 
   it.concurrent('rejects negative build_time input', async () => {
@@ -212,11 +212,11 @@ describe('credits pricing API', () => {
         price_per_unit: tier.price_per_unit,
       }))).toEqual([
         { step_min: 0, step_max: 5000, price_per_unit: 0.05 },
-        { step_min: 5000, step_max: 6000, price_per_unit: 0.16 },
-        { step_min: 6000, step_max: 30000, price_per_unit: 0.14 },
+        { step_min: 5000, step_max: 6000, price_per_unit: 0.08 },
+        { step_min: 6000, step_max: 30000, price_per_unit: 0.07 },
       ])
-      expect(data.breakdown.build_time.cost).toBeCloseTo(11.68, 5)
-      expect(data.total_cost).toBeCloseTo(11.68, 5)
+      expect(data.breakdown.build_time.cost).toBeCloseTo(7.94, 5)
+      expect(data.total_cost).toBeCloseTo(7.94, 5)
     }
     finally {
       await executeSQL('DELETE FROM public.capgo_credits_steps WHERE org_id = $1 AND type = $2', [ORG_ID, 'build_time'])


### PR DESCRIPTION
## Summary
- double included native build seconds for Solo, Maker, Team, and Enterprise plans
- halve each global `build_time` credit pricing tier
- backfill affected `stripe_info` build-time and plan status using credit-aware current-cycle overage logic, including credit-only orgs with zero included limits
- update seed data, pgTAP expectations, and focused Vitest fixtures

## Validation
- `bun lint` (passed with existing warnings in unrelated frontend files)
- `bun run supabase:with-env -- bunx vitest run tests/credit-pricing-ui.unit.test.ts tests/credit-usage-posthog.unit.test.ts tests/credits-pricing.test.ts tests/build_time_tracking.test.ts`
- `bunx supabase test db --workdir .context/supabase-worktrees/c85d6572 --local supabase/tests/00-supabase_test_helpers.sql supabase/tests/08_plan_functions.sql supabase/tests/32_test_usage_credits.sql`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- GitHub CI on `5883ff3b016e56b36d4afb396130a92761b61a6d`: all checks passed