### PR TITLE
fix(cli): skip web-only Capacitor plugins in cap-sync-stale prescan

### DIFF
--- a/cli/src/build/prescan/checks/shared.ts
+++ b/cli/src/build/prescan/checks/shared.ts
@@ -1,7 +1,7 @@
-// src/build/prescan/checks/shared.ts
 import type { Finding, PrescanCheck, ScanContext } from '../types'
+import { createRequire } from 'node:module'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { getPlatformDirFromCapacitorConfig } from '../../platform-paths'
 import { gradleApplicationId, readTextIfExists } from '../gradle'
 
@@ -26,6 +26,19 @@ function gradleModuleName(dep: string): string {
   return dep.replace(/^@/, '').replace(/\//g, '-')
 }
 
+
+/** Web-only Capacitor plugins (e.g. @capacitor/motion) ship JS only — cap sync never adds them to Gradle. */
+function hasNativeAndroidPlugin(projectDir: string, dep: string): boolean {
+  try {
+    const require = createRequire(join(projectDir, 'package.json'))
+    const pkgPath = require.resolve(`${dep}/package.json`)
+    return existsSync(join(dirname(pkgPath), 'android'))
+  }
+  catch {
+    return false
+  }
+}
+
 export const capSyncStale: PrescanCheck = {
   id: 'shared/cap-sync-stale',
   platforms: ['ios', 'android'],
@@ -41,9 +54,10 @@ export const capSyncStale: PrescanCheck = {
       })
       return findings
     }
-    const plugins = capacitorPluginDeps(ctx.projectDir)
+    const pluginDeps = capacitorPluginDeps(ctx.projectDir)
+    const nativeAndroidPlugins = pluginDeps.filter(dep => hasNativeAndroidPlugin(ctx.projectDir, dep))
     const platformDir = getPlatformDirFromCapacitorConfig(ctx.config, ctx.platform)
