### PR TITLE
fix(cli): preserve prompt stdin during init replay

### DIFF
--- a/cli/src/init/replay.ts
+++ b/cli/src/init/replay.ts
@@ -248,6 +248,9 @@ export function queryTerminalPixelSize(timeoutMs = TERMINAL_PIXEL_SIZE_TIMEOUT_M
     let response = ''
     const wasPaused = stdin.isPaused()
     const wasRaw = stdin.isRaw
+    const initialDataListeners = stdin.listenerCount('data')
+    const initialKeypressListeners = stdin.listenerCount('keypress')
+    const initialReadableListeners = stdin.listenerCount('readable')
     const timer = setTimeout(() => cleanup(undefined), timeoutMs)
     timer.unref?.()
 
@@ -258,10 +261,13 @@ export function queryTerminalPixelSize(timeoutMs = TERMINAL_PIXEL_SIZE_TIMEOUT_M
       settled = true
       clearTimeout(timer)
       stdin.off('data', onData)
+      const inputWasClaimed = stdin.listenerCount('data') > initialDataListeners
+        || stdin.listenerCount('keypress') > initialKeypressListeners
+        || stdin.listenerCount('readable') > initialReadableListeners
       try {
-        if (!wasRaw)
+        if (!inputWasClaimed && !wasRaw)
           stdin.setRawMode(false)
-        if (wasPaused)
+        if (!inputWasClaimed && wasPaused)
           stdin.pause()
       }
       catch {}

--- a/cli/test/test-init-replay.mjs
+++ b/cli/test/test-init-replay.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict'
+import { stdin, stdout } from 'node:process'
 import { applyCommandAnalyticsOptOut, applyRawCommandAnalyticsOptOut } from '../src/analytics/opt-out.ts'
-import { buildInitReplayBody, createTerminalInteractionEvents, createTerminalSnapshot, createTerminalSnapshotNode, getReplayViewportSize, parseTerminalPixelSizeResponse, renderRedactedTerminalFrame, renderRedactedTerminalText, resolveCapgoReplayUrl, resolveReplayUrlForFlush, resolveSupabaseReplayUrl, shouldStartInitReplay } from '../src/init/replay.ts'
+import { buildInitReplayBody, createTerminalInteractionEvents, createTerminalSnapshot, createTerminalSnapshotNode, getReplayViewportSize, parseTerminalPixelSizeResponse, queryTerminalPixelSize, renderRedactedTerminalFrame, renderRedactedTerminalText, resolveCapgoReplayUrl, resolveReplayUrlForFlush, resolveSupabaseReplayUrl, shouldStartInitReplay } from '../src/init/replay.ts'
 
 console.log('🧪 Testing init replay telemetry...\n')
 
@@ -43,6 +44,66 @@ assert.deepEqual(getReplayViewportSize(20, 5, { height: 412, width: 640 }), { he
 const pixelSizedFrame = await renderRedactedTerminalFrame('small real terminal', 20, 5, { height: 412, width: 640 })
 assert.equal(pixelSizedFrame.width, 640, 'terminal frame uses reported pixel width')
 assert.equal(pixelSizedFrame.height, 412, 'terminal frame uses reported pixel height')
+
+function replaceProcessProperty(target, key, value) {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key)
+  Object.defineProperty(target, key, {
+    configurable: true,
+    value,
+    writable: true,
+  })
+  return () => {
+    if (descriptor)
+      Object.defineProperty(target, key, descriptor)
+    else delete target[key]
+  }
+}
+
+{
+  const restoreFns = []
+  const rawModeCalls = []
+  const promptListener = () => {}
+  let pauseCalls = 0
+  let paused = true
+
+  try {
+    restoreFns.push(replaceProcessProperty(stdin, 'isTTY', true))
+    restoreFns.push(replaceProcessProperty(stdout, 'isTTY', true))
+    restoreFns.push(replaceProcessProperty(stdin, 'isRaw', false))
+    restoreFns.push(replaceProcessProperty(stdin, 'isPaused', () => paused))
+    restoreFns.push(replaceProcessProperty(stdin, 'setRawMode', (value) => {
+      rawModeCalls.push(value)
+      Object.defineProperty(stdin, 'isRaw', {
+        configurable: true,
+        value,
+        writable: true,
+      })
+      return stdin
+    }))
+    restoreFns.push(replaceProcessProperty(stdin, 'resume', () => {
+      paused = false
+      return stdin
+    }))
+    restoreFns.push(replaceProcessProperty(stdin, 'pause', () => {
+      pauseCalls += 1
+      paused = true
+      return stdin
+    }))
+    restoreFns.push(replaceProcessProperty(stdout, 'write', () => true))
+
+    const pixelQuery = queryTerminalPixelSize(1000)
+    stdin.on('keypress', promptListener)
+    stdin.emit('data', '\u001B[4;412;640t')
+    assert.deepEqual(await pixelQuery, { height: 412, width: 640 }, 'terminal pixel query still reads the terminal response')
+    assert.deepEqual(rawModeCalls, [true], 'terminal pixel query does not disable raw mode after a prompt claims stdin')
+    assert.equal(pauseCalls, 0, 'terminal pixel query does not pause stdin after a prompt claims stdin')
+  }
+  finally {
+    stdin.off('keypress', promptListener)
+    while (restoreFns.length > 0)
+      restoreFns.pop()()
+  }
+}
 
 const redacted = await renderRedactedTerminalText([
   'capg_1234567890abcdef',


### PR DESCRIPTION
## Summary
- prevent the init replay terminal-size probe from disabling raw mode or pausing stdin after Ink/prompt code has claimed input
- add a regression test covering replay pixel-size capture racing with prompt stdin listeners

## Tests
- bun run --cwd cli test:init-replay
- bun run --cwd cli lint
- bun run cli:typecheck
- bun run --cwd cli test:update-prompt