### PR TITLE
[codex] Split global stats usage shard processing

### DIFF
--- a/cloudflare_workers/api/index.ts
+++ b/cloudflare_workers/api/index.ts
@@ -55,7 +55,7 @@ import { app as cron_reconcile_build_status } from '../../supabase/functions/_ba
 import { app as cron_stat_app } from '../../supabase/functions/_backend/triggers/cron_stat_app.ts'
 import { app as cron_stat_org } from '../../supabase/functions/_backend/triggers/cron_stat_org.ts'
 import { app as cron_sync_sub } from '../../supabase/functions/_backend/triggers/cron_sync_sub.ts'
-import { app as logsnag_insights, logsnagInsightsShardApps } from '../../supabase/functions/_backend/triggers/logsnag_insights.ts'
+import { app as logsnag_insights, logsnagInsightsLegacyUsageApp, logsnagInsightsShardApps } from '../../supabase/functions/_backend/triggers/logsnag_insights.ts'
 import { app as on_app_create } from '../../supabase/functions/_backend/triggers/on_app_create.ts'
 import { app as on_app_delete } from '../../supabase/functions/_backend/triggers/on_app_delete.ts'
 import { app as on_app_update } from '../../supabase/functions/_backend/triggers/on_app_update.ts'
@@ -146,7 +146,14 @@ appTriggers.route('/cron_reconcile_build_status', cron_reconcile_build_status)
 appTriggers.route('/credit_usage_alerts', credit_usage_alerts)
 appTriggers.route('/logsnag_insights', logsnag_insights)
 appTriggers.route('/logsnag_insights_core', logsnagInsightsShardApps.core)
-appTriggers.route('/logsnag_insights_usage', logsnagInsightsShardApps.usage)
+appTriggers.route('/logsnag_insights_usage', logsnagInsightsLegacyUsageApp)
+appTriggers.route('/logsnag_insights_usage_updates', logsnagInsightsShardApps.usage_updates)
+appTriggers.route('/logsnag_insights_usage_devices', logsnagInsightsShardApps.usage_devices)
+appTriggers.route('/logsnag_insights_usage_device_platforms', logsnagInsightsShardApps.usage_device_platforms)
+appTriggers.route('/logsnag_insights_usage_registrations', logsnagInsightsShardApps.usage_registrations)
+appTriggers.route('/logsnag_insights_usage_storage', logsnagInsightsShardApps.usage_storage)
+appTriggers.route('/logsnag_insights_usage_success_rate', logsnagInsightsShardApps.usage_success_rate)
+appTriggers.route('/logsnag_insights_usage_demo_apps', logsnagInsightsShardApps.usage_demo_apps)
 appTriggers.route('/logsnag_insights_revenue', logsnagInsightsShardApps.revenue)
 appTriggers.route('/logsnag_insights_plugins', logsnagInsightsShardApps.plugins)
 appTriggers.route('/logsnag_insights_builds', logsnagInsightsShardApps.builds)

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -6,7 +6,7 @@ import { sql } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
 
 import { getLastMonthAnalyticsWindowStart, getPluginBreakdownCF, readActiveAppsCF, readLastMonthDevicesByPlatformCF, readLastMonthDevicesCF, readLastMonthUpdatesCF } from '../utils/cloudflare.ts'
-import { GLOBAL_STATS_SHARDS, REQUIRED_GLOBAL_STATS_SHARDS } from '../utils/global_stats.ts'
+import { GLOBAL_STATS_SHARDS, REQUIRED_GLOBAL_STATS_SHARDS, USAGE_GLOBAL_STATS_SHARDS } from '../utils/global_stats.ts'
 import { BRES, middlewareAPISecret, quickError } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { logsnagInsights } from '../utils/logsnag.ts'
@@ -1391,23 +1391,6 @@ async function ensureGlobalStatsSnapshotRow(c: Context, dateId: string): Promise
   }
 }
 