-    if (ctx.platform === 'android' && plugins.length > 0) {
+    if (ctx.platform === 'android' && nativeAndroidPlugins.length > 0) {
       const settings = readTextIfExists(join(ctx.projectDir, platformDir, 'capacitor.settings.gradle'))
       if (settings === null) {
         findings.push({
@@ -54,7 +68,7 @@ export const capSyncStale: PrescanCheck = {
         })
       }
       else {
-        const missing = plugins.filter(p => !settings.includes(`:${gradleModuleName(p)}`))
+        const missing = nativeAndroidPlugins.filter(p => !settings.includes(`:${gradleModuleName(p)}`))
         if (missing.length > 0) {
           findings.push({
             id: 'shared/cap-sync-stale',
@@ -66,7 +80,7 @@ export const capSyncStale: PrescanCheck = {
         }
       }
     }
-    if (ctx.platform === 'ios' && plugins.length > 0) {
+    if (ctx.platform === 'ios' && pluginDeps.length > 0) {
       const hasCocoaPodsSync = existsSync(join(ctx.projectDir, platformDir, 'App', 'Podfile'))
       const hasSpmSync = existsSync(join(ctx.projectDir, platformDir, 'App', 'CapApp-SPM', 'Package.swift'))
       if (!hasCocoaPodsSync && !hasSpmSync) {

--- a/cli/test/prescan/checks-shared.test.ts
+++ b/cli/test/prescan/checks-shared.test.ts
@@ -4,6 +4,10 @@ import { bundleIdConsistency, capSyncStale, nodeLinkerLayout } from '../../src/b
 import { makeCtx, makeProject } from './helpers'
 
 const PKG = JSON.stringify({ dependencies: { '@capacitor/core': '7.0.0', '@capacitor/camera': '7.0.0', '@capacitor/android': '7.0.0' } })
+const CAMERA_ANDROID = {
+  'node_modules/@capacitor/camera/package.json': JSON.stringify({ name: '@capacitor/camera' }),
+  'node_modules/@capacitor/camera/android/build.gradle': 'android',
+}
 
 describe('shared/cap-sync-stale', () => {
   it('errors when webDir is missing', async () => {
@@ -18,6 +22,7 @@ describe('shared/cap-sync-stale', () => {
       'package.json': PKG,
       'dist/index.html': '<html></html>',
       'android/capacitor.settings.gradle': `include ':capacitor-android'\n// no camera here`,
+      ...CAMERA_ANDROID,
     })
     const ctx = makeCtx({ projectDir: dir, platform: 'android', config: { appId: 'com.demo.app', appName: 'x', webDir: 'dist' } as any })
     const findings = await capSyncStale.run(ctx)
@@ -28,6 +33,27 @@ describe('shared/cap-sync-stale', () => {
     const dir = makeProject({
       'package.json': PKG,
       'dist/index.html': '<html></html>',
+      'android/capacitor.settings.gradle': `include ':capacitor-android'\ninclude ':capacitor-camera'\nproject(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')`,
+      ...CAMERA_ANDROID,
+    })
+    const ctx = makeCtx({ projectDir: dir, platform: 'android', config: { appId: 'com.demo.app', appName: 'x', webDir: 'dist' } as any })
+    expect(await capSyncStale.run(ctx)).toEqual([])
+  })
+
+  it('passes when a web-only @capacitor plugin has no android native project', async () => {
+    const dir = makeProject({
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@capacitor/core': '8.0.0',
+          '@capacitor/android': '8.0.0',
+          '@capacitor/camera': '8.0.0',
+          '@capacitor/motion': '8.0.0',
+        },
+      }),
+      'dist/index.html': '<html></html>',
+      ...CAMERA_ANDROID,
+      'node_modules/@capacitor/motion/package.json': JSON.stringify({ name: '@capacitor/motion' }),
+      'node_modules/@capacitor/motion/dist/index.js': 'export {}',
       'android/capacitor.settings.gradle': `include ':capacitor-android'\ninclude ':capacitor-camera'\nproject(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')`,
     })
     const ctx = makeCtx({ projectDir: dir, platform: 'android', config: { appId: 'com.demo.app', appName: 'x', webDir: 'dist' } as any })
@@ -79,6 +105,7 @@ describe('shared/cap-sync-stale — platform sync-artifact errors', () => {
     const dir = makeProject({
       'package.json': PKG,
       'dist/index.html': '<html></html>',
+      ...CAMERA_ANDROID,
       // no android/capacitor.settings.gradle
     })
     const ctx = makeCtx({ projectDir: dir, platform: 'android', config: { appId: 'com.demo.app', appName: 'x', webDir: 'dist' } as any })


### PR DESCRIPTION
## Summary (AI generated)

- Fix `shared/cap-sync-stale` prescan false positive for `@capacitor/motion`
- Only require native Android plugins (those with an `android/` folder) in `capacitor.settings.gradle`
- Add test coverage for web-only Capacitor plugins

## Motivation (AI generated)

`@capacitor/motion` is a web-only Capacitor plugin (JS only, no native Android project). Running `cap sync android` does not add it to `capacitor.settings.gradle`, but the prescan check treated every `@capacitor/*` dependency as a native plugin and reported it as missing.

## Business Impact (AI generated)

Unblocks Android cloud builds for the Capgo sandbox app and any customer project using web-only Capacitor plugins alongside native ones.

## Test Plan (AI generated)

- [x] `bun run cli:check` passes locally
- [x] New test: web-only `@capacitor/motion` does not trigger cap-sync-stale error when camera is synced
- [ ] CI green

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android sync checks now only flag missing native plugin entries for plugins that include Android code, reducing false warnings for web-only plugins.
  * iOS sync artifact checks continue to validate plugin dependencies consistently, improving sync status accuracy.

* **Tests**
  * Updated test coverage to reflect Android plugin scenarios more clearly and reduce duplicated fixture setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->