### PR TITLE
feat(billing): halve bandwidth credit prices and double plan limits

### DIFF
--- a/supabase/migrations/20260619080908_halve_bandwidth_credit_prices_double_plan_limits.sql
+++ b/supabase/migrations/20260619080908_halve_bandwidth_credit_prices_double_plan_limits.sql
@@ -1,0 +1,289 @@
+UPDATE public.plans
+SET
+  bandwidth = bandwidth * 2,
+  updated_at = now()
+WHERE bandwidth > 0;
+
+
+WITH desired_steps (step_min, step_max, price_per_unit, unit_factor) AS (
+  VALUES
+    (0::bigint, 1099511627776::bigint, 0.06::double precision, 1073741824::bigint),
+    (1099511627776::bigint, 2199023255552::bigint, 0.05::double precision, 1073741824::bigint),
+    (2199023255552::bigint, 6597069766656::bigint, 0.0425::double precision, 1073741824::bigint),
+    (6597069766656::bigint, 13194139533312::bigint, 0.035::double precision, 1073741824::bigint),
+    (13194139533312::bigint, 27487790694400::bigint, 0.0275::double precision, 1073741824::bigint),
+    (27487790694400::bigint, 69269232549888::bigint, 0.02::double precision, 1073741824::bigint),
+    (69269232549888::bigint, 139637976727552::bigint, 0.015::double precision, 1073741824::bigint),
+    (139637976727552::bigint, 9223372036854775807::bigint, 0.01::double precision, 1073741824::bigint)
+),
+updated_steps AS (
+  UPDATE public.capgo_credits_steps AS existing
+  SET
+    price_per_unit = desired_steps.price_per_unit,
+    unit_factor = desired_steps.unit_factor
+  FROM desired_steps
+  WHERE existing.type = 'bandwidth'
+    AND existing.org_id IS NULL
+    AND existing.step_min = desired_steps.step_min
+    AND existing.step_max = desired_steps.step_max
+  RETURNING existing.step_min, existing.step_max
+)
+INSERT INTO public.capgo_credits_steps (
+  type,
+  step_min,
+  step_max,
+  price_per_unit,
+  unit_factor,
+  org_id
+)
+SELECT
+  'bandwidth',
+  desired_steps.step_min,
+  desired_steps.step_max,
+  desired_steps.price_per_unit,
+  desired_steps.unit_factor,
+  NULL
+FROM desired_steps
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM updated_steps
+  WHERE updated_steps.step_min = desired_steps.step_min
+    AND updated_steps.step_max = desired_steps.step_max
+);
+
+
+WITH affected_orgs AS (
+  SELECT
+    o.id AS org_id,
+    si.customer_id,
+    p.name AS plan_name,
+    (
+      o.has_usage_credits IS TRUE
+      AND NOT (
+        si.trial_at > now()
+        OR (
+          si.status = 'succeeded'::public.stripe_status
+          AND (
+            si.subscription_anchor_end IS NULL
+            OR si.subscription_anchor_end > now()
+          )
+        )
+      )
+    ) AS is_credit_only,
+    CASE
+      WHEN o.has_usage_credits IS TRUE
+        AND NOT (
+          si.trial_at > now()
+          OR (
+            si.status = 'succeeded'::public.stripe_status
+            AND (
+              si.subscription_anchor_end IS NULL
+              OR si.subscription_anchor_end > now()
+            )
+          )
+        )
+        THEN 0::bigint
+      ELSE p.bandwidth
+    END AS plan_bandwidth
+  FROM public.orgs AS o
+  JOIN public.stripe_info AS si ON si.customer_id = o.customer_id
+  JOIN public.plans AS p ON p.stripe_id = si.product_id
+  WHERE si.bandwidth_exceeded IS TRUE
+),
+org_cycle AS (
+  SELECT
+    affected_orgs.org_id,
+    affected_orgs.customer_id,
+    affected_orgs.plan_name,
+    affected_orgs.is_credit_only,
+    affected_orgs.plan_bandwidth,
+    cycle.subscription_anchor_start::date AS cycle_start,
+    cycle.subscription_anchor_end::date AS cycle_end
+  FROM affected_orgs
+  CROSS JOIN LATERAL public.get_cycle_info_org(affected_orgs.org_id) AS cycle
+),
+org_usage AS (
+  SELECT
+    org_cycle.org_id,
+    org_cycle.customer_id,
+    org_cycle.plan_name,
+    org_cycle.is_credit_only,
+    org_cycle.plan_bandwidth,
+    org_cycle.cycle_start,
+    org_cycle.cycle_end,
+    GREATEST(
+      COALESCE(metrics.bandwidth, 0)::numeric - COALESCE(org_cycle.plan_bandwidth, 0)::numeric,
+      0::numeric
+    ) AS bandwidth_overage
+  FROM org_cycle
+  CROSS JOIN LATERAL public.get_total_metrics(
+    org_cycle.org_id,
+    org_cycle.cycle_start,
+    org_cycle.cycle_end
+  ) AS metrics
+),
+org_plan_status AS (
+  SELECT
+    org_usage.org_id,
+    org_usage.customer_id,
+    org_usage.plan_name,
+    org_usage.is_credit_only,
+    org_usage.plan_bandwidth,
+    org_usage.cycle_start,
+    org_usage.cycle_end,
+    org_usage.bandwidth_overage,
+    plan_fit.is_good_plan,
+    plan_fit.mau_percent,
+    plan_fit.bandwidth_percent,
+    plan_fit.storage_percent,
+    plan_fit.build_time_percent
+  FROM org_usage
+  CROSS JOIN LATERAL public.get_plan_usage_and_fit_uncached(org_usage.org_id) AS plan_fit
+),
+org_credit_cost AS (
+  SELECT
+    org_plan_status.org_id,
+    org_plan_status.customer_id,
+    org_plan_status.plan_name,
+    org_plan_status.plan_bandwidth,
+    org_plan_status.is_credit_only,
+    org_plan_status.cycle_start,
+    org_plan_status.cycle_end,
+    org_plan_status.bandwidth_overage,
+    org_plan_status.is_good_plan,
+    org_plan_status.mau_percent,
+    org_plan_status.bandwidth_percent,
+    org_plan_status.storage_percent,
+    org_plan_status.build_time_percent,
+    credit_cost.credit_cost_per_unit
+  FROM org_plan_status
+  CROSS JOIN LATERAL public.calculate_credit_cost(
+    'bandwidth'::public.credit_metric_type,
+    org_plan_status.bandwidth_overage
+  ) AS credit_cost
+),
+org_credit_debits AS (
+  SELECT
+    org_credit_cost.org_id,
+    org_credit_cost.customer_id,
+    org_credit_cost.plan_name,
+    org_credit_cost.is_credit_only,
+    org_credit_cost.plan_bandwidth,
+    org_credit_cost.bandwidth_overage,
+    org_credit_cost.is_good_plan,
+    org_credit_cost.mau_percent,
+    org_credit_cost.bandwidth_percent,
+    org_credit_cost.storage_percent,
+    org_credit_cost.build_time_percent,
+    org_credit_cost.credit_cost_per_unit,
+    COALESCE(SUM(uoe.credits_debited), 0::numeric) AS existing_credits_debited
+  FROM org_credit_cost
+  LEFT JOIN public.usage_overage_events AS uoe
+    ON uoe.org_id = org_credit_cost.org_id
+    AND uoe.metric = 'bandwidth'::public.credit_metric_type
+    AND uoe.billing_cycle_start IS NOT DISTINCT FROM org_credit_cost.cycle_start
+    AND uoe.billing_cycle_end IS NOT DISTINCT FROM org_credit_cost.cycle_end
+  GROUP BY
+    org_credit_cost.org_id,
+    org_credit_cost.customer_id,
+    org_credit_cost.plan_name,
+    org_credit_cost.is_credit_only,
+    org_credit_cost.plan_bandwidth,
+    org_credit_cost.bandwidth_overage,
+    org_credit_cost.is_good_plan,
+    org_credit_cost.mau_percent,
+    org_credit_cost.bandwidth_percent,
+    org_credit_cost.storage_percent,
+    org_credit_cost.build_time_percent,
+    org_credit_cost.credit_cost_per_unit
+),
+org_credit_status AS (
+  SELECT
+    org_credit_debits.customer_id,
+    org_credit_debits.is_credit_only,
+    org_credit_debits.plan_name,
+    org_credit_debits.plan_bandwidth,
+    org_credit_debits.bandwidth_overage,
+    org_credit_debits.is_good_plan,
+    org_credit_debits.mau_percent,
+    org_credit_debits.bandwidth_percent,
+    org_credit_debits.storage_percent,
+    org_credit_debits.build_time_percent,
+    CASE
+      WHEN org_credit_debits.bandwidth_overage <= 0 THEN 0::numeric
+      WHEN COALESCE(org_credit_debits.credit_cost_per_unit, 0::numeric) > 0 THEN GREATEST(
+        org_credit_debits.bandwidth_overage - LEAST(
+          org_credit_debits.bandwidth_overage,
+          org_credit_debits.existing_credits_debited / org_credit_debits.credit_cost_per_unit
+        ),
+        0::numeric
+      )
+      ELSE org_credit_debits.bandwidth_overage
+    END AS bandwidth_unpaid_overage
+  FROM org_credit_debits
+),
+org_final_status AS (
+  SELECT
+    org_credit_status.customer_id,
+    org_credit_status.plan_name,
+    org_credit_status.is_credit_only,
+    org_credit_status.bandwidth_unpaid_overage,
+    CASE
+      WHEN org_credit_status.plan_name = 'Enterprise'
+        AND NOT org_credit_status.is_credit_only
+        THEN true
+      WHEN org_credit_status.is_good_plan
+        AND NOT org_credit_status.is_credit_only
+        THEN true
+      WHEN NOT org_credit_status.is_credit_only
+        AND org_credit_status.bandwidth_unpaid_overage <= 0
+        AND COALESCE(org_credit_status.mau_percent, 0::double precision) <= 100
+        AND COALESCE(org_credit_status.bandwidth_percent, 0::double precision) <= 100
+        AND COALESCE(org_credit_status.storage_percent, 0::double precision) <= 100
+        AND COALESCE(org_credit_status.build_time_percent, 0::double precision) <= 100
+        THEN true
+      WHEN org_credit_status.is_credit_only
+        AND org_credit_status.bandwidth_unpaid_overage <= 0
+        AND COALESCE(org_credit_status.mau_percent, 0::double precision) = 0
+        AND COALESCE(org_credit_status.bandwidth_percent, 0::double precision) = 0
+        AND COALESCE(org_credit_status.storage_percent, 0::double precision) = 0
+        AND COALESCE(org_credit_status.build_time_percent, 0::double precision) = 0
+        THEN true
+      ELSE false
+    END AS is_good_plan,
+    GREATEST(
+      COALESCE(org_credit_status.mau_percent, 0::double precision),
+      COALESCE(
+        CASE
+          WHEN COALESCE(org_credit_status.plan_bandwidth, 0) > 0
+            AND org_credit_status.bandwidth_overage > 0
+            THEN (
+              (
+                org_credit_status.plan_bandwidth::numeric
+                + org_credit_status.bandwidth_unpaid_overage
+              ) * 100::numeric / org_credit_status.plan_bandwidth::numeric
+            )::double precision
+          ELSE org_credit_status.bandwidth_percent
+        END,
+        0::double precision
+      ),
+      COALESCE(org_credit_status.storage_percent, 0::double precision),
+      COALESCE(org_credit_status.build_time_percent, 0::double precision)
+    ) AS total_percent
+  FROM org_credit_status
+)
+UPDATE public.stripe_info AS si
+SET
+  bandwidth_exceeded = CASE
+    WHEN (
+      org_final_status.plan_name = 'Enterprise'
+      AND NOT org_final_status.is_credit_only
+    ) OR org_final_status.bandwidth_unpaid_overage <= 0
+      THEN false
+    ELSE si.bandwidth_exceeded
+  END,
+  is_good_plan = org_final_status.is_good_plan,
+  plan_usage = COALESCE(ROUND(org_final_status.total_percent)::bigint, si.plan_usage),
+  updated_at = now()
+FROM org_final_status
+WHERE si.customer_id = org_final_status.customer_id;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -81,10 +81,10 @@ BEGIN
     (NOW(), encode(extensions.digest('deleted@capgo.app'::bytea, 'sha256'::text)::bytea, 'hex'::text), '00000000-0000-0000-0000-000000000001');
 
     INSERT INTO "public"."plans" ("created_at", "updated_at", "name", "description", "price_m", "price_y", "stripe_id", "credit_id", "id", "price_m_id", "price_y_id", "storage", "bandwidth", "mau", "market_desc", "build_time_unit", "native_build_concurrency") VALUES
