### PR TITLE
feat(cli): prescan PostHog telemetry on every build-request gate outcome

### DIFF
--- a/cli/src/build/prescan/command.ts
+++ b/cli/src/build/prescan/command.ts
@@ -100,6 +100,8 @@ export async function prescanCommand(appId: string | undefined, options: Prescan
       event: 'Prescan run',
       icon: '🛡️',
       tags: {
+        'source': 'standalone',
+        'result': report.counts.error > 0 ? (options.ignoreFatal ? 'bypassed' : 'blocked') : report.counts.warning > 0 ? 'warned' : 'clean',
         'app-id': appId ?? 'unknown',
         'platform': options.platform ?? 'unknown',
         'errors': String(report.counts.error),
@@ -129,6 +131,13 @@ export interface PrescanGateOptions {
   warn?: (msg: string) => void
 }
 
+export interface PrescanGateResult {
+  decision: 'proceed' | 'block'
+  /** null when the gate was disabled or the scan crashed (no scan ran) */
+  report: PrescanReport | null
+  crashed: boolean
+}
+
 /**
  * Used by build request. Runs the scan via the provided thunk, prints the report,
  * and resolves to 'proceed' | 'block'. NEVER throws: a crashing scanner proceeds with a notice
@@ -137,9 +146,9 @@ export interface PrescanGateOptions {
 export async function runPrescanGate(
   opts: PrescanGateOptions,
   scan: () => Promise<PrescanReport>,
-): Promise<'proceed' | 'block'> {
+): Promise<PrescanGateResult> {
   if (!opts.enabled)
-    return 'proceed'
+    return { decision: 'proceed', report: null, crashed: false }
   const noop = (): void => {}
   const print = opts.print ?? (opts.silent ? noop : (msg: string) => log.message(msg))
   const warn = opts.warn ?? (opts.silent ? noop : (msg: string) => log.warn(msg))
@@ -149,15 +158,15 @@ export async function runPrescanGate(
   }
   catch (e) {
     warn(`prescan crashed and was skipped: ${e instanceof Error ? e.message : String(e)}`)
-    return 'proceed'
+    return { decision: 'proceed', report: null, crashed: true }
   }
   if (report.findings.length > 0)
     print(renderTerminalReport(report, {}))
   const outcome = decideOutcome(report, { ignoreFatal: opts.ignoreFatal, failOnWarnings: opts.failOnWarnings })
-  if (outcome === 'ask') {
-    if (opts.interactive === false)
-      return 'proceed'
-    return resolveWarningGate('ask', { silent: opts.silent })
-  }
-  return outcome
+  let decision: 'proceed' | 'block'
+  if (outcome === 'ask')
+    decision = opts.interactive === false ? 'proceed' : await resolveWarningGate('ask', { silent: opts.silent })
+  else
+    decision = outcome
+  return { decision, report, crashed: false }
 }

--- a/cli/src/build/prescan/command.ts
+++ b/cli/src/build/prescan/command.ts
@@ -101,7 +101,7 @@ export async function prescanCommand(appId: string | undefined, options: Prescan
       icon: '🛡️',
       tags: {
         'source': 'standalone',
-        'result': report.counts.error > 0 ? (options.ignoreFatal ? 'bypassed' : 'blocked') : report.counts.warning > 0 ? 'warned' : 'clean',
+        'result': report.counts.error > 0 ? (options.ignoreFatal ? 'bypassed' : 'blocked') : report.counts.warning > 0 ? (options.failOnWarnings ? 'blocked' : 'warned') : 'clean',
         'app-id': appId ?? 'unknown',
         'platform': options.platform ?? 'unknown',
         'errors': String(report.counts.error),

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1691,7 +1691,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
               ? 'skipped'
               : pc.error > 0
                   ? (options.prescanIgnoreFatal ? 'bypassed' : 'blocked')
-                  : pc.warning > 0 ? 'warned' : 'clean'
+                  : pc.warning > 0 ? (options.failOnWarnings ? 'blocked' : 'warned') : 'clean'
         await sendEvent(options.apikey, {
           channel: 'native-builder',
           event: 'Prescan run',
@@ -1706,7 +1706,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
             'errors': String(pc?.error ?? 0),
             'warnings': String(pc?.warning ?? 0),
             'finding-ids': gateReport ? gateReport.findings.filter(finding => finding.severity !== 'info').map(finding => finding.id).join(',').slice(0, 200) : '',
-            'bypassed': String(Boolean(options.prescanIgnoreFatal)),
+            'bypassed': String(prescanResult === 'bypassed'),
           },
           notify: false,
         }).catch(() => {})

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1652,7 +1652,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
     // the dashboard + skewed "Build requested" telemetry).
     if (options.prescan === true) {
       const { executePrescan, runPrescanGate } = await import('./prescan/command')
-      const gate = await runPrescanGate(
+      const { decision: gateDecision, report: gateReport, crashed: gateCrashed } = await runPrescanGate(
         {
           enabled: true,
           ignoreFatal: options.prescanIgnoreFatal,
@@ -1680,19 +1680,38 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
           supaAnon: options.supaAnon,
         })).report,
       )
-      if (gate === 'block') {
+      // Telemetry: emit one `Prescan run` event for the build-request gate on EVERY
+      // outcome (clean / warned / blocked / bypassed / crashed) so PostHog sees the full
+      // funnel — run volume, block rate, and which checks fire — not just blocks.
+      {
+        const pc = gateReport?.counts
+        const prescanResult = gateCrashed
+          ? 'crashed'
+          : !pc
+              ? 'skipped'
+              : pc.error > 0
+                  ? (options.prescanIgnoreFatal ? 'bypassed' : 'blocked')
+                  : pc.warning > 0 ? 'warned' : 'clean'
         await sendEvent(options.apikey, {
           channel: 'native-builder',
-          event: 'Prescan blocked',
+          event: 'Prescan run',
           icon: '🛡️',
           org_id: orgId,
           tracking_version: 2,
           tags: {
+            'source': 'build-request',
+            'result': prescanResult,
             'app-id': appId,
             'platform': platform,
+            'errors': String(pc?.error ?? 0),
+            'warnings': String(pc?.warning ?? 0),
+            'finding-ids': gateReport ? gateReport.findings.filter(finding => finding.severity !== 'info').map(finding => finding.id).join(',').slice(0, 200) : '',
+            'bypassed': String(Boolean(options.prescanIgnoreFatal)),
           },
           notify: false,
-        }).catch()
+        }).catch(() => {})
+      }
+      if (gateDecision === 'block') {
         // Thrown (not exit(1)) so requestBuildInternal keeps its no-exit contract for SDK
         // callers: the outer catch logs the message and returns { success: false }, and
         // requestBuildCommand turns that into exit code 1.

--- a/cli/test/prescan/command.test.ts
+++ b/cli/test/prescan/command.test.ts
@@ -55,24 +55,24 @@ describe('runPrescanGate', () => {
   }
   it('returns proceed when scan disabled', async () => {
     const r = await runPrescanGate({ enabled: false }, async () => fakeReport(9, 9))
-    expect(r).toBe('proceed')
+    expect(r.decision).toBe('proceed')
   })
   it('blocks on errors', async () => {
     const r = await runPrescanGate({ enabled: true, silent: true }, async () => fakeReport(1, 0))
-    expect(r).toBe('block')
+    expect(r.decision).toBe('block')
   })
   it('proceeds on errors with ignoreFatal', async () => {
     const r = await runPrescanGate({ enabled: true, ignoreFatal: true, silent: true }, async () => fakeReport(1, 0))
-    expect(r).toBe('proceed')
+    expect(r.decision).toBe('proceed')
   })
   it('proceeds (non-interactive) on warnings', async () => {
     const r = await runPrescanGate({ enabled: true, interactive: false, silent: true }, async () => fakeReport(0, 1))
-    expect(r).toBe('proceed')
+    expect(r.decision).toBe('proceed')
   })
   it('never throws when the scan itself crashes — proceeds with a notice', async () => {
     const warned: string[] = []
     const r = await runPrescanGate({ enabled: true, warn: m => warned.push(m) }, async () => { throw new Error('scanner bug') })
-    expect(r).toBe('proceed')
+    expect(r.decision).toBe('proceed')
     expect(warned.join('\n')).toContain('scanner bug')
   })
   it('renders the report through the caller-provided print sink', async () => {
@@ -84,15 +84,32 @@ describe('runPrescanGate', () => {
   it('silent gate writes NOTHING to stdout (Ink/MCP callers own the channel)', async () => {
     const out = await captureStdout(async () => {
       const r = await runPrescanGate({ enabled: true, silent: true, interactive: false }, async () => fakeReport(2, 1))
-      expect(r).toBe('block')
+      expect(r.decision).toBe('block')
     })
     expect(out).toBe('')
   })
   it('silent gate writes NOTHING to stdout when the scan crashes', async () => {
     const out = await captureStdout(async () => {
       const r = await runPrescanGate({ enabled: true, silent: true }, async () => { throw new Error('boom') })
-      expect(r).toBe('proceed')
+      expect(r.decision).toBe('proceed')
     })
     expect(out).toBe('')
+  })
+  // The build-request gate telemetry reads result.report (counts + finding ids) and
+  // result.crashed, so lock that contract.
+  it('surfaces the report on a normal run (for telemetry)', async () => {
+    const r = await runPrescanGate({ enabled: true, silent: true, interactive: false }, async () => fakeReport(1, 2))
+    expect(r.report?.counts).toEqual({ error: 1, warning: 2, info: 0 })
+    expect(r.crashed).toBe(false)
+  })
+  it('reports null + crashed=true when the scan throws', async () => {
+    const r = await runPrescanGate({ enabled: true, silent: true }, async () => { throw new Error('boom') })
+    expect(r.report).toBeNull()
+    expect(r.crashed).toBe(true)
+  })
+  it('reports null when the gate is disabled', async () => {
+    const r = await runPrescanGate({ enabled: false }, async () => fakeReport(9, 9))
+    expect(r.report).toBeNull()
+    expect(r.crashed).toBe(false)
   })
 })


### PR DESCRIPTION
## What

Follow-up to #2534 (build pre-scan). Gives PostHog full visibility into how prescan is performing on the **build-request** path, which previously only emitted on blocks.

Before: the `build request` gate fired a sparse `Prescan blocked` event (`app-id` + `platform`, **blocks only**) — no run volume, no block rate, no per-check data on the primary path.

After:
- `runPrescanGate` returns `{ decision, report, crashed }` so the gate can read the report.
- The gate fires a unified **`Prescan run`** event on **every** outcome — `clean` / `warned` / `blocked` / `bypassed` / `crashed` — tagged with `source=build-request`, `result`, `errors`, `warnings`, **`finding-ids`** (which checks fired), and a `bypassed` flag.
- The standalone `build prescan` `Prescan run` event is enriched with `source=standalone` + the same `result` tag, so both paths form one funnel in PostHog.

## Why

So we can see, per build platform: how often prescan runs, the block rate, the **top firing checks** (the #1 preventable issues), warning-vs-error mix, store-access (Play/Apple) failures, and bypass usage.

## Safety
- No credential material is ever tagged (only counts + check ids + platform/app-id).
- Telemetry stays fire-and-forget (`.catch`) — it can never break or slow a build.

## Test plan
- [x] Build clean (`bun run build`)
- [x] Prescan suite green (357 tests; +3 new for the gate return-shape contract the telemetry depends on)
- [ ] After merge: confirm `Prescan run` events with `source=build-request` appear in PostHog and the dashboard populates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced build prescan telemetry now reports a richer “result” breakdown (including clean/warned/blocked/bypassed) and captures error/warning counts.
  * Updated prescan gate reporting to reflect crashes and disabled states more clearly.
  * Non-interactive gating no longer prompts when an interactive decision would otherwise be required; it automatically proceeds.
* **Tests**
  * Strengthened prescan gate tests to validate returned decision, reporting details, and crash/disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->