### PR TITLE
feat(admin): subscription health snapshots and paying org breakdown

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2246,5 +2246,11 @@
   "restore-account": "Restore account",
   "restoring-account": "Restoring account...",
   "translation-not-ready": "Translation is being prepared. Try again in a bit.",
-  "translation-unavailable": "This language is not available right now."
+  "translation-unavailable": "This language is not available right now.",
+  "active-canceled-orgs": "Active Canceled Orgs",
+  "active-canceled-organizations": "Active Canceled (Paid Period)",
+  "active-canceled-orgs-description": "Canceled in Stripe but still inside the paid subscription period",
+  "active-past-due-orgs": "Active Past Due Orgs",
+  "active-past-due-organizations": "Active Past Due (Still Access)",
+  "active-past-due-orgs-description": "Past due in Stripe but still retain Capgo access until cancel or period end"
 }

--- a/src/pages/admin/dashboard/index.vue
+++ b/src/pages/admin/dashboard/index.vue
@@ -118,7 +118,7 @@ const totalUsersTrendSeries = computed(() => {
 
   return [
     {
-      label: 'Total Users',
+      label: 'Registered Users',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.users,
@@ -260,7 +260,7 @@ displayStore.defaultBack = '/dashboard'
               </div>
             </div>
 
-            <!-- Total Users Card -->
+            <!-- Registered Users Card -->
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div class="flex items-start justify-between mb-4">
                 <div class="p-3 rounded-lg bg-secondary/10">
@@ -269,7 +269,7 @@ displayStore.defaultBack = '/dashboard'
               </div>
               <div>
                 <p class="text-sm text-slate-600 dark:text-slate-400">
-                  Total Users
+                  Registered Users
                 </p>
                 <div v-if="isLoadingGlobalStatsTrend" class="my-2">
                   <span class="loading loading-spinner loading-lg text-secondary" />

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -59,6 +59,8 @@ const globalStatsTrendData = ref<Array<{
   upgraded_orgs: number
   past_due_orgs: number
   past_due_orgs_average_days: number
+  active_canceled_orgs: number
+  active_past_due_orgs: number
   mrr: number
   previous_mrr: number
   previous_mrr_solo: number
@@ -79,6 +81,9 @@ const globalStatsTrendData = ref<Array<{
   average_ltv: number
   shortest_ltv: number
   longest_ltv: number
+  paying_orgs_subscription?: number
+  paying_orgs_credits?: number
+  paying_orgs_total?: number
 }>>([])
 
 const isLoadingGlobalStatsTrend = ref(false)
@@ -182,6 +187,38 @@ const pastDueAverageDaysSeries = computed(() => {
         value: item.past_due_orgs_average_days || 0,
       })),
       color: '#f59e0b', // amber
+    },
+  ]
+})
+
+const activeCanceledOrgSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: t('active-canceled-organizations'),
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.active_canceled_orgs || 0,
+      })),
+      color: '#f97316', // orange
+    },
+  ]
+})
+
+const activePastDueOrgSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: t('active-past-due-organizations'),
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.active_past_due_orgs || 0,
+      })),
+      color: '#dc2626', // red
     },
   ]
 })
@@ -615,6 +652,34 @@ displayStore.defaultBack = '/dashboard'
             </div>
           </div>
 
+          <!-- Paid Organization Breakdown -->
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Total Paid Organizations</p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-success">{{ (latestGlobalStats.paying_orgs_total || latestGlobalStats.paying || 0).toLocaleString() }}</p>
+                <p v-else class="mt-2 text-3xl font-bold text-success">0</p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Subscription and/or available credits</p>
+              </div>
+            </div>
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Subscription</p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-primary">{{ (latestGlobalStats.paying_orgs_subscription || latestGlobalStats.paying || 0).toLocaleString() }}</p>
+                <p v-else class="mt-2 text-3xl font-bold text-primary">0</p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Active subscription organizations</p>
+              </div>
+            </div>
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Credits</p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-accent">{{ (latestGlobalStats.paying_orgs_credits || 0).toLocaleString() }}</p>
+                <p v-else class="mt-2 text-3xl font-bold text-accent">0</p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Organizations with available credits</p>
+              </div>
+            </div>
+          </div>
+
           <!-- Revenue Metrics Cards -->
           <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
             <!-- Total Paying Organizations -->
@@ -780,6 +845,52 @@ displayStore.defaultBack = '/dashboard'
                 </p>
               </div>
             </div>
