### PR TITLE
fix(api): avoid install source reads on device list

### DIFF
--- a/src/components/dashboard/StoreReleaseValidationModal.vue
+++ b/src/components/dashboard/StoreReleaseValidationModal.vue
@@ -23,8 +23,11 @@ const TRACK_UNKNOWN_INSTALL_SOURCES = ['google_play', 'amazon_appstore', 'samsun
 const REMINDER_EVENT = 'store-release-validation-needed'
 const DOWNLOAD_PLATFORMS = ['ios', 'android', 'electron'] as const
 const DEVICE_COUNT_RETRY_MS = 30_000
+const INSTALL_SOURCE_COUNTS_CACHE_MS = 1000 * 60 * 60 * 24 * 30
+const INSTALL_SOURCE_COUNTS_CACHE_PREFIX = 'capgo-store-release-install-source-counts'
 
 type DownloadPlatform = typeof DOWNLOAD_PLATFORMS[number]
+type InstallSourceCounts = Record<string, number>
 type ChannelRow = Database['public']['Tables']['channels']['Row']
 type ReleaseChannelKey = 'allow_dev' | 'allow_device' | 'allow_emulator' | 'allow_prod' | 'android' | 'app_id' | 'electron' | 'id' | 'ios' | 'name' | 'public'
 type ReleaseChannel = Pick<ChannelRow, ReleaseChannelKey>
@@ -91,11 +94,49 @@ function scheduleStatusRetry(appId: string, requestId: number) {
   }, DEVICE_COUNT_RETRY_MS)
 }
 
