### PR TITLE
fix(cli): --ai-analytics/--send-logs skip the build-failure menu (honor explicit opt-in in any terminal)

### DIFF
--- a/cli/src/ai/analyze.ts
+++ b/cli/src/ai/analyze.ts
@@ -3,20 +3,23 @@ import { cleanupCapturedJobFiles, getAiPromptPath, getLogCapturePath } from './l
 import { SYSTEM_PROMPT } from './prompt'
 import { createSseParser } from './sse'
 
-export type AnalyzeBehavior = 'show_menu' | 'ask_then_menu' | 'auto_upload' | 'skip'
+export type AnalyzeBehavior = 'ask_then_menu' | 'auto_upload' | 'skip'
 
 export interface DecideInput {
   isTTY: boolean
   aiAnalyticsFlag: boolean
+  sendLogsFlag: boolean
 }
 
 export function decideAnalyzeBehavior(input: DecideInput): AnalyzeBehavior {
-  if (input.isTTY && input.aiAnalyticsFlag)
-    return 'show_menu'
-  if (input.isTTY && !input.aiAnalyticsFlag)
-    return 'ask_then_menu'
-  if (!input.isTTY && input.aiAnalyticsFlag)
+  // Explicit opt-in via --ai-analytics or --send-logs means the user has
+  // already chosen - run the action(s) directly, never prompt (any terminal).
+  if (input.aiAnalyticsFlag || input.sendLogsFlag)
     return 'auto_upload'
+  // No flags + interactive terminal: ask, then show the help menu.
+  if (input.isTTY)
+    return 'ask_then_menu'
+  // No flags + non-interactive (CI/CD): stay silent (+ existing CI tip).
   return 'skip'
 }
 
@@ -41,11 +44,12 @@ export interface CiFailureActions {
   tip: string | null
 }
 
