### PR TITLE
fix(admin-stats): repair stale completed shards

### DIFF
--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -256,6 +256,7 @@ const GLOBAL_STATS_COMPLETION_MARKERS = [
 ] as const
 const GLOBAL_STATS_SHARD_SET = new Set<string>(GLOBAL_STATS_SHARDS)
 const GLOBAL_STATS_COMPLETION_MARKER_SET = new Set<string>(GLOBAL_STATS_COMPLETION_MARKERS)
+const GLOBAL_STATS_BUILD_AVG_EPSILON = 0.05
 
 type GlobalStatsShard = typeof GLOBAL_STATS_SHARDS[number]
 type GlobalStatsCompletionMarker = typeof GLOBAL_STATS_COMPLETION_MARKERS[number]
@@ -270,6 +271,38 @@ interface LogsnagInsightsPayload {
   retry_count?: unknown
   shard?: unknown
   date_id?: unknown
+}
+
+interface BuildShardStats {
+  totalSeconds: Record<'ios' | 'android', number>
+  avgSeconds: Record<'ios' | 'android', number>
+  counts: Record<'ios' | 'android', number>
+}
+
+interface GlobalStatsRepairRow {
+  dateId: string
+  completedShards: Set<GlobalStatsCompletionMarker>
+  orgs: number
+  bundleStorageGb: number
+  buildTotalSecondsDayIos: number
+  buildTotalSecondsDayAndroid: number
+  buildAvgSecondsDayIos: number
+  buildAvgSecondsDayAndroid: number
+  buildCountDayIos: number
+  buildCountDayAndroid: number
+}
+
+interface GlobalStatsRepairSqlRow {
+  date_id: string
+  completed_shards: unknown
+  orgs: number | string | null
+  bundle_storage_gb: number | string | null
+  build_total_seconds_day_ios: number | string | null
+  build_total_seconds_day_android: number | string | null
+  build_avg_seconds_day_ios: number | string | null
+  build_avg_seconds_day_android: number | string | null
+  build_count_day_ios: number | string | null
+  build_count_day_android: number | string | null
 }
 
 interface ScheduleLogsnagInsightsUpdateOptions {
@@ -1467,6 +1500,86 @@ function normalizeCompletedGlobalStatsShards(value: unknown): Set<GlobalStatsCom
   return new Set(parsed.filter((shard): shard is GlobalStatsCompletionMarker => typeof shard === 'string' && GLOBAL_STATS_COMPLETION_MARKER_SET.has(shard)))
 }
 