+
+            <!-- Active Canceled (Paid Period) -->
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div class="flex items-start justify-between mb-4">
+                <div class="p-3 rounded-lg bg-warning/10">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current text-warning"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /></svg>
+                </div>
+              </div>
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  {{ t('active-canceled-orgs') }}
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-warning">
+                  {{ (latestGlobalStats.active_canceled_orgs || 0).toLocaleString() }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-warning">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  {{ t('active-canceled-orgs-description') }}
+                </p>
+              </div>
+            </div>
+
+            <!-- Active Past Due (Still Access) -->
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div class="flex items-start justify-between mb-4">
+                <div class="p-3 rounded-lg bg-error/10">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current text-error"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86l-8.5 14.74A2 2 0 003.55 22h16.9a2 2 0 001.76-3.4l-8.5-14.74a2 2 0 00-3.42 0z" /></svg>
+                </div>
+              </div>
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  {{ t('active-past-due-orgs') }}
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-error">
+                  {{ (latestGlobalStats.active_past_due_orgs || 0).toLocaleString() }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-error">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  {{ t('active-past-due-orgs-description') }}
+                </p>
+              </div>
+            </div>
           </div>
 
           <!-- Charts - 2 per row -->
@@ -830,6 +941,30 @@ displayStore.defaultBack = '/dashboard'
                 :series="pastDueAverageDaysSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
                 :value-suffix="` ${t('days')}`"
+              />
+            </ChartCard>
+          </div>
+
+          <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard
+              :title="t('active-canceled-organizations')"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="activeCanceledOrgSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="activeCanceledOrgSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
+              />
+            </ChartCard>
+
+            <ChartCard
+              :title="t('active-past-due-organizations')"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="activePastDueOrgSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="activePastDueOrgSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
               />
             </ChartCard>
           </div>

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -119,6 +119,9 @@ const globalStatsTrendData = ref<Array<{
   devices_last_month: number
   trial_extended_orgs: number
   trial_extended_subscribed_orgs: number
+  paying_orgs_subscription?: number
+  paying_orgs_credits?: number
+  paying_orgs_total?: number
 }>>([])
 
 const isLoadingGlobalStatsTrend = ref(false)
@@ -797,19 +800,23 @@ const onboardingFunnelStages = computed(() => {
 })
 
 // Onboarding funnel trend for multi-line chart
+function normalizeTrendDate(value: string) {
+  return value.includes('T') ? value.split('T')[0] : value
+}
+
 const onboardingFunnelTrendSeries = computed(() => {
   if (!onboardingFunnelData.value || !onboardingFunnelData.value.trend)
     return []
 
   const trend = onboardingFunnelData.value.trend
-  const demoAppsCreatedByDate = new Map(globalStatsTrendData.value.map(item => [item.date, item.demo_apps_created]))
-  const userRegistrationsByDate = new Map(globalStatsTrendData.value.map(item => [item.date, item.registers_today]))
+  const demoAppsCreatedByDate = new Map(globalStatsTrendData.value.map(item => [normalizeTrendDate(item.date), item.demo_apps_created]))
+  const userRegistrationsByDate = new Map(globalStatsTrendData.value.map(item => [normalizeTrendDate(item.date), item.registers_today]))
   return [
     {
       label: t('user-registrations'),
       data: trend.map(item => ({
         date: item.date,
-        value: userRegistrationsByDate.get(item.date) ?? 0,
+        value: userRegistrationsByDate.get(normalizeTrendDate(item.date)) ?? 0,
       })),
       color: '#3b82f6', // blue
     },
@@ -849,7 +856,7 @@ const onboardingFunnelTrendSeries = computed(() => {
       label: t('demo-apps-created'),
       data: trend.map(item => ({
         date: item.date,
-        value: demoAppsCreatedByDate.get(item.date) ?? 0,
+        value: demoAppsCreatedByDate.get(normalizeTrendDate(item.date)) ?? 0,
       })),
       color: '#ef4444', // red
     },
@@ -981,27 +988,29 @@ displayStore.defaultBack = '/dashboard'
           </ChartCard>
 
           <!-- Organization Metrics Cards -->
-          <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-            <!-- Paying Organizations -->
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
-              <div class="flex items-start justify-between mb-4">
-                <div class="p-3 rounded-lg bg-success/10">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current text-success"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                </div>
-              </div>
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">
-                  Paying Organizations
-                </p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-success">
-                  {{ latestGlobalStats.paying.toLocaleString() }}
-                </p>
-                <p v-else class="mt-2 text-3xl font-bold text-success">
-                  0
-                </p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                  Active paying organizations
-                </p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Total Paid Organizations</p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-emerald-500">{{ (latestGlobalStats.paying_orgs_total || latestGlobalStats.paying || 0).toLocaleString() }}</p>
+                <p v-else class="mt-2 text-3xl font-bold text-emerald-500">0</p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Subscription and/or available credits</p>
+              </div>
+            </div>
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Subscription</p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-primary">{{ (latestGlobalStats.paying_orgs_subscription || latestGlobalStats.paying || 0).toLocaleString() }}</p>
+                <p v-else class="mt-2 text-3xl font-bold text-primary">0</p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Active subscription organizations</p>
+              </div>
+            </div>
+            <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+              <div>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Credits</p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-accent">{{ (latestGlobalStats.paying_orgs_credits || 0).toLocaleString() }}</p>
+                <p v-else class="mt-2 text-3xl font-bold text-accent">0</p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Organizations with available credits</p>
               </div>
             </div>
 

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -134,6 +134,24 @@ interface PastDueOrgRow extends CustomerIdRow {
   past_due_at?: string | null
   updated_at?: string | null
 }
+interface SubscriptionAccessSnapshotCounts {
+  active_canceled_orgs: number
+  active_past_due_orgs: number
+}
+interface SubscriptionAccessRow extends CustomerIdRow {
+  created_at?: string | null
+  paid_at?: string | null
+  canceled_at?: string | null
+  past_due_at?: string | null
+  subscription_anchor_end?: string | null
+  status?: string | null
+  is_good_plan?: boolean | null
+}
+interface SubscriptionAccessSnapshotSqlRow {
+  [key: string]: unknown
+  active_canceled_orgs: number | string | null
+  active_past_due_orgs: number | string | null
+}
 const REVENUE_ACTIVE_STRIPE_STATUSES: Database['public']['Enums']['stripe_status'][] = ['succeeded']
 
 function getDateId(targetDate = new Date()): string {
@@ -554,14 +572,102 @@ function calculatePastDueOrgStats(rows: PastDueOrgRow[], snapshotAt: Date): Past
   }
 }
 
-function hasPersistedPastDueStats(snapshot: Pick<GlobalStatsSnapshotRow, 'past_due_orgs' | 'past_due_orgs_average_days'> | null | undefined): boolean {
-  return (Number(snapshot?.past_due_orgs) || 0) > 0 || (Number(snapshot?.past_due_orgs_average_days) || 0) > 0
+function getEmptySubscriptionAccessSnapshotCounts(): SubscriptionAccessSnapshotCounts {
+  return {
+    active_canceled_orgs: 0,
+    active_past_due_orgs: 0,
+  }
+}
+
+function normalizeSubscriptionAccessSnapshotCounts(
+  row: SubscriptionAccessSnapshotSqlRow | null | undefined,
+): SubscriptionAccessSnapshotCounts {
+  return {
+    active_canceled_orgs: Number(row?.active_canceled_orgs) || 0,
+    active_past_due_orgs: Number(row?.active_past_due_orgs) || 0,
+  }
+}
+
+function isActiveCanceledAtSnapshot(row: SubscriptionAccessRow, snapshotExclusiveEnd: Date): boolean {
+  if (!row.customer_id || row.is_good_plan !== true)
+    return false
+
+  if (!row.paid_at || new Date(row.paid_at).getTime() >= snapshotExclusiveEnd.getTime())
+    return false
+
+  if (!row.canceled_at || new Date(row.canceled_at).getTime() >= snapshotExclusiveEnd.getTime())
+    return false
+
+  if (!row.subscription_anchor_end || new Date(row.subscription_anchor_end).getTime() <= snapshotExclusiveEnd.getTime())
+    return false
+
+  if (row.created_at && new Date(row.created_at).getTime() >= snapshotExclusiveEnd.getTime())
+    return false
+
+  return true
+}
+
+function isActivePastDueAtSnapshot(row: SubscriptionAccessRow, snapshotExclusiveEnd: Date): boolean {
+  if (!row.customer_id || row.is_good_plan !== true)
+    return false
+
+  if (!row.paid_at || new Date(row.paid_at).getTime() >= snapshotExclusiveEnd.getTime())
+    return false
+
+  if (!row.past_due_at || new Date(row.past_due_at).getTime() >= snapshotExclusiveEnd.getTime())
+    return false
+
+  if (!row.subscription_anchor_end || new Date(row.subscription_anchor_end).getTime() <= snapshotExclusiveEnd.getTime())
+    return false
+
+  if (row.canceled_at && new Date(row.canceled_at).getTime() < snapshotExclusiveEnd.getTime())
+    return false
+
+  if (row.status !== 'succeeded')
+    return false
+
+  if (row.created_at && new Date(row.created_at).getTime() >= snapshotExclusiveEnd.getTime())
+    return false
+
+  return true
+}
+
+function calculateSubscriptionAccessSnapshotCounts(
+  rows: SubscriptionAccessRow[],
+  snapshotExclusiveEnd: Date,
+): SubscriptionAccessSnapshotCounts {
+  const activeCanceled = new Set<string>()
+  const activePastDue = new Set<string>()
+
+  for (const row of rows) {
+    if (isActiveCanceledAtSnapshot(row, snapshotExclusiveEnd))
+      activeCanceled.add(row.customer_id)
+    if (isActivePastDueAtSnapshot(row, snapshotExclusiveEnd))
+      activePastDue.add(row.customer_id)
+  }
+
+  return {
+    active_canceled_orgs: activeCanceled.size,
+    active_past_due_orgs: activePastDue.size,
+  }
+}
+
+type MutableSubscriptionHealthSnapshot = Pick<
+  GlobalStatsSnapshotRow,
+  'past_due_orgs' | 'past_due_orgs_average_days' | 'active_canceled_orgs' | 'active_past_due_orgs'
+>
+
+function hasPersistedPastDueStats(snapshot: MutableSubscriptionHealthSnapshot | null | undefined): boolean {
+  return (Number(snapshot?.past_due_orgs) || 0) > 0
+    || (Number(snapshot?.past_due_orgs_average_days) || 0) > 0
+    || (Number(snapshot?.active_canceled_orgs) || 0) > 0
+    || (Number(snapshot?.active_past_due_orgs) || 0) > 0
 }
 
 function shouldRefreshMutablePastDueStats(
   window: DailyWindow,
   referenceDate = new Date(),
-  snapshot?: Pick<GlobalStatsSnapshotRow, 'past_due_orgs' | 'past_due_orgs_average_days'> | null,
+  snapshot?: MutableSubscriptionHealthSnapshot | null,
 ) {
   if (window.prevDayDateId === getDailyWindow(referenceDate).prevDayDateId)
     return true
@@ -1706,6 +1812,57 @@ async function getBillingSnapshotCounts(c: Context, snapshotExclusiveEnd: Date):
     await closeClient(c, pgClient)
   }
 }
+
+async function getSubscriptionAccessSnapshotCounts(c: Context, snapshotExclusiveEnd: Date): Promise<SubscriptionAccessSnapshotCounts> {
+  const pgClient = getPgClient(c, false)
+  const drizzleClient = getDrizzleClient(pgClient)
+  const snapshotExclusiveEndIso = snapshotExclusiveEnd.toISOString()
+
+  try {
+    const result = await drizzleClient.execute<SubscriptionAccessSnapshotSqlRow>(sql`
+      WITH active_canceled AS (
+        SELECT DISTINCT ON (si.customer_id)
+          si.customer_id
+        FROM public.stripe_info si
+        WHERE si.is_good_plan = true
+          AND si.created_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND si.paid_at IS NOT NULL
+          AND si.paid_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND si.canceled_at IS NOT NULL
+          AND si.canceled_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND si.subscription_anchor_end > ${snapshotExclusiveEndIso}::timestamptz
+        ORDER BY si.customer_id, si.created_at DESC
+      ),
+      active_past_due AS (
+        SELECT DISTINCT ON (si.customer_id)
+          si.customer_id
+        FROM public.stripe_info si
+        WHERE si.is_good_plan = true
+          AND si.created_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND si.paid_at IS NOT NULL
+          AND si.paid_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND si.past_due_at IS NOT NULL
+          AND si.past_due_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND si.subscription_anchor_end > ${snapshotExclusiveEndIso}::timestamptz
+          AND (si.canceled_at IS NULL OR si.canceled_at >= ${snapshotExclusiveEndIso}::timestamptz)
+          AND si.status = 'succeeded'::public.stripe_status
+        ORDER BY si.customer_id, si.created_at DESC
+      )
+      SELECT
+        (SELECT COUNT(*)::int FROM active_canceled) AS active_canceled_orgs,
+        (SELECT COUNT(*)::int FROM active_past_due) AS active_past_due_orgs
+    `)
+
+    return normalizeSubscriptionAccessSnapshotCounts(result.rows[0])
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'subscription access snapshot counts error', error })
+    return getEmptySubscriptionAccessSnapshotCounts()
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
+}
 async function getCoreSnapshotCounts(c: Context, snapshotExclusiveEnd: Date): Promise<CoreSnapshotCounts> {
   const pgClient = getPgClient(c, false)
   const drizzleClient = getDrizzleClient(pgClient)
@@ -1787,6 +1944,29 @@ async function getCoreSnapshotCounts(c: Context, snapshotExclusiveEnd: Date): Pr
   }
   finally {
     await closeClient(c, pgClient)
+  }
+}
+
+async function countRegisteredUsersForSnapshot(c: Context, snapshotExclusiveEnd: Date): Promise<number> {
+  const db = getPgClient(c, false)
+  const snapshotExclusiveEndIso = snapshotExclusiveEnd.toISOString()
+
+  try {
+    const result = await db.query<{ count: number | string | null }>(`
+      SELECT COUNT(*)::int AS count
+      FROM public.users u
+      WHERE u.created_at < $1::timestamptz
+        AND u.created_via_invite = false
+    `, [snapshotExclusiveEndIso])
+
+    return Number(result.rows[0]?.count) || 0
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'count registered users for snapshot error', error })
+    return 0
+  }
+  finally {
+    await closeClient(c, db)
   }
 }
 
@@ -1875,11 +2055,7 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
     countAllApps(c, window.prevDayEnd),
     countAllUpdates(c, window.prevDayEnd),
     countAllUpdatesExternal(c, window.prevDayEnd),
-    supabase
-      .from('users')
-      .select('id', { count: 'exact', head: true })
-      .lt('created_at', snapshotEndIso)
-      .then(res => res.count ?? 0),
+    countRegisteredUsersForSnapshot(c, window.prevDayEnd),
     supabase
       .from('orgs')
       .select('id', { count: 'exact', head: true })
@@ -2034,6 +2210,7 @@ async function runRevenueGlobalStatsShard(c: Context, window: DailyWindow): Prom
     upgraded_orgs,
     trialExtensionStats,
     pastDueOrgStats,
+    subscriptionAccessCounts,
     credits_bought,
     credits_consumed,
   ] = await Promise.all([
@@ -2107,6 +2284,9 @@ async function runRevenueGlobalStatsShard(c: Context, window: DailyWindow): Prom
           return calculatePastDueOrgStats((res.data || []) as PastDueOrgRow[], nextDayStart)
         })()
       : Promise.resolve({ past_due_orgs: 0, past_due_orgs_average_days: 0 }),