-// Pure decision for the NON-INTERACTIVE (CI/CD) build-failure path. Both flags
-// are independent and additive: --ai-analytics and --send-logs can both be
-// passed and both run. When neither is passed we surface a one-line tip instead
-// of failing silently. Interactive terminals never reach this — they use the
-// decideAnalyzeBehavior clack menu instead.
+// Pure decision for the direct-action build-failure path (CI/CD, or any terminal
+// when --ai-analytics/--send-logs is passed). Both flags are independent and
+// additive: --ai-analytics and --send-logs can both be passed and both run.
+// When neither is passed we surface a one-line tip instead of failing silently.
+// No-flag interactive terminals never reach this; they use the
+// decideAnalyzeBehavior ask_then_menu flow instead.
 export function decideCiFailureActions(input: CiFailureActionsInput): CiFailureActions {
   return {
     runAiAnalysis: input.aiAnalyticsFlag,

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -2103,6 +2103,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
         const behavior = decideAnalyzeBehavior({
           isTTY: process.stdout.isTTY === true,
           aiAnalyticsFlag: options.aiAnalytics === true,
+          sendLogsFlag: options.sendLogs === true,
         })
 
         const AI_WARNING = '⚠ AI can make mistakes. Always verify the diagnosis against the full log before applying the suggested fix.'
@@ -2388,8 +2389,10 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
 
         try {
           if (behavior === 'skip' || behavior === 'auto_upload') {
-            // Non-interactive (CI/CD). --ai-analytics and --send-logs are
-            // independent and additive: run whichever the user opted into.
+            // Direct-action path: 'auto_upload' (an explicit --ai-analytics
+            // and/or --send-logs opt-in, in ANY terminal) or 'skip' (no flags,
+            // non-interactive). --ai-analytics and --send-logs are independent
+            // and additive: run whichever the user opted into, never prompt.
             // The neither-flag discoverability tip is NOT emitted here - it is
             // printed at the build-failure point (see shouldPrintCiTip above),
             // because reaching this block requires captureEnabled, which is
@@ -2412,16 +2415,14 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
             }
           }
           else {
-            // interactive: show_menu or ask_then_menu
-            if (behavior === 'ask_then_menu') {
-              const wants = await confirm({ message: 'Build failed. See help options (email Capgo support / AI analysis)?' })
-              if (!wants || typeof wants === 'symbol') {
-                // user cancelled or declined — skip
-                await emitSkipChoice()
-              }
-              else {
-                await showMenu()
-              }
+            // No flags + interactive terminal: ask_then_menu. (auto_upload and
+            // skip are handled above; show_menu no longer exists - an explicit
+            // --ai-analytics/--send-logs opt-in now resolves to auto_upload and
+            // runs directly without prompting, in any terminal.)
+            const wants = await confirm({ message: 'Build failed. See help options (email Capgo support / AI analysis)?' })
+            if (!wants || typeof wants === 'symbol') {
+              // user cancelled or declined: skip
+              await emitSkipChoice()
             }
             else {
               await showMenu()

--- a/cli/test/test-ai-analyze-flow.mjs
+++ b/cli/test/test-ai-analyze-flow.mjs
@@ -42,6 +42,7 @@ await expectBehavior('matrix: TTY + send-logs → auto_upload', { isTTY: true, a
 await expectBehavior('matrix: TTY + both flags → auto_upload', { isTTY: true, aiAnalyticsFlag: true, sendLogsFlag: true }, 'auto_upload')
 await expectBehavior('matrix: non-TTY + ai-analytics → auto_upload', { isTTY: false, aiAnalyticsFlag: true, sendLogsFlag: false }, 'auto_upload')
 await expectBehavior('matrix: non-TTY + send-logs → auto_upload', { isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: true }, 'auto_upload')
+await expectBehavior('matrix: non-TTY + both flags → auto_upload', { isTTY: false, aiAnalyticsFlag: true, sendLogsFlag: true }, 'auto_upload')
 await expectBehavior('matrix: TTY + no flags → ask_then_menu', { isTTY: true, aiAnalyticsFlag: false, sendLogsFlag: false }, 'ask_then_menu')
 await expectBehavior('matrix: non-TTY + no flags → skip', { isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: false }, 'skip')
 

--- a/cli/test/test-ai-analyze-flow.mjs
+++ b/cli/test/test-ai-analyze-flow.mjs
@@ -26,25 +26,24 @@ await mkdir(TEST_DIR, { recursive: true })
 process.env.CAPGO_AI_LOG_BASE_DIR = TEST_DIR
 
 // ---- decideAnalyzeBehavior matrix ----
-await test('matrix: interactive + flag set → show_menu', () => {
-  const r = decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: true })
-  if (r !== 'show_menu') throw new Error(`got ${r}`)
-})
+// Explicit opt-in (--ai-analytics OR --send-logs) always runs the action(s)
+// directly without prompting, in ANY terminal. No flags: interactive gets the
+// ask-then-menu flow, non-interactive stays silent (skip).
+function expectBehavior(name, input, want) {
+  return test(name, () => {
+    const r = decideAnalyzeBehavior(input)
+    if (r !== want) throw new Error(`got ${r}, want ${want}`)
+  })
+}
 
-await test('matrix: interactive + flag unset → ask_then_menu', () => {
-  const r = decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: false })
-  if (r !== 'ask_then_menu') throw new Error(`got ${r}`)
-})
-
-await test('matrix: non-interactive + flag set → auto_upload', () => {
-  const r = decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: true })
-  if (r !== 'auto_upload') throw new Error(`got ${r}`)
-})
-
-await test('matrix: non-interactive + flag unset → skip', () => {
-  const r = decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: false })
-  if (r !== 'skip') throw new Error(`got ${r}`)
-})
+// TTY + --ai-analytics: was 'show_menu' (the bug); now runs directly.
+await expectBehavior('matrix: TTY + ai-analytics → auto_upload', { isTTY: true, aiAnalyticsFlag: true, sendLogsFlag: false }, 'auto_upload')
+await expectBehavior('matrix: TTY + send-logs → auto_upload', { isTTY: true, aiAnalyticsFlag: false, sendLogsFlag: true }, 'auto_upload')
+await expectBehavior('matrix: TTY + both flags → auto_upload', { isTTY: true, aiAnalyticsFlag: true, sendLogsFlag: true }, 'auto_upload')
+await expectBehavior('matrix: non-TTY + ai-analytics → auto_upload', { isTTY: false, aiAnalyticsFlag: true, sendLogsFlag: false }, 'auto_upload')
+await expectBehavior('matrix: non-TTY + send-logs → auto_upload', { isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: true }, 'auto_upload')
+await expectBehavior('matrix: TTY + no flags → ask_then_menu', { isTTY: true, aiAnalyticsFlag: false, sendLogsFlag: false }, 'ask_then_menu')
+await expectBehavior('matrix: non-TTY + no flags → skip', { isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: false }, 'skip')
 
 // ---- writeLocalAiFile ----
 await test('writeLocalAiFile writes prompt + <BUILD_LOG> boundary + logs', async () => {

--- a/cli/test/test-ai-onboarding-mode.mjs
+++ b/cli/test/test-ai-onboarding-mode.mjs
@@ -31,21 +31,28 @@ const TEST_DIR = join(tmpdir(), `capgo-ai-onboarding-test-${Date.now()}`)
 await mkdir(TEST_DIR, { recursive: true })
 process.env.CAPGO_AI_LOG_BASE_DIR = TEST_DIR
 
-// ---- decideAnalyzeBehavior unchanged ----
-await test('decideAnalyzeBehavior matrix unchanged: interactive+flag → show_menu', () => {
-  if (decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: true }) !== 'show_menu')
+// ---- decideAnalyzeBehavior: direct CLI invocation behavior ----
+// An explicit --ai-analytics/--send-logs opt-in runs the action(s) directly
+// without prompting, in ANY terminal (this is the build-failure fix). No flags:
+// interactive asks-then-menus, non-interactive stays silent.
+await test('decideAnalyzeBehavior: interactive + ai-analytics → auto_upload', () => {
+  if (decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: true, sendLogsFlag: false }) !== 'auto_upload')
     throw new Error('regression')
 })