+function getEmptyBuildShardStats(): BuildShardStats {
+  return {
+    totalSeconds: { ios: 0, android: 0 },
+    avgSeconds: { ios: 0, android: 0 },
+    counts: { ios: 0, android: 0 },
+  }
+}
+
+function normalizeGlobalStatsRepairNumber(value: number | string | null): number {
+  const numericValue = Number(value)
+  return Number.isFinite(numericValue) ? numericValue : 0
+}
+
+function normalizeGlobalStatsRepairRow(row: GlobalStatsRepairSqlRow): GlobalStatsRepairRow {
+  return {
+    dateId: row.date_id,
+    completedShards: normalizeCompletedGlobalStatsShards(row.completed_shards),
+    orgs: normalizeGlobalStatsRepairNumber(row.orgs),
+    bundleStorageGb: normalizeGlobalStatsRepairNumber(row.bundle_storage_gb),
+    buildTotalSecondsDayIos: normalizeGlobalStatsRepairNumber(row.build_total_seconds_day_ios),
+    buildTotalSecondsDayAndroid: normalizeGlobalStatsRepairNumber(row.build_total_seconds_day_android),
+    buildAvgSecondsDayIos: normalizeGlobalStatsRepairNumber(row.build_avg_seconds_day_ios),
+    buildAvgSecondsDayAndroid: normalizeGlobalStatsRepairNumber(row.build_avg_seconds_day_android),
+    buildCountDayIos: normalizeGlobalStatsRepairNumber(row.build_count_day_ios),
+    buildCountDayAndroid: normalizeGlobalStatsRepairNumber(row.build_count_day_android),
+  }
+}
+
+function areGlobalStatsNumbersDifferent(actual: number, expected: number, epsilon = 0): boolean {
+  return Math.abs(actual - expected) > epsilon
+}
+
+function isGlobalStatsBuildShardStale(row: GlobalStatsRepairRow, expectedStats: BuildShardStats): boolean {
+  return areGlobalStatsNumbersDifferent(row.buildTotalSecondsDayIos, expectedStats.totalSeconds.ios)
+    || areGlobalStatsNumbersDifferent(row.buildTotalSecondsDayAndroid, expectedStats.totalSeconds.android)
+    || areGlobalStatsNumbersDifferent(row.buildAvgSecondsDayIos, expectedStats.avgSeconds.ios, GLOBAL_STATS_BUILD_AVG_EPSILON)
+    || areGlobalStatsNumbersDifferent(row.buildAvgSecondsDayAndroid, expectedStats.avgSeconds.android, GLOBAL_STATS_BUILD_AVG_EPSILON)
+    || areGlobalStatsNumbersDifferent(row.buildCountDayIos, expectedStats.counts.ios)
+    || areGlobalStatsNumbersDifferent(row.buildCountDayAndroid, expectedStats.counts.android)
+}
+
+function getGlobalStatsStaleRepairShards(row: GlobalStatsRepairRow, expectedBuildStats: BuildShardStats = getEmptyBuildShardStats()): GlobalStatsShard[] {
+  const staleShards: GlobalStatsShard[] = []
+
+  if (row.completedShards.has('core') && row.orgs <= 0)
+    staleShards.push('core')
+  if (row.completedShards.has('usage_storage') && row.bundleStorageGb <= 0)
+    staleShards.push('usage_storage')
+  if (row.completedShards.has('builds') && isGlobalStatsBuildShardStale(row, expectedBuildStats))
+    staleShards.push('builds')
+
+  return staleShards
+}
+
+function uniqueGlobalStatsShards(shards: readonly GlobalStatsShard[]): GlobalStatsShard[] {
+  return GLOBAL_STATS_SHARDS.filter(shard => shards.includes(shard))
+}
+
+function filterCandidateGlobalStatsShards(shards: readonly GlobalStatsShard[], candidateShards?: readonly GlobalStatsShard[]): GlobalStatsShard[] {
+  if (!candidateShards)
+    return uniqueGlobalStatsShards(shards)
+
+  const candidateShardSet = new Set(candidateShards)
+  return uniqueGlobalStatsShards(shards.filter(shard => candidateShardSet.has(shard)))
+}
+
+function getGlobalStatsRepairShardQueueCandidates(
+  completedShards: ReadonlySet<GlobalStatsCompletionMarker>,
+  staleShards: readonly GlobalStatsShard[] = [],
+  candidateShards?: readonly GlobalStatsShard[],
+): GlobalStatsShard[] {
+  const missingRequiredShards = filterCandidateGlobalStatsShards(getMissingGlobalStatsRequiredShards(completedShards), candidateShards)
+  const staleRequiredShards = filterCandidateGlobalStatsShards(staleShards, candidateShards)
+  if (missingRequiredShards.length > 0 || staleRequiredShards.length > 0)
+    return uniqueGlobalStatsShards([...missingRequiredShards, ...staleRequiredShards])
+
+  const missingShards = candidateShards ? candidateShards.filter(shard => !completedShards.has(shard)) : getMissingGlobalStatsShards(completedShards)
+  return filterCandidateGlobalStatsShards(missingShards, candidateShards)
+}
+
 function getMissingGlobalStatsRequiredShards(completedShards: ReadonlySet<GlobalStatsCompletionMarker>): RequiredGlobalStatsShard[] {
   return REQUIRED_GLOBAL_STATS_SHARDS.filter(shard => !completedShards.has(shard))
 }