-async function resetGlobalStatsCompletedShards(c: Context, dateId: string): Promise<void> {
-  const db = getPgClient(c)
-
-  try {
-    const result = await db.query(
-      `UPDATE public.global_stats
-      SET completed_shards = '[]'::jsonb
-      WHERE date_id = $1`,
-      [dateId],
-    )
-    if (result.rowCount !== 1)
-      throw new Error(`Expected one global_stats row for ${dateId}, reset ${result.rowCount ?? 0}`)
-  }
-  finally {
-    await closeClient(c, db)
-  }
-}
 
 async function updateGlobalStatsSnapshot(c: Context, dateId: string, patch: GlobalStatsSnapshotPatch): Promise<void> {
   await ensureGlobalStatsSnapshotRow(c, dateId)
@@ -1702,20 +1685,19 @@ async function queueLogsnagInsightsShard(c: Context, shard: GlobalStatsShard, da
   }
 }
 
-async function queueMissingLogsnagInsightsShards(
+async function queueLogsnagInsightsShards(
   c: Context,
   dateId: string,
-  completedShards: ReadonlySet<GlobalStatsCompletionMarker>,
+  shards: readonly GlobalStatsShard[],
 ): Promise<Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }>> {
-  const missingShards = getMissingGlobalStatsShards(completedShards)
-  if (missingShards.length === 0)
+  if (shards.length === 0)
     return []
 
   const db = getPgClient(c)
   const queued: Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }> = []
 
   try {
-    for (const shard of missingShards) {
+    for (const shard of shards) {
       const delaySeconds = getLogsnagInsightsShardDelaySeconds(shard)
       const msgId = await queueLogsnagInsightsMessage(db, buildLogsnagInsightsShardMessage(shard, dateId), delaySeconds)
       queued.push({ shard, msgId, delaySeconds })
@@ -1728,35 +1710,79 @@ async function queueMissingLogsnagInsightsShards(
   return queued
 }
 
-async function dispatchMissingLogsnagInsightsShards(c: Context, dateId: string): Promise<void> {
+async function queueMissingLogsnagInsightsShards(
+  c: Context,
+  dateId: string,
+  completedShards: ReadonlySet<GlobalStatsCompletionMarker>,
+  candidateShards: readonly GlobalStatsShard[] = GLOBAL_STATS_SHARDS,
+): Promise<Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }>> {
+  const missingShards = candidateShards.filter(shard => !completedShards.has(shard))
+  return queueLogsnagInsightsShards(c, dateId, missingShards)
+}
+
+async function dispatchMissingLogsnagInsightsShardsFor(
+  c: Context,
+  dateId: string,
+  candidateShards: readonly GlobalStatsShard[],
+  noMissingMessage: string,
+  queuedMessage: string,
+): Promise<void> {
   await ensureGlobalStatsSnapshotRow(c, dateId)
   const completedShards = await readCompletedGlobalStatsShards(c, dateId)
-  const queued = await queueMissingLogsnagInsightsShards(c, dateId, completedShards)
+  const queued = await queueMissingLogsnagInsightsShards(c, dateId, completedShards, candidateShards)
+  const completedShardNames = Array.from(completedShards).sort((a, b) => a.localeCompare(b))
+
   if (queued.length === 0) {
     cloudlog({
       requestId: c.get('requestId'),
-      message: 'No missing logsnag insights global stats shards to queue',
+      message: noMissingMessage,
       dateId,
-      completedShards: Array.from(completedShards).sort((a, b) => a.localeCompare(b)),
+      completedShards: completedShardNames,
     })
     return
   }
 
   cloudlog({
     requestId: c.get('requestId'),
-    message: 'Queued missing logsnag insights global stats shards',
+    message: queuedMessage,
     dateId,
     queued,
-    completedShards: Array.from(completedShards).sort((a, b) => a.localeCompare(b)),
+    completedShards: completedShardNames,
   })
+}
+
+async function dispatchMissingLogsnagInsightsShards(c: Context, dateId: string): Promise<void> {
+  await dispatchMissingLogsnagInsightsShardsFor(
+    c,
+    dateId,
+    GLOBAL_STATS_SHARDS,
+    'No missing logsnag insights global stats shards to queue',
+    'Queued missing logsnag insights global stats shards',
+  )
+}
+
+async function dispatchMissingLogsnagInsightsUsageShards(c: Context, dateId: string): Promise<void> {
+  await dispatchMissingLogsnagInsightsShardsFor(
+    c,
+    dateId,
+    USAGE_GLOBAL_STATS_SHARDS,
+    'No missing logsnag insights usage shards to queue',
+    'Queued missing logsnag insights usage shards',
+  )
 }
 
 async function dispatchLogsnagInsightsShards(c: Context, dateId: string): Promise<void> {
   await ensureGlobalStatsSnapshotRow(c, dateId)
-  await resetGlobalStatsCompletedShards(c, dateId)
-  const queued = await queueMissingLogsnagInsightsShards(c, dateId, new Set())
+  const completedShards = await readCompletedGlobalStatsShards(c, dateId)
+  const queued = await queueMissingLogsnagInsightsShards(c, dateId, completedShards)
 
-  cloudlog({ requestId: c.get('requestId'), message: 'Queued logsnag insights global stats shards', dateId, queued })
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'Queued logsnag insights global stats shards',
+    dateId,
+    queued,
+    completedShards: Array.from(completedShards).sort((a, b) => a.localeCompare(b)),
+  })
 }
 async function getBillingSnapshotCounts(c: Context, snapshotExclusiveEnd: Date): Promise<BillingSnapshotCounts> {
   const pgClient = getPgClient(c, false)
@@ -2186,50 +2212,61 @@ async function getBundleStorageGb(c: Context): Promise<number> {
   return Number.isFinite(gigabytes) ? Number(gigabytes.toFixed(2)) : 0
 }
 
-async function runUsageGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
-  const metricWindow = getMetricWindowFromDailyWindow(window)
-  const dayStartIso = metricWindow.dayStart.toISOString()
-  const nextDayStartIso = metricWindow.nextDayStart.toISOString()
-  const currentUsageMetricsPromise = (async () => {
-    const [bundleStorageGb, successRate] = await Promise.all([
-      getBundleStorageGb(c),
-      (async () => {
-        const res = await getUpdateStats(c)
-        cloudlog({ requestId: c.get('requestId'), message: 'success_rate', successRate: res.total.success_rate })
-        return res.total.success_rate
-      })(),
-    ])
-    return { bundleStorageGb, successRate }
-  })()
-  const [
-    updatesLastMonth,
-    devicesLastMonth,
-    devicesByPlatform,
-    registersToday,
-    currentUsageMetrics,
-    demoAppsCreated,
-  ] = await Promise.all([
-    readLastMonthUpdatesCF(c, window.prevDayEnd),
-    readLastMonthDevicesCF(c, window.prevDayEnd),
-    readLastMonthDevicesByPlatformCF(c, window.prevDayEnd),
-    getRegistersToday(c, dayStartIso, nextDayStartIso),
-    currentUsageMetricsPromise,
-    countDemoSeededApps(c, dayStartIso, nextDayStartIso),
-  ])
+async function updateUsageGlobalStatsSnapshot(
+  c: Context,
+  window: DailyWindow,
+  message: string,
+  patch: GlobalStatsSnapshotPatch,
+  logContext: Record<string, unknown>,
+): Promise<void> {
+  await updateGlobalStatsSnapshot(c, window.prevDayDateId, patch)
+  cloudlog({
+    requestId: c.get('requestId'),
+    message,
+    dateId: window.prevDayDateId,
+    ...logContext,
+  })
+}
 
-  const snapshotPatch: GlobalStatsSnapshotPatch = {
-    demo_apps_created: demoAppsCreated,
-    devices_last_month: devicesLastMonth,
+async function runUsageUpdatesGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const updatesLastMonth = await readLastMonthUpdatesCF(c, window.prevDayEnd)
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage updates shard', { updates_last_month: updatesLastMonth }, { updatesLastMonth })
+}
+
+async function runUsageDevicesGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const devicesLastMonth = await readLastMonthDevicesCF(c, window.prevDayEnd)
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage devices shard', { devices_last_month: devicesLastMonth }, { devicesLastMonth })
+}
+
+async function runUsageDevicePlatformsGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const devicesByPlatform = await readLastMonthDevicesByPlatformCF(c, window.prevDayEnd)
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage device platforms shard', {
     devices_last_month_android: devicesByPlatform.android,
     devices_last_month_ios: devicesByPlatform.ios,
-    registers_today: registersToday,
-    updates_last_month: updatesLastMonth,
-    bundle_storage_gb: currentUsageMetrics.bundleStorageGb,
-    success_rate: currentUsageMetrics.successRate,
-  }
+  }, { devicesByPlatform })
+}
 
