### PR TITLE
fix(security): restrict group metadata access to members and admins

### DIFF
--- a/supabase/functions/_backend/private/groups.ts
+++ b/supabase/functions/_backend/private/groups.ts
@@ -36,7 +36,7 @@ app.get('/:org_id', sValidator('param', orgIdParamSchema, invalidOrgIdHook), asy
     return c.json({ error: 'Unauthorized' }, 401)
   }
 
-  if (!(await checkPermission(c, 'org.read_members', { orgId }))) {
+  if (!(await checkPermission(c, 'org.update_user_roles', { orgId }))) {
     return c.json({ error: 'Forbidden' }, 403)
   }
 
@@ -299,8 +299,22 @@ app.get('/:group_id/members', sValidator('param', groupIdParamSchema, invalidGro
       return c.json({ error: 'Group not found' }, 404)
     }
 
-    if (!(await checkPermission(c, 'org.read_members', { orgId: group.org_id }))) {
-      return c.json({ error: 'Forbidden' }, 403)
+    const canManageGroup = await checkPermission(c, 'org.update_user_roles', { orgId: group.org_id })
+    if (!canManageGroup) {
+      const [membership] = await drizzle
+        .select({ userId: schema.group_members.user_id })
+        .from(schema.group_members)
+        .where(
+          and(
+            eq(schema.group_members.group_id, groupId),
+            eq(schema.group_members.user_id, userId),
+          ),
+        )
+        .limit(1)
+
+      if (!membership) {
+        return c.json({ error: 'Forbidden' }, 403)
+      }
     }
 
     // Fetch members with details

--- a/supabase/functions/_backend/private/groups.ts
+++ b/supabase/functions/_backend/private/groups.ts
@@ -1,6 +1,7 @@
 import { sValidator } from '@hono/standard-validator'
+import { HTTPException } from 'hono/http-exception'
 import { and, eq } from 'drizzle-orm'
-import { createHono, middlewareAuth, useCors } from '../utils/hono.ts'
+import { createHono, middlewareAuth, quickError, useCors } from '../utils/hono.ts'
 import { cloudlogErr } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { schema } from '../utils/postgres_schema.ts'
@@ -313,7 +314,7 @@ app.get('/:group_id/members', sValidator('param', groupIdParamSchema, invalidGro
         .limit(1)
 
       if (!membership) {
-        return c.json({ error: 'Forbidden' }, 403)
+        throw quickError(403, 'forbidden', 'Forbidden')
       }
     }
 
@@ -332,6 +333,9 @@ app.get('/:group_id/members', sValidator('param', groupIdParamSchema, invalidGro
     return c.json(members)
   }
   catch (error) {
+    if (error instanceof HTTPException) {
+      throw error
+    }
     cloudlogErr({
       requestId: c.get('requestId'),
       message: 'group_members_fetch_failed',

--- a/supabase/migrations/20260626211025_fix_group_rls_member_only_access.sql
+++ b/supabase/migrations/20260626211025_fix_group_rls_member_only_access.sql
@@ -1,0 +1,71 @@
+-- Fix horizontal privilege escalation on groups and group_members.
+-- Org members who are not in a group must not read group metadata or membership lists.
+
+CREATE OR REPLACE FUNCTION public.is_current_user_group_member(p_group_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.group_members gm
+    WHERE gm.group_id = p_group_id
+      AND gm.user_id = (SELECT auth.uid())
+  );
+$$;
+
+ALTER FUNCTION public.is_current_user_group_member(uuid) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.is_current_user_group_member(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_current_user_group_member(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_current_user_group_member(uuid) TO service_role;
+
+COMMENT ON FUNCTION public.is_current_user_group_member(uuid) IS
+  'RLS helper: true when auth.uid() belongs to the given group. SECURITY DEFINER to avoid group_members policy recursion.';
+
+DROP POLICY IF EXISTS groups_select ON public.groups;
+
+CREATE POLICY groups_select ON public.groups
+FOR SELECT
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM (SELECT auth.uid() AS current_uid) AS actor_ref
+        WHERE (
+            public.is_current_user_group_member(groups.id)
+            OR public.check_min_rights(
+                public.rbac_right_admin()::public.user_min_right,
+                actor_ref.current_uid,
+                groups.org_id,
+                NULL::varchar,
+                NULL::bigint
+            )
+        )
+    )
+);
+
+DROP POLICY IF EXISTS group_members_select ON public.group_members;
+
+CREATE POLICY group_members_select ON public.group_members
+FOR SELECT
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM (SELECT auth.uid() AS current_uid) AS actor_ref
+        WHERE (
+            public.is_current_user_group_member(group_members.group_id)
+            OR EXISTS (
+                SELECT 1 FROM public.groups g
+                WHERE g.id = group_members.group_id
+                    AND public.check_min_rights(
+                        public.rbac_right_admin()::public.user_min_right,
+                        actor_ref.current_uid,
+                        g.org_id,
+                        NULL::varchar,
+                        NULL::bigint
+                    )
+            )
+        )
+    )
+);

--- a/supabase/tests/34_test_rbac_rls.sql
+++ b/supabase/tests/34_test_rbac_rls.sql
@@ -4,7 +4,7 @@ BEGIN;
 SELECT plan(8);
 
 -- Test admin user: 'test_admin' maps to c591b04e-cf29-4945-b9a0-776d0672061a (admin@capgo.app)
--- Test regular user: 'test_user' maps to 6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5 (test@capgo.app)
+-- Test regular org member: 'test_user2' maps to 6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5 (test2@capgo.app)
 -- Demo org: 046a36ac-e03c-4590-9257-bd6c9dba9ee8
 -- 1) Regular user can read roles
 SELECT tests.authenticate_as('test_user');
@@ -44,7 +44,7 @@ VALUES
     'Test group for RLS'
 );
 
-SELECT tests.authenticate_as('test_user');
+SELECT tests.authenticate_as('test_user2');
 
 SELECT
     ok(
@@ -56,7 +56,7 @@ SELECT
                 org_id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
                 AND name = 'Test Group RLS'
         ),
-    'Regular user cannot read org groups they do not belong to'
+    'Regular org member cannot read org groups they do not belong to'
     );
 
 -- 4) Regular user can read groups after joining
@@ -74,7 +74,7 @@ WHERE
 
 RESET ROLE;
 
-SELECT tests.authenticate_as('test_user');
+SELECT tests.authenticate_as('test_user2');
 
 SELECT
     ok(

--- a/supabase/tests/34_test_rbac_rls.sql
+++ b/supabase/tests/34_test_rbac_rls.sql
@@ -1,7 +1,7 @@
 -- Test RLS policies for RBAC tables
 BEGIN;
 
-SELECT plan(7);
+SELECT plan(8);
 
 -- Test admin user: 'test_admin' maps to c591b04e-cf29-4945-b9a0-776d0672061a (admin@capgo.app)
 -- Test regular user: 'test_user' maps to 6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5 (test@capgo.app)
@@ -32,8 +32,7 @@ SELECT
         'Regular user can read permissions'
     );
 
--- 3) Regular user can read their org's groups
--- First create a test group as admin
+-- 3) Regular user cannot read org groups they do not belong to
 SELECT tests.authenticate_as('test_admin');
 
 INSERT INTO