@@ -1489,6 +1602,21 @@ function shouldSkipCompletedGlobalStatsShardRetry(
   shard: GlobalStatsShard,
 ): boolean {
   return shard !== 'notifications' && completedShards.has(shard)
+}
+
+async function shouldSkipGlobalStatsShardUpdate(
+  c: Context,
+  dateId: string,
+  completedShards: ReadonlySet<GlobalStatsCompletionMarker>,
+  shard: GlobalStatsShard,
+): Promise<boolean> {
+  if (!shouldSkipCompletedGlobalStatsShardRetry(completedShards, shard))
+    return false
+
+  if (await readCompletedGlobalStatsRepairShardStale(c, dateId, shard))
+    return false
+
+  return true
 }
 
 function getGlobalStatsNotificationStepAction(
@@ -1743,10 +1871,11 @@ async function queueMissingLogsnagInsightsShards(
   c: Context,
   dateId: string,
   completedShards: ReadonlySet<GlobalStatsCompletionMarker>,
-  candidateShards: readonly GlobalStatsShard[] = getGlobalStatsShardQueueCandidates(completedShards),
+  candidateShards?: readonly GlobalStatsShard[],
+  staleShards: readonly GlobalStatsShard[] = [],
 ): Promise<Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }>> {
-  const missingShards = candidateShards.filter(shard => !completedShards.has(shard))
-  return queueLogsnagInsightsShards(c, dateId, missingShards)
+  const shardsToQueue = getGlobalStatsRepairShardQueueCandidates(completedShards, staleShards, candidateShards)
+  return queueLogsnagInsightsShards(c, dateId, shardsToQueue)
 }
 
 function getLogsnagInsightsShardQueueKey(shard: GlobalStatsShard, dateId: string): string {
@@ -1782,25 +1911,99 @@ async function readQueuedLogsnagInsightsShardKeys(c: Context, dateIds: readonly 
   }
 }
 