-  await updateGlobalStatsSnapshot(c, window.prevDayDateId, snapshotPatch)
-  cloudlog({ requestId: c.get('requestId'), message: 'Updated global stats usage shard', dateId: window.prevDayDateId, updatesLastMonth, devicesLastMonth, registersToday })
+async function runUsageRegistrationsGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const metricWindow = getMetricWindowFromDailyWindow(window)
+  const registersToday = await getRegistersToday(c, metricWindow.dayStart.toISOString(), metricWindow.nextDayStart.toISOString())
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage registrations shard', { registers_today: registersToday }, { registersToday })
+}
+
+async function runUsageStorageGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const bundleStorageGb = await getBundleStorageGb(c)
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage storage shard', { bundle_storage_gb: bundleStorageGb }, { bundleStorageGb })
+}
+
+async function runUsageSuccessRateGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const res = await getUpdateStats(c)
+  const successRate = res.total.success_rate
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage success rate shard', { success_rate: successRate }, { successRate })
+}
+
+async function runUsageDemoAppsGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
+  const metricWindow = getMetricWindowFromDailyWindow(window)
+  const demoAppsCreated = await countDemoSeededApps(c, metricWindow.dayStart.toISOString(), metricWindow.nextDayStart.toISOString())
+  await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage demo apps shard', { demo_apps_created: demoAppsCreated }, { demoAppsCreated })
 }
 
 async function runRevenueGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
