### PR TITLE
feat(billing): track checkout starts

### DIFF
--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -183,6 +183,31 @@ async function prefetchStripeCheckoutUrl(plan: Database['public']['Tables']['pla
   }
 }
 
+function trackPlanCheckoutStarted(plan: Database['public']['Tables']['plans']['Row'], isYear: boolean, checkoutSource: string) {
+  const orgId = currentOrganization.value?.gid
+  if (!orgId || !plan.stripe_id)
+    return
+
+  sendEvent({
+    channel: 'usage',
+    event: 'Checkout Started',
+    icon: '💳',
+    org_id: orgId,
+    tracking_version: 2,
+    notify: false,
+    tags: {
+      product_id: plan.stripe_id,
+      plan_name: plan.name,
+      recurrence: isYear ? 'year' : 'month',
+      checkout_source: checkoutSource,
+      current_plan_name: currentPlan.value?.name ?? '',
+      plan_price: isYear ? plan.price_y : plan.price_m,
+      plan_price_monthly: plan.price_m,
+      plan_price_yearly: plan.price_y,
+    },
+  }).catch()
+}
+
 async function openSafariStripeCheckout(plan: Database['public']['Tables']['plans']['Row'], isYear: boolean) {
   const url = await prefetchStripeCheckoutUrl(plan, isYear)
   if (!url) {
@@ -205,6 +230,7 @@ async function openSafariStripeCheckout(plan: Database['public']['Tables']['plan
         href: url,
         target: '_blank',
         rel: 'noopener noreferrer',
+        handler: () => trackPlanCheckoutStarted(plan, isYear, 'safari_confirm'),
       },
     ],
   })