-    (NOW(), NOW(), 'Maker', 'plan.maker.desc', 39, 396, 'prod_LQIs1Yucml9ChU', 'prod_TJRd2hFHZsBIPK', '440cfd69-0cfd-486e-b59b-cb99f7ae76a0', 'price_1KjSGyGH46eYKnWwL4h14DsK', 'price_1KjSKIGH46eYKnWwFG9u4tNi', 3221225472, 268435456000, 10000, 'Best for small business owners', 7200, 3),
-    (NOW(), NOW(), 'Enterprise', 'plan.payasyougo.desc', 239, 4799, 'prod_MH5Jh6ajC9e7ZH', 'prod_TJRd2hFHZsBIPK', '745d7ab3-6cd6-4d65-b257-de6782d5ba50', 'price_1LYX8yGH46eYKnWwzeBjISvW', 'price_1LYX8yGH46eYKnWwzeBjISvW', 12884901888, 3221225472000, 1000000, 'Best for scalling enterprises', 1200000, 6),
-    (NOW(), NOW(), 'Solo', 'plan.solo.desc', 14, 146, 'prod_LQIregjtNduh4q', 'prod_TJRd2hFHZsBIPK', '526e11d8-3c51-4581-ac92-4770c602f47c', 'price_1LVvuZGH46eYKnWwuGKOf4DK', 'price_1LVvuIGH46eYKnWwHMDCrxcH', 1073741824, 13958643712, 2000, 'Best for independent developers', 3600, 2),
-    (NOW(), NOW(), 'Team', 'plan.team.desc', 99, 998, 'prod_LQIugvJcPrxhda', 'prod_TJRd2hFHZsBIPK', 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77', 'price_1KjSIUGH46eYKnWwWHvg8XYs', 'price_1KjSLlGH46eYKnWwAwMW2wiW', 6442450944, 536870912000, 100000, 'Best for medium enterprises', 36000, 4);
+    (NOW(), NOW(), 'Maker', 'plan.maker.desc', 39, 396, 'prod_LQIs1Yucml9ChU', 'prod_TJRd2hFHZsBIPK', '440cfd69-0cfd-486e-b59b-cb99f7ae76a0', 'price_1KjSGyGH46eYKnWwL4h14DsK', 'price_1KjSKIGH46eYKnWwFG9u4tNi', 3221225472, 536870912000, 10000, 'Best for small business owners', 7200, 3),
+    (NOW(), NOW(), 'Enterprise', 'plan.payasyougo.desc', 239, 4799, 'prod_MH5Jh6ajC9e7ZH', 'prod_TJRd2hFHZsBIPK', '745d7ab3-6cd6-4d65-b257-de6782d5ba50', 'price_1LYX8yGH46eYKnWwzeBjISvW', 'price_1LYX8yGH46eYKnWwzeBjISvW', 12884901888, 6442450944000, 1000000, 'Best for scalling enterprises', 1200000, 6),
+    (NOW(), NOW(), 'Solo', 'plan.solo.desc', 14, 146, 'prod_LQIregjtNduh4q', 'prod_TJRd2hFHZsBIPK', '526e11d8-3c51-4581-ac92-4770c602f47c', 'price_1LVvuZGH46eYKnWwuGKOf4DK', 'price_1LVvuIGH46eYKnWwHMDCrxcH', 1073741824, 27917287424, 2000, 'Best for independent developers', 3600, 2),
+    (NOW(), NOW(), 'Team', 'plan.team.desc', 99, 998, 'prod_LQIugvJcPrxhda', 'prod_TJRd2hFHZsBIPK', 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77', 'price_1KjSIUGH46eYKnWwWHvg8XYs', 'price_1KjSLlGH46eYKnWwAwMW2wiW', 6442450944, 1073741824000, 100000, 'Best for medium enterprises', 36000, 4);
 
     INSERT INTO
       "public"."capgo_credits_steps" (
@@ -104,12 +104,12 @@ BEGIN
       ('mau', 25000000, 40000000, 0.001, 1, NULL),
       ('mau', 40000000, 100000000, 0.0009, 1, NULL),
       ('mau', 100000000, 9223372036854775807, 0.0007, 1, NULL),
-      ('bandwidth', 0, 1099511627776, 0.12, 1073741824, NULL), -- 0–1 TB
+      ('bandwidth', 0, 1099511627776, 0.06, 1073741824, NULL), -- 0–1 TB
       (
         'bandwidth',
         1099511627776,
         2199023255552,
-        0.10,
+        0.05,
         1073741824,
         NULL
       ), -- 1–2 TB
@@ -117,7 +117,7 @@ BEGIN
         'bandwidth',
         2199023255552,
         6597069766656,
-        0.085,
+        0.0425,
         1073741824,
         NULL
       ), -- 2–6 TB
@@ -125,7 +125,7 @@ BEGIN
         'bandwidth',
         6597069766656,
         13194139533312,
-        0.07,
+        0.035,
         1073741824,
         NULL
       ), -- 6–12 TB
@@ -133,7 +133,7 @@ BEGIN
         'bandwidth',
         13194139533312,
         27487790694400,
-        0.055,
+        0.0275,
         1073741824,
         NULL
       ), -- 12–25 TB