-async function readGlobalStatsCompletionRows(c: Context, dateIds: readonly string[]): Promise<Map<string, Set<GlobalStatsCompletionMarker>>> {
+async function readGlobalStatsRepairRows(c: Context, dateIds: readonly string[]): Promise<Map<string, GlobalStatsRepairRow>> {
   if (dateIds.length === 0)
     return new Map()
 
   const db = getPgClient(c)
 
   try {
-    const result = await db.query<{ date_id: string, completed_shards: unknown }>(
-      `SELECT date_id, completed_shards
+    const result = await db.query<GlobalStatsRepairSqlRow>(
+      `SELECT
+        date_id,
+        completed_shards,
+        orgs,
+        bundle_storage_gb,
+        build_total_seconds_day_ios,
+        build_total_seconds_day_android,
+        build_avg_seconds_day_ios,
+        build_avg_seconds_day_android,
+        build_count_day_ios,
+        build_count_day_android
       FROM public.global_stats
       WHERE date_id = ANY($1::text[])`,
       [dateIds],
     )
 
-    return new Map(result.rows.map(row => [row.date_id, normalizeCompletedGlobalStatsShards(row.completed_shards)]))
+    return new Map(result.rows.map((row) => {
+      const repairRow = normalizeGlobalStatsRepairRow(row)
+      return [repairRow.dateId, repairRow]
+    }))
   }
   finally {
     await closeClient(c, db)
   }
+}
+
+async function readDailyBuildStatsByDate(c: Context, dateIds: readonly string[]): Promise<Map<string, BuildShardStats>> {
+  const uniqueDateIds = Array.from(new Set(dateIds)).sort((a, b) => a.localeCompare(b))
+  if (uniqueDateIds.length === 0)
+    return new Map()
+
+  const start = new Date(`${uniqueDateIds[0]}T00:00:00.000Z`)
+  const end = new Date(`${uniqueDateIds[uniqueDateIds.length - 1]}T00:00:00.000Z`)
+  end.setUTCDate(end.getUTCDate() + 1)
+
+  const db = getPgClient(c, false)
+
+  try {
+    const result = await db.query<{ date_id: string, platform: string, total_seconds: number | string | null, avg_seconds: number | string | null, total_builds: number | string | null }>(
+      `SELECT
+        to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS date_id,
+        platform,
+        COALESCE(SUM(billable_seconds), 0)::bigint AS total_seconds,
+        COALESCE(ROUND(AVG(billable_seconds)::numeric, 1), 0)::float AS avg_seconds,
+        COUNT(*)::int AS total_builds
+      FROM public.build_logs
+      WHERE created_at >= $1
+        AND created_at < $2
+        AND platform IN ('ios', 'android')
+      GROUP BY date_id, platform`,
+      [start, end],
+    )
+
+    const statsByDate = new Map(uniqueDateIds.map(dateId => [dateId, getEmptyBuildShardStats()]))
+    for (const row of result.rows) {
+      if (row.platform !== 'ios' && row.platform !== 'android')
+        continue
+
+      const stats = statsByDate.get(row.date_id) ?? getEmptyBuildShardStats()
+      stats.totalSeconds[row.platform] = normalizeGlobalStatsRepairNumber(row.total_seconds)
+      stats.avgSeconds[row.platform] = normalizeGlobalStatsRepairNumber(row.avg_seconds)
+      stats.counts[row.platform] = normalizeGlobalStatsRepairNumber(row.total_builds)
+      statsByDate.set(row.date_id, stats)
+    }
+
+    return statsByDate
+  }
+  finally {
+    await closeClient(c, db)
+  }
+}
+
+async function readCompletedGlobalStatsRepairShardStale(c: Context, dateId: string, shard: GlobalStatsShard): Promise<boolean> {
+  if (shard !== 'core' && shard !== 'usage_storage' && shard !== 'builds')
+    return false
+
+  const repairRow = (await readGlobalStatsRepairRows(c, [dateId])).get(dateId)
+  if (!repairRow || !repairRow.completedShards.has(shard))
+    return false
+
+  const buildStats = shard === 'builds'
+    ? (await readDailyBuildStatsByDate(c, [dateId])).get(dateId) ?? getEmptyBuildShardStats()
+    : getEmptyBuildShardStats()
+
+  return getGlobalStatsStaleRepairShards(repairRow, buildStats).includes(shard)
 }
 
 async function repairRecentMissingGlobalStatsSnapshots(c: Context, anchorDateId: string): Promise<void> {
@@ -1808,29 +2011,36 @@ async function repairRecentMissingGlobalStatsSnapshots(c: Context, anchorDateId:
   if (dateIds.length === 0)
     return
 
-  const [completionRows, queuedShardKeys] = await Promise.all([
-    readGlobalStatsCompletionRows(c, dateIds),
+  const [repairRows, queuedShardKeys] = await Promise.all([
+    readGlobalStatsRepairRows(c, dateIds),
     readQueuedLogsnagInsightsShardKeys(c, dateIds),
   ])
-  const missingDateIds = dateIds.filter(dateId => !completionRows.has(dateId))
+  const missingDateIds = dateIds.filter(dateId => !repairRows.has(dateId))
   await ensureGlobalStatsSnapshotRows(c, missingDateIds)
 
-  const queuedByDate: Array<{ dateId: string, queued: Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }> }> = []
+  const buildStatsByDate = await readDailyBuildStatsByDate(c, Array.from(repairRows.values()).flatMap((row) => {
+    if (!row.completedShards.has('builds'))
+      return []
+    return [row.dateId]
+  }))
+
+  const queuedByDate: Array<{ dateId: string, staleShards: GlobalStatsShard[], queued: Array<{ shard: GlobalStatsShard, msgId: number, delaySeconds: number }> }> = []
   for (const dateId of dateIds) {
-    const completedShards = completionRows.get(dateId) ?? new Set<GlobalStatsCompletionMarker>()
-    const shardsToQueue = getGlobalStatsShardQueueCandidates(completedShards)
-      .filter(shard => !completedShards.has(shard))
+    const repairRow = repairRows.get(dateId)
+    const completedShards = repairRow?.completedShards ?? new Set<GlobalStatsCompletionMarker>()
+    const staleShards = repairRow ? getGlobalStatsStaleRepairShards(repairRow, buildStatsByDate.get(dateId) ?? getEmptyBuildShardStats()) : []
+    const shardsToQueue = getGlobalStatsRepairShardQueueCandidates(completedShards, staleShards)
       .filter(shard => !queuedShardKeys.has(getLogsnagInsightsShardQueueKey(shard, dateId)))
 
     const queued = await queueLogsnagInsightsShards(c, dateId, shardsToQueue)
     if (queued.length > 0)
-      queuedByDate.push({ dateId, queued })
+      queuedByDate.push({ dateId, staleShards, queued })
   }
 
   if (missingDateIds.length > 0 || queuedByDate.length > 0) {
     cloudlog({
       requestId: c.get('requestId'),
-      message: 'Repaired recent missing global stats snapshots',
+      message: 'Repaired recent missing or stale global stats snapshots',
       anchorDateId,
       missingDateIds,
       queuedByDate,
@@ -1846,8 +2056,13 @@ async function dispatchMissingLogsnagInsightsShardsFor(
   queuedMessage: string,
 ): Promise<void> {
   await ensureGlobalStatsSnapshotRow(c, dateId)
-  const completedShards = await readCompletedGlobalStatsShards(c, dateId)
-  const queued = await queueMissingLogsnagInsightsShards(c, dateId, completedShards, candidateShards)
+  const repairRow = (await readGlobalStatsRepairRows(c, [dateId])).get(dateId)
+  const completedShards = repairRow?.completedShards ?? new Set<GlobalStatsCompletionMarker>()
+  const buildStats = repairRow?.completedShards.has('builds')
+    ? (await readDailyBuildStatsByDate(c, [dateId])).get(dateId) ?? getEmptyBuildShardStats()
+    : getEmptyBuildShardStats()
+  const staleShards = repairRow ? getGlobalStatsStaleRepairShards(repairRow, buildStats) : []
+  const queued = await queueMissingLogsnagInsightsShards(c, dateId, completedShards, candidateShards, staleShards)
   const completedShardNames = Array.from(completedShards).sort((a, b) => a.localeCompare(b))
 
   if (queued.length === 0) {
@@ -1856,6 +2071,7 @@ async function dispatchMissingLogsnagInsightsShardsFor(
       message: noMissingMessage,
       dateId,
       completedShards: completedShardNames,
+      staleShards,
     })
     return
   }
@@ -1866,6 +2082,7 @@ async function dispatchMissingLogsnagInsightsShardsFor(
     dateId,
     queued,
     completedShards: completedShardNames,
+    staleShards,
   })
 }
 
@@ -2866,6 +3083,10 @@ export const logsnagInsightsTestUtils = {
   getMissingGlobalStatsRequiredShards,
   getMissingGlobalStatsShards,
   getGlobalStatsShardQueueCandidates,
+  getGlobalStatsRepairShardQueueCandidates,
+  getGlobalStatsStaleRepairShards,
+  isGlobalStatsBuildShardStale,
+  getEmptyBuildShardStats,
   buildRecentGlobalStatsRepairDateIds,
   hasCompletedGlobalStatsNotifications,
   shouldSkipCompletedGlobalStatsShardRetry,
@@ -2893,7 +3114,7 @@ export const app = new Hono<MiddlewareKeyVariables>()
 
 async function runLogsnagInsightsShard(c: Context, shard: GlobalStatsShard, dateId: string): Promise<void> {
   const completedShards = await readCompletedGlobalStatsShards(c, dateId)
-  if (shouldSkipCompletedGlobalStatsShardRetry(completedShards, shard)) {
+  if (await shouldSkipGlobalStatsShardUpdate(c, dateId, completedShards, shard)) {
     cloudlog({
       requestId: c.get('requestId'),
       message: 'Skipping completed logsnag insights shard retry',

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -162,6 +162,77 @@ describe('logsnag revenue metric helpers', () => {
     expect(logsnagInsightsTestUtils.getMissingGlobalStatsShards(sent)).toEqual([])
   })
 
+  it.concurrent('requeues stale completed global stats shards before notifications', () => {
+    const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
+      'core',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
+      'revenue',
+      'plugins',
+      'builds',
+      'retention',
+      'paid_products',
+      'ltv',
+    ])
+    const staleRow = {
+      dateId: '2026-06-17',
+      completedShards: ready,
+      orgs: 0,
+      bundleStorageGb: 0,
+      buildTotalSecondsDayIos: 1908,
+      buildTotalSecondsDayAndroid: 0,
+      buildAvgSecondsDayIos: 59.6,
+      buildAvgSecondsDayAndroid: 0,
+      buildCountDayIos: 32,
+      buildCountDayAndroid: 0,
+    }
+    const expectedBuildStats = {
+      totalSeconds: { ios: 3816, android: 0 },
+      avgSeconds: { ios: 119.3, android: 0 },
+      counts: { ios: 32, android: 0 },
+    }
+
+    const staleShards = logsnagInsightsTestUtils.getGlobalStatsStaleRepairShards(staleRow, expectedBuildStats)
+
+    expect(staleShards).toEqual(['core', 'usage_storage', 'builds'])
+    expect(logsnagInsightsTestUtils.getGlobalStatsRepairShardQueueCandidates(ready, staleShards)).toEqual(['core', 'usage_storage', 'builds'])
+    expect(logsnagInsightsTestUtils.getGlobalStatsRepairShardQueueCandidates(ready)).toEqual(['notifications'])
+  })
+
+  it.concurrent('keeps fresh completed global stats shards eligible for notifications', () => {
+    const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
+      'core',
+      ...logsnagInsightsTestUtils.USAGE_GLOBAL_STATS_SHARDS,
+      'revenue',
+      'plugins',
+      'builds',
+      'retention',
+      'paid_products',
+      'ltv',
+    ])
+    const freshRow = {
+      dateId: '2026-06-17',
+      completedShards: ready,
+      orgs: 6639,
+      bundleStorageGb: 489.89,
+      buildTotalSecondsDayIos: 3816,
+      buildTotalSecondsDayAndroid: 0,
+      buildAvgSecondsDayIos: 119.3,
+      buildAvgSecondsDayAndroid: 0,
+      buildCountDayIos: 32,
+      buildCountDayAndroid: 0,
+    }
+    const expectedBuildStats = {
+      totalSeconds: { ios: 3816, android: 0 },
+      avgSeconds: { ios: 119.3, android: 0 },
+      counts: { ios: 32, android: 0 },
+    }
+
+    const staleShards = logsnagInsightsTestUtils.getGlobalStatsStaleRepairShards(freshRow, expectedBuildStats)
+
+    expect(staleShards).toEqual([])
+    expect(logsnagInsightsTestUtils.getGlobalStatsRepairShardQueueCandidates(ready, staleShards)).toEqual(['notifications'])
+  })
+
   it.concurrent('detects completed global stats notifications for idempotent retries', () => {
     const ready = logsnagInsightsTestUtils.normalizeCompletedGlobalStatsShards([
       'core',


### PR DESCRIPTION
## Summary

- detect stale completed `global_stats` shards during the 30-day admin-stats repair pass
- requeue stale required shards before notifications so bad completed markers cannot hide broken columns
- let `core`, `usage_storage`, and `builds` shard endpoints rerun when the stored snapshot values prove stale
- add unit coverage for completed-shard markers with stale production-shaped data

## Production failure table

| What was broken | When it started failing | Why it failed / PR | How this PR fixes it |
| --- | --- | --- | --- |
| Missing `global_stats` rows for completed days | `2026-06-15` and `2026-06-16` are absent. `2026-06-30` is current-day/incomplete and not treated as broken. | The historical dispatcher path did not repair absent recent rows. PR #2484 got global snapshots running again, but the missing rows from the outage window were not backfilled by completed-shard checks. | The repair pass keeps creating missing rows and queues required shards for those dates. This preserves the #2597 row repair and makes every admin-stats run fill missing completed days. |
| `bundle_storage_gb` | `2026-06-18` through `2026-06-29` are `0`; current source aggregate is `490.08 GB`. | PR #2590 split usage into separate shards. The storage shard was separated and the old storage query could not finish; Cloudflare showed `waitUntil()` cancellation for the usage storage trigger, and production PGMQ still has `logsnag_insights_usage_storage` messages for `2026-06-17` through `2026-06-29` with `read_ct=0`. | #2597 optimized storage to use `app_versions_meta`; this PR additionally treats `bundle_storage_gb <= 0` with completed `usage_storage` as stale and requeues `usage_storage` before notifications. |
| iOS build day seconds / average | In the inspected completed window, stale from `2026-06-14` and `2026-06-17` through `2026-06-29`; values equal `build_time_unit`, while source `billable_seconds` is exactly 2x. Example `2026-06-29`: snapshot `3629s`, source `7258s`. | PR #1829 introduced daily build stats from `build_time_unit`; PR #1832 kept the seconds columns on that source. #2597 switched the writer to `billable_seconds`, but rows already marked `builds` completed were skipped and never replayed. | The repair pass compares recent `global_stats` build fields against bounded `build_logs.billable_seconds` aggregates and requeues `builds` when they differ, even if `completed_shards` already contains `builds`. |
| `orgs` count | `2026-06-14` is `0`; source count for that day is `6639`. | PR #2568 added `orgs` to the core snapshot after the row was already marked `core` completed, so the completed marker blocked replay. | A completed `core` shard with `orgs <= 0` is now considered stale and `core` is requeued before notifications. |

Notes from production checks:
- Source-checked zeros for `demo_apps_created`, `trial_extended_subscribed_orgs`, `upgraded_orgs`, and Android build zeros matched their source data and are not treated as broken.
- Production PGMQ also shows notification messages for `2026-06-17` through `2026-06-28` with `read_ct=3-4`, confirming notifications retried before storage was complete.

## Tests

- `bunx vitest run tests/logsnag-insights-revenue.unit.test.ts`
- `bunx vitest run tests/logsnag-insights-revenue.unit.test.ts tests/public-stats.unit.test.ts`
- `bun lint`
- `bun lint:backend`
- `bun typecheck`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

`bun test:backend` was not run locally because `bun run supabase:status` did not return after 90s in this isolated worktree; CI should cover the DB-backed suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin-stats orchestration and can re-run completed shards with extra DB reads against `global_stats` and `build_logs`, but logic is bounded to repair paths and covered by new unit tests.
> 
> **Overview**
> Extends the **30-day admin-stats repair pass** so days marked complete can still be fixed when snapshot columns are wrong. Completed `core`, `usage_storage`, and `builds` markers no longer block reruns when stored values look stale.
> 
> **Stale detection** compares `global_stats` to repair heuristics: `orgs <= 0` on completed `core`, `bundle_storage_gb <= 0` on completed `usage_storage`, and iOS/Android build totals/averages/counts on completed `builds` against bounded `build_logs.billable_seconds` aggregates (with a small epsilon on averages). Repair reads richer rows than `completed_shards` alone and uses `getGlobalStatsRepairShardQueueCandidates` to **requeue missing or stale required shards before `notifications`**.
> 
> Shard HTTP handlers call **`shouldSkipGlobalStatsShardUpdate`**, which still skips idempotent retries unless the completed shard is stale for that date. Logging now includes `staleShards` when dispatching or repairing. Unit tests cover stale vs fresh production-shaped rows and queue ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f55199b789f8c528271000b93eda4ff590a9721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair handling for analytics updates so outdated results are detected and reprocessed automatically.
  * Reduced missed or duplicate processing by better distinguishing incomplete, stale, and fresh update states.
  * Expanded queueing behavior to include only the necessary follow-up work, helping keep notifications and related updates accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->