@@ -224,15 +250,18 @@ async function openChangePlan(plan: Database['public']['Tables']['plans']['Row']
   // get the current url
   isSubscribeLoading.value[index] = true
   if (plan.stripe_id) {
+    const checkoutIsYearly = plan.price_y !== plan.price_m ? isYearly.value : false
     if (isSafariBrowser()) {
-      const shouldContinue = await openSafariStripeCheckout(plan, plan.price_y !== plan.price_m ? isYearly.value : false)
+      const shouldContinue = await openSafariStripeCheckout(plan, checkoutIsYearly)
       if (!shouldContinue) {
         isSubscribeLoading.value[index] = false
         return
       }
     }
     else {
-      await openCheckout(plan.stripe_id, `${window.location.href}?success=1`, `${window.location.href}?cancel=1`, plan.price_y !== plan.price_m ? isYearly.value : false, currentOrganization?.value?.gid ?? '')
+      const didOpenCheckout = await openCheckout(plan.stripe_id, `${window.location.href}?success=1`, `${window.location.href}?cancel=1`, checkoutIsYearly, currentOrganization?.value?.gid ?? '')
+      if (didOpenCheckout)
+        trackPlanCheckoutStarted(plan, checkoutIsYearly, 'direct')
     }
   }
   isSubscribeLoading.value[index] = false

--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -250,7 +250,7 @@ async function openChangePlan(plan: Database['public']['Tables']['plans']['Row']
   // get the current url
   isSubscribeLoading.value[index] = true
   if (plan.stripe_id) {
-    const checkoutIsYearly = plan.price_y !== plan.price_m ? isYearly.value : false
+    const checkoutIsYearly = plan.price_y === plan.price_m ? false : isYearly.value
     if (isSafariBrowser()) {
       const shouldContinue = await openSafariStripeCheckout(plan, checkoutIsYearly)
       if (!shouldContinue) {
@@ -259,7 +259,7 @@ async function openChangePlan(plan: Database['public']['Tables']['plans']['Row']
       }
     }
     else {
-      const didOpenCheckout = await openCheckout(plan.stripe_id, `${window.location.href}?success=1`, `${window.location.href}?cancel=1`, checkoutIsYearly, currentOrganization?.value?.gid ?? '')
+      const didOpenCheckout = await openCheckout(plan.stripe_id, `${globalThis.location.href}?success=1`, `${globalThis.location.href}?cancel=1`, checkoutIsYearly, currentOrganization?.value?.gid ?? '')
       if (didOpenCheckout)
         trackPlanCheckoutStarted(plan, checkoutIsYearly, 'direct')
     }

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -33,7 +33,7 @@ export function openBlank(link: string) {
     presentActionSheetOpen(link)
     return true
   }
-  return Boolean(window.open(link, '_blank'))
+  return Boolean(globalThis.open(link, '_blank'))
 }
 export async function openPortal(orgId: string, t: ComposerTranslation) {
   let url = ''
@@ -47,7 +47,7 @@ export async function openPortal(orgId: string, t: ComposerTranslation) {
   // datafast_visitor_id
 
   const prem = supabase.functions.invoke('private/stripe_portal', {
-    body: JSON.stringify({ callbackUrl: window.location.href, orgId }),
+    body: JSON.stringify({ callbackUrl: globalThis.location.href, orgId }),
   }).then(({ data }) => {
     if (data?.url) {
       url = data.url
@@ -147,7 +147,7 @@ export async function startCreditTopUp(orgId: string, quantity = 100) {
       console.error('Failed to start credit top-up', error ?? data)
       throw error ?? new Error('Missing checkout URL')
     }
-    window.location.href = data.url
+    globalThis.location.href = data.url
   }
   catch (error) {
     console.error('Cannot start credit top-up checkout', error)

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -29,10 +29,11 @@ async function presentActionSheetOpen(url: string) {
 }
 export function openBlank(link: string) {
   console.log('openBlank', link)
-  if (Capacitor.getPlatform() === 'ios')
+  if (Capacitor.getPlatform() === 'ios') {
     presentActionSheetOpen(link)
-  else
-    window.open(link, '_blank')
+    return true
+  }
+  return Boolean(window.open(link, '_blank'))
 }
 export async function openPortal(orgId: string, t: ComposerTranslation) {
   let url = ''
@@ -102,7 +103,7 @@ export async function openCheckout(priceId: string, successUrl: string, cancelUr
   const supabase = useSupabase()
   const session = await supabase.auth.getSession()
   if (!session)
-    return
+    return false
   const datafastAttribution = await getDatafastAttribution()
   try {
     const resp = await supabase.functions.invoke('private/stripe_checkout', {
@@ -118,11 +119,13 @@ export async function openCheckout(priceId: string, successUrl: string, cancelUr
       }),
     })
     if (!resp.error && resp.data?.url)
-      openBlank(resp.data.url)
+      return openBlank(resp.data.url)
+    return false
   }
   catch (error) {
     console.error(error)
     toast.error('Cannot get your checkout')
+    return false
   }
 }
 

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -5,6 +5,7 @@ import type { BentoTrackingPayload } from '../utils/tracking.ts'
 import { Hono } from 'hono/tiny'
 import { BUILDER_RECOVERY_MILESTONES, buildBuilderOnboardingBentoEvent } from '../utils/builder_onboarding_recovery.ts'
 import { BUNDLE_INCOMPATIBLE_EVENT, buildBundleCompatibilityBentoEvent } from '../utils/bundle_compatibility_recovery.ts'
+import { buildPlanCheckoutStartedBentoEvent, PLAN_CHECKOUT_STARTED_EVENT } from '../utils/checkout_tracking.ts'
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareV2 } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
@@ -51,6 +52,16 @@ function toIdString(value: unknown): string | undefined {
   if (typeof value === 'number' || typeof value === 'bigint')
     return String(value)
   return undefined
+}
+
+function tagString(tags: Record<string, unknown> | undefined, key: string) {
+  const value = tags?.[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function tagNumber(tags: Record<string, unknown> | undefined, key: string) {
+  const value = tags?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 async function resolveTrackingUserId(
@@ -270,6 +281,41 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
     }
   }
 
+  // Plan checkout start: the frontend emits this only when the user accepts the
+  // Stripe navigation, not when the checkout URL is prefetched.
+  let planCheckoutBentoEvent: BentoTrackingPayload | undefined
+  if (onboardingOrgId && trackedBody.event === PLAN_CHECKOUT_STARTED_EVENT) {
+    if (!(await checkPermission(c, 'org.update_billing', { orgId: onboardingOrgId }))) {
+      throw quickError(403, 'no_permission', 'You cannot send checkout events for this organization')
+    }
+
+    const { data: orgData, error: orgError } = await supabase
+      .from('orgs')
+      .select('id, name')
+      .eq('id', onboardingOrgId)
+      .single()
+
+    if (orgError || !orgData) {
+      cloudlog({ requestId: c.get('requestId'), message: 'plan checkout bento lookup failed; skipping signal', org: orgError })
+    }
+    else {
+      const tags = trackedBody.tags ?? {}
+      planCheckoutBentoEvent = buildPlanCheckoutStartedBentoEvent({
+        event: trackedBody.event,
+        orgId: onboardingOrgId,
+        orgName: orgData.name,
+        productId: tagString(tags, 'product_id'),
+        planName: tagString(tags, 'plan_name'),
+        recurrence: tagString(tags, 'recurrence'),
+        checkoutSource: tagString(tags, 'checkout_source'),
+        currentPlanName: tagString(tags, 'current_plan_name'),
+        planPrice: tagNumber(tags, 'plan_price'),
+        planPriceMonthly: tagNumber(tags, 'plan_price_monthly'),
+        planPriceYearly: tagNumber(tags, 'plan_price_yearly'),
+      })
+    }
+  }
+
   // Bundle compatibility failure (capgo bundle upload / bundle compatibility):
   // when the CLI reports an incompatible bundle, emit a Bento signal so a
   // lifecycle automation can react. Mirrors the builder block above; resolves
@@ -366,7 +412,7 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   }
 
   // Exactly one of these is ever set (distinct event names); `??` picks the active one.
-  const bentoEvent = onboardingBentoEvent ?? builderBentoEvent ?? bundleIncompatibleBentoEvent
+  const bentoEvent = onboardingBentoEvent ?? builderBentoEvent ?? planCheckoutBentoEvent ?? bundleIncompatibleBentoEvent
   await sendEventToTracking(c, {
     ...trackedBody,
     bento: bentoEvent,

--- a/supabase/functions/_backend/utils/checkout_tracking.ts
+++ b/supabase/functions/_backend/utils/checkout_tracking.ts
@@ -1,0 +1,63 @@
+import type { BentoTrackingPayload } from './tracking.ts'
+
+export const PLAN_CHECKOUT_STARTED_EVENT = 'Checkout Started'
+
+export interface PlanCheckoutStartedBentoInput {
+  event: string
+  orgId: string | undefined
+  orgName: string | undefined
+  productId: string | undefined
+  planName: string | undefined
+  recurrence: string | undefined
+  checkoutSource: string | undefined
+  currentPlanName: string | undefined
+  planPrice: number | undefined
+  planPriceMonthly: number | undefined
+  planPriceYearly: number | undefined
+}
+
+function normalizeRecurrence(recurrence: string | undefined) {
+  if (recurrence === 'month' || recurrence === 'year')
+    return recurrence
+  return 'unknown'
+}
+
+function recurrenceToPlanType(recurrence: string) {
+  if (recurrence === 'year')
+    return 'yearly'
+  if (recurrence === 'month')
+    return 'monthly'
+  return 'unknown'
+}
+
+export function buildPlanCheckoutStartedBentoEvent(input: PlanCheckoutStartedBentoInput): BentoTrackingPayload | undefined {
+  if (input.event !== PLAN_CHECKOUT_STARTED_EVENT)
+    return undefined
+  if (!input.orgId)
+    return undefined
+
+  const recurrence = normalizeRecurrence(input.recurrence)
+  const productId = input.productId ?? ''
+  const planName = input.planName ?? ''
+
+  return {
+    cron: '* * * * *',
+    event: 'user:checkout_started',
+    preferenceKey: 'credit_usage',
+    uniqId: `checkout_started:${productId || planName}:${recurrence}`,
+    audience: 'billing',
+    data: {
+      org_id: input.orgId,
+      org_name: input.orgName ?? '',
+      product_id: productId,
+      plan_name: planName,
+      plan_type: recurrenceToPlanType(recurrence),
+      recurrence,
+      checkout_source: input.checkoutSource ?? 'plans',
+      current_plan_name: input.currentPlanName ?? '',
+      plan_price: input.planPrice ?? 0,
+      plan_price_monthly: input.planPriceMonthly ?? 0,
+      plan_price_yearly: input.planPriceYearly ?? 0,
+    },
+  }
+}

--- a/tests/checkout-tracking.unit.test.ts
+++ b/tests/checkout-tracking.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlanCheckoutStartedBentoEvent, PLAN_CHECKOUT_STARTED_EVENT } from '../supabase/functions/_backend/utils/checkout_tracking.ts'
+
+const base = {
+  event: PLAN_CHECKOUT_STARTED_EVENT,
+  orgId: 'org-1',
+  orgName: 'Demo Org',
+  productId: 'prod_demo',
+  planName: 'Team',
+  recurrence: 'year',
+  checkoutSource: 'direct',
+  currentPlanName: 'Maker',
+  planPrice: 999,
+  planPriceMonthly: 99,
+  planPriceYearly: 999,
+}
+
+describe('buildPlanCheckoutStartedBentoEvent', () => {
+  it.concurrent('builds a billing-audience Bento payload for a checkout start', () => {
+    const r = buildPlanCheckoutStartedBentoEvent(base)
+    expect(r).toBeDefined()
+    expect(r!.event).toBe('user:checkout_started')
+    expect(r!.preferenceKey).toBe('credit_usage')
+    expect(r!.audience).toBe('billing')
+    expect(r!.cron).toBe('* * * * *')
+    expect(r!.uniqId).toBe('checkout_started:prod_demo:year')
+    expect(r!.data).toMatchObject({
+      org_id: 'org-1',
+      org_name: 'Demo Org',
+      product_id: 'prod_demo',
+      plan_name: 'Team',
+      plan_type: 'yearly',
+      recurrence: 'year',
+      checkout_source: 'direct',
+      current_plan_name: 'Maker',
+      plan_price: 999,
+      plan_price_monthly: 99,
+      plan_price_yearly: 999,
+    })
+  })
+
+  it.concurrent('returns undefined for other event names or missing org ids', () => {
+    expect(buildPlanCheckoutStartedBentoEvent({ ...base, event: 'Checkout Created' })).toBeUndefined()
+    expect(buildPlanCheckoutStartedBentoEvent({ ...base, orgId: undefined })).toBeUndefined()
+  })
+
+  it.concurrent('normalizes missing optional fields', () => {
+    const r = buildPlanCheckoutStartedBentoEvent({
+      ...base,
+      orgName: undefined,
+      productId: undefined,
+      planName: undefined,
+      recurrence: undefined,
+      checkoutSource: undefined,
+      currentPlanName: undefined,
+      planPrice: undefined,
+      planPriceMonthly: undefined,
+      planPriceYearly: undefined,
+    })
+    expect(r).toBeDefined()
+    expect(r!.uniqId).toBe('checkout_started::unknown')
+    expect(r!.data).toMatchObject({
+      org_name: '',
+      product_id: '',
+      plan_name: '',
+      plan_type: 'unknown',
+      recurrence: 'unknown',
+      checkout_source: 'plans',
+      current_plan_name: '',
+      plan_price: 0,
+      plan_price_monthly: 0,
+      plan_price_yearly: 0,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Emit a frontend `Checkout Started` event only when the user opens Stripe checkout from the plans page.
- Map that event through `/private/events` to Bento as `user:checkout_started` for billing recipients, while PostHog receives the normal tracking event.
- Add a pure Bento payload helper and unit coverage for the checkout-start mapping.

## Checks
- `bunx vitest run tests/checkout-tracking.unit.test.ts`
- `bun lint` (passes with existing unrelated warnings)
- `bun lint:backend`
- `bun typecheck`
- `bunx vitest run tests/checkout-tracking.unit.test.ts tests/tracking.unit.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing UX and the events pipeline with RBAC on checkout events, but does not change Stripe checkout creation or subscription logic beyond return-value gating for analytics.
> 
> **Overview**
> Adds **checkout-start analytics** on the organization plans page so billing lifecycle tooling can react when someone actually leaves for Stripe—not when a checkout URL is only prefetched.
> 
> The plans flow now emits a **`Checkout Started`** usage event (with plan, recurrence, price, and `checkout_source` of `direct` or `safari_confirm`) only after the user confirms navigation: on non-Safari when `openCheckout` successfully opens Stripe, and on Safari when they confirm the new-tab dialog. **`openCheckout`** and **`openBlank`** now return booleans so the UI can gate tracking on a successful open.
> 
> On **`/private/events`**, that event is authorized with **`org.update_billing`**, enriched with org context, and mapped to a Bento **`user:checkout_started`** signal for the billing audience; PostHog still gets the normal tracked event. A small **`checkout_tracking`** helper plus unit tests cover the Bento payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17bc3ed502d520ed873401b28f8d7e42d882155c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->