@@ -141,7 +141,7 @@ BEGIN
         'bandwidth',
         27487790694400,
         69269232549888,
-        0.04,
+        0.02,
         1073741824,
         NULL
       ), -- 25–63 TB
@@ -149,7 +149,7 @@ BEGIN
         'bandwidth',
         69269232549888,
         139637976727552,
-        0.03,
+        0.015,
         1073741824,
         NULL
       ), -- 63–127 TB
@@ -157,7 +157,7 @@ BEGIN
         'bandwidth',
         139637976727552,
         9223372036854775807,
-        0.02,
+        0.01,
         1073741824,
         NULL
       ), -- 127+ TB

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -81,10 +81,10 @@ BEGIN
     (NOW(), encode(extensions.digest('deleted@capgo.app'::bytea, 'sha256'::text)::bytea, 'hex'::text), '00000000-0000-0000-0000-000000000001');
 
     INSERT INTO "public"."plans" ("created_at", "updated_at", "name", "description", "price_m", "price_y", "stripe_id", "credit_id", "id", "price_m_id", "price_y_id", "storage", "bandwidth", "mau", "market_desc", "build_time_unit", "native_build_concurrency") VALUES
-    (NOW(), NOW(), 'Maker', 'plan.maker.desc', 39, 396, 'prod_LQIs1Yucml9ChU', 'prod_TJRd2hFHZsBIPK', '440cfd69-0cfd-486e-b59b-cb99f7ae76a0', 'price_1KjSGyGH46eYKnWwL4h14DsK', 'price_1KjSKIGH46eYKnWwFG9u4tNi', 3221225472, 536870912000, 10000, 'Best for small business owners', 7200, 3),
-    (NOW(), NOW(), 'Enterprise', 'plan.payasyougo.desc', 239, 4799, 'prod_MH5Jh6ajC9e7ZH', 'prod_TJRd2hFHZsBIPK', '745d7ab3-6cd6-4d65-b257-de6782d5ba50', 'price_1LYX8yGH46eYKnWwzeBjISvW', 'price_1LYX8yGH46eYKnWwzeBjISvW', 12884901888, 6442450944000, 1000000, 'Best for scalling enterprises', 1200000, 6),
-    (NOW(), NOW(), 'Solo', 'plan.solo.desc', 14, 146, 'prod_LQIregjtNduh4q', 'prod_TJRd2hFHZsBIPK', '526e11d8-3c51-4581-ac92-4770c602f47c', 'price_1LVvuZGH46eYKnWwuGKOf4DK', 'price_1LVvuIGH46eYKnWwHMDCrxcH', 1073741824, 27917287424, 2000, 'Best for independent developers', 3600, 2),
-    (NOW(), NOW(), 'Team', 'plan.team.desc', 99, 998, 'prod_LQIugvJcPrxhda', 'prod_TJRd2hFHZsBIPK', 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77', 'price_1KjSIUGH46eYKnWwWHvg8XYs', 'price_1KjSLlGH46eYKnWwAwMW2wiW', 6442450944, 1073741824000, 100000, 'Best for medium enterprises', 36000, 4);
+    (NOW(), NOW(), 'Maker', 'plan.maker.desc', 39, 396, 'prod_LQIs1Yucml9ChU', 'prod_TJRd2hFHZsBIPK', '440cfd69-0cfd-486e-b59b-cb99f7ae76a0', 'price_1KjSGyGH46eYKnWwL4h14DsK', 'price_1KjSKIGH46eYKnWwFG9u4tNi', 3221225472, 2147483648000, 10000, 'Best for small business owners', 7200, 3),
+    (NOW(), NOW(), 'Enterprise', 'plan.payasyougo.desc', 239, 4799, 'prod_MH5Jh6ajC9e7ZH', 'prod_TJRd2hFHZsBIPK', '745d7ab3-6cd6-4d65-b257-de6782d5ba50', 'price_1LYX8yGH46eYKnWwzeBjISvW', 'price_1LYX8yGH46eYKnWwzeBjISvW', 12884901888, 42949672960000, 1000000, 'Best for scalling enterprises', 1200000, 6),
+    (NOW(), NOW(), 'Solo', 'plan.solo.desc', 14, 146, 'prod_LQIregjtNduh4q', 'prod_TJRd2hFHZsBIPK', '526e11d8-3c51-4581-ac92-4770c602f47c', 'price_1LVvuZGH46eYKnWwuGKOf4DK', 'price_1LVvuIGH46eYKnWwHMDCrxcH', 1073741824, 214748364800, 2000, 'Best for independent developers', 3600, 2),
+    (NOW(), NOW(), 'Team', 'plan.team.desc', 99, 998, 'prod_LQIugvJcPrxhda', 'prod_TJRd2hFHZsBIPK', 'abd76414-8f90-49a5-b3a4-8ff4d2e12c77', 'price_1KjSIUGH46eYKnWwWHvg8XYs', 'price_1KjSLlGH46eYKnWwAwMW2wiW', 6442450944, 4294967296000, 100000, 'Best for medium enterprises', 36000, 4);
 
     INSERT INTO
       "public"."capgo_credits_steps" (

--- a/supabase/tests/08_plan_functions.sql
+++ b/supabase/tests/08_plan_functions.sql
@@ -15,7 +15,7 @@ SELECT
 SELECT
     results_eq(
         'SELECT (get_current_plan_max_org(''22dbad8a-b885-4309-9b3b-a09f8460fb6d'')).bandwidth',
-        $$VALUES (27917287424::bigint)$$,
+        $$VALUES (214748364800::bigint)$$,
         'get_current_plan_max_org test - correct bandwidth'
     );
 

--- a/supabase/tests/08_plan_functions.sql
+++ b/supabase/tests/08_plan_functions.sql
@@ -15,7 +15,7 @@ SELECT
 SELECT
     results_eq(
         'SELECT (get_current_plan_max_org(''22dbad8a-b885-4309-9b3b-a09f8460fb6d'')).bandwidth',
-        $$VALUES (13958643712::bigint)$$,
+        $$VALUES (27917287424::bigint)$$,
         'get_current_plan_max_org test - correct bandwidth'
     );
 

--- a/supabase/tests/13_test_plan_math.sql
+++ b/supabase/tests/13_test_plan_math.sql
@@ -37,7 +37,7 @@ BEGIN
   SELECT * from get_plan_usage_percent_detailed('046a36ac-e03c-4590-9257-bd6c9dba9ee8') limit 1 into usage;
   RETURN NEXT IS(usage.storage_percent, (SELECT CAST ('30.0' AS DOUBLE PRECISION)), 'Storage usage = 30% for "Solo" plan');
   RETURN NEXT IS(usage.mau_percent, (SELECT CAST ('0.0' AS DOUBLE PRECISION)), 'Mau usage = 0% for "Solo" plan');
-  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('0.5' AS DOUBLE PRECISION)), 'Bandwidth usage = 0.5% for "Solo" plan');
+  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('0.0' AS DOUBLE PRECISION)), 'Bandwidth usage = 0% for "Solo" plan (sub-1% truncates)');
 
   -- Let's now add a second app to this org.
   ALTER TABLE public.app_versions DISABLE TRIGGER force_valid_owner_org_app_versions;
