### PR TITLE
fix(cli): use console.capgo.app for web console links

### DIFF
--- a/cli/src/build/onboarding/mcp/engine.ts
+++ b/cli/src/build/onboarding/mcp/engine.ts
@@ -7,6 +7,7 @@ import type { ChoiceOption, NextStepResult, Platform } from './contract.js'
 import type { IosCarried, TailParkedState } from './session-state.js'
 import type { BuildOutputRecord } from '../../output-record.js'
 import type { TailEffectProgress, TailStep, TailStepCtx } from '../tail/flow.js'
+import { consoleWebUrl } from '../../../utils.js'
 import { buildAppIdConflictSuggestions } from '../../../init/app-conflict.js'
 import { ONBOARDING_RULES } from './contract.js'
 import { explainForState } from './explanations.js'
@@ -3421,7 +3422,7 @@ async function enterTailAfterBuild(
   rec: BuildOutputRecord,
 ): Promise<NextStepResult | null> {
   try {
-    const buildUrl = `https://capgo.app/app/${appId}/builds`
+    const buildUrl = consoleWebUrl(`/app/${appId}/builds`)
     if (platform === 'ios') {
       if (!deps.iosEffectDeps?.detectCiSecretTargets || !deps.iosEffectDeps.saveProgress)
         return null

--- a/cli/src/build/onboarding/tail/flow.ts
+++ b/cli/src/build/onboarding/tail/flow.ts
@@ -25,6 +25,7 @@
 // The core stays IO-free: every concrete helper (createCiSecretEntries,
 // detectCiSecretTargets, …, requestBuildInternal) is injected by the driver.
 
+import { consoleWebUrl } from '../../../utils.js'
 import type { BuildCredentials } from '../../../schemas/build.js'
 import type { BuildLogger, BuildRequestOptions, BuildRequestResult } from '../../request.js'
 import type { AsyncCommandRunner, CiSecretDiscovery, CiSecretEntry, CiSecretSetupAdvice, CiSecretTarget, CommandRunner } from '../ci-secrets.js'
@@ -1099,7 +1100,7 @@ export async function runTailEffect<P extends TailEffectProgress>(
           return { progress }
 
         if (result.success) {
-          const url = `https://capgo.app/app/${progress.appId}/builds`
+          const url = consoleWebUrl(`/app/${progress.appId}/builds`)
           // Blank line + queued line — parity with setBuildOutput([..., '', queued]).
           deps.onBuildOutput?.('')
           deps.onBuildOutput?.(`✔ Build queued — ${url}`)

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -30,7 +30,7 @@ import { copyToClipboard, revealInFinder } from '../support/clipboard'
 import { appendInternalLog, getInternalLogPath, startInternalLog } from '../support/internal-log'
 import { showReplicationProgress } from '../replicationProgress'
 import { formatRunnerCommand, splitRunnerCommand } from '../runner-command'
-import { createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
+import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { buildAppIdConflictSuggestions, isAppAlreadyExistsError } from './app-conflict'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { appendInitStreamingLine, clearInitStreamingOutput, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus } from './runtime'
@@ -1791,7 +1791,7 @@ async function selectOrganizationForInit(
 
   if (organization.enforcing_2fa && !organization['2fa_has_access']) {
     pLog.error(`The organization "${organization.name}" requires all members to have 2FA enabled.`)
-    pLog.error('Enable 2FA at https://web.capgo.app/settings/account and try again.')
+    pLog.error(`Enable 2FA at ${consoleWebUrl('/settings/account')} and try again.`)
     throw new Error('2FA required for selected organization')
   }
 
@@ -4748,7 +4748,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
         discardResumedState()
       }
       else if (blocked2fa) {
-        pLog.warn(`Organization "${savedOrg.name}" now requires 2FA. Enable it at https://web.capgo.app/settings/account`)
+        pLog.warn(`Organization "${savedOrg.name}" now requires 2FA. Enable it at ${consoleWebUrl('/settings/account')}`)
         pLog.warn('Please select a different organization or enable 2FA and try again.')
         organization = await selectOrganizationForInit(supabase, options.apikey)
         discardResumedState()

--- a/cli/src/organization/list.ts
+++ b/cli/src/organization/list.ts
@@ -5,6 +5,7 @@ import { Table } from '@sauber/table'
 import { trackEvent } from '../analytics/track'
 import { checkAlerts } from '../api/update'
 import {
+  consoleWebUrl,
   createSupabaseClient,
   findSavedKey,
   formatError,
@@ -48,7 +49,7 @@ function displayOrganizations(data: Organization[], silent: boolean) {
     for (const org of noAccessOrgs) {
       log.warn(`   - ${org.name} (${org.gid})`)
     }
-    log.warn(`\nTo regain access, enable 2FA on your account at https://web.capgo.app/settings/account`)
+    log.warn(`\nTo regain access, enable 2FA on your account at ${consoleWebUrl('/settings/account')}`)
   }
 }
 

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -39,6 +39,13 @@ export const defaultHost = 'https://capgo.app'
 export const defaultFileHost = 'https://files.capgo.app'
 export const defaultApiHost = 'https://api.capgo.app'
 export const defaultHostWeb = 'https://console.capgo.app'
+
+/** Build a console web-app URL (settings, builds, connect, etc.). */
+export function consoleWebUrl(path = ''): string {
+  if (!path)
+    return defaultHostWeb
+  return `${defaultHostWeb}${path.startsWith('/') ? path : `/${path}`}`
+}
 export const UPLOAD_TIMEOUT = 120000
 export const ALERT_UPLOAD_SIZE_BYTES = 1024 * 1024 * 20 // 20MB
 export const MAX_UPLOAD_LENGTH_BYTES = 1024 * 1024 * 1024 // 1GB
@@ -129,7 +136,7 @@ export async function check2FAAccessForOrg(supabase: SupabaseClient<Database>, o
   }
   if (reject2fa) {
     if (!silent)
-      log.error(`🔐 Access Denied: 2FA Required. Enable 2FA at https://web.capgo.app/settings/account`)
+      log.error(`🔐 Access Denied: 2FA Required. Enable 2FA at ${consoleWebUrl('/settings/account')}`)
     throw new Error('2FA required for this organization')
   }
 }
@@ -1634,7 +1641,7 @@ export function show2FADeniedError(organizationName?: string): never {
     log.error(`\nThis organization requires all members to have 2FA enabled.`)
   }
   log.error(`\nTo regain access:`)
-  log.error(`  1. Go to https://web.capgo.app/settings/account`)
+  log.error(`  1. Go to ${consoleWebUrl('/settings/account')}`)
   log.error(`  2. Enable Two-Factor Authentication on your account`)
   log.error(`  3. Try your command again`)
   log.error(`\nFor more information, visit: https://capgo.app/docs/webapp/2fa-enforcement/\n`)

--- a/cli/src/utils/security_policy_errors.ts
+++ b/cli/src/utils/security_policy_errors.ts
@@ -28,13 +28,13 @@ export type SecurityPolicyErrorCode = typeof SECURITY_POLICY_ERRORS[keyof typeof
 
 export const SECURITY_POLICY_MESSAGES: Record<string, string> = {
   [SECURITY_POLICY_ERRORS.ORG_REQUIRES_EXPIRING_KEY]:
-    'This organization requires API keys with expiration dates.\n\nPlease generate a new API key with an expiration:\n  1. Go to https://web.capgo.app/dashboard/apikeys\n  2. Create a new API key with an expiration date\n  3. Update your CLI configuration with: capgo login [new-key]\n  4. Try this command again',
+    'This organization requires API keys with expiration dates.\n\nPlease generate a new API key with an expiration:\n  1. Go to https://console.capgo.app/dashboard/apikeys\n  2. Create a new API key with an expiration date\n  3. Update your CLI configuration with: capgo login [new-key]\n  4. Try this command again',
 
   [SECURITY_POLICY_ERRORS.EXPIRATION_REQUIRED]:
-    'This organization requires API keys to have an expiration date.\n\nPlease generate a new API key with an expiration:\n  1. Go to https://web.capgo.app/dashboard/apikeys\n  2. Create a new API key with an expiration date\n  3. Update your CLI configuration with: capgo login [new-key]\n  4. Try this command again',
+    'This organization requires API keys to have an expiration date.\n\nPlease generate a new API key with an expiration:\n  1. Go to https://console.capgo.app/dashboard/apikeys\n  2. Create a new API key with an expiration date\n  3. Update your CLI configuration with: capgo login [new-key]\n  4. Try this command again',
 
   [SECURITY_POLICY_ERRORS.EXPIRATION_EXCEEDS_MAX]:
-    'Your API key expiration date exceeds the maximum allowed by this organization.\n\nPlease generate a new API key with a shorter expiration:\n  1. Go to https://web.capgo.app/dashboard/apikeys\n  2. Create a new API key with a valid expiration date\n  3. Update your CLI configuration with: capgo login [new-key]\n  4. Try this command again',
+    'Your API key expiration date exceeds the maximum allowed by this organization.\n\nPlease generate a new API key with a shorter expiration:\n  1. Go to https://console.capgo.app/dashboard/apikeys\n  2. Create a new API key with a valid expiration date\n  3. Update your CLI configuration with: capgo login [new-key]\n  4. Try this command again',
 }
 
 // ============================================================================

--- a/cli/test/helpers/onboarding-fixtures.mjs
+++ b/cli/test/helpers/onboarding-fixtures.mjs
@@ -107,14 +107,14 @@ export function staticStepFixtures() {
     // NOTE: ish.ErrorStep is deliberately NOT here — it's unbounded and scrolls
     // (see header). Only its compact form renders inline, and that's ~20 rows.
     fi('ios-no-platform', h(ish.NoPlatformStep, { iosDir: 'apps/mobile/platforms/ios-native', addIosCommand: 'npx cap add ios', syncIosCommand: 'npx cap sync ios', onChange: noop, ...C }), false),
-    fi('ios-build-complete', h(ish.BuildCompleteStep, { buildUrl: `https://capgo.app/app/${LONG_APP_ID}/builds`, ciSecretUploadSummary: 'Uploaded 12 secrets to GitHub Actions repository secrets', buildRequestCommand: `npx @capgo/cli build --app ${LONG_APP_ID}`, ...C }), false),
+    fi('ios-build-complete', h(ish.BuildCompleteStep, { buildUrl: `https://console.capgo.app/app/${LONG_APP_ID}/builds`, ciSecretUploadSummary: 'Uploaded 12 secrets to GitHub Actions repository secrets', buildRequestCommand: `npx @capgo/cli build --app ${LONG_APP_ID}`, ...C }), false),
     fi('ios-platform-select', h(ish.PlatformSelectStep, { appId: LONG_APP_ID, onChange: noop, ...C })),
     fi('ios-adding-platform', h(ish.AddingPlatformStep, { addIosCommand: 'npx cap add ios', doctorCommand: 'npx @capgo/cli doctor', ...C }), false),
     // ── shared (rendered by the Android app) ─────────────────────────────────
     fi('welcome', h(ish.WelcomeStep), false),
     f('no-platform', h(ash.NoPlatformStep, { androidDir: 'apps/mobile/platforms/android-native', ...C }), false),
     f('credentials-exist-choose', h(ash.CredentialsExistStep, { appId: 'com.x.y', onChoose: noop, ...C })),
-    f('build-complete', h(ash.BuildCompleteStep, { uploadSummary: null, buildUrl: 'https://capgo.app/app/com.example.app/builds', ...C }), false),
+    f('build-complete', h(ash.BuildCompleteStep, { uploadSummary: null, buildUrl: 'https://console.capgo.app/app/com.example.app/builds', ...C }), false),
     f('error', h(ash.ErrorStep, { message: LONG_ERR, onChoose: noop, ...C })),
     // ── ci ──────────────────────────────────────────────────────────────────
     f('ci-secrets-setup', h(androidCi.CiSecretsSetupStep, { advice: CI_ADVICE, onChoose: noop, ...C })),

--- a/cli/test/test-android-tail-engine.mjs
+++ b/cli/test/test-android-tail-engine.mjs
@@ -726,7 +726,7 @@ await test("androidViewForStep('build-complete') is a done view", async () => {
 // adding the tail markers exercises only the new Phase-6 routing.
 
 const CREDS_SAVED = { savedAt: '2026-06-03T01:00:00.000Z' }
-const BUILD_REQUESTED = { buildUrl: `https://capgo.app/app/${APP_ID}/builds` }
+const BUILD_REQUESTED = { buildUrl: `https://console.capgo.app/app/${APP_ID}/builds` }
 const CI_UPLOADED_GH = { provider: 'github', count: 3 }
 
 /**

--- a/cli/test/test-android-tail-render.mjs
+++ b/cli/test/test-android-tail-render.mjs
@@ -241,7 +241,7 @@ test('build-complete surfaces the upload summary, workflow path, build url and f
   assertContains(
     h(BuildCompleteStep, {
       uploadSummary: 'Uploaded 5 env vars to GitHub Actions',
-      buildUrl: 'https://capgo.app/app/com.example.app/builds',
+      buildUrl: 'https://console.capgo.app/app/com.example.app/builds',
       workflowWrittenPath: '/repo/.github/workflows/capgo-build.yml',
     }),
     [
@@ -251,7 +251,7 @@ test('build-complete surfaces the upload summary, workflow path, build url and f
       '/repo/.github/workflows/capgo-build.yml',
       'Dispatch it from GitHub Actions to kick off an Android build.',
       'Track your build:',
-      'https://capgo.app/app/com.example.app/builds',
+      'https://console.capgo.app/app/com.example.app/builds',
       'Press Enter to finish',
     ],
     'build-complete-full',

--- a/cli/test/test-android-tail-routing.mjs
+++ b/cli/test/test-android-tail-routing.mjs
@@ -81,7 +81,7 @@ const GITHUB_TARGET = { provider: 'github', label: 'GitHub Actions repository se
 const GITLAB_TARGET = { provider: 'gitlab', label: 'GitLab CI/CD variables', cli: 'glab' }
 
 const CREDS_SAVED = { savedAt: '2026-06-03T01:00:00.000Z' }
-const BUILD_REQUESTED = { buildUrl: `https://capgo.app/app/${APP_ID}/builds` }
+const BUILD_REQUESTED = { buildUrl: `https://console.capgo.app/app/${APP_ID}/builds` }
 const CI_UPLOADED_GH = { provider: 'github', count: 3 }
 
 // A FULLY-provisioned OAuth progress whose keystore + provisioning gates are all

--- a/cli/test/test-frame-fit-android-shared.mjs
+++ b/cli/test/test-frame-fit-android-shared.mjs
@@ -94,7 +94,7 @@ test(`build-complete [dense, bare] fits ${BODY_BUDGET_ROWS}-row budget`, () => {
 })
 test(`build-complete [dense, url only] fits ${BODY_BUDGET_ROWS}-row budget`, () => {
   assertFitsBudget(
-    h(BuildCompleteStep, { uploadSummary: null, buildUrl: 'https://capgo.app/app/com.example.app/builds', dense: true }),
+    h(BuildCompleteStep, { uploadSummary: null, buildUrl: 'https://console.capgo.app/app/com.example.app/builds', dense: true }),
     'build-complete-dense-url',
   )
 })
@@ -102,7 +102,7 @@ test(`build-complete [dense, summary + url] fits ${BODY_BUDGET_ROWS}-row budget`
   assertFitsBudget(
     h(BuildCompleteStep, {
       uploadSummary: 'Uploaded 5 env vars to GitHub Actions',
-      buildUrl: 'https://capgo.app/app/com.example.app/builds',
+      buildUrl: 'https://console.capgo.app/app/com.example.app/builds',
       dense: true,
     }),
     'build-complete-dense-summary-url',
@@ -112,7 +112,7 @@ test(`build-complete [dense, long summary] fits ${BODY_BUDGET_ROWS}-row budget`,
   assertFitsBudget(
     h(BuildCompleteStep, {
       uploadSummary: 'Uploaded 12 build environment variables to the GitHub Actions repository secrets store',
-      buildUrl: 'https://capgo.app/app/com.example.app/builds',
+      buildUrl: 'https://console.capgo.app/app/com.example.app/builds',
       dense: true,
     }),
     'build-complete-dense-long-summary',

--- a/cli/test/test-ios-tail-handoff.mjs
+++ b/cli/test/test-ios-tail-handoff.mjs
@@ -521,7 +521,7 @@ await test('runIosEffect throws for a NON-tail, not-yet-implemented effect step 
 // parity — existing files unaffected).
 
 const CREDS_SAVED = { savedAt: '2026-06-03T01:00:00.000Z' }
-const BUILD_REQUESTED = { buildUrl: `https://capgo.app/app/${APP_ID}/builds` }
+const BUILD_REQUESTED = { buildUrl: `https://console.capgo.app/app/${APP_ID}/builds` }
 const CI_UPLOADED_GH = { provider: 'github', count: 3 }
 
 /** A fully-provisioned create-new progress: cert + profile persisted, so without

--- a/cli/test/test-ios-tui-render.mjs
+++ b/cli/test/test-ios-tui-render.mjs
@@ -1002,7 +1002,7 @@ test('build-complete (bare) shows the all-set box, the credentials-ready line an
 test('build-complete surfaces the cloud-build line and the tracking url when a build was kicked off', () => {
   assertContains(
     h(BuildCompleteStep, {
-      buildUrl: 'https://capgo.app/app/com.example.app/builds',
+      buildUrl: 'https://console.capgo.app/app/com.example.app/builds',
       ciSecretUploadSummary: null,
       buildRequestCommand: 'npx @capgo/cli build request',
     }),
@@ -1010,7 +1010,7 @@ test('build-complete surfaces the cloud-build line and the tracking url when a b
       'You\'re all set!',
       'Your iOS app is building in the cloud.',
       'Track it at',
-      'https://capgo.app/app/com.example.app/builds',
+      'https://console.capgo.app/app/com.example.app/builds',
       'Press Enter to finish',
     ],
     'build-complete-build-url',

--- a/cli/test/test-tail-engine-shared.mjs
+++ b/cli/test/test-tail-engine-shared.mjs
@@ -330,7 +330,7 @@ await test('GAP1: requesting-build emits header + blank + queued lines via onBui
   assertEquals(res.next, 'build-complete', 'success with no entries finishes at build-complete')
   assert(buildLines[0] === `Requesting build for ${APP_ID} (android)...`, 'first build-viewer line is the header (replaces, not the side-log)')
   assert(buildLines.includes(''), 'a blank line precedes the queued line (parity with setBuildOutput([..., \'\', queued]))')
-  assert(buildLines.some(l => /^✔ Build queued — https:\/\/capgo\.app\/app\//.test(l)), 'queued line goes to the build viewer')
+  assert(buildLines.some(l => /^✔ Build queued — https:\/\/console\.capgo\.app\/app\//.test(l)), 'queued line goes to the build viewer')
 })
 
 await test('GAP1: requesting-build emits the no-key 2-line UX via onBuildOutput and finishes at build-complete', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Fix build onboarding success screen linking to `capgo.app/app/.../builds` instead of the console
- Add shared `consoleWebUrl()` helper in CLI utils and use it for builds, 2FA, and API key settings links
- Replace stale `web.capgo.app` references with `console.capgo.app`
- Update onboarding tests and the `cli-mcp-tests` e2e golden

## Motivation (AI generated)

After requesting a cloud build, the CLI showed a tracking URL on the marketing domain (`capgo.app`), which does not host the builds UI. Users need `console.capgo.app` for `/app/.../builds`, `/connect`, `/settings/account`, and `/dashboard/apikeys`.

## Business Impact (AI generated)

Fixes a confusing dead-end link in the iOS/Android build onboarding flow. Users can now click through directly to track their cloud build in the Capgo console.

## Test Plan (AI generated)

- [x] `bun run lint` in `cli/`
- [x] `bun run build` in `cli/`
- [x] Pre-commit typecheck passed
- [ ] Run `bun run cli:test` or targeted onboarding tail tests in CI

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CLI messages and onboarding steps to use consistent Capgo Console URLs for build tracking, “regain access,” and 2FA-related settings links.
  * Added shared URL helper and replaced hardcoded `capgo.app` / `web.capgo.app` links with the unified `console.capgo.app` domain (including API key expiration guidance).
* **Tests**
  * Updated onboarding fixtures and CLI test expectations to reflect the new console build URL host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->