### PR TITLE
fix(admin): bucket rolling admin stats cache keys

### DIFF
--- a/src/stores/adminDashboard.ts
+++ b/src/stores/adminDashboard.ts
@@ -136,10 +136,10 @@ export const useAdminDashboardStore = defineStore('adminDashboard', () => {
     const { start, end } = range
     const orgPart = selectedOrgId.value || 'global'
     const appPart = selectedAppId.value || 'all'
-    const endBucket = dateRangeMode.value === 'custom'
-      ? end.toISOString()
-      : end.toISOString().slice(0, 16)
-    return `${category}-${orgPart}-${appPart}-${start.toISOString()}-${endBucket}`
+    const isCustom = dateRangeMode.value === 'custom'
+    const startBucket = isCustom ? start.toISOString() : start.toISOString().slice(0, 16)
+    const endBucket = isCustom ? end.toISOString() : end.toISOString().slice(0, 16)
+    return `${category}-${orgPart}-${appPart}-${startBucket}-${endBucket}`
   }
 
   function isCacheValid(cacheKey: string): boolean {


### PR DESCRIPTION
## Summary
- Address CodeRabbit review on #2537: bucket both `start` and `end` in `getCacheKey` for preset date ranges so rolling windows reuse cache entries instead of creating near-unique keys every fetch

## Test plan
- [ ] Open Admin dashboard with a preset date range (30 days)
- [ ] Reload twice within the same minute and confirm stats still load correctly
- [ ] Change date range and confirm fresh data is fetched


Made with [Cursor](https://cursor.com)