@@ -76,7 +76,7 @@ BEGIN
   SELECT * from get_plan_usage_percent_detailed('046a36ac-e03c-4590-9257-bd6c9dba9ee8') limit 1 into usage;
   RETURN NEXT IS(usage.storage_percent, (SELECT CAST ('40.0' AS DOUBLE PRECISION)), 'Storage usage = 40% for "Solo" plan (2 apps)');
   RETURN NEXT IS(usage.mau_percent, (SELECT CAST ('1.0' AS DOUBLE PRECISION)), 'Mau usage = 1% for "Solo" plan (2 apps)');
-  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('1.0' AS DOUBLE PRECISION)), 'Bandwidth usage = 1% for "Solo" plan (2 apps)');
+  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('0.0' AS DOUBLE PRECISION)), 'Bandwidth usage = 0% for "Solo" plan (2 apps, sub-1% truncates)');
 END;
 $$ LANGUAGE plpgsql;
 

--- a/supabase/tests/13_test_plan_math.sql
+++ b/supabase/tests/13_test_plan_math.sql
@@ -37,7 +37,7 @@ BEGIN
   SELECT * from get_plan_usage_percent_detailed('046a36ac-e03c-4590-9257-bd6c9dba9ee8') limit 1 into usage;
   RETURN NEXT IS(usage.storage_percent, (SELECT CAST ('30.0' AS DOUBLE PRECISION)), 'Storage usage = 30% for "Solo" plan');
   RETURN NEXT IS(usage.mau_percent, (SELECT CAST ('0.0' AS DOUBLE PRECISION)), 'Mau usage = 0% for "Solo" plan');