+    refreshPastDueStats
+      ? getSubscriptionAccessSnapshotCounts(c, nextDayStart)
+      : Promise.resolve(getEmptySubscriptionAccessSnapshotCounts()),
     supabase
       .from('usage_credit_grants')
       .select('credits_total')
@@ -2161,6 +2341,8 @@ async function runRevenueGlobalStatsShard(c: Context, window: DailyWindow): Prom
   if (refreshPastDueStats) {
     snapshotPatch.past_due_orgs = pastDueOrgStats.past_due_orgs
     snapshotPatch.past_due_orgs_average_days = pastDueOrgStats.past_due_orgs_average_days
+    snapshotPatch.active_canceled_orgs = subscriptionAccessCounts.active_canceled_orgs
+    snapshotPatch.active_past_due_orgs = subscriptionAccessCounts.active_past_due_orgs
   }
 
   await updateGlobalStatsSnapshot(c, window.prevDayDateId, snapshotPatch)
@@ -2286,17 +2468,17 @@ async function readGlobalStatsSnapshot(c: Context, dateId: string): Promise<Glob
   return data as GlobalStatsSnapshotRow
 }
 
-async function readGlobalStatsPastDueSnapshot(c: Context, dateId: string): Promise<Pick<GlobalStatsSnapshotRow, 'past_due_orgs' | 'past_due_orgs_average_days'> | null> {
+async function readGlobalStatsPastDueSnapshot(c: Context, dateId: string): Promise<MutableSubscriptionHealthSnapshot | null> {
   const { data, error } = await supabaseAdmin(c)
     .from('global_stats')
-    .select('past_due_orgs, past_due_orgs_average_days')
+    .select('past_due_orgs, past_due_orgs_average_days, active_canceled_orgs, active_past_due_orgs')
     .eq('date_id', dateId)
     .maybeSingle()
 
   if (error)
     throw error
 
-  return data as Pick<GlobalStatsSnapshotRow, 'past_due_orgs' | 'past_due_orgs_average_days'> | null
+  return data as MutableSubscriptionHealthSnapshot | null
 }
 
 function getNumber(value: number | null | undefined): number {
@@ -2478,6 +2660,10 @@ export const logsnagInsightsTestUtils = {
   REVENUE_ACTIVE_STRIPE_STATUSES,
   LOGSNAG_INSIGHTS_BACKGROUND_MAX_RETRIES,
   calculatePastDueOrgStats,
+  calculateSubscriptionAccessSnapshotCounts,
+  isActiveCanceledAtSnapshot,
+  isActivePastDueAtSnapshot,
+  normalizeSubscriptionAccessSnapshotCounts,
   shouldRefreshMutablePastDueStats,
   calculateChurnRevenue,
   calculateNrr,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1170,6 +1170,8 @@ export interface AdminGlobalStatsTrend {
   trial_extended_subscribed_orgs: number
   past_due_orgs: number
   past_due_orgs_average_days: number
+  active_canceled_orgs: number
+  active_past_due_orgs: number
   mrr: number
   previous_mrr: number
   previous_mrr_solo: number
@@ -1213,6 +1215,9 @@ export interface AdminGlobalStatsTrend {
   build_count_day_android: number
   builder_active_paying_clients_60d: number
   live_updates_active_paying_clients_60d: number
+  paying_orgs_subscription: number
+  paying_orgs_credits: number
+  paying_orgs_total: number
 }
 
 export async function getAdminGlobalStatsTrend(
@@ -1275,6 +1280,8 @@ export async function getAdminGlobalStatsTrend(
         gs.new_paying_orgs::int AS new_paying_orgs,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'past_due_orgs', '')::int, 0)::int AS past_due_orgs,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'past_due_orgs_average_days', '')::float, 0)::float AS past_due_orgs_average_days,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'active_canceled_orgs', '')::int, 0)::int AS active_canceled_orgs,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'active_past_due_orgs', '')::int, 0)::int AS active_past_due_orgs,
         gs.canceled_orgs::int AS canceled_orgs,
         COALESCE(gs.upgraded_orgs, 0)::int AS upgraded_orgs,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'trial_extended_orgs', '')::int, 0)::int AS trial_extended_orgs,
