### PR TITLE
Fix org ownership transfer on owner self-removal

### DIFF
--- a/supabase/migrations/20260630133811_transfer_org_owner_on_self_removal.sql
+++ b/supabase/migrations/20260630133811_transfer_org_owner_on_self_removal.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE FUNCTION public.delete_org_member_role(
+    p_org_id uuid,
+    p_user_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_actor_id uuid;
+    v_org_created_by uuid;
+    v_successor_user_id uuid;
+BEGIN
+    v_actor_id := auth.uid();
+
+    -- Check if user has permission to update roles.
+    IF NOT public.rbac_check_permission_direct(
+        public.rbac_perm_org_update_user_roles(),
+        v_actor_id,
+        p_org_id,
+        NULL,
+        NULL
+    ) THEN
+        RAISE EXCEPTION 'NO_PERMISSION_TO_UPDATE_ROLES';
+    END IF;
+
+    -- Lock the org row so ownership transfer and member removal stay atomic.
+    SELECT o.created_by INTO v_org_created_by
+    FROM public.orgs AS o
+    WHERE o.id = p_org_id
+    FOR UPDATE;
+
+    IF p_user_id = v_org_created_by THEN
+        IF v_actor_id IS DISTINCT FROM p_user_id THEN
+            RAISE EXCEPTION 'CANNOT_CHANGE_OWNER_ROLE';
+        END IF;
+
+        SELECT rb.principal_id INTO v_successor_user_id
+        FROM public.role_bindings AS rb
+        INNER JOIN public.roles AS r ON rb.role_id = r.id
+        WHERE rb.principal_id <> p_user_id
+            AND rb.principal_type = public.rbac_principal_user()
+            AND rb.scope_type = public.rbac_scope_org()
+            AND rb.org_id = p_org_id
+            AND r.name = public.rbac_role_org_super_admin()
+        ORDER BY rb.granted_at ASC NULLS LAST, rb.principal_id ASC
+        LIMIT 1;
+
+        IF v_successor_user_id IS NULL THEN
+            RAISE EXCEPTION 'CANNOT_REMOVE_LAST_SUPER_ADMIN';
+        END IF;
+
+        UPDATE public.orgs AS o
+        SET created_by = v_successor_user_id
+        WHERE o.id = p_org_id;
+    ELSE
+        -- Check if removing a super_admin and if this is the last super_admin.
+        IF EXISTS (
+            SELECT 1
+            FROM public.role_bindings AS rb
+            INNER JOIN public.roles AS r ON rb.role_id = r.id
+            WHERE rb.principal_id = p_user_id
+                AND rb.principal_type = public.rbac_principal_user()
+                AND rb.scope_type = public.rbac_scope_org()
+                AND rb.org_id = p_org_id
+                AND r.name = public.rbac_role_org_super_admin()
+        ) THEN
+            IF (
+                SELECT COUNT(*)
+                FROM public.role_bindings AS rb
+                INNER JOIN public.roles AS r ON rb.role_id = r.id
+                WHERE rb.scope_type = public.rbac_scope_org()
+                    AND rb.org_id = p_org_id
+                    AND rb.principal_type = public.rbac_principal_user()
+                    AND r.name = public.rbac_role_org_super_admin()
+            ) <= 1 THEN
+                RAISE EXCEPTION 'CANNOT_REMOVE_LAST_SUPER_ADMIN';
+            END IF;
+        END IF;
+    END IF;
+
+    -- Delete ALL role bindings for this user in this org.
+    DELETE FROM public.role_bindings AS rb
+    WHERE rb.principal_id = p_user_id
+        AND rb.principal_type = public.rbac_principal_user()
+        AND rb.org_id = p_org_id;
+
+    RETURN 'OK';
+END;
+$$;
+
+ALTER FUNCTION public.delete_org_member_role(uuid, uuid) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.delete_org_member_role(uuid, uuid) IS
+'Deletes all organization member role bindings across org, app, and channel
+scopes. Requires org.update_user_roles permission. Owners can only remove
+themselves after another org_super_admin exists; ownership is transferred to
+that successor before removal. Returns OK on success.';
+
+REVOKE ALL ON FUNCTION public.delete_org_member_role(uuid, uuid) FROM public;
+GRANT ALL ON FUNCTION public.delete_org_member_role(uuid, uuid)
+TO authenticated;
+GRANT ALL ON FUNCTION public.delete_org_member_role(uuid, uuid) TO service_role;

--- a/tests/org-ownership-transfer.test.ts
+++ b/tests/org-ownership-transfer.test.ts
@@ -1,0 +1,98 @@
+import type { Database } from '../src/types/supabase.types'
+import { randomUUID } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  getSupabaseClient,
+  SUPABASE_ANON_KEY,
+  SUPABASE_BASE_URL,
+  USER_EMAIL,
+  USER_ID,
+  USER_ID_2,
+  USER_PASSWORD,
+} from './test-utils.ts'
+
+const orgId = randomUUID()
+const orgName = `Ownership transfer ${orgId}`
+
+function createAuthClient() {
+  return createClient<Database>(SUPABASE_BASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+    },
+  })
+}
+
+describe('organization ownership transfer', () => {
+  const authClient = createAuthClient()
+
+  beforeAll(async () => {
+    const { error: signInError } = await authClient.auth.signInWithPassword({
+      email: USER_EMAIL,
+      password: USER_PASSWORD,
+    })
+    if (signInError)
+      throw signInError
+
+    const supabase = getSupabaseClient()
+    await supabase.from('orgs').insert({
+      id: orgId,
+      created_by: USER_ID,
+      management_email: `ownership-transfer-${orgId}@capgo.app`,
+      name: orgName,
+      updated_at: new Date().toISOString(),
+      use_new_rbac: true,
+    }).throwOnError()
+
+    await supabase.from('org_users').insert({
+      org_id: orgId,
+      user_id: USER_ID_2,
+      user_right: 'read',
+    }).throwOnError()
+  })
+
+  afterAll(async () => {
+    const supabase = getSupabaseClient()
+    const { data: org } = await supabase
+      .from('orgs')
+      .select('customer_id')
+      .eq('id', orgId)
+      .maybeSingle()
+
+    await supabase.from('role_bindings').delete().eq('org_id', orgId)
+    await supabase.from('org_users').delete().eq('org_id', orgId)
+    await supabase.from('orgs').delete().eq('id', orgId)
+
+    if (org?.customer_id?.startsWith('pending_')) {
+      await supabase.from('stripe_info').delete().eq('customer_id', org.customer_id)
+    }
+  })
+
+  it('lets an owner delegate super admin and leave the org', async () => {
+    const promoteResult = await authClient.rpc('update_org_member_role', {
+      p_org_id: orgId,
+      p_user_id: USER_ID_2,
+      p_new_role_name: 'org_super_admin',
+    })
+
+    expect(promoteResult.error).toBeNull()
+    expect(promoteResult.data).toBe('OK')
+
+    const leaveResult = await authClient.rpc('delete_org_member_role', {
+      p_org_id: orgId,
+      p_user_id: USER_ID,
+    })
+
+    expect(leaveResult.error).toBeNull()
+    expect(leaveResult.data).toBe('OK')
+
+    const { data: org, error: orgError } = await getSupabaseClient()
+      .from('orgs')
+      .select('created_by')
+      .eq('id', orgId)
+      .single()
+
+    expect(orgError).toBeNull()
+    expect(org?.created_by).toBe(USER_ID_2)
+  })
+})