-  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('1.0' AS DOUBLE PRECISION)), 'Bandwidth usage = 1% for "Solo" plan');
+  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('0.5' AS DOUBLE PRECISION)), 'Bandwidth usage = 0.5% for "Solo" plan');
 
   -- Let's now add a second app to this org.
   ALTER TABLE public.app_versions DISABLE TRIGGER force_valid_owner_org_app_versions;
@@ -76,7 +76,7 @@ BEGIN
   SELECT * from get_plan_usage_percent_detailed('046a36ac-e03c-4590-9257-bd6c9dba9ee8') limit 1 into usage;
   RETURN NEXT IS(usage.storage_percent, (SELECT CAST ('40.0' AS DOUBLE PRECISION)), 'Storage usage = 40% for "Solo" plan (2 apps)');
   RETURN NEXT IS(usage.mau_percent, (SELECT CAST ('1.0' AS DOUBLE PRECISION)), 'Mau usage = 1% for "Solo" plan (2 apps)');
-  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('2.0' AS DOUBLE PRECISION)), 'Bandwidth usage = 2% for "Solo" plan (2 apps)');
+  RETURN NEXT IS(usage.bandwidth_percent, (SELECT CAST ('1.0' AS DOUBLE PRECISION)), 'Bandwidth usage = 1% for "Solo" plan (2 apps)');
 END;
 $$ LANGUAGE plpgsql;
 

