### PR TITLE
[codex] Fix dashboard docs URL

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -89,7 +89,7 @@ const tabs = computed<Tab[]>(() => {
       label: 'documentation',
       icon: IconDoc,
       key: '#',
-      onClick: () => window.open('https://docs.capgo.app', '_blank', 'noopener,noreferrer'),
+      onClick: () => window.open('https://capgo.app/docs', '_blank', 'noopener,noreferrer'),
       redirect: true,
     },
     {


### PR DESCRIPTION
## Summary

- Update the dashboard sidebar documentation link from the old `docs.capgo.app` host to `https://capgo.app/docs`.

## Why

The docs now live under `capgo.app/docs`, so the sidebar should point users to the current documentation entry point.

## Validation

- `bun lint` (passes; existing warnings remain in unrelated admin dashboard and compatibility files)
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL change on an external navigation link with no auth, data, or business-logic impact.
> 
> **Overview**
> Updates the dashboard sidebar **Documentation** item so it opens **`https://capgo.app/docs`** instead of the old **`docs.capgo.app`** host, matching where docs are hosted now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57beddd6086fb1a4457a6164fc550f1bf2e6ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the documentation sidebar link to point to the current docs site.
  * The link still opens in a new tab with safe browsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->