### PR TITLE
fix(security): allow Turnstile under CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -6,7 +6,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.bunny.net; connect-src 'self' https: wss:; media-src 'self' data: blob: https:; frame-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.bunny.net; connect-src 'self' https: wss:; media-src 'self' data: blob: https:; frame-src 'self' https://challenges.cloudflare.com https:; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests
 /api/*
   cache-control: public, s-max-age=60
 /.well-known/*

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -9,8 +9,9 @@ const consoleHeaders = readFileSync(new URL('../public/_headers', import.meta.ur
 describe('security response headers', () => {
   it.concurrent('declares a CSP for the console app static responses', () => {
     expect(consoleHeaders).toContain('Content-Security-Policy: default-src \'self\'')
-    expect(consoleHeaders).toContain('script-src \'self\' \'unsafe-inline\'')
+    expect(consoleHeaders).toContain('script-src \'self\' \'unsafe-inline\' https://challenges.cloudflare.com')
     expect(consoleHeaders).toContain('style-src \'self\' \'unsafe-inline\' https://fonts.bunny.net')
+    expect(consoleHeaders).toContain('frame-src \'self\' https://challenges.cloudflare.com')
     expect(consoleHeaders).toContain('frame-ancestors \'none\'')
   })
 


### PR DESCRIPTION
## Summary
- allow Cloudflare Turnstile under the console CSP so captcha tokens can be generated on login
- add CSP regression assertions for the Turnstile script and frame host

## Why
The merged CSP from #2588 blocked the Turnstile API script because `script-src` only allowed `'self'` and `'unsafe-inline'`. The login page uses `vue-turnstile` and passes `captchaToken` to Supabase Auth, so blocking the script leaves the token empty and Supabase rejects login with `captcha protection: request disallowed (no captcha_token found)`.

## Test plan
- `bunx vitest run tests/security-headers.unit.test.ts`
- `bunx eslint tests/security-headers.unit.test.ts`
- `bun typecheck`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## Live evidence
- `curl -I https://console.capgo.app/login` currently shows a CSP without `https://challenges.cloudflare.com` in `script-src`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CSP allowlist change for a single trusted Cloudflare origin; no auth or API logic changes.
> 
> **Overview**
> **Unblocks Cloudflare Turnstile on the console** by extending the static `Content-Security-Policy` in `public/_headers` so login can load the captcha script and iframe from `https://challenges.cloudflare.com`.
> 
> `script-src` now includes that host alongside `'self'` and `'unsafe-inline'`, and `frame-src` explicitly allows it (in addition to existing `https:`). **Regression coverage** in `tests/security-headers.unit.test.ts` asserts both directives so a future CSP tighten cannot silently break captcha again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144ff5ad6e85287424bd8706dbf1a8bf1a01f9b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security settings to allow additional trusted content sources, including challenge-related embeds and secure media/network requests.
* **Tests**
  * Adjusted security header checks to match the updated policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->