@@ -45,7 +44,36 @@ VALUES
     'Test group for RLS'
 );
 
--- Now check regular user can see it (they're member of Demo org)
+SELECT tests.authenticate_as('test_user');
+
+SELECT
+    ok(
+        NOT EXISTS (
+            SELECT 1
+            FROM
+                public.groups
+            WHERE
+                org_id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+                AND name = 'Test Group RLS'
+        ),
+    'Regular user cannot read org groups they do not belong to'
+    );
+
+-- 4) Regular user can read groups after joining
+SET LOCAL ROLE service_role;
+
+INSERT INTO public.group_members (group_id, user_id, added_by)
+SELECT
+    groups.id,
+    '6f0d1a2e-59ed-4769-b9d7-4d9615b28fe5',
+    'c591b04e-cf29-4945-b9a0-776d0672061a'
+FROM public.groups
+WHERE
+    org_id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    AND name = 'Test Group RLS';
+
+RESET ROLE;
+
 SELECT tests.authenticate_as('test_user');
 
 SELECT
@@ -58,10 +86,10 @@ SELECT
                 org_id = '046a36ac-e03c-4590-9257-bd6c9dba9ee8'
                 AND name = 'Test Group RLS'
         ),
-    'Regular user can read their org groups'
+    'Regular user can read groups they belong to'
     );
 