@@ -1345,7 +1352,10 @@ export async function getAdminGlobalStatsTrend(
         COALESCE(NULLIF(to_jsonb(gs) ->> 'build_count_day_ios', '')::int, NULLIF(to_jsonb(gs) ->> 'builds_day_ios', '')::int, 0)::int AS build_count_day_ios,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'build_count_day_android', '')::int, NULLIF(to_jsonb(gs) ->> 'builds_day_android', '')::int, 0)::int AS build_count_day_android,
         COALESCE(NULLIF(to_jsonb(gs) ->> 'builder_active_paying_clients_60d', '')::int, 0)::int AS builder_active_paying_clients_60d,
-        COALESCE(NULLIF(to_jsonb(gs) ->> 'live_updates_active_paying_clients_60d', '')::int, 0)::int AS live_updates_active_paying_clients_60d
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'live_updates_active_paying_clients_60d', '')::int, 0)::int AS live_updates_active_paying_clients_60d,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'paying_orgs_subscription', '')::int, gs.paying::int, 0)::int AS paying_orgs_subscription,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'paying_orgs_credits', '')::int, 0)::int AS paying_orgs_credits,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'paying_orgs_total', '')::int, gs.paying::int, 0)::int AS paying_orgs_total
       FROM completed_stats gs
       LEFT JOIN completed_stats prev ON prev.date_id = (
         CASE
@@ -1374,7 +1384,7 @@ export async function getAdminGlobalStatsTrend(
     const result = await drizzleClient.execute(query)
 
     const data: AdminGlobalStatsTrend[] = result.rows.map((row: any) => ({
-      date: row.date,
+      date: normalizeAdminStatsDate(row.date),
       apps: Number(row.apps) || 0,
       apps_active: Number(row.apps_active) || 0,
       users: Number(row.users) || 0,
@@ -1406,6 +1416,8 @@ export async function getAdminGlobalStatsTrend(
       paying_yearly: Number(row.paying_yearly) || 0,
       past_due_orgs: Number(row.past_due_orgs) || 0,
       past_due_orgs_average_days: Number(row.past_due_orgs_average_days) || 0,
+      active_canceled_orgs: Number(row.active_canceled_orgs) || 0,
+      active_past_due_orgs: Number(row.active_past_due_orgs) || 0,
       paying_monthly: Number(row.paying_monthly) || 0,
       new_paying_orgs: Number(row.new_paying_orgs) || 0,
       canceled_orgs: Number(row.canceled_orgs) || 0,
@@ -1455,7 +1467,27 @@ export async function getAdminGlobalStatsTrend(
       build_count_day_android: Number(row.build_count_day_android) || 0,
       builder_active_paying_clients_60d: Number(row.builder_active_paying_clients_60d) || 0,
       live_updates_active_paying_clients_60d: Number(row.live_updates_active_paying_clients_60d) || 0,
+      paying_orgs_subscription: Number(row.paying_orgs_subscription) || 0,
+      paying_orgs_credits: Number(row.paying_orgs_credits) || 0,
+      paying_orgs_total: Number(row.paying_orgs_total) || 0,
     }))
+
+    if (data.length > 0) {
+      const latestIndex = data.length - 1
+      if (data[latestIndex].users <= 0) {
+        const liveRegisteredUsers = await getLiveRegisteredUsersCount(c)
+        if (liveRegisteredUsers > 0)
+          data[latestIndex].users = liveRegisteredUsers
+      }
+
+      const livePayingBreakdown = await getAdminPayingOrgBreakdown(c)
+      data[latestIndex] = {
+        ...data[latestIndex],
+        paying_orgs_subscription: livePayingBreakdown.paying_orgs_subscription || data[latestIndex].paying_orgs_subscription,
+        paying_orgs_credits: livePayingBreakdown.paying_orgs_credits || data[latestIndex].paying_orgs_credits,
+        paying_orgs_total: livePayingBreakdown.paying_orgs_total || data[latestIndex].paying_orgs_total,
+      }
+    }
 
     cloudlog({ requestId: c.get('requestId'), message: 'getAdminGlobalStatsTrend result', resultCount: data.length })
 
@@ -1487,6 +1519,123 @@ interface AdminUtcDateRange {
   startDay: Date
   seriesEndDay: Date
   endExclusive: Date
+}
+
+export function normalizeAdminStatsDate(value: unknown): string {
+  if (value instanceof Date)
+    return value.toISOString().split('T')[0]
+
+  const rawValue = String(value ?? '').trim()
+  if (!rawValue)
+    return ''
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(rawValue))
+    return rawValue
+
+  const parsed = new Date(rawValue)
+  if (!Number.isNaN(parsed.getTime()))
+    return parsed.toISOString().split('T')[0]
+
+  return rawValue.slice(0, 10)
+}
+
+async function getLiveRegisteredUsersCount(c: Context): Promise<number> {
+  const pgClient = getPgClient(c)
+  const drizzleClient = getDrizzleClient(pgClient)
+
+  try {
+    const result = await drizzleClient.execute(sql`
+      SELECT COUNT(*)::int AS count
+      FROM public.users u
+      WHERE u.created_via_invite = false
+    `)
+
+    return Number((result.rows[0] as { count?: number | string | null } | undefined)?.count) || 0
+  }
+  catch (error) {
+    logPgError(c, 'getLiveRegisteredUsersCount', error)
+    return 0
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
+}
+
+export interface AdminPayingOrgBreakdown {
+  paying_orgs_subscription: number
+  paying_orgs_credits: number
+  paying_orgs_total: number
+}
+
+export async function getAdminPayingOrgBreakdown(c: Context): Promise<AdminPayingOrgBreakdown> {
+  const emptyResult: AdminPayingOrgBreakdown = {
+    paying_orgs_subscription: 0,
+    paying_orgs_credits: 0,
+    paying_orgs_total: 0,
+  }
+
+  const pgClient = getPgClient(c)
+  const drizzleClient = getDrizzleClient(pgClient)
+
+  try {
+    const result = await drizzleClient.execute(sql`
+      WITH active_subscriptions AS (
+        SELECT DISTINCT ON (si.customer_id)
+          si.customer_id
+        FROM public.stripe_info si
+        INNER JOIN public.plans p ON p.stripe_id = si.product_id
+        WHERE si.is_good_plan = true
+          AND si.status IN (
+            'succeeded'::public.stripe_status,
+            'canceled'::public.stripe_status,
+            'deleted'::public.stripe_status
+          )
+          AND (si.canceled_at IS NULL OR si.canceled_at > NOW())
+          AND si.subscription_anchor_end > NOW()
+        ORDER BY si.customer_id, si.created_at DESC
+      ),
+      subscription_orgs AS (
+        SELECT DISTINCT o.id AS org_id
+        FROM public.orgs o
+        INNER JOIN active_subscriptions active ON active.customer_id = o.customer_id
+      ),
+      credit_orgs AS (
+        SELECT DISTINCT ucb.org_id
+        FROM public.usage_credit_balances ucb
+        WHERE COALESCE(ucb.available_credits, 0) > 0
+      )
+      SELECT
+        (SELECT COUNT(*)::int FROM subscription_orgs) AS paying_orgs_subscription,
+        (SELECT COUNT(*)::int FROM credit_orgs) AS paying_orgs_credits,
+        (
+          SELECT COUNT(*)::int
+          FROM (
+            SELECT org_id FROM subscription_orgs
+            UNION
+            SELECT org_id FROM credit_orgs
+          ) paid_orgs
+        ) AS paying_orgs_total
+    `)
+
+    const row = result.rows[0] as {
+      paying_orgs_subscription?: number | string | null
+      paying_orgs_credits?: number | string | null
+      paying_orgs_total?: number | string | null
+    } | undefined
+
+    return {
+      paying_orgs_subscription: Number(row?.paying_orgs_subscription) || 0,
+      paying_orgs_credits: Number(row?.paying_orgs_credits) || 0,
+      paying_orgs_total: Number(row?.paying_orgs_total) || 0,
+    }
+  }
+  catch (error) {
+    logPgError(c, 'getAdminPayingOrgBreakdown', error)
+    return emptyResult
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
 }
 
 function getAdminUtcDateRange(start_date: string, end_date: string): AdminUtcDateRange {

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1449,6 +1449,8 @@ export type Database = {
       }
       global_stats: {
         Row: {
+          active_canceled_orgs: number
+          active_past_due_orgs: number
           apps: number
           apps_active: number | null
           average_ltv: number
@@ -1629,6 +1631,8 @@ export type Database = {
           users_active?: number | null
         }
         Update: {
+          active_canceled_orgs?: number
+          active_past_due_orgs?: number
           apps?: number
           apps_active?: number | null
           average_ltv?: number

--- a/supabase/migrations/20260623110724_active_subscription_access_snapshots.sql
+++ b/supabase/migrations/20260623110724_active_subscription_access_snapshots.sql
@@ -1,0 +1,9 @@
+ALTER TABLE public.global_stats
+ADD COLUMN IF NOT EXISTS active_canceled_orgs integer DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS active_past_due_orgs integer DEFAULT 0 NOT NULL;
+
+COMMENT ON COLUMN public.global_stats.active_canceled_orgs IS
+'Organizations canceled in Stripe but still inside the paid subscription period at snapshot time.';
+
+COMMENT ON COLUMN public.global_stats.active_past_due_orgs IS
+'Organizations in Stripe past_due status that still retain Capgo access until cancel or period end at snapshot time.';

--- a/tests/admin-stats.unit.test.ts
+++ b/tests/admin-stats.unit.test.ts
@@ -146,3 +146,13 @@ describe('buildPluginBreakdownResult', () => {
     ])
   })
 })
+
+import { normalizeAdminStatsDate } from '../supabase/functions/_backend/utils/pg.ts'
+
+describe('normalizeAdminStatsDate', () => {
+  it.concurrent('normalizes Date objects and ISO timestamps to YYYY-MM-DD', () => {
+    expect(normalizeAdminStatsDate(new Date('2026-06-20T15:30:00.000Z'))).toBe('2026-06-20')
+    expect(normalizeAdminStatsDate('2026-06-20T00:00:00.000Z')).toBe('2026-06-20')
+    expect(normalizeAdminStatsDate('2026-06-20')).toBe('2026-06-20')
+  })
+})

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -270,6 +270,65 @@ describe('logsnag revenue metric helpers', () => {
     })
   })
 
+  it.concurrent('counts active canceled and active past due orgs at a snapshot boundary', () => {
+    const snapshotEnd = new Date('2026-03-25T00:00:00.000Z')
+
+    expect(logsnagInsightsTestUtils.calculateSubscriptionAccessSnapshotCounts([
+      {
+        customer_id: 'cus_canceled_active',
+        is_good_plan: true,
+        paid_at: '2026-01-01T00:00:00.000Z',
+        canceled_at: '2026-03-20T00:00:00.000Z',
+        subscription_anchor_end: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        customer_id: 'cus_canceled_expired',
+        is_good_plan: true,
+        paid_at: '2026-01-01T00:00:00.000Z',
+        canceled_at: '2026-03-20T00:00:00.000Z',
+        subscription_anchor_end: '2026-03-24T00:00:00.000Z',
+      },
+      {
+        customer_id: 'cus_past_due_active',
+        is_good_plan: true,
+        status: 'succeeded',
+        paid_at: '2026-01-01T00:00:00.000Z',
+        past_due_at: '2026-03-22T00:00:00.000Z',
+        subscription_anchor_end: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        customer_id: 'cus_past_due_canceled',
+        is_good_plan: true,
+        status: 'succeeded',
+        paid_at: '2026-01-01T00:00:00.000Z',
+        past_due_at: '2026-03-22T00:00:00.000Z',
+        canceled_at: '2026-03-23T00:00:00.000Z',
+        subscription_anchor_end: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        customer_id: 'cus_past_due_stale_status',
+        is_good_plan: true,
+        status: 'canceled',
+        paid_at: '2026-01-01T00:00:00.000Z',
+        past_due_at: '2026-03-22T00:00:00.000Z',
+        subscription_anchor_end: '2026-04-01T00:00:00.000Z',
+      },
+    ], snapshotEnd)).toEqual({
+      active_canceled_orgs: 2,
+      active_past_due_orgs: 1,
+    })
+  })
+
+  it.concurrent('normalizes subscription access snapshot SQL rows', () => {
+    expect(logsnagInsightsTestUtils.normalizeSubscriptionAccessSnapshotCounts({
+      active_canceled_orgs: '3',
+      active_past_due_orgs: null,
+    })).toEqual({
+      active_canceled_orgs: 3,
+      active_past_due_orgs: 0,
+    })
+  })
+
   it.concurrent('only refreshes mutable past-due stats for the current daily snapshot or an empty first fill', () => {
     const currentWindow = logsnagInsightsTestUtils.getCompletedDayWindowForDateId('2026-03-24')
     const replayReferenceDate = new Date('2026-03-26T00:00:00.000Z')
@@ -285,12 +344,12 @@ describe('logsnag revenue metric helpers', () => {
     expect(logsnagInsightsTestUtils.shouldRefreshMutablePastDueStats(
       currentWindow,
       replayReferenceDate,
-      { past_due_orgs: 0, past_due_orgs_average_days: 0 },
+      { past_due_orgs: 0, past_due_orgs_average_days: 0, active_canceled_orgs: 0, active_past_due_orgs: 0 },
     )).toBe(true)
     expect(logsnagInsightsTestUtils.shouldRefreshMutablePastDueStats(
       currentWindow,
       replayReferenceDate,
-      { past_due_orgs: 2, past_due_orgs_average_days: 3.8 },
+      { past_due_orgs: 2, past_due_orgs_average_days: 3.8, active_canceled_orgs: 0, active_past_due_orgs: 0 },
     )).toBe(false)
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- Add daily `global_stats` snapshots for `active_canceled_orgs` and `active_past_due_orgs` (orgs still in paid access after Stripe cancel or past_due)
- Fix admin registered-user count to exclude invite-created accounts and align onboarding registration chart dates
- Add live paying-org breakdown (subscription vs credits vs total) to admin revenue/users dashboards with new cards and trend charts

## Motivation (AI generated)

Capgo counts `stripe_info.status = 'succeeded'` for active subscribers, which intentionally includes past_due subs and canceled subs still inside the billing period. That diverges from Stripe revenue-active counts and can overstate subscribers when rows go stale after the paid period ends. Operators need explicit daily counts and charts for these transitional states, plus a clearer split between subscription-paid and credit-paid orgs.

## Business Impact (AI generated)

Improves revenue ops visibility into subscription risk (past due, canceled-but-active) and reduces misleading admin subscriber totals. Helps prioritize retention outreach and reconcile Capgo vs Stripe subscriber numbers without manual SQL.

## Test Plan (AI generated)

- [ ] Apply migration `20260623110724_active_subscription_access_snapshots.sql` locally (`bun run supabase:db:reset`)
- [ ] Run revenue shard / daily snapshot and verify `active_canceled_orgs` and `active_past_due_orgs` are written to `global_stats`
- [ ] Open admin Revenue dashboard: confirm new summary cards and trend charts render
- [ ] Verify registered users count excludes invite signups and onboarding registration line chart is non-zero
- [ ] Verify paying org breakdown cards show subscription / credits / total
- [x] `bun test tests/logsnag-insights-revenue.unit.test.ts tests/admin-stats.unit.test.ts`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics for tracking organizations with active canceled and past-due subscription statuses
  * Introduced paid organization breakdown tracking (subscription-derived vs credit-derived)
  * Enhanced admin dashboards with new metric cards and visualizations for subscription access statuses

* **Updates**
  * Updated dashboard terminology: "Users" now displays as "Registered Users" for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->