### PR TITLE
fix(cli): normalize Windows path separators in SPM Package.swift for cloud builds

### DIFF
--- a/cli/src/build/platform-paths.ts
+++ b/cli/src/build/platform-paths.ts
@@ -53,3 +53,21 @@ export function getPlatformDirFromCapacitorConfig(capConfig: any, platform: 'ios
   }
   return platform
 }
+
+/**
+ * Normalize Windows path separators inside native dependency path literals.
+ * Capacitor CLI on Windows writes backslashes into SPM Package.swift, CocoaPods
+ * Podfiles, and Gradle settings — Swift treats `\` as escape sequences and SPM
+ * resolution fails on macOS builders.
+ */
+export function normalizeNativeDependencyPathsInText(content: string): string {
+  const normalizePathBody = (pathBody: string) => pathBody.replace(/\\/g, '/')
+
+  return content
+    .replace(/(path:\s*["'])((?:[^"'\\]|\\.)*)(["'])/g, (_match, open: string, pathBody: string, close: string) =>
+      `${open}${normalizePathBody(pathBody)}${close}`)
+    .replace(/(:path\s*=>\s*["'])((?:[^"'\\]|\\.)*)(["'])/g, (_match, open: string, pathBody: string, close: string) =>
+      `${open}${normalizePathBody(pathBody)}${close}`)
+    .replace(/(new\s+File\s*\(\s*["'])((?:[^"'\\]|\\.)*)(["']\s*\))/g, (_match, open: string, pathBody: string, close: string) =>
+      `${open}${normalizePathBody(pathBody)}${close}`)
+}

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -69,7 +69,7 @@ import { mergeCredentials, MIN_OUTPUT_RETENTION_SECONDS, parseInAppUpdatePriorit
 import { buildProvisioningMap } from './credentials-command'
 import { withCwd } from './cwd'
 import { writeBuildOutputRecord } from './output-record'
-import { getPlatformDirFromCapacitorConfig } from './platform-paths'
+import { getPlatformDirFromCapacitorConfig, normalizeNativeDependencyPathsInText } from './platform-paths'
 import { handleCustomMsg } from './qr.js'
 import { trackBuilderUpload } from './telemetry.js'
 
@@ -742,9 +742,9 @@ async function extractNativeDependencies(
       const spmContent = await readFileAsync(spmPackagePath, 'utf-8')
       // Match lines like: .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app")
       // The path can have varying numbers of ../ depending on project structure
-      const spmMatches = spmContent.matchAll(/\.package\s*\([^)]*path:\s*["'](?:\.\.\/)*node_modules\/([^"']+)["']\s*\)/g)
+      const spmMatches = spmContent.matchAll(/\.package\s*\([^)]*path:\s*["'](?:\.\.[\\/])*node_modules[\\/]([^"']+)["']\s*\)/g)
       for (const match of spmMatches) {
-        let pkgPath = match[1]
+        let pkgPath = match[1].replace(/\\/g, '/')
         const lastNmIdx = pkgPath.lastIndexOf('node_modules/')
         if (lastNmIdx !== -1)
           pkgPath = pkgPath.substring(lastNmIdx + 'node_modules/'.length)
@@ -773,7 +773,7 @@ async function extractNativeDependencies(
       for (const podfilePath of uniqPodfiles) {
         const podfileContent = await readFileAsync(podfilePath, 'utf-8')
         // Match lines like: pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
-        const podMatches = podfileContent.matchAll(/pod\s+['"][^'"]+['"],\s*:path\s*=>\s*['"](?:\.\.\/)+node_modules\/([^'"]+)['"]/g)
+        const podMatches = podfileContent.matchAll(/pod\s+['"][^'"]+['"],\s*:path\s*=>\s*['"](?:\.\.[\\/])+node_modules[\\/]([^'"]+)['"]/g)
         for (const match of podMatches) {
           let pkgPath = match[1]
           const lastNmIdx = pkgPath.lastIndexOf('node_modules/')
@@ -791,9 +791,9 @@ async function extractNativeDependencies(
       const settingsContent = await readFileAsync(settingsGradlePath, 'utf-8')
       // Match lines like: project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
       // Also matches pnpm paths: new File('../node_modules/.pnpm/@pkg@ver/node_modules/@scope/pkg/android')
-      const gradleMatches = settingsContent.matchAll(/new\s+File\s*\(\s*['"]\.\.\/node_modules\/([^'"]+)['"]\s*\)/g)
+      const gradleMatches = settingsContent.matchAll(/new\s+File\s*\(\s*['"]\.\.[\\/]node_modules[\\/]([^'"]+)['"]\s*\)/g)
       for (const match of gradleMatches) {
-        let fullPath = match[1]
+        let fullPath = match[1].replace(/\\/g, '/')
 
         // Normalize pnpm paths: .pnpm/@pkg+name@ver/node_modules/@scope/pkg/android → @scope/pkg
         const lastNodeModulesIdx = fullPath.lastIndexOf('node_modules/')
@@ -1130,7 +1130,8 @@ export async function zipDirectory(projectDir: string, outputPath: string, platf
     if (!textExtensions.has(ext) && basename !== 'Podfile')
       continue
     const original = entry.getData().toString('utf-8')
-    let rewritten = original.replace(pnpmPathPattern, 'node_modules/').replace(bunPathPattern, 'node_modules/')
+    let rewritten = normalizeNativeDependencyPathsInText(original)
+    rewritten = rewritten.replace(pnpmPathPattern, 'node_modules/').replace(bunPathPattern, 'node_modules/')
 
     // pnpm can leave deep relative paths in iOS files like Package.swift and Pods output.
     // Collapse any excessive ../ before project-root ios/ or node_modules/ paths back to

--- a/cli/test/test-build-zip-filter.mjs
+++ b/cli/test/test-build-zip-filter.mjs
@@ -306,6 +306,60 @@ await t('generated build zip rewrites bun isolated-store paths to flat node_modu
   }
 })
 
+await t('generated build zip normalizes Windows path separators in ios Package.swift', async () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
+  const zipPath = join(testRoot, 'build.zip')
+
+  try {
+    writeFile(
+      join(testRoot, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@capacitor/core': '^8.0.0',
+          '@capacitor/app': '^8.0.0',
+        },
+      }, null, 2),
+    )
+
+    writeFile(
+      join(testRoot, 'capacitor.config.json'),
+      JSON.stringify({
+        ios: { path: 'ios' },
+        appId: 'com.example.app',
+        appName: 'Example',
+      }, null, 2),
+    )
+
+    writeFile(
+      join(testRoot, 'ios/App/CapApp-SPM/Package.swift'),
+      'let package = Package(name: "CapApp-SPM", dependencies: [.package(name: "CapacitorApp", path: "..\\..\\..\\node_modules\\@capacitor\\app")])\n',
+    )
+
+    writeFile(join(testRoot, 'www', 'index.html'), '<!doctype html><html></html>')
+    writeFile(
+      join(testRoot, 'node_modules', '@capacitor', 'app', 'package.json'),
+      JSON.stringify({ name: '@capacitor/app', version: '8.0.0' }, null, 2),
+    )
+    writeFile(
+      join(testRoot, 'node_modules', '@capacitor', 'app', 'Package.swift'),
+      'let package = Package(name: "CapacitorApp")\n',
+    )
+
+    await zipDirectory(testRoot, zipPath, 'ios', {
+      ios: { path: 'ios' },
+    })
+
+    const zip = new AdmZip(zipPath)
+    assert.equal(
+      zip.readAsText('ios/App/CapApp-SPM/Package.swift'),
+      'let package = Package(name: "CapApp-SPM", dependencies: [.package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app")])\n',
+    )
+  }
+  finally {
+    rmSync(testRoot, { recursive: true, force: true })
+  }
+})
+
 await t('generated build zip rewrites bun isolated-store paths to flat node_modules (android settings.gradle)', async () => {
   const testRoot = mkdtempSync(join(tmpdir(), 'capgo-build-zip-filter-'))
   const zipPath = join(testRoot, 'build.zip')

--- a/cli/test/test-platform-paths.mjs
+++ b/cli/test/test-platform-paths.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { getPlatformDirFromCapacitorConfig, normalizeRelPath } from '../src/build/platform-paths.ts'
+import { getPlatformDirFromCapacitorConfig, normalizeNativeDependencyPathsInText, normalizeRelPath } from '../src/build/platform-paths.ts'
 
 function t(name, fn) {
   try {
@@ -46,5 +46,25 @@ t('getPlatformDirFromCapacitorConfig falls back on "."', () => {
     'android',
   )
 })
+
+
+t('normalizeNativeDependencyPathsInText fixes Windows separators in SPM paths', () => {
+  const input = 'let package = Package(dependencies: [.package(name: "CapacitorApp", path: "..\\..\\..\\node_modules\\@capacitor\\app")])'
+  const expected = 'let package = Package(dependencies: [.package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app")])'
+  assert.equal(normalizeNativeDependencyPathsInText(input), expected)
+})
+
+t('normalizeNativeDependencyPathsInText fixes Windows separators in CocoaPods and Gradle paths', () => {
+  const input = [
+    "pod 'CapacitorApp', :path => '..\\node_modules\\@capacitor\\app'",
+    "project(':capacitor-app').projectDir = new File('..\\node_modules\\@capacitor\\app\\android')",
+  ].join('\n')
+  const expected = [
+    "pod 'CapacitorApp', :path => '../node_modules/@capacitor/app'",
+    "project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')",
+  ].join('\n')
+  assert.equal(normalizeNativeDependencyPathsInText(input), expected)
+})
+
 
 process.stdout.write('OK\n')


### PR DESCRIPTION
## Summary (AI generated)

- Add `normalizeNativeDependencyPathsInText()` to rewrite Windows backslashes to forward slashes in SPM, CocoaPods, and Gradle local package path literals
- Apply normalization when packaging iOS/Android projects for cloud builds, before existing pnpm/bun path collapsing
- Update native dependency extraction regexes to recognize both `\` and `/` separators so Windows-synced projects include the right `node_modules` packages in the upload zip

## Motivation (AI generated)

Capacitor CLI on Windows writes backslashes into `ios/App/CapApp-SPM/Package.swift` local package paths. Swift treats `\` as an escape sequence, so `xcodebuild` fails SPM dependency resolution on macOS cloud builders with errors like `invalid escape sequence in literal`.

Users reported having to manually edit `Package.swift` after every `npx cap sync ios`, even on Capacitor CLI 8.4.1.

## Business Impact (AI generated)

- Unblocks iOS cloud builds for teams developing on Windows without manual file edits
- Reduces failed build jobs and support churn for SPM-based Capacitor projects
- Keeps the existing bun/pnpm path normalization pipeline working for Windows-generated paths too

## Test Plan (AI generated)

- [x] `bun test/test-platform-paths.mjs` — unit tests for SPM, Podfile, and Gradle path normalization
- [x] `bun test/test-build-zip-filter.mjs` — integration test verifying Windows `Package.swift` paths are rewritten in the build zip
- [x] `bun run lint` and `bun run build` in `cli/`

Generated with AI

Made with [Cursor](https://cursor.com)