### PR TITLE
feat(api): add Hyperdrive direct EU binding to API worker

### DIFF
--- a/cloudflare_workers/api/wrangler.jsonc
+++ b/cloudflare_workers/api/wrangler.jsonc
@@ -71,7 +71,13 @@
           "database_id": "81236a0c-db6e-454d-87da-944fa9bc100c"
         }
       ],
-      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "2860ca0f6b1e416fb8651792895cbffa" }]
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "2860ca0f6b1e416fb8651792895cbffa" }],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE_CAPGO_DIRECT_EU",
+          "id": "ae1fe6178b564adc9fc9a71ccc769a35"
+        }
+      ]
     },
     "preprod": {
       "name": "capgo_api-preprod",
@@ -127,7 +133,13 @@
           "database_id": "81236a0c-db6e-454d-87da-944fa9bc100c"
         }
       ],
-      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "9c405a5248604951a2a12125799bc21b" }]
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "9c405a5248604951a2a12125799bc21b" }],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE_CAPGO_DIRECT_EU",
+          "id": "ae1fe6178b564adc9fc9a71ccc769a35"
+        }
+      ]
     },
     "alpha": {
       "name": "capgo_api-alpha",
@@ -183,7 +195,13 @@
           "database_id": "81236a0c-db6e-454d-87da-944fa9bc100c"
         }
       ],
-      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "16a85350d8a246ff857a645c8f51d6ae" }]
+      "kv_namespaces": [{ "binding": "CHANNEL_SELF_STORE", "id": "16a85350d8a246ff857a645c8f51d6ae" }],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE_CAPGO_DIRECT_EU",
+          "id": "ae1fe6178b564adc9fc9a71ccc769a35"
+        }
+      ]
     },
     "local": {
       "name": "capgo_api-local",


### PR DESCRIPTION
## Summary (AI generated)

- Add `HYPERDRIVE_CAPGO_DIRECT_EU` Hyperdrive binding to the API Cloudflare worker (`prod`, `preprod`, `alpha`)
- Reuses the same Hyperdrive config ID as the plugin worker (`ae1fe6178b564adc9fc9a71ccc769a35`)
- Enables `getDatabaseURL()` to route API worker DB traffic through Hyperdrive instead of `MAIN_SUPABASE_DB_URL`

## Motivation (AI generated)

The API worker (`api.capgo.app`) was connecting to Postgres via the `MAIN_SUPABASE_DB_URL` secret (`x-database-source: sb_pooler_main`), while the plugin worker already uses Hyperdrive. After Supabase Enforce SSL, raw `pg` connections from the API worker failed for endpoints like `/private/latency` and `/replication`. Hyperdrive handles TLS to the primary and matches the plugin hot-path setup.

## Business Impact (AI generated)

Restores API worker database connectivity for console/admin endpoints (replication monitoring, latency checks, and other `getPgClient` paths) without relying on fragile pooler URL SSL modes in Node `pg`.

## Test Plan (AI generated)

- [ ] Merge and deploy API worker: `bun run deploy:cloudflare:api:prod`
- [ ] Verify `curl -H "apisecret: $API_SECRET" https://api.capgo.app/private/latency` returns `200` with `x-database-source: HYPERDRIVE_CAPGO_DIRECT_EU`
- [ ] Verify `curl -H "apisecret: $API_SECRET" https://api.capgo.app/replication` returns slot data (200 or 503 with slots, not 500)
- [ ] Confirm admin replication dashboard loads slot status

Generated with AI

Made with [Cursor](https://cursor.com)