-async function countDevicesByInstallSource(appId: string, installSources: string[]) {
+function getInstallSourceCountsCacheKey(appId: string) {
+  return `${INSTALL_SOURCE_COUNTS_CACHE_PREFIX}:${appId}`
+}
+
+function readCachedInstallSourceCounts(appId: string): InstallSourceCounts | null {
+  if (typeof localStorage === 'undefined')
+    return null
+
+  const raw = localStorage.getItem(getInstallSourceCountsCacheKey(appId))
+  if (!raw)
+    return null
+
+  try {
+    const cached = JSON.parse(raw) as { expiresAt?: number, counts?: InstallSourceCounts }
+    if (!cached.expiresAt || cached.expiresAt <= Date.now() || !cached.counts)
+      return null
+    return cached.counts
+  }
+  catch {
+    localStorage.removeItem(getInstallSourceCountsCacheKey(appId))
+    return null
+  }
+}
+
+function writeCachedInstallSourceCounts(appId: string, counts: InstallSourceCounts) {
+  if (typeof localStorage === 'undefined')
+    return
+
+  localStorage.setItem(getInstallSourceCountsCacheKey(appId), JSON.stringify({
+    expiresAt: Date.now() + INSTALL_SOURCE_COUNTS_CACHE_MS,
+    counts,
+  }))
+}
+
+async function getInstallSourceCounts(appId: string) {
+  const cached = readCachedInstallSourceCounts(appId)
+  if (cached)
+    return cached
+
   const { data: currentSession } = await supabase.auth.getSession()
   const currentJwt = currentSession.session?.access_token
   if (!currentJwt)
-    throw new Error('Cannot count devices by install source without a session')
+    throw new Error('Cannot count install sources without a session')
 
   const response = await fetch(`${defaultApiHost}/private/devices`, {
     method: 'POST',
@@ -104,17 +145,22 @@ async function countDevicesByInstallSource(appId: string, installSources: string
       'authorization': `Bearer ${currentJwt}`,
     },
     body: JSON.stringify({
-      count: true,
+      installSourceCounts: true,
       appId,
-      installSources,
     }),
   })
 
   if (!response.ok)
-    throw new Error(`Cannot count devices by install source: ${response.status}`)
+    throw new Error(`Cannot count install sources: ${response.status}`)
 
-  const data = await response.json() as { count: number }
-  return data.count
+  const data = await response.json() as { installSources: InstallSourceCounts }
+  const counts = data.installSources ?? {}
+  writeCachedInstallSourceCounts(appId, counts)
+  return counts
+}
+
+function countInstallSources(counts: InstallSourceCounts, installSources: string[]) {
+  return installSources.reduce((total, source) => total + (counts[source] ?? 0), 0)
 }
 const shouldPrompt = computed(() => {
   return !isLoading.value && hasLiveUpdateBundle.value && !hasStoreInstalledDevice.value && !hasDeviceCountError.value && !hasDismissedPrompt.value
@@ -276,47 +322,28 @@ async function loadStatus() {
       hasTrackUnknownDevice.value = false
       return
     }
-    let releaseDeviceCount = 0
-    let testDeviceCount = 0
-    let trackUnknownDeviceCount = 0
+
+    let installSourceCounts: InstallSourceCounts
     hasDeviceCountError.value = false
     try {
-      releaseDeviceCount = await countDevicesByInstallSource(appId, RELEASE_INSTALL_SOURCES)
+      installSourceCounts = await getInstallSourceCounts(appId)
     }
     catch (error) {
       if (requestId !== loadStatusRequestId)
         return
-      console.error('Cannot count production store release validation devices', error)
+      console.error('Cannot count store release validation install sources', error)
       hasDeviceCountError.value = true
       scheduleStatusRetry(appId, requestId)
       return
     }
 
-    const [testDeviceResult, trackUnknownDeviceResult] = await Promise.allSettled([
-      countDevicesByInstallSource(appId, TEST_INSTALL_SOURCES),
-      countDevicesByInstallSource(appId, TRACK_UNKNOWN_INSTALL_SOURCES),
-    ])
-
     if (requestId !== loadStatusRequestId)
       return
-
-    if (testDeviceResult.status === 'fulfilled')
-      testDeviceCount = testDeviceResult.value
-    else
-      console.error('Cannot count TestFlight release validation devices', testDeviceResult.reason)
-
-    if (trackUnknownDeviceResult.status === 'fulfilled')
-      trackUnknownDeviceCount = trackUnknownDeviceResult.value
-    else
-      console.error('Cannot count Android store release validation devices', trackUnknownDeviceResult.reason)
 
     clearStatusRetry()
-    if (requestId !== loadStatusRequestId)
-      return
-
-    hasStoreInstalledDevice.value = releaseDeviceCount > 0
-    hasTestFlightDevice.value = testDeviceCount > 0
-    hasTrackUnknownDevice.value = trackUnknownDeviceCount > 0
+    hasStoreInstalledDevice.value = countInstallSources(installSourceCounts, RELEASE_INSTALL_SOURCES) > 0
+    hasTestFlightDevice.value = countInstallSources(installSourceCounts, TEST_INSTALL_SOURCES) > 0
+    hasTrackUnknownDevice.value = countInstallSources(installSourceCounts, TRACK_UNKNOWN_INSTALL_SOURCES) > 0
   }
   catch (error) {
     if (requestId !== loadStatusRequestId)

--- a/supabase/functions/_backend/private/devices.ts
+++ b/supabase/functions/_backend/private/devices.ts
@@ -8,11 +8,12 @@ import { middlewareV2 } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { appIdSchema, cursorSchema, deviceIdSchema, hasInvalidQueryLimitInput, hasUnsafeDevicesQueryText, queryLimitSchema, safeQueryTextSchema } from '../utils/privateAnalyticsValidation.ts'
 import { checkPermission } from '../utils/rbac.ts'
-import { countDevices, readDevices } from '../utils/stats.ts'
+import { countDevices, countInstallSources, readDevices } from '../utils/stats.ts'
 
 interface DataDevice {
   appId: string
   count?: boolean
+  installSourceCounts?: boolean
   versionName?: string
   devicesId?: string[]
   deviceIds?: string[] // TODO: remove when migration is done
@@ -30,10 +31,10 @@ const orderItemSchema = type({
   'key': 'string <= 64',
   'sortable?': literalUnion(['asc', 'desc']),
 })
-
 const devicesBodySchema = type({
   'appId': appIdSchema,
   'count?': 'boolean',
+  'installSourceCounts?': 'boolean',
   'versionName?': safeQueryTextSchema,
   'devicesId?': deviceIdSchema.array(),
   'deviceIds?': deviceIdSchema.array(),
@@ -65,9 +66,12 @@ app.post('/', middlewareV2(['read', 'write', 'all', 'upload']), async (c) => {
   if (!(await checkPermission(c, 'app.read_devices', { appId: body.appId }))) {
     throw simpleError('app_access_denied', 'You can\'t access this app', { app_id: body.appId })
   }
+
   const devicesIds = body.devicesId ?? body.deviceIds ?? []
+  if (body.installSourceCounts)
+    return c.json({ installSources: await countInstallSources(c, body.appId) })
   if (body.count)
-    return c.json({ count: await countDevices(c, body.appId, body.customIdMode ?? false, devicesIds, body.versionName, body.search?.trim(), body.installSources) })
+    return c.json({ count: await countDevices(c, body.appId, body.customIdMode ?? false, devicesIds, body.versionName, body.search?.trim()) })
   return c.json(await readDevices(c, {
     app_id: body.appId,
     version_name: body.versionName,

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -16,6 +16,7 @@ function escapeSqlString(value: string): string {
 }
 
 const MAX_ANALYTICS_QUERY_LIMIT = 50_000
+const INSTALL_SOURCE_COUNT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 30
 
 export function normalizeAnalyticsLimit(limit: unknown, fallback = DEFAULT_LIMIT): number {
   if (typeof limit !== 'number' || !Number.isFinite(limit))
@@ -613,6 +614,40 @@ GROUP BY version_name`
   return {}
 }
 
+function buildInstallSourceList(installSources: string[]) {
+  return installSources.map(source => `'${escapeSqlString(source)}'`).join(', ')
+}
+export async function countInstallSourcesCF(c: Context, app_id: string): Promise<Record<string, number>> {
+  const cache = new CacheHelper(c)
+  const cacheKey = cache.buildRequest('/internal/install-source-counts', { app_id })
+  const cached = await cache.matchJson<Record<string, number>>(cacheKey)
+  if (cached)
+    return cached
+
+  const query = `SELECT
+  install_source,
+  COUNT(*) AS total
+FROM (
+  SELECT
+    blob1 AS device_id,
+    argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source
+  FROM device_info
+  WHERE index1 = '${escapeSqlString(app_id)}'
+  GROUP BY blob1
+)
+WHERE install_source != ''
+GROUP BY install_source`
+
+  cloudlog({ requestId: c.get('requestId'), message: 'countInstallSourcesCF query', query })
+  const res = await runQueryToCFA<{ install_source: string, total: number }>(c, query)
+  const counts = res.reduce<Record<string, number>>((acc, row) => {
+    acc[row.install_source] = row.total
+    return acc
+  }, {})
+  await cache.putJson(cacheKey, counts, INSTALL_SOURCE_COUNT_CACHE_TTL_SECONDS)
+  return counts
+}
+
 export async function countDevicesCF(
   c: Context,
   app_id: string,
@@ -620,7 +655,6 @@ export async function countDevicesCF(
   deviceIds: string[] = [],
   versionName?: string,
   search?: string,
-  installSources?: string[],
 ) {
   // Use Analytics Engine DEVICE_INFO for counting devices
   const conditions = [`index1 = '${escapeSqlString(app_id)}'`]
@@ -649,19 +683,9 @@ export async function countDevicesCF(
   if (versionName)
     conditions.push(`blob2 = '${escapeSqlString(versionName)}'`)
 
-  const sourceFilter = installSources?.length
-    ? `WHERE install_source IN (${installSources.map(source => `'${escapeSqlString(source)}'`).join(', ')})`
-    : ''
-  const query = `SELECT COUNT(*) AS total
-FROM (
-  SELECT
-    blob1 AS device_id,
-    argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source
+  const query = `SELECT COUNT(DISTINCT blob1) AS total
 FROM device_info
-WHERE ${conditions.join(' AND ')}
-  GROUP BY blob1
-)
-${sourceFilter}`
+WHERE ${conditions.join(' AND ')}`
 
   cloudlog({ requestId: c.get('requestId'), message: 'countDevicesCF query', query })
   try {
@@ -670,8 +694,6 @@ ${sourceFilter}`
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading device count from Analytics Engine', error: serializeError(e), query })
-    if (installSources?.length)
-      throw e
   }
   return 0
 }
@@ -722,6 +744,15 @@ function buildReadDevicesCFCursorCondition(cursor: string | undefined, devicesOr
   return `(updated_at ${comparison} toDateTime('${safeCursorTime}') OR (updated_at = toDateTime('${safeCursorTime}') AND device_id > '${safeCursorDeviceId}'))`
 }
 
+function buildReadDevicesCFOuterConditions(params: ReadDevicesParams, devicesOrder: DevicesOrderCF | null) {
+  const conditions = [buildReadDevicesCFCursorCondition(params.cursor, devicesOrder)]
+
+  if (params.installSources?.length)
+    conditions.push(`install_source IN (${buildInstallSourceList(params.installSources)})`)
+
+  return conditions.filter(Boolean)
+}
+
 export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode: boolean) {
   const limit = normalizeAnalyticsLimit(params.limit)
   const conditions: string[] = [`index1 = '${escapeSqlString(params.app_id)}'`]
@@ -755,10 +786,8 @@ export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode:
   }
 
   const devicesOrder = getReadDevicesCFOrder(params)
-  const outerConditions = [
-    buildReadDevicesCFCursorCondition(params.cursor, devicesOrder),
-    params.installSources?.length ? `install_source IN (${params.installSources.map(source => `'${escapeSqlString(source)}'`).join(', ')})` : '',
-  ].filter(Boolean)
+  const includeInstallSource = Boolean(params.installSources?.length)
+  const outerConditions = buildReadDevicesCFOuterConditions(params, devicesOrder)
   const outerFilter = outerConditions.length ? `WHERE ${outerConditions.join(' AND ')}` : ''
   let orderBy = 'device_id ASC'
   if (devicesOrder) {
@@ -778,7 +807,7 @@ export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode:
     '    argMax(blob6, timestamp) AS version_build,',
     '    argMax(blob7, timestamp) AS default_channel,',
     '    argMax(blob8, timestamp) AS key_id,',
-    '    argMax(blob9, CASE WHEN blob9 != \'\' THEN timestamp ELSE toDateTime(\'1970-01-01 00:00:00\') END) AS install_source,',
+    includeInstallSource ? '    argMax(blob9, CASE WHEN blob9 != \'\' THEN timestamp ELSE toDateTime(\'1970-01-01 00:00:00\') END) AS install_source,' : '',
     '    argMax(double1, timestamp) AS platform,',
     '    argMax(double2, timestamp) AS is_prod,',
     '    argMax(double3, timestamp) AS is_emulator,',

--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -4,11 +4,11 @@ import type { MiddlewareKeyVariables } from './hono.ts'
 import type { Database } from './supabase.types.ts'
 import type { DeviceRes, DeviceWithoutCreatedAt, NativeVersionUsage, ReadDevicesParams, ReadDevicesResponse, ReadStatsParams, StatsActions, StatsMetadata, VersionUsage } from './types.ts'
 import { getRuntimeKey } from 'hono/adapter'
-import { countDevicesCF, countUpdatesFromLogsCF, countUpdatesFromLogsExternalCF, createIfNotExistStoreInfo, getAppsFromCF, getUpdateStatsCF, readBandwidthUsageCF, readDevicesCF, readDeviceUsageCF, readDeviceVersionCountsCF, readNativeVersionUsageCF, readStatsCF, readStatsVersionCF, trackBandwidthUsageCF, trackDevicesCF, trackDeviceUsageCF, trackLogsCF, trackLogsCFExternal, trackVersionUsageCF, updateStoreApp } from './cloudflare.ts'
+import { countDevicesCF, countInstallSourcesCF, countUpdatesFromLogsCF, countUpdatesFromLogsExternalCF, createIfNotExistStoreInfo, getAppsFromCF, getUpdateStatsCF, readBandwidthUsageCF, readDevicesCF, readDeviceUsageCF, readDeviceVersionCountsCF, readNativeVersionUsageCF, readStatsCF, readStatsVersionCF, trackBandwidthUsageCF, trackDevicesCF, trackDeviceUsageCF, trackLogsCF, trackLogsCFExternal, trackVersionUsageCF, updateStoreApp } from './cloudflare.ts'
 import { isDemoApp } from './demo.ts'
 import { simpleError, simpleError200 } from './hono.ts'
 import { cloudlog } from './logging.ts'
-import { countDevicesSB, getAppsFromSB, getUpdateStatsSB, readBandwidthUsageSB, readDevicesSB, readDeviceUsageSB, readDeviceVersionCountsSB, readNativeVersionUsageSB, readStatsSB, readStatsStorageSB, readStatsVersionSB, supabaseWithAuth, trackBandwidthUsageSB, trackDevicesSB, trackDeviceUsageSB, trackLogsSB, trackMetaSB, trackVersionUsageSB } from './supabase.ts'
+import { countDevicesSB, countInstallSourcesSB, getAppsFromSB, getUpdateStatsSB, readBandwidthUsageSB, readDevicesSB, readDeviceUsageSB, readDeviceVersionCountsSB, readNativeVersionUsageSB, readStatsSB, readStatsStorageSB, readStatsVersionSB, supabaseWithAuth, trackBandwidthUsageSB, trackDevicesSB, trackDeviceUsageSB, trackLogsSB, trackMetaSB, trackVersionUsageSB } from './supabase.ts'
 import { DEFAULT_LIMIT } from './types.ts'
 import { backgroundTask, getEnv, isInternalVersionName } from './utils.ts'
 
@@ -329,18 +329,21 @@ export function countDevices(
   deviceIds: string[] = [],
   versionName?: string,
   search?: string,
-  installSources?: string[],
 ) {
-  // Install-source device writes live in Analytics Engine on Workers. Returning
-  // Postgres counts here would make store validation think no release exists.
-  if (installSources?.length && getRuntimeKey() === 'workerd' && c.env.DEVICE_INFO && !shouldUseAnalyticsEngine(c)) {
-    throw simpleError('analytics_engine_unavailable', 'Cannot count devices by install source without Analytics Engine read configuration')
-  }
-
   const trimmedSearch = search?.trim()
   if (shouldUseAnalyticsEngine(c))
-    return countDevicesCF(c, app_id, customIdMode, deviceIds, versionName, trimmedSearch, installSources)
-  return countDevicesSB(c, app_id, customIdMode, deviceIds, versionName, trimmedSearch, installSources)
+    return countDevicesCF(c, app_id, customIdMode, deviceIds, versionName, trimmedSearch)
+  return countDevicesSB(c, app_id, customIdMode, deviceIds, versionName, trimmedSearch)
+}
+
+export function countInstallSources(c: Context, app_id: string) {
+  if (getRuntimeKey() === 'workerd' && c.env.DEVICE_INFO && !shouldUseAnalyticsEngine(c)) {
+    throw simpleError('analytics_engine_unavailable', 'Cannot count install sources without Analytics Engine read configuration')
+  }
+
+  if (shouldUseAnalyticsEngine(c))
+    return countInstallSourcesCF(c, app_id)
+  return countInstallSourcesSB(c, app_id)
 }
 
 export async function readDevices(c: Context, params: ReadDevicesParams, customIdMode: boolean): Promise<ReadDevicesResponse> {

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1552,6 +1552,32 @@ export async function readDevicesSB(c: Context, params: ReadDevicesParams, custo
   return data ?? []
 }
 
+export async function countInstallSourcesSB(c: Context, app_id: string): Promise<Record<string, number>> {
+  const pgClient = await getPgClient(c)
+  try {
+    const result = await pgClient.query<{ install_source: string, total: string }>(`
+      SELECT install_source, COUNT(*)::text AS total
+      FROM public.devices
+      WHERE app_id = $1
+        AND install_source IS NOT NULL
+        AND install_source != ''
+      GROUP BY install_source
+    `, [app_id])
+
+    return result.rows.reduce<Record<string, number>>((acc, row) => {
+      acc[row.install_source] = Number(row.total)
+      return acc
+    }, {})
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Error counting install sources', error })
+    return {}
+  }
+  finally {
+    closeClient(c, pgClient)
+  }
+}
+
 /**
  * Count how many devices match the supplied filters so pagination totals stay accurate.
  */
@@ -1562,7 +1588,6 @@ export async function countDevicesSB(
   deviceIds: string[] = [],
   versionName?: string,
   search?: string,
-  installSources?: string[],
 ) {
   let req = supabaseAdmin(c)
     .from('devices')
@@ -1593,15 +1618,10 @@ export async function countDevicesSB(
   if (versionName)
     req = req.eq('version_name', versionName)
 
-  if (installSources?.length)
-    req = req.in('install_source', installSources)
-
   const { count, error } = await req
 
   if (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error counting devices', error })
-    if (installSources?.length)
-      throw new Error(error.message)
     return 0
   }
   return count ?? 0

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -1,8 +1,8 @@
 import type { Context } from 'hono'
 import { createClient } from '@supabase/supabase-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { buildReadDevicesCFQuery, countDevicesCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
-import { countDevicesSB, readDevicesSB } from '../supabase/functions/_backend/utils/supabase.ts'
+import { buildReadDevicesCFQuery, countDevicesCF, countInstallSourcesCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { readDevicesSB } from '../supabase/functions/_backend/utils/supabase.ts'
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(),
@@ -33,6 +33,7 @@ function createContextMock() {
       CF_ANALYTICS_TOKEN: 'cf-analytics-token',
       CF_ACCOUNT_ANALYTICS_ID: 'cf-account-id',
     },
+    req: { url: 'http://localhost/private/devices' },
     get: vi.fn((key: string) => key === 'requestId' ? 'test-request' : undefined),
   }
 }
@@ -56,6 +57,16 @@ describe('buildReadDevicesCFQuery', () => {
     expect(groupByIndex).toBeGreaterThan(-1)
     expect(cursorIndex).toBeGreaterThan(groupByIndex)
     expect(query).toContain('ORDER BY device_id ASC')
+  })
+
+  it.concurrent('does not read install source blob on default device listing', () => {
+    const query = buildReadDevicesCFQuery({
+      app_id: 'com.example.app',
+      limit: 1,
+    }, false)
+
+    expect(query).not.toContain('blob9')
+    expect(query).not.toContain('install_source')
   })
 
   it.concurrent('applies descending cursor pagination after device grouping', () => {
@@ -110,15 +121,14 @@ describe('buildReadDevicesCFQuery', () => {
     expect(query).toContain(`WHERE device_id > '11111111-1111-4111-8111-111111111111' AND install_source IN ('app_store', 'amazon_appstore')`)
   })
 })
-
 describe('countDevicesCF', () => {
-  it('filters install sources after device grouping', async () => {
+  it('does not read install source blob on default device counts', async () => {
     let query = ''
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       query = String(init?.body ?? '')
       return new Response(JSON.stringify({
         meta: [{ name: 'total', type: 'UInt64' }],
-        data: [{ total: 7 }],
+        data: [{ total: 12 }],
       }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -130,36 +140,70 @@ describe('countDevicesCF', () => {
       createContextMock() as unknown as Context,
       'com.example.app',
       false,
-      [],
-      undefined,
-      undefined,
-      ['app_store', 'testflight'],
     )
 
-    const groupByIndex = query.indexOf('GROUP BY blob1')
-    const installSourceFilterIndex = query.indexOf(`install_source IN ('app_store', 'testflight')`)
-
-    expect(count).toBe(7)
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(query).toContain("argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source")
-    expect(installSourceFilterIndex).toBeGreaterThan(groupByIndex)
+    expect(count).toBe(12)
+    expect(query).toContain('COUNT(DISTINCT blob1) AS total')
+    expect(query).not.toContain('blob9')
+    expect(query).not.toContain('install_source')
   })
+})
 
-  it('throws install source count failures instead of returning zero', async () => {
-    const fetchMock = vi.fn(async () => {
-      throw new Error('analytics unavailable')
+describe('countInstallSourcesCF', () => {
+  it('counts latest install sources in a dedicated aggregate query', async () => {
+    let query = ''
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      query = String(init?.body ?? '')
+      return new Response(JSON.stringify({
+        meta: [
+          { name: 'install_source', type: 'String' },
+          { name: 'total', type: 'UInt64' },
+        ],
+        data: [
+          { install_source: 'app_store', total: 3 },
+          { install_source: 'testflight', total: 2 },
+        ],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(countDevicesCF(
-      createContextMock() as unknown as Context,
-      'com.example.app',
-      false,
-      [],
-      undefined,
-      undefined,
-      ['app_store'],
-    )).rejects.toThrow('runQueryToCFA encountered an error')
+    const counts = await countInstallSourcesCF(createContextMock() as unknown as Context, 'com.example.app')
+
+    expect(counts).toEqual({ app_store: 3, testflight: 2 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(query).toContain('GROUP BY install_source')
+    expect(query).toContain('argMax(blob9')
+    expect(query).not.toContain('COUNT(DISTINCT blob1) AS total')
+  })
+
+  it('reuses cached install source counts for the same app', async () => {
+    const cachedResponses = new Map<string, Response>()
+    vi.stubGlobal('caches', {
+      open: vi.fn(async () => ({
+        match: vi.fn(async (request: Request) => cachedResponses.get(request.url)),
+        put: vi.fn(async (request: Request, response: Response) => {
+          cachedResponses.set(request.url, response)
+        }),
+      })),
+    })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      meta: [
+        { name: 'install_source', type: 'String' },
+        { name: 'total', type: 'UInt64' },
+      ],
+      data: [{ install_source: 'app_store', total: 3 }],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const context = createContextMock() as unknown as Context
+    await expect(countInstallSourcesCF(context, 'com.example.app')).resolves.toEqual({ app_store: 3 })
+    await expect(countInstallSourcesCF(context, 'com.example.app')).resolves.toEqual({ app_store: 3 })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -196,46 +240,4 @@ describe('readDevicesSB', () => {
     expect(query.in).toHaveBeenCalledWith('install_source', ['app_store', 'testflight'])
   })
 
-  it('applies install source filters to counts', async () => {
-    const { client, query } = createReadDevicesQueryMock()
-    vi.mocked(createClient).mockReturnValue(client as unknown as ReturnType<typeof createClient>)
-
-    const count = await countDevicesSB(
-      createContextMock() as unknown as Context,
-      'com.example.app',
-      false,
-      [],
-      undefined,
-      undefined,
-      ['app_store', 'testflight'],
-    )
-
-    expect(count).toBe(12)
-    expect(query.in).toHaveBeenCalledWith('install_source', ['app_store', 'testflight'])
-  })
-
-  it('throws Supabase install source count failures instead of returning zero', async () => {
-    const query = {
-      select: vi.fn(() => query),
-      eq: vi.fn(() => query),
-      in: vi.fn(() => query),
-      then: vi.fn((resolve, reject) => Promise.resolve({ count: null, error: { message: 'database unavailable' } }).then(resolve, reject)),
-    }
-    const client = {
-      from: vi.fn(() => query),
-    }
-    vi.mocked(createClient).mockReturnValue(client as unknown as ReturnType<typeof createClient>)
-
-    await expect(countDevicesSB(
-      createContextMock() as unknown as Context,
-      'com.example.app',
-      false,
-      [],
-      undefined,
-      undefined,
-      ['app_store'],
-    )).rejects.toThrow('database unavailable')
-
-    expect(query.in).toHaveBeenCalledWith('install_source', ['app_store'])
-  })
 })

--- a/tests/stats-device-count.unit.test.ts
+++ b/tests/stats-device-count.unit.test.ts
@@ -1,10 +1,9 @@
 import type { Context } from 'hono'
 import { getRuntimeKey } from 'hono/adapter'
-import { HTTPException } from 'hono/http-exception'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { countDevicesCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
-import { countDevices } from '../supabase/functions/_backend/utils/stats.ts'
-import { countDevicesSB } from '../supabase/functions/_backend/utils/supabase.ts'
+import { countDevicesCF, countInstallSourcesCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { countInstallSources } from '../supabase/functions/_backend/utils/stats.ts'
+import { countDevicesSB, countInstallSourcesSB } from '../supabase/functions/_backend/utils/supabase.ts'
 
 vi.mock('hono/adapter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('hono/adapter')>()
@@ -17,62 +16,56 @@ vi.mock('hono/adapter', async (importOriginal) => {
 
 vi.mock('../supabase/functions/_backend/utils/cloudflare.ts', () => ({
   countDevicesCF: vi.fn(),
+  countInstallSourcesCF: vi.fn(),
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
   countDevicesSB: vi.fn(),
+  countInstallSourcesSB: vi.fn(),
 }))
-
 function createContextMock(env: Record<string, unknown>) {
   return {
     env,
     get: vi.fn((key: string) => key === 'requestId' ? 'test-request' : undefined),
   } as unknown as Context
 }
-
-describe('countDevices install-source routing', () => {
+describe('countInstallSources routing', () => {
   beforeEach(() => {
     vi.mocked(getRuntimeKey).mockReset()
     vi.mocked(countDevicesCF).mockReset()
     vi.mocked(countDevicesSB).mockReset()
+    vi.mocked(countInstallSourcesCF).mockReset()
+    vi.mocked(countInstallSourcesSB).mockReset()
   })
 
   it('fails install-source counts when Worker writes use Analytics Engine but read config is missing', () => {
     vi.mocked(getRuntimeKey).mockReturnValue('workerd')
 
-    expect(() => countDevices(
+    expect(() => countInstallSources(
       createContextMock({ DEVICE_INFO: {} }),
       'com.example.app',
-      false,
-      [],
-      undefined,
-      undefined,
-      ['app_store'],
-    )).toThrow(HTTPException)
+    )).toThrow('Cannot count install sources without Analytics Engine read configuration')
 
-    expect(countDevicesCF).not.toHaveBeenCalled()
-    expect(countDevicesSB).not.toHaveBeenCalled()
+    expect(countInstallSourcesCF).not.toHaveBeenCalled()
+    expect(countInstallSourcesSB).not.toHaveBeenCalled()
   })
 
   it('uses Analytics Engine for install-source counts when read config is available', async () => {
     vi.mocked(getRuntimeKey).mockReturnValue('workerd')
-    vi.mocked(countDevicesCF).mockReturnValue(Promise.resolve(4))
+    vi.mocked(countInstallSourcesCF).mockReturnValue(Promise.resolve({ app_store: 4 }))
 
-    await expect(countDevices(
+    await expect(countInstallSources(
       createContextMock({
         DEVICE_INFO: {},
         CF_ANALYTICS_TOKEN: 'token',
         CF_ACCOUNT_ANALYTICS_ID: 'account',
       }),
       'com.example.app',
-      false,
-      [],
-      undefined,
-      undefined,
-      ['app_store'],
-    )).resolves.toBe(4)
+    )).resolves.toEqual({ app_store: 4 })
 
-    expect(countDevicesCF).toHaveBeenCalledTimes(1)
+    expect(countInstallSourcesCF).toHaveBeenCalledTimes(1)
+    expect(countInstallSourcesSB).not.toHaveBeenCalled()
+    expect(countDevicesCF).not.toHaveBeenCalled()
     expect(countDevicesSB).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- keep normal Analytics Engine device list/count queries on the old blob1-blob8 shape
- only read blob9/install_source when an install-source filter is explicitly requested
- add regression tests that default device listing/count queries do not reference blob9

## Why
The store release validation PR made the normal device list query always select blob9. If the Analytics Engine query cannot read that blob, readDevicesCF catches the error and returns an empty list, which makes the backend report no devices.

## Tests
- bunx vitest run tests/cloudflare-device-pagination.unit.test.ts tests/stats-device-count.unit.test.ts
- bun typecheck
- bun lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core device analytics query shapes and a private devices API contract; incorrect behavior would hide devices or skew store-validation prompts, but scope is limited and covered by targeted unit tests.
> 
> **Overview**
> Restores **default** Analytics Engine device **list** and **count** queries to the blob1–blob8 shape so they no longer always select `blob9`/`install_source`. That regression could make `readDevicesCF` fail and return an empty device list when `blob9` isn’t readable.
> 
> **Install-source filtering** on device listing still works: `buildReadDevicesCFQuery` only includes the `blob9`/`install_source` projection and outer `install_source IN (...)` filter when `installSources` is passed on `readDevices`. `countDevices` no longer accepts `installSources`; install-source totals are a separate path.
> 
> Adds **`installSourceCounts`** on `POST /private/devices` (`countInstallSources` → `countInstallSourcesCF` / `countInstallSourcesSB`), with a **30-day** edge cache on Workers. **Store release validation** uses one aggregated fetch (plus **localStorage** cache) instead of three per-source count calls.
> 
> Tests assert default list/count SQL does not reference `blob9` and cover the new aggregate + cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332a14a0365325b90d167a75fcea69bd5744c7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->