--- 4) Regular user cannot see groups from other orgs
+-- 5) Regular user cannot see groups from other orgs
 -- Create a group in Admin org
 SELECT tests.authenticate_as('test_admin');
 
@@ -89,7 +117,7 @@ SELECT
     'Regular user cannot see groups from other orgs'
     );
 
--- 5) Admin can see role_bindings for their org
+-- 6) Admin can see role_bindings for their org
 SELECT tests.authenticate_as('test_admin');
 
 -- Seed a deterministic binding outside RLS; this test is about SELECT visibility.
@@ -142,7 +170,7 @@ SELECT
     'Admin can see role bindings for their org'
     );
 
--- 6) User cannot see role_bindings from other orgs
+-- 7) User cannot see role_bindings from other orgs
 -- Note: We don't delete/recreate bindings because of super_admin protection trigger
 -- Instead, we verify test_user (different org) cannot see test_admin's bindings
 SELECT tests.authenticate_as('test_user');
@@ -160,7 +188,7 @@ SELECT
     'User cannot see role bindings from other orgs'
     );
 
--- 7) Test admin cannot create roles
+-- 8) Test admin cannot create roles
 SELECT tests.authenticate_as('test_admin');
 
 SELECT

--- a/tests/groups-rls.test.ts
+++ b/tests/groups-rls.test.ts
@@ -1,0 +1,196 @@
+import type { PoolClient } from 'pg'
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { POSTGRES_URL, USER_ID, USER_ID_2 } from './test-utils.ts'
+
+const fixtureId = randomUUID()
+const orgId = randomUUID()
+const groupName = `Group RLS Secret ${fixtureId}`
+
+let pool: Pool
+let groupId: string
+
+async function withAuthenticatedUser<T>(userId: string, fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    await client.query('SET LOCAL ROLE authenticated')
+    await client.query('SELECT set_config($1, $2, true)', ['request.jwt.claim.sub', userId])
+    await client.query('SELECT set_config($1, $2, true)', [
+      'request.jwt.claims',
+      JSON.stringify({ sub: userId, role: 'authenticated', aud: 'authenticated' }),
+    ])
+    const result = await fn(client)
+    await client.query('COMMIT')
+    return result
+  }
+  catch (error) {
+    try {
+      await client.query('ROLLBACK')
+    }
+    catch {
+      // Ignore rollback failures for clearer root error handling.
+    }
+    throw error
+  }
+  finally {
+    client.release()
+  }
+}
+
+beforeAll(async () => {
+  pool = new Pool({ connectionString: POSTGRES_URL })
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+
+    await client.query(`
+      INSERT INTO public.orgs (id, created_by, name, management_email, use_new_rbac)
+      VALUES ($1::uuid, $2::uuid, $3, $4, true)
+    `, [orgId, USER_ID, `Group RLS Org ${fixtureId}`, `group-rls-${fixtureId}@capgo.app`])
+
+    await client.query(`
+      INSERT INTO public.org_users (org_id, user_id, user_right)
+      VALUES ($1::uuid, $2::uuid, 'read'::public.user_min_right)
+    `, [orgId, USER_ID_2])
+
+    const groupResult = await client.query(`
+      INSERT INTO public.groups (org_id, name, description, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
+      RETURNING id
+    `, [orgId, groupName, 'Restricted group for RLS regression', USER_ID])
+    groupId = groupResult.rows[0].id
+
+    await client.query(`
+      INSERT INTO public.group_members (group_id, user_id, added_by)
+      VALUES ($1::uuid, $2::uuid, $2::uuid)
+    `, [groupId, USER_ID])
+
+    await client.query('COMMIT')
+  }
+  catch (error) {
+    await client.query('ROLLBACK')
+    throw error
+  }
+  finally {
+    client.release()
+  }
+})
+
+afterAll(async () => {
+  const client = await pool.connect()
+  try {
+    await client.query('DELETE FROM public.orgs WHERE id = $1::uuid', [orgId])
+  }
+  finally {
+    client.release()
+    await pool.end()
+  }
+})
+
+describe('groups RLS', () => {
+  it.concurrent('denies org members from listing groups they do not belong to', async () => {
+    const rows = await withAuthenticatedUser(USER_ID_2, async (client) => {
+      const result = await client.query(`
+        SELECT id, org_id, name, description, created_at
+        FROM public.groups
+        WHERE org_id = $1::uuid
+        ORDER BY name ASC
+      `, [orgId])
+      return result.rows
+    })
+
+    expect(rows).toEqual([])
+  })
+
+  it.concurrent('denies org members from reading group metadata by id', async () => {
+    const rows = await withAuthenticatedUser(USER_ID_2, async (client) => {
+      const result = await client.query(`
+        SELECT id, org_id, name, description, created_at
+        FROM public.groups
+        WHERE id = $1::uuid
+      `, [groupId])
+      return result.rows
+    })
+
+    expect(rows).toEqual([])
+  })
+
+  it.concurrent('denies org members from reading group membership lists', async () => {
+    const rows = await withAuthenticatedUser(USER_ID_2, async (client) => {
+      const result = await client.query(`
+        SELECT user_id
+        FROM public.group_members
+        WHERE group_id = $1::uuid
+      `, [groupId])
+      return result.rows
+    })
+
+    expect(rows).toEqual([])
+  })
+
+  it.concurrent('allows org admins to list groups in their org', async () => {
+    const rows = await withAuthenticatedUser(USER_ID, async (client) => {
+      const result = await client.query(`
+        SELECT id
+        FROM public.groups
+        WHERE org_id = $1::uuid
+      `, [orgId])
+      return result.rows
+    })
+
+    expect(rows.some(row => row.id === groupId)).toBe(true)
+  })
+
+  it.concurrent('allows org admins to read group membership lists', async () => {
+    const rows = await withAuthenticatedUser(USER_ID, async (client) => {
+      const result = await client.query(`
+        SELECT user_id
+        FROM public.group_members
+        WHERE group_id = $1::uuid
+      `, [groupId])
+      return result.rows
+    })
+
+    expect(rows.some(row => row.user_id === USER_ID)).toBe(true)
+  })
+
+  it.concurrent('allows group members to read their group metadata and members after joining', async () => {
+    const client = await pool.connect()
+    try {
+      await client.query(`
+        INSERT INTO public.group_members (group_id, user_id, added_by)
+        VALUES ($1::uuid, $2::uuid, $3::uuid)
+      `, [groupId, USER_ID_2, USER_ID])
+
+      const groupRows = await withAuthenticatedUser(USER_ID_2, async (queryClient) => {
+        const result = await queryClient.query(`
+          SELECT id
+          FROM public.groups
+          WHERE id = $1::uuid
+        `, [groupId])
+        return result.rows
+      })
+      expect(groupRows).toHaveLength(1)
+      expect(groupRows[0]?.id).toBe(groupId)
+
+      const memberRows = await withAuthenticatedUser(USER_ID_2, async (queryClient) => {
+        const result = await queryClient.query(`
+          SELECT user_id
+          FROM public.group_members
+          WHERE group_id = $1::uuid
+        `, [groupId])
+        return result.rows
+      })
+      expect(memberRows.some(row => row.user_id === USER_ID_2)).toBe(true)
+    }
+    finally {
+      await client.query(`
+        DELETE FROM public.group_members
+        WHERE group_id = $1::uuid AND user_id = $2::uuid
+      `, [groupId, USER_ID_2])
+      client.release()
+    }
+  })
+})

