### PR TITLE
[codex] Add security response headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -6,6 +6,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.bunny.net; connect-src 'self' https: wss:; media-src 'self' data: blob: https:; frame-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests
 /api/*
   cache-control: public, s-max-age=60
 /.well-known/*

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -239,7 +239,7 @@ export function createHono(functionName: string, _version: string) {
     // ADD HEADER TO IDENTIFY WORKER SOURCE
     const name = `${getEnv(c, 'ENV_NAME') || functionName}-${CapgoVersion}`
     c.header('X-Worker-Source', name)
-    const hostname = c.req.header('host') || new URL(c.req.url).hostname
+    const hostname = new URL(c.req.url).hostname
     if (!isPreviewHost(hostname))
       c.header('Content-Security-Policy', API_CONTENT_SECURITY_POLICY)
     return next()

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -101,8 +101,108 @@ export interface MiddlewareKeyVariables {
   }
 }
 
+const CAPGO_CONSOLE_SUBDOMAIN = 'console'
+
+const DEFAULT_CORS_ALLOWED_ORIGINS = new Set([
+  ...['capgo.app', 'preprod.capgo.app', 'development.capgo.app'].map(domain => `https://${CAPGO_CONSOLE_SUBDOMAIN}.${domain}`),
+  'https://capgo.app',
+  'https://www.capgo.app',
+  'https://web.capgo.app',
+])
+
+function normalizeHttpOrigin(origin: string) {
+  try {
+    const parsed = new URL(origin)
+    if (!['http:', 'https:'].includes(parsed.protocol))
+      return ''
+    return parsed.origin
+  }
+  catch {
+    return ''
+  }
+}
+
+function normalizeCustomOrigin(origin: string) {
+  try {
+    const parsed = new URL(origin)
+    if (['http:', 'https:'].includes(parsed.protocol))
+      return ''
+    if (!parsed.hostname)
+      return ''
+    return `${parsed.protocol}//${parsed.host}`
+  }
+  catch {
+    return ''
+  }
+}
+
+function normalizeNativeOrigin(origin: string) {
+  try {
+    const parsed = new URL(origin)
+    if (!['capacitor:', 'ionic:', 'localhost:'].includes(parsed.protocol))
+      return ''
+    if (parsed.hostname !== 'localhost')
+      return ''
+    return normalizeCustomOrigin(origin)
+  }
+  catch {
+    return ''
+  }
+}
+
+function normalizeConfiguredCorsOrigin(origin: string) {
+  return normalizeHttpOrigin(origin) || normalizeCustomOrigin(origin)
+}
+
+function isLocalHttpOrigin(origin: string) {
+  try {
+    const parsed = new URL(origin)
+    if (!['http:', 'https:'].includes(parsed.protocol))
+      return false
+    return ['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname)
+  }
+  catch {
+    return false
+  }
+}
+
+function getConfiguredCorsAllowedOrigins(c: Context) {
+  return [
+    getEnv(c, 'WEBAPP_URL'),
+    ...getEnv(c, 'CORS_ALLOWED_ORIGINS').split(','),
+  ]
+    .map(origin => normalizeConfiguredCorsOrigin(origin.trim()))
+    .filter(Boolean)
+}
+
+export function getAllowedCorsOrigin(origin: string, c: Context) {
+  const nativeOrigin = normalizeNativeOrigin(origin)
+  if (nativeOrigin)
+    return nativeOrigin
+
+  const httpOrigin = normalizeHttpOrigin(origin)
+  const configuredOrigins = getConfiguredCorsAllowedOrigins(c)
+
+  if (httpOrigin) {
+    if (isLocalHttpOrigin(origin))
+      return httpOrigin
+
+    if (DEFAULT_CORS_ALLOWED_ORIGINS.has(httpOrigin))
+      return httpOrigin
+
+    if (configuredOrigins.includes(httpOrigin))
+      return httpOrigin
+  }
+
+  const customOrigin = normalizeCustomOrigin(origin)
+  if (customOrigin && configuredOrigins.includes(customOrigin))
+    return customOrigin
+
+  return null
+}
+
 export const useCors = cors({
-  origin: '*',
+  origin: getAllowedCorsOrigin,
   allowHeaders: ['Content-Type', 'Authorization', 'X-Capgo-Spoof-Admin-Authorization', 'capgkey', 'capgo_api', 'x-api-key', 'x-limited-key-id', 'apisecret', 'apikey', 'x-client-info'],
   allowMethods: ['POST', 'GET', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 })

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -210,6 +210,22 @@ export const middlewareAPISecret = honoFactory.createMiddleware(async (c, next) 
 })
 
 export const BRES = { status: 'ok' }
+export const API_CONTENT_SECURITY_POLICY = [
+  'default-src \'none\'',
+  'base-uri \'none\'',
+  'form-action \'none\'',
+  'frame-ancestors \'none\'',
+  'object-src \'none\'',
+  'script-src \'none\'',
+  'style-src \'none\'',
+  'img-src \'none\'',
+  'connect-src \'none\'',
+  'upgrade-insecure-requests',
+].join('; ')
+
+function isPreviewHost(hostname: string) {
+  return /^[^.]+\.preview(?:\.[^.]+)?\.(?:capgo\.app|usecapgo\.com)$/i.test(hostname)
+}
 
 export function createHono(functionName: string, _version: string) {
   let appGlobal
@@ -223,6 +239,9 @@ export function createHono(functionName: string, _version: string) {
     // ADD HEADER TO IDENTIFY WORKER SOURCE
     const name = `${getEnv(c, 'ENV_NAME') || functionName}-${CapgoVersion}`
     c.header('X-Worker-Source', name)
+    const hostname = c.req.header('host') || new URL(c.req.url).hostname
+    if (!isPreviewHost(hostname))
+      c.header('Content-Security-Policy', API_CONTENT_SECURITY_POLICY)
     return next()
   })
 

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -106,8 +106,6 @@ const CAPGO_CONSOLE_SUBDOMAIN = 'console'
 const DEFAULT_CORS_ALLOWED_ORIGINS = new Set([
   ...['capgo.app', 'preprod.capgo.app', 'development.capgo.app'].map(domain => `https://${CAPGO_CONSOLE_SUBDOMAIN}.${domain}`),
   'https://capgo.app',
-  'https://www.capgo.app',
-  'https://web.capgo.app',
 ])
 
 function normalizeHttpOrigin(origin: string) {

--- a/tests/plugin-cors.unit.test.ts
+++ b/tests/plugin-cors.unit.test.ts
@@ -13,7 +13,7 @@ describe('cloudflare plugin CORS', () => {
     }))
 
     expect(response.status).toBe(204)
-    expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://web.capgo.app')
     const allowMethods = response.headers.get('access-control-allow-methods')?.toLowerCase()
     const allowHeaders = response.headers.get('access-control-allow-headers')?.toLowerCase()
     expect(allowMethods).toContain('options')

--- a/tests/plugin-cors.unit.test.ts
+++ b/tests/plugin-cors.unit.test.ts
@@ -6,14 +6,14 @@ describe('cloudflare plugin CORS', () => {
     const response = await pluginWorker.fetch(new Request('https://api.capgo.app/updates/manifest_size', {
       method: 'OPTIONS',
       headers: {
-        'origin': 'https://web.capgo.app',
+        'origin': 'https://console.capgo.app',
         'access-control-request-method': 'POST',
         'access-control-request-headers': 'content-type,authorization',
       },
     }))
 
     expect(response.status).toBe(204)
-    expect(response.headers.get('access-control-allow-origin')).toBe('https://web.capgo.app')
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://console.capgo.app')
     const allowMethods = response.headers.get('access-control-allow-methods')?.toLowerCase()
     const allowHeaders = response.headers.get('access-control-allow-headers')?.toLowerCase()
     expect(allowMethods).toContain('options')

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -33,11 +33,14 @@ describe('security response headers', () => {
     expect(response.headers.get('content-security-policy')).toBe(API_CONTENT_SECURITY_POLICY)
   })
 
-  it.concurrent('does not apply the API CSP to preview subdomains', async () => {
+  it.concurrent.each([
+    'https://123-com-example-app.preview.preprod.capgo.app/',
+    'https://123-com-example-app.preview.preprod.capgo.app:8443/',
+  ])('does not apply the API CSP to preview subdomain %s', async (url) => {
     const app = createHono('files', 'test')
     app.get('/', c => c.html('<!DOCTYPE html><html><body>preview</body></html>'))
 
-    const response = await app.fetch(new Request('https://123-com-example-app.preview.preprod.capgo.app/'))
+    const response = await app.fetch(new Request(url))
 
     expect(response.status).toBe(200)
     expect(response.headers.get('content-security-policy')).toBeNull()

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import apiWorker from '../cloudflare_workers/api/index.ts'
 import pluginWorker from '../cloudflare_workers/plugin/index.ts'
-import { API_CONTENT_SECURITY_POLICY, createAllCatch, createHono } from '../supabase/functions/_backend/utils/hono.ts'
+import { API_CONTENT_SECURITY_POLICY, createAllCatch, createHono, getAllowedCorsOrigin, useCors } from '../supabase/functions/_backend/utils/hono.ts'
 
 const consoleHeaders = readFileSync(new URL('../public/_headers', import.meta.url), 'utf8')
 
@@ -44,5 +44,77 @@ describe('security response headers', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('content-security-policy')).toBeNull()
+  })
+
+  it.concurrent.each([
+    'https://console.capgo.app',
+    'https://console.preprod.capgo.app',
+    'capacitor://localhost',
+    'ionic://localhost',
+    'localhost://localhost',
+    'https://localhost',
+    'http://localhost:5173',
+  ])('allows trusted CORS origin %s without using wildcard', async (origin) => {
+    const app = createHono('api', 'test')
+    app.use('/cors-test', useCors)
+    app.get('/cors-test', c => c.json({ status: 'ok' }))
+
+    const response = await app.fetch(new Request('https://api.preprod.capgo.app/cors-test', {
+      headers: { origin },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('access-control-allow-origin')).toBe(origin)
+  })
+
+  it('allows the runtime WEBAPP_URL CORS origin', () => {
+    vi.stubEnv('WEBAPP_URL', 'https://console.selfhost.example')
+    try {
+      expect(getAllowedCorsOrigin('https://console.selfhost.example', {} as Parameters<typeof getAllowedCorsOrigin>[1])).toBe('https://console.selfhost.example')
+    }
+    finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('allows runtime CORS_ALLOWED_ORIGINS custom native origins', () => {
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', 'myapp://localhost')
+    try {
+      expect(getAllowedCorsOrigin('myapp://localhost', {} as Parameters<typeof getAllowedCorsOrigin>[1])).toBe('myapp://localhost')
+    }
+    finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it.concurrent('does not emit wildcard CORS for untrusted origins', async () => {
+    const app = createHono('api', 'test')
+    app.use('/cors-test', useCors)
+    app.get('/cors-test', c => c.json({ status: 'ok' }))
+
+    const response = await app.fetch(new Request('https://api.preprod.capgo.app/cors-test', {
+      headers: { origin: 'https://evil.example' },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it.concurrent('does not emit wildcard CORS on rejected preflight requests', async () => {
+    const app = createHono('api', 'test')
+    app.use('/cors-test', useCors)
+    app.get('/cors-test', c => c.json({ status: 'ok' }))
+
+    const response = await app.fetch(new Request('https://api.preprod.capgo.app/cors-test', {
+      method: 'OPTIONS',
+      headers: {
+        'origin': 'https://evil.example',
+        'access-control-request-method': 'GET',
+      },
+    }))
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
+    expect(response.headers.get('access-control-allow-methods')).toContain('GET')
   })
 })

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import apiWorker from '../cloudflare_workers/api/index.ts'
+import pluginWorker from '../cloudflare_workers/plugin/index.ts'
+import { API_CONTENT_SECURITY_POLICY, createAllCatch, createHono } from '../supabase/functions/_backend/utils/hono.ts'
+
+const consoleHeaders = readFileSync(new URL('../public/_headers', import.meta.url), 'utf8')
+
+describe('security response headers', () => {
+  it.concurrent('declares a CSP for the console app static responses', () => {
+    expect(consoleHeaders).toContain('Content-Security-Policy: default-src \'self\'')
+    expect(consoleHeaders).toContain('script-src \'self\' \'unsafe-inline\'')
+    expect(consoleHeaders).toContain('style-src \'self\' \'unsafe-inline\' https://fonts.bunny.net')
+    expect(consoleHeaders).toContain('frame-ancestors \'none\'')
+  })
+
+  it.concurrent.each([
+    ['api', apiWorker, 'https://api.preprod.capgo.app/ok', 200],
+    ['plugin', pluginWorker, 'https://plugin.preprod.capgo.app/ok', 200],
+  ] as const)('sets the API CSP on %s worker responses', async (_name, worker, url, status) => {
+    const response = await worker.fetch(new Request(url))
+
+    expect(response.status).toBe(status)
+    expect(response.headers.get('content-security-policy')).toBe(API_CONTENT_SECURITY_POLICY)
+  })
+
+  it.concurrent('sets the API CSP on files worker fallback responses', async () => {
+    const app = createHono('files', 'test')
+    createAllCatch(app, 'files')
+    const response = await app.fetch(new Request('https://files.preprod.capgo.app/'))
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('content-security-policy')).toBe(API_CONTENT_SECURITY_POLICY)
+  })
+
+  it.concurrent('does not apply the API CSP to preview subdomains', async () => {
+    const app = createHono('files', 'test')
+    app.get('/', c => c.html('<!DOCTYPE html><html><body>preview</body></html>'))
+
+    const response = await app.fetch(new Request('https://123-com-example-app.preview.preprod.capgo.app/'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-security-policy')).toBeNull()
+  })
+})

--- a/tests/stats-export-cors.test.ts
+++ b/tests/stats-export-cors.test.ts
@@ -14,7 +14,7 @@ describe('[OPTIONS] /private/stats/export', () => {
     })
 
     expect(res.status).toBe(204)
-    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+    expect(res.headers.get('access-control-allow-origin')).toBe('http://localhost:5173')
     expect(res.headers.get('access-control-allow-methods')).toContain('OPTIONS')
     expect(res.headers.get('access-control-allow-headers')?.toLowerCase()).toContain('authorization')
   })


### PR DESCRIPTION
## Summary (AI generated)

- Add a Content-Security-Policy header to the console static `_headers` config.
- Add a strict `default-src 'none'` CSP to shared API/plugin/files worker responses.
- Skip the strict worker CSP for preview subdomains so customer bundle previews are not broken.
- Replace shared API CORS wildcard responses with an explicit origin allowlist.
- Keep Capacitor/native compatibility for `capacitor://localhost`, `ionic://localhost`, `localhost://localhost`, and local `http(s)://localhost` origins.
- Add `WEBAPP_URL` and `CORS_ALLOWED_ORIGINS` runtime support for self-hosted/custom trusted origins, including explicit custom native schemes.

## Motivation (AI generated)

Security scanning reported missing CSP headers on `console.preprod.capgo.app`, `api.preprod.capgo.app`, `plugin.preprod.capgo.app`, and `files.preprod.capgo.app`, and wildcard CORS on `api.preprod.capgo.app`. The CSP issue came from missing response policies on the static console and shared worker middleware. The CORS issue came from the shared Hono `useCors` middleware returning `Access-Control-Allow-Origin: *`.

## Business Impact (AI generated)

This closes the reported defense-in-depth gaps without changing API payloads or authentication. The CSP preview-host exclusion avoids breaking customer bundle previews. The CORS allowlist removes wildcard browser access while preserving the native/mobile app origins needed by Capacitor WebViews and local development.

## Test Plan (AI generated)

- [x] Reproduced the reported CORS wildcard on preprod before the code change with `curl -sS -D - -o /dev/null -H 'Origin: https://evil.example' https://api.preprod.capgo.app/private/plans`
- [x] Reproduced the reported CORS wildcard preflight on preprod before the code change with `curl -sS -D - -o /dev/null -X OPTIONS -H 'Origin: https://evil.example' -H 'Access-Control-Request-Method: GET' https://api.preprod.capgo.app/private/plans`
- [x] `curl -sS -D - -o /dev/null https://console.preprod.capgo.app/`
- [x] `curl -sS -D - -o /dev/null https://api.preprod.capgo.app/ok`
- [x] `curl -sS -D - -o /dev/null https://plugin.preprod.capgo.app/ok`
- [x] `curl -sS -D - -o /dev/null https://files.preprod.capgo.app/`
- [x] `bunx vitest run tests/security-headers.unit.test.ts tests/plugin-cors.unit.test.ts tests/stats-export-cors.test.ts`
- [x] `bunx eslint tests/security-headers.unit.test.ts tests/plugin-cors.unit.test.ts tests/stats-export-cors.test.ts supabase/functions/_backend/utils/hono.ts`
- [x] `bun lint:backend`
- [x] `bun run typecheck:backend`
- [x] `bun typecheck`
- [x] `bun lint` (passes with existing unrelated warnings)

Generated with AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CORS allowlist changes can break browser clients if a legitimate origin was omitted; preview CSP exclusion is intentional but narrows protection on those hosts only.
> 
> **Overview**
> Adds **Content-Security-Policy** on the console static site via `public/_headers`, and applies a strict **`default-src 'none'`** CSP on shared API/plugin/files worker responses through `createHono`, with **no CSP on preview subdomains** so customer bundle previews keep working.
> 
> Replaces shared Hono **`useCors`** **`origin: '*'`** with **`getAllowedCorsOrigin`**: Capgo console hosts, local dev, Capacitor/Ionic/native schemes, plus **`WEBAPP_URL`** and **`CORS_ALLOWED_ORIGINS`**. Untrusted origins get no `Access-Control-Allow-Origin` header.
> 
> Tests cover static CSP, worker CSP (including preview exclusion), trusted vs rejected CORS, and updated plugin/stats export expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41bc8c4cceb51a5b0762f368fad91504aeb2ca84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->