@@ -2696,6 +2733,7 @@ export const logsnagInsightsTestUtils = {
   readLogsnagInsightsPayload,
   REVENUE_ACTIVE_STRIPE_STATUSES,
   LOGSNAG_INSIGHTS_BACKGROUND_MAX_RETRIES,
+  USAGE_GLOBAL_STATS_SHARDS,
   calculatePastDueOrgStats,
   calculateSubscriptionAccessSnapshotCounts,
   isActiveCanceledAtSnapshot,
@@ -2752,8 +2790,32 @@ async function runLogsnagInsightsShard(c: Context, shard: GlobalStatsShard, date
       await runCoreGlobalStatsShard(c, window)
       await markGlobalStatsShardComplete(c, dateId, shard)
       return
-    case 'usage':
-      await runUsageGlobalStatsShard(c, window)
+    case 'usage_updates':
+      await runUsageUpdatesGlobalStatsShard(c, window)
+      await markGlobalStatsShardComplete(c, dateId, shard)
+      return
+    case 'usage_devices':
+      await runUsageDevicesGlobalStatsShard(c, window)
+      await markGlobalStatsShardComplete(c, dateId, shard)
+      return
+    case 'usage_device_platforms':
+      await runUsageDevicePlatformsGlobalStatsShard(c, window)
+      await markGlobalStatsShardComplete(c, dateId, shard)
+      return
+    case 'usage_registrations':
+      await runUsageRegistrationsGlobalStatsShard(c, window)
+      await markGlobalStatsShardComplete(c, dateId, shard)
+      return
+    case 'usage_storage':
+      await runUsageStorageGlobalStatsShard(c, window)
+      await markGlobalStatsShardComplete(c, dateId, shard)
+      return
+    case 'usage_success_rate':
+      await runUsageSuccessRateGlobalStatsShard(c, window)
+      await markGlobalStatsShardComplete(c, dateId, shard)
+      return
+    case 'usage_demo_apps':
+      await runUsageDemoAppsGlobalStatsShard(c, window)
       await markGlobalStatsShardComplete(c, dateId, shard)
       return
     case 'revenue':
@@ -2881,9 +2943,24 @@ function createLogsnagInsightsShardApp(shard: GlobalStatsShard): Hono<Middleware
   return shardApp
 }
 
+export const logsnagInsightsLegacyUsageApp = new Hono<MiddlewareKeyVariables>()
+
+logsnagInsightsLegacyUsageApp.post('/', middlewareAPISecret, async (c) => {
+  const payload = await readLogsnagInsightsPayload(c)
+  const snapshotDateId = resolveLogsnagInsightsSnapshotDateId(payload)
+  await dispatchMissingLogsnagInsightsUsageShards(c, snapshotDateId)
+  return c.json(BRES, 202)
+})
+
 export const logsnagInsightsShardApps: Record<GlobalStatsShard, Hono<MiddlewareKeyVariables>> = {
   core: createLogsnagInsightsShardApp('core'),
-  usage: createLogsnagInsightsShardApp('usage'),
+  usage_updates: createLogsnagInsightsShardApp('usage_updates'),
+  usage_devices: createLogsnagInsightsShardApp('usage_devices'),
+  usage_device_platforms: createLogsnagInsightsShardApp('usage_device_platforms'),
+  usage_registrations: createLogsnagInsightsShardApp('usage_registrations'),
+  usage_storage: createLogsnagInsightsShardApp('usage_storage'),
+  usage_success_rate: createLogsnagInsightsShardApp('usage_success_rate'),
+  usage_demo_apps: createLogsnagInsightsShardApp('usage_demo_apps'),
   revenue: createLogsnagInsightsShardApp('revenue'),
   plugins: createLogsnagInsightsShardApp('plugins'),
   builds: createLogsnagInsightsShardApp('builds'),

--- a/supabase/functions/_backend/utils/global_stats.ts
+++ b/supabase/functions/_backend/utils/global_stats.ts
@@ -1,6 +1,16 @@
+export const USAGE_GLOBAL_STATS_SHARDS = [
+  'usage_updates',
+  'usage_devices',
+  'usage_device_platforms',
+  'usage_registrations',
+  'usage_storage',
+  'usage_success_rate',
+  'usage_demo_apps',
+] as const
+
 export const REQUIRED_GLOBAL_STATS_SHARDS = [
   'core',
-  'usage',
+  ...USAGE_GLOBAL_STATS_SHARDS,
   'revenue',
   'plugins',
   'builds',

--- a/supabase/functions/triggers/index.ts
+++ b/supabase/functions/triggers/index.ts
@@ -7,7 +7,7 @@ import { app as cron_reconcile_build_status } from '../_backend/triggers/cron_re
 import { app as cron_stat_app } from '../_backend/triggers/cron_stat_app.ts'
 import { app as cron_stat_org } from '../_backend/triggers/cron_stat_org.ts'
 import { app as cron_sync_sub } from '../_backend/triggers/cron_sync_sub.ts'
-import { app as logsnag_insights, logsnagInsightsShardApps } from '../_backend/triggers/logsnag_insights.ts'
+import { app as logsnag_insights, logsnagInsightsLegacyUsageApp, logsnagInsightsShardApps } from '../_backend/triggers/logsnag_insights.ts'
 import { app as on_app_create } from '../_backend/triggers/on_app_create.ts'
 import { app as on_app_delete } from '../_backend/triggers/on_app_delete.ts'
 import { app as on_app_update } from '../_backend/triggers/on_app_update.ts'
@@ -36,7 +36,14 @@ const appGlobal = createHono(functionName, version)
 appGlobal.route('/cron_email', cron_email)
 appGlobal.route('/logsnag_insights', logsnag_insights)
 appGlobal.route('/logsnag_insights_core', logsnagInsightsShardApps.core)
-appGlobal.route('/logsnag_insights_usage', logsnagInsightsShardApps.usage)
+appGlobal.route('/logsnag_insights_usage', logsnagInsightsLegacyUsageApp)
+appGlobal.route('/logsnag_insights_usage_updates', logsnagInsightsShardApps.usage_updates)
+appGlobal.route('/logsnag_insights_usage_devices', logsnagInsightsShardApps.usage_devices)
+appGlobal.route('/logsnag_insights_usage_device_platforms', logsnagInsightsShardApps.usage_device_platforms)
+appGlobal.route('/logsnag_insights_usage_registrations', logsnagInsightsShardApps.usage_registrations)
+appGlobal.route('/logsnag_insights_usage_storage', logsnagInsightsShardApps.usage_storage)
+appGlobal.route('/logsnag_insights_usage_success_rate', logsnagInsightsShardApps.usage_success_rate)
+appGlobal.route('/logsnag_insights_usage_demo_apps', logsnagInsightsShardApps.usage_demo_apps)
 appGlobal.route('/logsnag_insights_revenue', logsnagInsightsShardApps.revenue)
 appGlobal.route('/logsnag_insights_plugins', logsnagInsightsShardApps.plugins)
 appGlobal.route('/logsnag_insights_builds', logsnagInsightsShardApps.builds)

--- a/supabase/migrations/20260629152310_split_global_stats_usage_shards.sql
+++ b/supabase/migrations/20260629152310_split_global_stats_usage_shards.sql
@@ -1,0 +1,36 @@
+UPDATE public.global_stats
+SET completed_shards = (
+  SELECT COALESCE(jsonb_agg(marker ORDER BY marker), '[]'::jsonb)
+  FROM (
+    SELECT DISTINCT marker
+    FROM (
+      SELECT marker
+      FROM jsonb_array_elements_text(
+        COALESCE(public.global_stats.completed_shards, '[]'::jsonb)
+      ) AS existing_markers(marker)
+      WHERE marker <> 'usage'
+
+      UNION ALL
+      SELECT 'usage_updates'
+
+      UNION ALL
+      SELECT 'usage_devices'
+
+      UNION ALL
+      SELECT 'usage_device_platforms'
+
+      UNION ALL
+      SELECT 'usage_registrations'
+
+      UNION ALL
+      SELECT 'usage_storage'
+
+      UNION ALL
+      SELECT 'usage_success_rate'
+
+      UNION ALL
+      SELECT 'usage_demo_apps'
+    ) markers
+  ) deduped
+)
+WHERE COALESCE(completed_shards, '[]'::jsonb) ? 'usage';

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -78,7 +78,7 @@ describe('logsnag revenue metric helpers', () => {
   it.concurrent('detects missing global stats shards before notifications', () => {
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsRequiredShards(new Set())).toEqual([
       'core',
-      'usage',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
       'revenue',
       'plugins',
       'builds',
@@ -89,7 +89,7 @@ describe('logsnag revenue metric helpers', () => {
 
     const completed = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',
-      'usage',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
       'plugins',
       'builds',
       'retention',
@@ -103,7 +103,7 @@ describe('logsnag revenue metric helpers', () => {
 
     const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',
-      'usage',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
       'revenue',
       'plugins',
       'builds',
@@ -113,6 +113,20 @@ describe('logsnag revenue metric helpers', () => {
     ])
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsRequiredShards(ready)).toEqual([])
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsShards(ready)).toEqual(['notifications'])
+
+    const legacyUsage = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
+      'core',
+      'usage',
+      'revenue',
+      'plugins',
+      'builds',
+      'retention',
+      'paid_products',
+      'ltv',
+    ])
+    expect(logsnagInsightsTestUtils.getMissingGlobalStatsRequiredShards(legacyUsage)).toEqual([
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
+    ])
 
     const sent = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       ...ready,
@@ -124,7 +138,7 @@ describe('logsnag revenue metric helpers', () => {
   it.concurrent('detects completed global stats notifications for idempotent retries', () => {
     const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',
-      'usage',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
       'revenue',
       'plugins',
       'builds',
@@ -156,14 +170,14 @@ describe('logsnag revenue metric helpers', () => {
     ])
 
     expect(logsnagInsightsTestUtils.shouldSkipCompletedGlobalStatsShardRetry(completed, 'core')).toBe(true)
-    expect(logsnagInsightsTestUtils.shouldSkipCompletedGlobalStatsShardRetry(completed, 'usage')).toBe(false)
+    expect(logsnagInsightsTestUtils.shouldSkipCompletedGlobalStatsShardRetry(completed, 'usage_updates')).toBe(false)
     expect(logsnagInsightsTestUtils.shouldSkipCompletedGlobalStatsShardRetry(completed, 'notifications')).toBe(false)
   })
 
   it.concurrent('derives only missing global stats shards for partial dispatcher retries', () => {
     const partial = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',
-      'usage',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
       'revenue',
     ])
 
@@ -187,7 +201,7 @@ describe('logsnag revenue metric helpers', () => {
   it.concurrent('uses notification claim markers to avoid replaying claimed sends', () => {
     const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',
-      'usage',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
       'revenue',
       'plugins',
       'builds',
@@ -490,6 +504,7 @@ describe('logsnag revenue metric helpers', () => {
 
   it.concurrent('builds shard messages as distinct queue HTTP calls', () => {
     expect(logsnagInsightsTestUtils.getLogsnagInsightsShardFunctionName('revenue')).toBe('logsnag_insights_revenue')
+    expect(logsnagInsightsTestUtils.getLogsnagInsightsShardFunctionName('usage_updates')).toBe('logsnag_insights_usage_updates')
     expect(logsnagInsightsTestUtils.buildLogsnagInsightsShardMessage('revenue', '2026-03-24')).toEqual({
       function_name: 'logsnag_insights_revenue',
       function_type: 'cloudflare',
@@ -509,6 +524,8 @@ describe('logsnag revenue metric helpers', () => {
 
   it.concurrent('normalizes global stats shard and date payloads', () => {
     expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsShard('core')).toBe('core')
+    expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsShard('usage_updates')).toBe('usage_updates')
+    expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsShard('usage')).toBeNull()
     expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsShard('bad')).toBeNull()
     expect(logsnagInsightsTestUtils.normalizeGlobalStatsDateId('2026-03-24')).toBe('2026-03-24')
     expect(logsnagInsightsTestUtils.normalizeGlobalStatsDateId('2026-02-30')).toBeNull()

--- a/tests/public-stats.unit.test.ts
+++ b/tests/public-stats.unit.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { REQUIRED_GLOBAL_STATS_SHARDS } from '../supabase/functions/_backend/utils/global_stats.ts'
 
 const mocks = vi.hoisted(() => {
   const maybeSingle = vi.fn()
@@ -68,16 +69,7 @@ describe('public stats endpoint', () => {
     })
     expect(mocks.from).toHaveBeenCalledWith('global_stats')
     expect(mocks.lte).toHaveBeenCalledWith('date_id', '2026-05-10')
-    expect(mocks.contains).toHaveBeenCalledWith('completed_shards', [
-      'core',
-      'usage',
-      'revenue',
-      'plugins',
-      'builds',
-      'retention',
-      'paid_products',
-      'ltv',
-    ])
+    expect(mocks.contains).toHaveBeenCalledWith('completed_shards', [...REQUIRED_GLOBAL_STATS_SHARDS])
     expect(mocks.order).toHaveBeenCalledWith('date_id', { ascending: false })
     expect(mocks.limit).toHaveBeenCalledWith(1)
   })


### PR DESCRIPTION
## Root cause

`logsnag_insights_usage` bundled every usage metric into one Cloudflare `waitUntil()` background task. Production logs showed those tasks being cancelled before completion, so the `usage` completion marker was never written and `global_stats` rows stayed incomplete.

A duplicate top-level dispatcher could also reset `completed_shards` for a date before requeueing work, which made reruns capable of removing markers that had already completed.

## Fix

- Split the old `usage` shard into independent queue shards:
  - `usage_updates`
  - `usage_devices`
  - `usage_device_platforms`
  - `usage_registrations`
  - `usage_storage`
  - `usage_success_rate`
  - `usage_demo_apps`
- Keep `/logsnag_insights_usage` as a compatibility route that only queues missing split usage shards for already queued legacy messages.
- Stop resetting `completed_shards` in the normal dispatcher; reruns now queue only missing shards.
- Add a migration that converts completed legacy `usage` markers into the new split markers.
- Update tests so the dashboard/public stats completion gate uses the shared required-shard list and rejects legacy `usage` as a current shard marker.

## Manual rerun note

Do not use a fixed number of `select public.process_function_queue('admin_stats'::text, 50);` calls as the success condition. Each call processes up to 50 currently available messages; delayed retries and newly fanned-out shards mean the correct stop condition is that the queue has no ready `admin_stats` messages and the target `global_stats.completed_shards` contains all required shards for the dates being repaired.

## Validation

- `bun run supabase:with-env -- bunx vitest run tests/logsnag-insights-revenue.unit.test.ts tests/public-stats.unit.test.ts`
- `bun run typecheck:backend`
- `bun run lint:backend`
- `bunx oxlint cloudflare_workers/api/index.ts`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daily global stats orchestration, completion gating for public stats, and a one-time DB migration that assumes a completed legacy `usage` marker means all usage metrics finished.
> 
> **Overview**
> Replaces the single **`usage`** LogSnag/global-stats queue shard with **seven smaller shards** (updates, devices, platforms, registrations, storage, success rate, demo apps), each with its own trigger route and worker handler so heavy usage work is less likely to die in one long background task.
> 
> **`/logsnag_insights_usage`** is kept as a **compatibility entry** that only enqueues **missing** split usage shards instead of running the old monolith. The main dispatcher **no longer resets** `global_stats.completed_shards` on rerun—it only queues shards that are not already marked complete.
> 
> A SQL migration rewrites rows that still have the legacy **`usage`** completion marker into the new split markers. Tests and public stats completion checks now use the shared **`REQUIRED_GLOBAL_STATS_SHARDS`** list and treat **`usage`** as invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7394e351b03f38b8d7143985d5de0996399e0c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->