--- a/tests/groups-rls.test.ts
+++ b/tests/groups-rls.test.ts
@@ -174,11 +174,15 @@ describe('groups RLS', () => {
       expect(rows.some(row => row.user_id === USER_ID)).toBe(false)
     }
     finally {
-      await client.query(`
-        DELETE FROM public.group_members
-        WHERE group_id = $1::uuid AND user_id = $2::uuid
-      `, [adminOnlyGroupId, USER_ID_2])
-      client.release()
+      try {
+        await client.query(`
+          DELETE FROM public.group_members
+          WHERE group_id = $1::uuid AND user_id = $2::uuid
+        `, [adminOnlyGroupId, USER_ID_2])
+      }
+      finally {
+        client.release()
+      }
     }
   })
 
@@ -212,11 +216,15 @@ describe('groups RLS', () => {
       expect(memberRows.some(row => row.user_id === USER_ID_2)).toBe(true)
     }
     finally {
-      await client.query(`
-        DELETE FROM public.group_members
-        WHERE group_id = $1::uuid AND user_id = $2::uuid
-      `, [memberGroupId, USER_ID_2])
-      client.release()
+      try {
+        await client.query(`
+          DELETE FROM public.group_members
+          WHERE group_id = $1::uuid AND user_id = $2::uuid
+        `, [memberGroupId, USER_ID_2])
+      }
+      finally {
+        client.release()
+      }
     }
   })
 })