--- a/tests/org-ownership-transfer.test.ts
+++ b/tests/org-ownership-transfer.test.ts
@@ -12,8 +12,10 @@ import {
   USER_PASSWORD,
 } from './test-utils.ts'
 
-const orgId = randomUUID()
-const orgName = `Ownership transfer ${orgId}`
+const USER_EMAIL_2 = 'test2@capgo.app'
+const transferOrgId = randomUUID()
+const protectedOrgId = randomUUID()
+const orgIds = [transferOrgId, protectedOrgId]
 
 function createAuthClient() {
   return createClient<Database>(SUPABASE_BASE_URL, SUPABASE_ANON_KEY, {
@@ -23,54 +25,70 @@ function createAuthClient() {
   })
 }
 
+async function createOrgWithMember(orgId: string) {
+  const supabase = getSupabaseClient()
+
+  await supabase.from('orgs').insert({
+    id: orgId,
+    created_by: USER_ID,
+    management_email: `ownership-transfer-${orgId}@capgo.app`,
+    name: `Ownership transfer ${orgId}`,
+    updated_at: new Date().toISOString(),
+    use_new_rbac: true,
+  }).throwOnError()
+
+  await supabase.from('org_users').insert({
+    org_id: orgId,
+    user_id: USER_ID_2,
+    user_right: 'read',
+  }).throwOnError()
+}
+
 describe('organization ownership transfer', () => {
-  const authClient = createAuthClient()
+  const ownerClient = createAuthClient()
+  const memberClient = createAuthClient()
 
   beforeAll(async () => {
-    const { error: signInError } = await authClient.auth.signInWithPassword({
+    const { error: ownerSignInError } = await ownerClient.auth.signInWithPassword({
       email: USER_EMAIL,
       password: USER_PASSWORD,
     })
-    if (signInError)
-      throw signInError
+    if (ownerSignInError)
+      throw ownerSignInError
 
-    const supabase = getSupabaseClient()
-    await supabase.from('orgs').insert({
-      id: orgId,
-      created_by: USER_ID,
-      management_email: `ownership-transfer-${orgId}@capgo.app`,
-      name: orgName,
-      updated_at: new Date().toISOString(),
-      use_new_rbac: true,
-    }).throwOnError()
+    const { error: memberSignInError } = await memberClient.auth.signInWithPassword({
+      email: USER_EMAIL_2,
+      password: USER_PASSWORD,
+    })
+    if (memberSignInError)
+      throw memberSignInError
 
-    await supabase.from('org_users').insert({
-      org_id: orgId,
-      user_id: USER_ID_2,
-      user_right: 'read',
-    }).throwOnError()
+    for (const orgId of orgIds) {
+      await createOrgWithMember(orgId)
+    }
   })
 
   afterAll(async () => {
     const supabase = getSupabaseClient()
-    const { data: org } = await supabase
+    const { data: orgs } = await supabase
       .from('orgs')
       .select('customer_id')
-      .eq('id', orgId)
-      .maybeSingle()
+      .in('id', orgIds)
 
-    await supabase.from('role_bindings').delete().eq('org_id', orgId)
-    await supabase.from('org_users').delete().eq('org_id', orgId)
-    await supabase.from('orgs').delete().eq('id', orgId)
+    await supabase.from('role_bindings').delete().in('org_id', orgIds)
+    await supabase.from('org_users').delete().in('org_id', orgIds)
+    await supabase.from('orgs').delete().in('id', orgIds)
 
-    if (org?.customer_id?.startsWith('pending_')) {
-      await supabase.from('stripe_info').delete().eq('customer_id', org.customer_id)
+    for (const org of orgs ?? []) {
+      if (org.customer_id?.startsWith('pending_')) {
+        await supabase.from('stripe_info').delete().eq('customer_id', org.customer_id)
+      }
     }
   })
 
   it('lets an owner delegate super admin and leave the org', async () => {
-    const promoteResult = await authClient.rpc('update_org_member_role', {
-      p_org_id: orgId,
+    const promoteResult = await ownerClient.rpc('update_org_member_role', {
+      p_org_id: transferOrgId,
       p_user_id: USER_ID_2,
       p_new_role_name: 'org_super_admin',
     })
@@ -78,8 +96,8 @@ describe('organization ownership transfer', () => {
     expect(promoteResult.error).toBeNull()
     expect(promoteResult.data).toBe('OK')
 
-    const leaveResult = await authClient.rpc('delete_org_member_role', {
-      p_org_id: orgId,
+    const leaveResult = await ownerClient.rpc('delete_org_member_role', {
+      p_org_id: transferOrgId,
       p_user_id: USER_ID,
     })
 
@@ -89,10 +107,38 @@ describe('organization ownership transfer', () => {
     const { data: org, error: orgError } = await getSupabaseClient()
       .from('orgs')
       .select('created_by')
-      .eq('id', orgId)
+      .eq('id', transferOrgId)
       .single()
 
     expect(orgError).toBeNull()
     expect(org?.created_by).toBe(USER_ID_2)
+  })
+
+  it('does not let another super admin remove the owner', async () => {
+    const promoteResult = await ownerClient.rpc('update_org_member_role', {
+      p_org_id: protectedOrgId,
+      p_user_id: USER_ID_2,
+      p_new_role_name: 'org_super_admin',
+    })
+
+    expect(promoteResult.error).toBeNull()
+    expect(promoteResult.data).toBe('OK')
+
+    const removeOwnerResult = await memberClient.rpc('delete_org_member_role', {
+      p_org_id: protectedOrgId,
+      p_user_id: USER_ID,
+    })
+
+    expect(removeOwnerResult.data).toBeNull()
+    expect(removeOwnerResult.error?.message).toContain('CANNOT_CHANGE_OWNER_ROLE')
+
+    const { data: org, error: orgError } = await getSupabaseClient()
+      .from('orgs')
+      .select('created_by')
+      .eq('id', protectedOrgId)
+      .single()
+
+    expect(orgError).toBeNull()
+    expect(org?.created_by).toBe(USER_ID)
   })
 })


### PR DESCRIPTION
## Summary

Fixes organization ownership transfer when the current owner delegates another member to `org_super_admin` and then leaves the organization.

The database RPC now handles the transfer atomically in `delete_org_member_role`:

1. verifies the caller still has `org.update_user_roles`
2. locks the org row
3. allows owner removal only when the caller is removing themselves
4. requires another `org_super_admin` to exist
5. transfers `orgs.created_by` to that successor before deleting the old owner's role bindings

## Security

This does not let another super admin force-transfer or remove the current owner. That path still raises `CANNOT_CHANGE_OWNER_ROLE`, and the regression test covers it.

The function keeps `SECURITY DEFINER`, `SET search_path = ''`, explicit owner, explicit revoke from public, and grants only to `authenticated` and `service_role`.

## Validation

- `bun run supabase:db:reset`
- `bun run lint:backend`
- `sqlfluff lint --dialect postgres supabase/migrations/20260630133811_transfer_org_owner_on_self_removal.sql`
- `bun run supabase:with-env -- bunx vitest run tests/org-ownership-transfer.test.ts tests/security-definer-execute-hardening.test.ts`
- `bun run supabase:with-env -- bunx vitest run tests/org-ownership-transfer.test.ts tests/organization-api.test.ts tests/private-role-bindings.test.ts tests/rbac-permissions.test.ts`
- `bunx supabase db lint --local` only reports an existing warning in `tests.authenticate_as`
- `git commit` pre-commit typechecks passed:
  - `bun run cli:typecheck`
  - `bun run typecheck:backend`
  - `bun run typecheck:frontend`

Draft until CI is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SECURITY DEFINER org membership/ownership logic in the database; rules are tightened for third-party owner removal but mistaken successor selection or race handling could affect org control.
> 
> **Overview**
> **`delete_org_member_role`** no longer always rejects removal of the org owner (`orgs.created_by`). The RPC now **locks the org row**, and when the target is the owner it only proceeds if the **caller is removing themselves**, another **`org_super_admin`** exists, and **`created_by`** is updated to that successor (oldest binding) **before** all of the user’s org role bindings are deleted. Any attempt by someone else to remove the owner still raises **`CANNOT_CHANGE_OWNER_ROLE`**.
> 
> Non-owner removal behavior is unchanged: last **`org_super_admin`** protection and cascading delete of org/app/channel bindings remain. The migration also documents the function and keeps **`SECURITY DEFINER`** execute grants limited to **`authenticated`** and **`service_role`**.
> 
> Adds **`tests/org-ownership-transfer.test.ts`** covering successful owner self-removal after delegating super admin and blocking a peer super admin from removing the owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010caf593e239dddfff08ff68e21d51f2705999f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->