### PR TITLE
fix(ci): fix visual-diff workflow YAML and knip entry

### DIFF
--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -8,11 +8,11 @@ on:
   pull_request:
     types:
       - opened
-      synchronize
-      reopened
-      labeled
-      unlabeled
-      edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - edited
 
 permissions:
   contents: read

--- a/knip.json
+++ b/knip.json
@@ -41,7 +41,8 @@
         "playwright/e2e/**/*.ts!",
         "playwright/support/**/*.ts!",
         "formkit.config.ts!",
-        "formkit.theme.ts!"
+        "formkit.theme.ts!",
+        "playwright/visual-diff.config.ts!"
       ],
       "project": [
         "src/**/*.{ts,vue}!",


### PR DESCRIPTION
## Summary (AI generated)

- Fix invalid YAML list syntax in `.github/workflows/visual-diff.yml` (`pull_request.types` entries were missing `-` prefixes)
- Register `playwright/visual-diff.config.ts` as a knip entry so dynamic imports are not flagged as unused exports

## Motivation (AI generated)

PR #2576 merged with a failing **Check dead code** job. Knip could not parse the workflow file and reported false unused exports after the visual-diff script switched to dynamic config loading.

## Business Impact (AI generated)

Restores green CI on main and allows the visual-diff workflow to run correctly on future PRs labeled `visual-change`.

## Test Plan (AI generated)

- [x] `bun run lint:deadcode` passes locally
- [x] CI run on `feat/visual-diff-pr-tool` at `e8861b52b` passed **Check dead code**

Generated with AI

Made with [Cursor](https://cursor.com)