--- a/tests/groups-rls.test.ts
+++ b/tests/groups-rls.test.ts
@@ -90,7 +90,7 @@ afterAll(async () => {
 })
 
 describe('groups RLS', () => {
-  it.concurrent('denies org members from listing groups they do not belong to', async () => {
+  it('denies org members from listing groups they do not belong to', async () => {
     const rows = await withAuthenticatedUser(USER_ID_2, async (client) => {
       const result = await client.query(`
         SELECT id, org_id, name, description, created_at
@@ -104,7 +104,7 @@ describe('groups RLS', () => {
     expect(rows).toEqual([])
   })
 
-  it.concurrent('denies org members from reading group metadata by id', async () => {
+  it('denies org members from reading group metadata by id', async () => {
     const rows = await withAuthenticatedUser(USER_ID_2, async (client) => {
       const result = await client.query(`
         SELECT id, org_id, name, description, created_at
@@ -117,7 +117,7 @@ describe('groups RLS', () => {
     expect(rows).toEqual([])
   })
 
-  it.concurrent('denies org members from reading group membership lists', async () => {
+  it('denies org members from reading group membership lists', async () => {
     const rows = await withAuthenticatedUser(USER_ID_2, async (client) => {
       const result = await client.query(`
         SELECT user_id
@@ -130,7 +130,7 @@ describe('groups RLS', () => {
     expect(rows).toEqual([])
   })
 
-  it.concurrent('allows org admins to list groups in their org', async () => {
+  it('allows org admins to list groups in their org', async () => {
     const rows = await withAuthenticatedUser(USER_ID, async (client) => {
       const result = await client.query(`
         SELECT id
@@ -143,7 +143,7 @@ describe('groups RLS', () => {
     expect(rows.some(row => row.id === groupId)).toBe(true)
   })
 
-  it.concurrent('allows org admins to read group membership lists', async () => {
+  it('allows org admins to read group membership lists', async () => {
     const rows = await withAuthenticatedUser(USER_ID, async (client) => {
       const result = await client.query(`
         SELECT user_id
@@ -156,7 +156,7 @@ describe('groups RLS', () => {
     expect(rows.some(row => row.user_id === USER_ID)).toBe(true)
   })
 
-  it.concurrent('allows group members to read their group metadata and members after joining', async () => {
+  it('allows group members to read their group metadata and members after joining', async () => {
     const client = await pool.connect()
     try {
       await client.query(`

--- a/tests/groups-rls.test.ts
+++ b/tests/groups-rls.test.ts
@@ -6,10 +6,12 @@ import { POSTGRES_URL, USER_ID, USER_ID_2 } from './test-utils.ts'
 
 const fixtureId = randomUUID()
 const orgId = randomUUID()
-const groupName = `Group RLS Secret ${fixtureId}`
+const memberGroupName = `Group RLS Member ${fixtureId}`
+const adminGroupName = `Group RLS Admin ${fixtureId}`
 
 let pool: Pool
-let groupId: string
+let memberGroupId: string
+let adminOnlyGroupId: string
 
 async function withAuthenticatedUser<T>(userId: string, fn: (client: PoolClient) => Promise<T>): Promise<T> {
   const client = await pool.connect()
@@ -55,17 +57,24 @@ beforeAll(async () => {
       VALUES ($1::uuid, $2::uuid, 'read'::public.user_min_right)
     `, [orgId, USER_ID_2])
 
-    const groupResult = await client.query(`
+    const memberGroupResult = await client.query(`
       INSERT INTO public.groups (org_id, name, description, created_by)
       VALUES ($1::uuid, $2, $3, $4::uuid)
       RETURNING id
-    `, [orgId, groupName, 'Restricted group for RLS regression', USER_ID])
-    groupId = groupResult.rows[0].id
+    `, [orgId, memberGroupName, 'Member-only group for RLS regression', USER_ID])
+    memberGroupId = memberGroupResult.rows[0].id
 
     await client.query(`
       INSERT INTO public.group_members (group_id, user_id, added_by)
       VALUES ($1::uuid, $2::uuid, $2::uuid)
-    `, [groupId, USER_ID])
+    `, [memberGroupId, USER_ID])
+
+    const adminGroupResult = await client.query(`
+      INSERT INTO public.groups (org_id, name, description, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
+      RETURNING id
+    `, [orgId, adminGroupName, 'Admin visibility group with no admin membership', USER_ID])
+    adminOnlyGroupId = adminGroupResult.rows[0].id
 
     await client.query('COMMIT')
   }
@@ -110,7 +119,7 @@ describe('groups RLS', () => {
         SELECT id, org_id, name, description, created_at
         FROM public.groups
         WHERE id = $1::uuid
-      `, [groupId])
+      `, [memberGroupId])
       return result.rows
     })
 
@@ -123,37 +132,54 @@ describe('groups RLS', () => {
         SELECT user_id
         FROM public.group_members
         WHERE group_id = $1::uuid
-      `, [groupId])
+      `, [memberGroupId])
       return result.rows
     })
 
     expect(rows).toEqual([])
   })
 
-  it('allows org admins to list groups in their org', async () => {
+  it('allows org admins to list groups in their org without group membership', async () => {
     const rows = await withAuthenticatedUser(USER_ID, async (client) => {
       const result = await client.query(`
         SELECT id
         FROM public.groups
-        WHERE org_id = $1::uuid
-      `, [orgId])
+        WHERE id = $1::uuid
+      `, [adminOnlyGroupId])
       return result.rows
     })
 
-    expect(rows.some(row => row.id === groupId)).toBe(true)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toBe(adminOnlyGroupId)
   })
 
-  it('allows org admins to read group membership lists', async () => {
-    const rows = await withAuthenticatedUser(USER_ID, async (client) => {
-      const result = await client.query(`
-        SELECT user_id
-        FROM public.group_members
-        WHERE group_id = $1::uuid
-      `, [groupId])
-      return result.rows
-    })
+  it('allows org admins to read group membership lists without group membership', async () => {
+    const client = await pool.connect()
+    try {
+      await client.query(`
+        INSERT INTO public.group_members (group_id, user_id, added_by)
+        VALUES ($1::uuid, $2::uuid, $3::uuid)
+      `, [adminOnlyGroupId, USER_ID_2, USER_ID])
 
-    expect(rows.some(row => row.user_id === USER_ID)).toBe(true)
+      const rows = await withAuthenticatedUser(USER_ID, async (queryClient) => {
+        const result = await queryClient.query(`
+          SELECT user_id
+          FROM public.group_members
+          WHERE group_id = $1::uuid
+        `, [adminOnlyGroupId])
+        return result.rows
+      })
+
+      expect(rows.some(row => row.user_id === USER_ID_2)).toBe(true)
+      expect(rows.some(row => row.user_id === USER_ID)).toBe(false)
+    }
+    finally {
+      await client.query(`
+        DELETE FROM public.group_members
+        WHERE group_id = $1::uuid AND user_id = $2::uuid
+      `, [adminOnlyGroupId, USER_ID_2])
+      client.release()
+    }
   })
 
   it('allows group members to read their group metadata and members after joining', async () => {
@@ -162,25 +188,25 @@ describe('groups RLS', () => {
       await client.query(`
         INSERT INTO public.group_members (group_id, user_id, added_by)
         VALUES ($1::uuid, $2::uuid, $3::uuid)
-      `, [groupId, USER_ID_2, USER_ID])
+      `, [memberGroupId, USER_ID_2, USER_ID])
 
       const groupRows = await withAuthenticatedUser(USER_ID_2, async (queryClient) => {
         const result = await queryClient.query(`
           SELECT id
           FROM public.groups
           WHERE id = $1::uuid
-        `, [groupId])
+        `, [memberGroupId])
         return result.rows
       })
       expect(groupRows).toHaveLength(1)
-      expect(groupRows[0]?.id).toBe(groupId)
+      expect(groupRows[0]?.id).toBe(memberGroupId)
 
       const memberRows = await withAuthenticatedUser(USER_ID_2, async (queryClient) => {
         const result = await queryClient.query(`
           SELECT user_id
           FROM public.group_members
           WHERE group_id = $1::uuid
-        `, [groupId])
+        `, [memberGroupId])
         return result.rows
       })
       expect(memberRows.some(row => row.user_id === USER_ID_2)).toBe(true)
@@ -189,7 +215,7 @@ describe('groups RLS', () => {
       await client.query(`
         DELETE FROM public.group_members
         WHERE group_id = $1::uuid AND user_id = $2::uuid
-      `, [groupId, USER_ID_2])
+      `, [memberGroupId, USER_ID_2])
       client.release()
     }
   })

--- a/tests/private-groups-access.test.ts
+++ b/tests/private-groups-access.test.ts
@@ -84,6 +84,9 @@ describe.skipIf(USE_CLOUDFLARE)('/private/groups access', () => {
     })
 
     expect(response.status).toBe(403)
+    const body = await response.json() as { error: string, message: string }
+    expect(body.error).toBe('forbidden')
+    expect(body.message).toBe('Forbidden')
   })
 
   it('allows org admins to read group members', async () => {
@@ -93,6 +96,7 @@ describe.skipIf(USE_CLOUDFLARE)('/private/groups access', () => {
 
     expect(response.status).toBe(200)
     const data = await response.json() as Array<{ user_id: string }>
-    expect(data.some(row => row.user_id === USER_ID)).toBe(true)
+    expect(data.every(row => row.user_id === USER_ID)).toBe(true)
+    expect(data).toHaveLength(1)
   })
 })

--- a/tests/private-groups-access.test.ts
+++ b/tests/private-groups-access.test.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto'
+import { env } from 'node:process'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  getAuthHeaders,
+  getAuthHeadersForCredentials,
+  getEndpointUrl,
+  getSupabaseClient,
+  USER_ID,
+  USER_ID_2,
+  USER_PASSWORD,
+} from './test-utils.ts'
+
+const USE_CLOUDFLARE = env.USE_CLOUDFLARE_WORKERS === 'true'
+const fixtureId = randomUUID()
+const orgId = randomUUID()
+
+let adminAuthHeaders: Record<string, string>
+let memberAuthHeaders: Record<string, string>
+let groupId: string
+
+beforeAll(async () => {
+  if (USE_CLOUDFLARE)
+    return
+
+  adminAuthHeaders = await getAuthHeaders()
+  memberAuthHeaders = await getAuthHeadersForCredentials('test2@capgo.app', USER_PASSWORD)
+
+  const supabase = getSupabaseClient()
+
+  const { error: orgError } = await supabase.from('orgs').insert({
+    id: orgId,
+    created_by: USER_ID,
+    name: `Private Groups Access Org ${fixtureId}`,
+    management_email: `private-groups-${fixtureId}@capgo.app`,
+    use_new_rbac: true,
+  })
+  if (orgError)
+    throw orgError
+
+  const { error: orgUsersError } = await supabase.from('org_users').insert({
+    org_id: orgId,
+    user_id: USER_ID_2,
+    user_right: 'read',
+  })
+  if (orgUsersError)
+    throw orgUsersError
+
+  const { data: group, error: groupError } = await supabase
+    .from('groups')
+    .insert({
+      org_id: orgId,
+      name: `Private Groups Access ${fixtureId}`,
+      description: 'Private API authorization regression',
+      created_by: USER_ID,
+    })
+    .select('id')
+    .single()
+  if (groupError)
+    throw groupError
+
+  groupId = group.id
+
+  const { error: groupMemberError } = await supabase.from('group_members').insert({
+    group_id: groupId,
+    user_id: USER_ID,
+    added_by: USER_ID,
+  })
+  if (groupMemberError)
+    throw groupMemberError
+})
+
+afterAll(async () => {
+  if (USE_CLOUDFLARE)
+    return
+
+  await getSupabaseClient().from('orgs').delete().eq('id', orgId)
+})
+
+describe.skipIf(USE_CLOUDFLARE)('/private/groups access', () => {
+  it('denies org members from reading group members', async () => {
+    const response = await fetch(getEndpointUrl(`/private/groups/${groupId}/members`), {
+      headers: memberAuthHeaders,
+    })
+
+    expect(response.status).toBe(403)
+  })
+
+  it('allows org admins to read group members', async () => {
+    const response = await fetch(getEndpointUrl(`/private/groups/${groupId}/members`), {
+      headers: adminAuthHeaders,
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json() as Array<{ user_id: string }>
+    expect(data.some(row => row.user_id === USER_ID)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Tightened `groups` and `group_members` SELECT RLS so org members can only read groups they belong to, while org admins retain full visibility.
- Added `is_current_user_group_member()` SECURITY DEFINER helper to avoid `group_members` policy recursion.
- Aligned `/private/groups` list and members endpoints with the same access model.
- Added regression coverage in `tests/groups-rls.test.ts` and `tests/private-groups-access.test.ts`.
- Updated pgTAP expectations in `supabase/tests/34_test_rbac_rls.sql`.

## Motivation (AI generated)

Penetration testing found horizontal privilege escalation: any authenticated org member could query PostgREST `groups` and `group_members` for groups they were not part of, exposing group metadata and membership lists.

## Business Impact (AI generated)

Closes an information disclosure path that could enable organizational reconnaissance and user enumeration. Org admins keep the ability to manage groups; regular members only see groups they belong to.

## Test Plan (AI generated)

- [x] `bun run supabase:with-env -- bunx vitest run tests/groups-rls.test.ts`
- [x] `bun run supabase:with-env -- bunx vitest run tests/private-groups-access.test.ts`
- [ ] Verify org admin can still manage groups in Organization Settings
- [ ] Verify non-member org user receives empty results for `/rest/v1/groups` and `/rest/v1/group_members`
- [ ] Verify group member can read their own group after being added

## Checklist (AI generated)

- [x] Security fix scoped to group access control
- [x] Postgres migration added via Supabase CLI
- [x] Regression tests added for RLS and private API paths
- [x] pgTAP expectations updated
- [ ] Deploy migration to production after merge

Generated with AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive authorization and RLS changes; incorrect deployment could break org admin group management or leave disclosure paths open.
> 
> **Overview**
> Fixes **horizontal privilege escalation** where any org member could read `groups` / `group_members` via PostgREST and the private API without belonging to those groups.
> 
> **Database:** Replaces `groups_select` and `group_members_select` so SELECT is allowed only if the caller is in the group (`is_current_user_group_member`, SECURITY DEFINER to avoid policy recursion) or has org **admin** rights via `check_min_rights`. Org admins keep full visibility without group membership.
> 
> **Private API (`groups.ts`):** Org group listing now requires `org.update_user_roles` instead of `org.read_members`. The group members endpoint uses the same admin gate, with a **group-membership** fallback so members can read their own group’s roster; forbidden cases return structured **403** via `quickError`, and `HTTPException` is rethrown instead of becoming 500.
> 
> **Tests:** pgTAP expectations updated for member-only vs admin access; new Vitest suites cover Postgres RLS and `/private/groups/.../members` authorization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e921acd9cb86662551cc51a93dc07508943203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authorization for private group listings and group member views so access is correctly limited to group members and/or org admins.
  * Improved error handling so missing authentication returns `401`, and insufficient permissions consistently return `403` (without being masked as server errors).

* **Tests**
  * Added regression coverage for private group member-list access behavior.
  * Expanded RLS/RBAC test assertions to verify member-only vs admin-only visibility and membership-based access paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->