-await test('decideAnalyzeBehavior matrix unchanged: interactive only → ask_then_menu', () => {
-  if (decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: false }) !== 'ask_then_menu')
+await test('decideAnalyzeBehavior: interactive + send-logs → auto_upload', () => {
+  if (decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: false, sendLogsFlag: true }) !== 'auto_upload')
     throw new Error('regression')
 })
-await test('decideAnalyzeBehavior matrix unchanged: CI+flag → auto_upload', () => {
-  if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: true }) !== 'auto_upload')
+await test('decideAnalyzeBehavior: interactive + no flags → ask_then_menu', () => {
+  if (decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: false, sendLogsFlag: false }) !== 'ask_then_menu')
     throw new Error('regression')
 })
-await test('decideAnalyzeBehavior matrix unchanged: CI alone → skip', () => {
-  if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: false }) !== 'skip')
+await test('decideAnalyzeBehavior: CI + ai-analytics → auto_upload', () => {
+  if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: true, sendLogsFlag: false }) !== 'auto_upload')
+    throw new Error('regression')
+})
+await test('decideAnalyzeBehavior: CI + no flags → skip', () => {
+  if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: false }) !== 'skip')
     throw new Error('regression')
 })
 

--- a/cli/test/test-ai-onboarding-mode.mjs
+++ b/cli/test/test-ai-onboarding-mode.mjs
@@ -55,6 +55,18 @@ await test('decideAnalyzeBehavior: CI + no flags → skip', () => {
   if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: false }) !== 'skip')
     throw new Error('regression')
 })
+await test('decideAnalyzeBehavior: interactive + both flags → auto_upload', () => {
+  if (decideAnalyzeBehavior({ isTTY: true, aiAnalyticsFlag: true, sendLogsFlag: true }) !== 'auto_upload')
+    throw new Error('regression')
+})
+await test('decideAnalyzeBehavior: CI + send-logs → auto_upload', () => {
+  if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: true }) !== 'auto_upload')
+    throw new Error('regression')
+})
+await test('decideAnalyzeBehavior: CI + both flags → auto_upload', () => {
+  if (decideAnalyzeBehavior({ isTTY: false, aiAnalyticsFlag: true, sendLogsFlag: true }) !== 'auto_upload')
+    throw new Error('regression')
+})
 
 // ---- runCapgoAiAnalysis ----
 function sseResponse(frames, status = 200) {


### PR DESCRIPTION
## What & why

User report: running `capgo build request --platform android --send-logs --ai-analytics` in an interactive terminal **still showed the build-failure menu** (Email support / Capgo AI / Local AI / Skip) and ignored the flags. If you pass `--ai-analytics` or `--send-logs`, you've already chosen - the CLI should just do it and never prompt, whether you're in a TTY, a script, or CI.

Root cause: `decideAnalyzeBehavior` returned `show_menu` for `isTTY && --ai-analytics` (so a terminal always got the menu), and `--send-logs` was only honored on the non-TTY path.

## Change

`decideAnalyzeBehavior` is now:
```ts
if (aiAnalyticsFlag || sendLogsFlag) return 'auto_upload' // explicit opt-in → run, never ask (any terminal)
if (isTTY) return 'ask_then_menu'                          // no flags + interactive → confirm + menu
return 'skip'                                              // no flags + non-interactive
```
- `--ai-analytics` and/or `--send-logs` now run the chosen action(s) directly with no menu and no confirm, in **any** terminal. Both flags are additive.
- The `'show_menu'` behavior is removed everywhere (type, decider, the dead `request.ts` branch, tests).
- **No-flag behavior is unchanged**: an interactive terminal still gets the confirm + help menu; non-interactive still stays silent (plus the existing CI discoverability tip).
- TTY `--ai-analytics` runs still render nicely-streamed markdown (the renderer already keys interactivity off `process.stdout.isTTY`).

## Scope

`build request` failure flow only. The onboarding (`init`/Ink, `caller-handled`) flow, MCP, and backend are untouched. No `cli-mcp-tests` change needed - the E2E journeys exercise the no-flag interactive menu, which is unchanged.

## Tests

Both `decideAnalyzeBehavior` suites now cover the full 2×2×2 matrix (`test-ai-analyze-flow.mjs`, `test-ai-onboarding-mode.mjs`), including the key regression: `TTY + --ai-analytics → auto_upload` (was the bug). typecheck + oxlint + build green; AI/support test suites pass.

## Hostile review (pre-PR)

CodeRabbit + Codex + a direct Claude read:
- **Codex:** no actionable issues.
- **CodeRabbit:** 2 findings, both test-matrix completeness - **fixed** (added the missing flag/TTY combinations to both suites).

Builds on the just-merged #2557 (which added `--send-logs` + the CI tip).

Claude-Session: https://claude.ai/code/session_01HpLvQussYqUczaSLSNxafD