--- a/tests/credit-pricing-ui.unit.test.ts
+++ b/tests/credit-pricing-ui.unit.test.ts
@@ -69,7 +69,7 @@ describe('credit pricing UI helpers', () => {
         type: 'bandwidth',
         step_min: 0,
         step_max: 1099511627776,
-        price_per_unit: 0.12,
+        price_per_unit: 0.06,
         unit_factor: 1073741824,
       },
       {
@@ -80,7 +80,7 @@ describe('credit pricing UI helpers', () => {
         unit_factor: 60,
       },
     ])).toEqual({
-      bandwidth: 0.12,
+      bandwidth: 0.06,
       build_time: 0.08,
     })
   })

--- a/tests/cron_stat_org.test.ts
+++ b/tests/cron_stat_org.test.ts
@@ -286,10 +286,10 @@ describe('[POST] /triggers/cron_stat_org', () => {
       .single()
     expect(latestBandwidthError).toBeFalsy()
 
-    // Solo plan bandwidth limit is 13958643712 (~13GB), so we need to exceed that
+    // Solo plan bandwidth limit is 27917287424 (~26GB), so we need to exceed that
     const { error: setBandwidthError } = await supabase
       .from('daily_bandwidth')
-      .update({ bandwidth: 20000000000 })
+      .update({ bandwidth: 32212254720 })
       .eq('app_id', APPNAME)
       .eq('date', latestBandwidthData?.date ?? '')
     expect(setBandwidthError).toBeFalsy()
@@ -473,10 +473,10 @@ describe('[POST] /triggers/cron_stat_org', () => {
       .limit(1)
       .single()
 
-    // Solo plan bandwidth limit is 13958643712 (~13GB), so use 20GB
+    // Solo plan bandwidth limit is 27917287424 (~26GB), so use 30GB
     await supabase
       .from('daily_bandwidth')
-      .update({ bandwidth: 20000000000 })
+      .update({ bandwidth: 32212254720 })
       .eq('app_id', APPNAME)
       .eq('date', latestBandwidthData?.date ?? '')
 

--- a/tests/cron_stat_org.test.ts
+++ b/tests/cron_stat_org.test.ts
@@ -286,10 +286,10 @@ describe('[POST] /triggers/cron_stat_org', () => {
       .single()
     expect(latestBandwidthError).toBeFalsy()
 
-    // Solo plan bandwidth limit is 27917287424 (~26GB), so we need to exceed that
+    // Solo plan bandwidth limit is 214748364800 (~200 GiB), so we need to exceed that
     const { error: setBandwidthError } = await supabase
       .from('daily_bandwidth')
-      .update({ bandwidth: 32212254720 })
+      .update({ bandwidth: 268435456000 })
       .eq('app_id', APPNAME)
       .eq('date', latestBandwidthData?.date ?? '')
     expect(setBandwidthError).toBeFalsy()
@@ -473,10 +473,10 @@ describe('[POST] /triggers/cron_stat_org', () => {
       .limit(1)
       .single()
 
-    // Solo plan bandwidth limit is 27917287424 (~26GB), so use 30GB
+    // Solo plan bandwidth limit is 214748364800 (~200 GiB), so use 250 GiB
     await supabase
       .from('daily_bandwidth')
-      .update({ bandwidth: 32212254720 })
+      .update({ bandwidth: 268435456000 })
       .eq('app_id', APPNAME)
       .eq('date', latestBandwidthData?.date ?? '')
 


### PR DESCRIPTION
## Summary (AI generated)

- Halves all global bandwidth credit overage tier prices in `capgo_credits_steps` (e.g. $0.12 → $0.06 per GiB for the first tier).
- Doubles included bandwidth on every plan from current production limits:
  - Solo: 100 → 200 GiB/month
  - Maker: 1,000 → 2,000 GiB/month
  - Team: 2,000 → 4,000 GiB/month
  - Enterprise: 20,000 → 40,000 GiB/month
- Recalculates `bandwidth_exceeded`, `is_good_plan`, and `plan_usage` for orgs currently flagged as bandwidth-exceeded.
- Fixes stale `seed.sql` bandwidth values (local seed previously showed 13 GB for Solo while prod/pricing page shows 100 GiB).

## Motivation (AI generated)

Bandwidth is a key cost driver for OTA delivery. This change gives customers more included bandwidth per plan while making pay-as-you-go bandwidth overage credits cheaper, improving value without changing subscription prices.

## Business Impact (AI generated)

- Customers get 2× included bandwidth on their current plan at no extra subscription cost.
- Bandwidth overage via credits costs 50% less, reducing friction for high-traffic apps and credit top-ups.
- Orgs blocked only because of bandwidth limits between the old and new thresholds are unblocked automatically on migration deploy.

## Test Plan (AI generated)

- [ ] Run `bun test tests/credit-pricing-ui.unit.test.ts`
- [ ] Run `bun run supabase:db:reset` and verify plan bandwidth limits in the console Plans page match doubled prod values (Solo = 200 GB)
- [ ] Verify Credits page shows halved bandwidth overage pricing (first tier $0.06/GiB)
- [ ] Run `bun test:backend` (especially `tests/cron_stat_org.test.ts` and Postgres plan math tests)
- [ ] Confirm orgs with `bandwidth_exceeded = true` are recalculated correctly after migration on staging

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Plan Updates**
  * Doubled bandwidth limits across all plan tiers (Maker, Enterprise, Solo, and Team).
  * Reduced bandwidth overage credit pricing by about 50% per unit across all tiers.
  * Updated billing/credit calculations and plan usage percentages to align with the new bandwidth economics.
* **Tests**
  * Adjusted plan and pricing-related test expectations to match the updated truncation and pricing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->