### PR TITLE
fix(backend): enforce SSL for hosted Supabase Postgres connections

### DIFF
--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -111,6 +111,96 @@ export function selectOne(pgClient: ReturnType<typeof getPgClient>) {
   return pgClient.query('SELECT 1')
 }
 
+function parseDatabaseUrl(databaseUrl: string): URL | null {
+  try {
+    return new URL(databaseUrl)
+  }
+  catch {
+    return null
+  }
+}
+
+export function isLocalDatabaseUrl(databaseUrl: string): boolean {
+  const parsed = parseDatabaseUrl(databaseUrl)
+  if (!parsed)
+    return false
+
+  const hostname = parsed.hostname.toLowerCase()
+  return hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname === '::1'
+    || hostname.startsWith('supabase_db_')
+}
+
+export function isHostedSupabaseDatabaseUrl(databaseUrl: string): boolean {
+  const parsed = parseDatabaseUrl(databaseUrl)
+  if (!parsed)
+    return false
+
+  const hostname = parsed.hostname.toLowerCase()
+  return hostname.endsWith('.supabase.co') || hostname.endsWith('.supabase.com')
+}
+
+function isSupabasePoolerDatabaseUrl(databaseUrl: string): boolean {
+  const parsed = parseDatabaseUrl(databaseUrl)
+  if (!parsed)
+    return false
+
+  const port = parsed.port || '5432'
+  return port === '6543' && isHostedSupabaseDatabaseUrl(databaseUrl)
+}
+
+function usesHyperdriveDatabaseSource(databaseSource: string): boolean {
+  return databaseSource.startsWith('HYPERDRIVE_')
+}
+
+export function shouldEnforceProdDatabaseSsl(databaseUrl: string, databaseSource: string): boolean {
+  if (usesHyperdriveDatabaseSource(databaseSource))
+    return false
+
+  return isHostedSupabaseDatabaseUrl(databaseUrl) && !isLocalDatabaseUrl(databaseUrl)
+}
+
+export function ensureProdDatabaseSslMode(databaseUrl: string): string {
+  const parsed = parseDatabaseUrl(databaseUrl)
+  if (!parsed || !isHostedSupabaseDatabaseUrl(databaseUrl) || isLocalDatabaseUrl(databaseUrl))
+    return databaseUrl
+
+  parsed.searchParams.delete('ssl')
+  const sslMode = parsed.searchParams.get('sslmode')?.toLowerCase()
+  if (!sslMode || sslMode === 'prefer' || sslMode === 'allow' || sslMode === 'disable')
+    parsed.searchParams.set('sslmode', 'require')
+
+  return parsed.toString()
+}
+
+function shouldAllowSelfSignedPgCertificate(c: Context, databaseUrl: string): boolean {
+  const allowSelfSigned = getEnv(c, 'PG_ALLOW_SELF_SIGNED_CERT')?.trim().toLowerCase()
+  if (allowSelfSigned === 'true' || allowSelfSigned === '1')
+    return true
+  if (allowSelfSigned === 'false' || allowSelfSigned === '0')
+    return false
+
+  const rejectUnauthorized = getEnv(c, 'PG_SSL_REJECT_UNAUTHORIZED')?.trim()
+  if (rejectUnauthorized === '0')
+    return true
+  if (rejectUnauthorized === '1')
+    return false
+
+  return isSupabasePoolerDatabaseUrl(databaseUrl)
+}
+
+export function getPgPoolSslOptions(
+  c: Context,
+  databaseUrl: string,
+  databaseSource: string,
+): false | { rejectUnauthorized: boolean } {
+  if (!shouldEnforceProdDatabaseSsl(databaseUrl, databaseSource))
+    return false
+
+  return { rejectUnauthorized: !shouldAllowSelfSignedPgCertificate(c, databaseUrl) }
+}
+
 function fixSupabaseHost(host: string): string {
   if (host.includes('postgres:postgres@supabase_db_')) {
     // Supabase adds a prefix to the hostname that breaks connection in local docker
@@ -333,9 +423,13 @@ export function getPgClient(c: Context, readOnly = false) {
   const dbName = String(c.get('databaseSource') ?? c.res.headers.get('X-Database-Source') ?? 'unknown source')
   cloudlog({ requestId, message: 'SUPABASE_DB_URL selected', dbName, appName, readOnly })
 
+  const connectionString = shouldEnforceProdDatabaseSsl(dbUrl, dbName)
+    ? ensureProdDatabaseSslMode(dbUrl)
+    : dbUrl
+  const ssl = getPgPoolSslOptions(c, connectionString, dbName)
   const isPooler = dbName.startsWith('sb_pooler')
   const options = {
-    connectionString: dbUrl,
+    connectionString,
     max: 4,
     application_name: `${appName}-${dbName}`,
     idleTimeoutMillis: 20000, // Increase from 2 to 20 seconds
@@ -343,6 +437,7 @@ export function getPgClient(c: Context, readOnly = false) {
     maxLifetimeMillis: 30 * 60 * 1000, // 30 minutes
     // PgBouncer/Supabase pooler doesn't support the 'options' startup parameter
     options: readOnly && !isPooler ? '-c default_transaction_read_only=on' : undefined,
+    ...(ssl ? { ssl } : {}),
   }
 
   const pool = new Pool(options)

--- a/tests/pg-prod-ssl.unit.test.ts
+++ b/tests/pg-prod-ssl.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ensureProdDatabaseSslMode,
+  getPgPoolSslOptions,
+  isHostedSupabaseDatabaseUrl,
+  isLocalDatabaseUrl,
+  shouldEnforceProdDatabaseSsl,
+} from '../supabase/functions/_backend/utils/pg.ts'
+
+describe('prod database ssl helpers', () => {
+  const prodDirectUrl = 'postgresql://postgres:secret@db.xvwzpoazmxkqosrdewyv.supabase.co:5432/postgres'
+  const prodPoolerUrl = 'postgresql://postgres.xvwzpoazmxkqosrdewyv:secret@aws-0-eu-central-1.pooler.supabase.com:6543/postgres'
+  const localUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+
+  it.concurrent('detects hosted Supabase URLs', () => {
+    expect(isHostedSupabaseDatabaseUrl(prodDirectUrl)).toBe(true)
+    expect(isHostedSupabaseDatabaseUrl(prodPoolerUrl)).toBe(true)
+    expect(isHostedSupabaseDatabaseUrl(localUrl)).toBe(false)
+  })
+
+  it.concurrent('detects local database URLs', () => {
+    expect(isLocalDatabaseUrl(localUrl)).toBe(true)
+    expect(isLocalDatabaseUrl('postgresql://postgres:postgres@localhost:5432/postgres')).toBe(true)
+    expect(isLocalDatabaseUrl('postgresql://postgres:postgres@supabase_db_capgo:5432/postgres')).toBe(true)
+    expect(isLocalDatabaseUrl(prodDirectUrl)).toBe(false)
+  })
+
+  it.concurrent('enforces SSL only for direct hosted Supabase connections', () => {
+    expect(shouldEnforceProdDatabaseSsl(prodDirectUrl, 'direct')).toBe(true)
+    expect(shouldEnforceProdDatabaseSsl(prodPoolerUrl, 'sb_pooler_main')).toBe(true)
+    expect(shouldEnforceProdDatabaseSsl(localUrl, 'direct')).toBe(false)
+    expect(shouldEnforceProdDatabaseSsl(prodDirectUrl, 'HYPERDRIVE_CAPGO_DIRECT_EU')).toBe(false)
+  })
+
+  it.concurrent('upgrades insecure prod connection strings to sslmode=require', () => {
+    expect(ensureProdDatabaseSslMode(`${prodDirectUrl}?sslmode=disable`)).toBe(`${prodDirectUrl}?sslmode=require`)
+    expect(ensureProdDatabaseSslMode(`${prodDirectUrl}?ssl=false`)).toBe(`${prodDirectUrl}?sslmode=require`)
+    expect(ensureProdDatabaseSslMode(prodDirectUrl)).toBe(`${prodDirectUrl}?sslmode=require`)
+    expect(ensureProdDatabaseSslMode(`${prodDirectUrl}?sslmode=verify-full`)).toBe(`${prodDirectUrl}?sslmode=verify-full`)
+    expect(ensureProdDatabaseSslMode(localUrl)).toBe(localUrl)
+  })
+
+  it.concurrent('enables TLS for prod poolers while allowing managed pooler certificates', () => {
+    const ctx = { env: {} } as any
+    expect(getPgPoolSslOptions(ctx, prodPoolerUrl, 'sb_pooler_main')).toEqual({ rejectUnauthorized: false })
+    expect(getPgPoolSslOptions(ctx, prodDirectUrl, 'direct')).toEqual({ rejectUnauthorized: true })
+    expect(getPgPoolSslOptions(ctx, localUrl, 'direct')).toBe(false)
+    expect(getPgPoolSslOptions(ctx, prodDirectUrl, 'HYPERDRIVE_CAPGO_DIRECT_EU')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Add prod-only Postgres SSL helpers in `getPgClient()` for hosted `*.supabase.co` / `*.supabase.com` URLs
- Upgrade insecure connection strings (`ssl=false`, `sslmode=disable`, missing mode) to `sslmode=require`
- Enable TLS in the `pg` pool for prod direct/pooler connections while skipping local dev and Hyperdrive routes
- Add unit tests covering prod vs local vs Hyperdrive behavior

## Motivation (AI generated)

Supabase **Enforce SSL on incoming connections** rejects non-SSL Postgres clients. After enabling it, `/private/latency` and other Edge Function paths that call `getPgClient()` started failing because connection strings were passed through without `sslmode=require` or explicit TLS options.

## Business Impact (AI generated)

Restores the Supabase DB latency health check and prevents silent Postgres connection failures across private Edge Functions that probe the primary database, without changing local development behavior.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/pg-prod-ssl.unit.test.ts`
- [x] ESLint on changed files
- [ ] After deploy, confirm `GET /private/latency` returns `200` on `functions.supabase.co`
- [ ] Confirm local `bun test:backend` / Supabase local dev still connects without SSL changes

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved SSL/TLS configuration and enforcement for database connections, with enhanced handling of production environments, local databases, and managed connection pooler scenarios. Better certificate verification controls for different deployment types.

* **Tests**
  * Added comprehensive unit test coverage for database connection security handling and SSL configuration validation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->