### PR TITLE
fix(admin-stats): repair missing snapshots and storage shard

### DIFF
--- a/src/components/dashboard/BuildTimeCard.vue
+++ b/src/components/dashboard/BuildTimeCard.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{ 'update:loading': [value: boolean] }>()
 const { t } = useI18n()
 const supabase = useSupabase()
 
-interface BuildLogRow { created_at: string | null, build_time_unit: number | null }
+interface BuildLogRow { created_at: string | null, billable_seconds: number | null }
 interface BuildTimeResult { minutesPerDay: number[], total: number, evolution: number }
 
 const { isLoading, result } = useBuildCardStats<BuildTimeResult>(props, emit, {
@@ -27,7 +27,7 @@ const { isLoading, result } = useBuildCardStats<BuildTimeResult>(props, emit, {
   load: async (window) => {
     const rows = await fetchAllRows<BuildLogRow>((from, to) => supabase
       .from('build_logs')
-      .select('created_at, build_time_unit')
+      .select('created_at, billable_seconds')
       .eq('app_id', props.appId)
       .gte('created_at', window.startISO)
       .lte('created_at', window.endISO)
@@ -37,12 +37,12 @@ const { isLoading, result } = useBuildCardStats<BuildTimeResult>(props, emit, {
     // Accumulate real build seconds per day, then convert to minutes for display.
     const secondsPerDay = Array.from({ length: window.dayCount }).fill(0) as number[]
     for (const row of rows) {
-      if (!row.created_at || row.build_time_unit == null)
+      if (!row.created_at || row.billable_seconds == null)
         continue
       const dayIndex = dayIndexInWindow(new Date(row.created_at), window.windowStart)
       if (dayIndex < 0 || dayIndex >= window.dayCount)
         continue
-      secondsPerDay[dayIndex] += row.build_time_unit
+      secondsPerDay[dayIndex] += row.billable_seconds
     }
 
     const minutesPerDay = secondsPerDay.map(seconds => Math.round((seconds / 60) * 10) / 10)

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -241,6 +241,7 @@ const LOGSNAG_INSIGHTS_BACKGROUND_MAX_RETRIES = 4
 const LOGSNAG_INSIGHTS_RETRY_DELAY_SECONDS = 300
 const LOGSNAG_INSIGHTS_QUEUE_NAME = 'admin_stats'
 const LOGSNAG_INSIGHTS_NOTIFICATION_DELAY_SECONDS = 180
+const LOGSNAG_INSIGHTS_RECENT_REPAIR_LOOKBACK_DAYS = 30
 const GLOBAL_STATS_NOTIFICATION_LOCK_NAMESPACE = 'logsnag_insights_notifications'
 const GLOBAL_STATS_NOTIFICATION_LOGSNAG_STEP = 'notifications_logsnag'
 const GLOBAL_STATS_NOTIFICATION_TRACKING_STEP = 'notifications_tracking'
@@ -359,6 +360,20 @@ function getCompletedDayWindowForDateId(dateId: string): DailyWindow {
     prevDayEnd,
     prevDayDateId: dateId,
   }
+}
+
+function buildRecentGlobalStatsRepairDateIds(anchorDateId: string, lookbackDays = LOGSNAG_INSIGHTS_RECENT_REPAIR_LOOKBACK_DAYS): string[] {
+  const anchor = new Date(`${anchorDateId}T00:00:00.000Z`)
+  if (Number.isNaN(anchor.getTime()))
+    return []
+
+  const dateIds: string[] = []
+  for (let offset = Math.max(0, Math.floor(lookbackDays)); offset >= 0; offset--) {
+    const date = new Date(anchor)
+    date.setUTCDate(anchor.getUTCDate() - offset)
+    dateIds.push(getDateId(date))
+  }
+  return dateIds
 }
 
 function getMetricWindowFromDailyWindow(window: DailyWindow): CurrentDayWindow {
@@ -1265,8 +1280,8 @@ async function aggregateDailyBuildStats(
     const query = sql`
       SELECT
         platform,
-        SUM(build_time_unit)::bigint AS total_seconds,
-        COALESCE(ROUND(AVG(build_time_unit)::numeric, 1), 0)::float AS avg_seconds,
+        SUM(billable_seconds)::bigint AS total_seconds,
+        COALESCE(ROUND(AVG(billable_seconds)::numeric, 1), 0)::float AS avg_seconds,
         COUNT(*)::int AS total_builds
       FROM build_logs
       WHERE created_at >= ${start}
@@ -1378,19 +1393,28 @@ async function getTrialExtensionStats(c: Context, window: CurrentDayWindow): Pro
 }
 
 async function ensureGlobalStatsSnapshotRow(c: Context, dateId: string): Promise<void> {
+  await ensureGlobalStatsSnapshotRows(c, [dateId])
+}
+
+async function ensureGlobalStatsSnapshotRows(c: Context, dateIds: readonly string[]): Promise<void> {
+  if (dateIds.length === 0)
+    return
+
   const db = getPgClient(c)
 
   try {
     await db.query(
-      'INSERT INTO public.global_stats (date_id, apps, updates, stars) VALUES ($1, 0, 0, 0) ON CONFLICT (date_id) DO NOTHING',
-      [dateId],
+      `INSERT INTO public.global_stats (date_id, apps, updates, stars)
+      SELECT DISTINCT date_id, 0, 0, 0
+      FROM unnest($1::text[]) AS input(date_id)
+      ON CONFLICT (date_id) DO NOTHING`,
+      [dateIds],
     )
   }
   finally {
     await closeClient(c, db)
   }
 }
-
 
 async function updateGlobalStatsSnapshot(c: Context, dateId: string, patch: GlobalStatsSnapshotPatch): Promise<void> {
   await ensureGlobalStatsSnapshotRow(c, dateId)
@@ -1449,6 +1473,11 @@ function getMissingGlobalStatsRequiredShards(completedShards: ReadonlySet<Global
 
 function getMissingGlobalStatsShards(completedShards: ReadonlySet<GlobalStatsCompletionMarker>): GlobalStatsShard[] {
   return GLOBAL_STATS_SHARDS.filter(shard => !completedShards.has(shard))
+}
+
+function getGlobalStatsShardQueueCandidates(completedShards: ReadonlySet<GlobalStatsCompletionMarker>): GlobalStatsShard[] {
+  const missingRequiredShards = getMissingGlobalStatsRequiredShards(completedShards)
+  return missingRequiredShards.length > 0 ? missingRequiredShards : getMissingGlobalStatsShards(completedShards)
 }
 
 function hasCompletedGlobalStatsNotifications(completedShards: ReadonlySet<GlobalStatsCompletionMarker>): boolean {
@@ -1714,16 +1743,105 @@ async function queueMissingLogsnagInsightsShards(
   c: Context,
   dateId: string,
   completedShards: ReadonlySet<GlobalStatsCompletionMarker>,
-  candidateShards: readonly GlobalStatsShard[] = GLOBAL_STATS_SHARDS,
+  candidateShards: readonly GlobalStatsShard[] = getGlobalStatsShardQueueCandidates(completedShards),
 ): Promise<Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }>> {
   const missingShards = candidateShards.filter(shard => !completedShards.has(shard))
   return queueLogsnagInsightsShards(c, dateId, missingShards)
 }
 
+function getLogsnagInsightsShardQueueKey(shard: GlobalStatsShard, dateId: string): string {
+  return `${dateId}:${getLogsnagInsightsShardFunctionName(shard)}`
+}
+
+async function readQueuedLogsnagInsightsShardKeys(c: Context, dateIds: readonly string[]): Promise<Set<string>> {
+  if (dateIds.length === 0)
+    return new Set()
+
+  const db = getPgClient(c)
+  const functionNames = GLOBAL_STATS_SHARDS.map(shard => getLogsnagInsightsShardFunctionName(shard))
+
+  try {
+    const result = await db.query<{ function_name: string | null, date_id: string | null }>(
+      `SELECT
+        message->>'function_name' AS function_name,
+        message->'payload'->>'date_id' AS date_id
+      FROM pgmq.q_admin_stats
+      WHERE message->>'function_name' = ANY($1::text[])
+        AND message->'payload'->>'date_id' = ANY($2::text[])`,
+      [functionNames, dateIds],
+    )
+
+    return new Set(result.rows.flatMap((row) => {
+      if (!row.function_name || !row.date_id)
+        return []
+      return [`${row.date_id}:${row.function_name}`]
+    }))
+  }
+  finally {
+    await closeClient(c, db)
+  }
+}
+
+async function readGlobalStatsCompletionRows(c: Context, dateIds: readonly string[]): Promise<Map<string, Set<GlobalStatsCompletionMarker>>> {
+  if (dateIds.length === 0)
+    return new Map()
+
+  const db = getPgClient(c)
+
+  try {
+    const result = await db.query<{ date_id: string, completed_shards: unknown }>(
+      `SELECT date_id, completed_shards
+      FROM public.global_stats
+      WHERE date_id = ANY($1::text[])`,
+      [dateIds],
+    )
+
+    return new Map(result.rows.map(row => [row.date_id, normalizeCompletedGlobalStatsShards(row.completed_shards)]))
+  }
+  finally {
+    await closeClient(c, db)
+  }
+}
+
+async function repairRecentMissingGlobalStatsSnapshots(c: Context, anchorDateId: string): Promise<void> {
+  const dateIds = buildRecentGlobalStatsRepairDateIds(anchorDateId).filter(dateId => dateId !== anchorDateId)
+  if (dateIds.length === 0)
+    return
+
+  const [completionRows, queuedShardKeys] = await Promise.all([
+    readGlobalStatsCompletionRows(c, dateIds),
+    readQueuedLogsnagInsightsShardKeys(c, dateIds),
+  ])
+  const missingDateIds = dateIds.filter(dateId => !completionRows.has(dateId))
+  await ensureGlobalStatsSnapshotRows(c, missingDateIds)
+
+  const queuedByDate: Array<{ dateId: string, queued: Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }> }> = []
+  for (const dateId of dateIds) {
+    const completedShards = completionRows.get(dateId) ?? new Set<GlobalStatsCompletionMarker>()
+    const shardsToQueue = getGlobalStatsShardQueueCandidates(completedShards)
+      .filter(shard => !completedShards.has(shard))
+      .filter(shard => !queuedShardKeys.has(getLogsnagInsightsShardQueueKey(shard, dateId)))
+
+    const queued = await queueLogsnagInsightsShards(c, dateId, shardsToQueue)
+    if (queued.length > 0)
+      queuedByDate.push({ dateId, queued })
+  }
+
+  if (missingDateIds.length > 0 || queuedByDate.length > 0) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Repaired recent missing global stats snapshots',
+      anchorDateId,
+      missingDateIds,
+      queuedByDate,
+    })
+  }
+}
+
 async function dispatchMissingLogsnagInsightsShardsFor(
   c: Context,
   dateId: string,
-  candidateShards: readonly GlobalStatsShard[],
+  candidateShards: readonly GlobalStatsShard[] | undefined,
   noMissingMessage: string,
   queuedMessage: string,
 ): Promise<void> {
@@ -1755,7 +1873,7 @@ async function dispatchMissingLogsnagInsightsShards(c: Context, dateId: string):
   await dispatchMissingLogsnagInsightsShardsFor(
     c,
     dateId,
-    GLOBAL_STATS_SHARDS,
+    undefined,
     'No missing logsnag insights global stats shards to queue',
     'Queued missing logsnag insights global stats shards',
   )
@@ -2747,6 +2865,8 @@ export const logsnagInsightsTestUtils = {
   getMetricWindowFromDailyWindow,
   getMissingGlobalStatsRequiredShards,
   getMissingGlobalStatsShards,
+  getGlobalStatsShardQueueCandidates,
+  buildRecentGlobalStatsRepairDateIds,
   hasCompletedGlobalStatsNotifications,
   shouldSkipCompletedGlobalStatsShardRetry,
   getGlobalStatsNotificationStepAction,
@@ -2886,6 +3006,7 @@ function scheduleLogsnagInsightsShardUpdate(
 }
 
 async function runLogsnagInsightsUpdate(c: Context, dateId = getDailyWindow().prevDayDateId, retryCount = 0): Promise<void> {
+  await repairRecentMissingGlobalStatsSnapshots(c, dateId)
   if (await shouldSkipCompletedLogsnagInsightsRetryDispatch(c, dateId, retryCount))
     return
 

--- a/supabase/migrations/20260630010932_optimize_global_stats_storage_repair.sql
+++ b/supabase/migrations/20260630010932_optimize_global_stats_storage_repair.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION "public"."total_bundle_storage_bytes"() RETURNS bigint
+    LANGUAGE "sql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  SELECT COALESCE(SUM(avm.size), 0)::bigint
+  FROM public.app_versions_meta avm
+  INNER JOIN public.app_versions av ON av.id = avm.id
+  WHERE av.deleted = false;
+$$;
+
+ALTER FUNCTION "public"."total_bundle_storage_bytes"() OWNER TO "postgres";
+
+COMMENT ON FUNCTION "public"."total_bundle_storage_bytes"() IS 'Returns active bundle storage in bytes from app_versions_meta.size for non-deleted app versions.';
+
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM "anon";
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM "authenticated";
+REVOKE ALL ON FUNCTION "public"."total_bundle_storage_bytes"() FROM "service_role";
+GRANT EXECUTE ON FUNCTION "public"."total_bundle_storage_bytes"() TO "service_role";

--- a/supabase/tests/52_test_total_bundle_storage_bytes.sql
+++ b/supabase/tests/52_test_total_bundle_storage_bytes.sql
@@ -40,8 +40,8 @@ BEGIN
 
   RETURN NEXT IS(
     public.total_bundle_storage_bytes(),
-    before_bytes + 300,
-    'total_bundle_storage_bytes should exclude deleted version bundle and manifest bytes'
+    before_bytes + 100,
+    'total_bundle_storage_bytes should count active version metadata bytes and ignore manifest bytes'
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import { readFileSync } from 'node:fs'
 import { Hono } from 'hono/tiny'
 import { describe, expect, it, vi } from 'vitest'
 import { logsnagInsightsTestUtils } from '../supabase/functions/_backend/triggers/logsnag_insights.ts'
@@ -75,6 +76,30 @@ describe('logsnag revenue metric helpers', () => {
     expect(dayDateId).toBe('2026-03-24')
   })
 
+  it.concurrent('builds a bounded recent repair window for missing global stats days', () => {
+    expect(logsnagInsightsTestUtils.buildRecentGlobalStatsRepairDateIds('2026-06-29', 2)).toEqual([
+      '2026-06-27',
+      '2026-06-28',
+      '2026-06-29',
+    ])
+    expect(logsnagInsightsTestUtils.buildRecentGlobalStatsRepairDateIds('2026-03-01', 2)).toEqual([
+      '2026-02-27',
+      '2026-02-28',
+      '2026-03-01',
+    ])
+  })
+
+  it.concurrent('keeps total bundle storage on version metadata instead of manifest rows', () => {
+    const migration = readFileSync(new URL('../supabase/migrations/20260630010932_optimize_global_stats_storage_repair.sql', import.meta.url), 'utf8')
+    const definition = migration.match(/CREATE OR REPLACE FUNCTION "public"\."total_bundle_storage_bytes"\(\) RETURNS bigint[\s\S]*?GRANT EXECUTE ON FUNCTION "public"\."total_bundle_storage_bytes"\(\) TO "service_role";/)?.[0]
+
+    expect(definition).toBeDefined()
+    expect(definition!).toContain('public.app_versions_meta')
+    expect(definition!).toContain('public.app_versions')
+    expect(definition!).not.toContain('public.manifest')
+    expect(definition!).not.toContain('file_size')
+  })
+
   it.concurrent('detects missing global stats shards before notifications', () => {
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsRequiredShards(new Set())).toEqual([
       'core',
@@ -100,6 +125,7 @@ describe('logsnag revenue metric helpers', () => {
     ])
 
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsRequiredShards(completed)).toEqual(['revenue'])
+    expect(logsnagInsightsTestUtils.getGlobalStatsShardQueueCandidates(completed)).toEqual(['revenue'])
 
     const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',
@@ -113,6 +139,7 @@ describe('logsnag revenue metric helpers', () => {
     ])
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsRequiredShards(ready)).toEqual([])
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsShards(ready)).toEqual(['notifications'])
+    expect(logsnagInsightsTestUtils.getGlobalStatsShardQueueCandidates(ready)).toEqual(['notifications'])
 
     const legacyUsage = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',


### PR DESCRIPTION
## Summary
- create missing recent global_stats rows during admin stats dispatch and queue only missing shard jobs
- keep notifications out of the queue until required shards are complete
- use billable_seconds for build-time admin stats and dashboard build-time charts
- replace total_bundle_storage_bytes() with an app_versions_meta aggregate so usage_storage no longer scans manifest rows

## Tests
- bunx vitest run tests/logsnag-insights-revenue.unit.test.ts tests/public-stats.unit.test.ts
- bun lint (passes with existing unrelated warnings in admin dashboard Vue files and compatibilityEvents.ts)
- bun lint:backend
- bun typecheck
- GitHub Actions: all PR checks passed, including both Run tests jobs and both Playwright jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the admin-stats dispatch/repair path and alters build-time and storage metric definitions, which can shift dashboards and LogSnag numbers without a simple rollback.
> 
> **Overview**
> **Repairs recent admin global-stats gaps** and tightens how shard jobs are queued: each dispatcher run backfills missing `global_stats` rows for the last 30 days (excluding the anchor day), re-queues only incomplete shards, and skips jobs already present in `pgmq`. **Notifications** stay deferred until all required shards finish via `getGlobalStatsShardQueueCandidates`.
> 
> **Build-time reporting** now sums **`billable_seconds`** from `build_logs` in the dashboard `BuildTimeCard` and in daily build aggregates for the builds shard (replacing `build_time_unit`).
> 
> **Bundle storage** for the usage storage shard: `total_bundle_storage_bytes()` now sums `app_versions_meta.size` for non-deleted versions instead of scanning `manifest` / `file_size`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c8f60e55c296200f87dd8df87ad2a72e8002ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->