### PR TITLE
fix(stats): fail closed on bandwidth analytics reads

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -465,7 +465,7 @@ export async function rawAnalyticsQuery(c: Context, query: string) {
   return []
 }
 
-export async function readBandwidthUsageCF(c: Context, app_id: string, period_start: string, period_end: string) {
+export async function readBandwidthUsageCF(c: Context, app_id: string, period_start: string, period_end: string, options: { throwOnError?: boolean } = {}) {
   if (!c.env.BANDWIDTH_USAGE)
     return [] as BandwidthUsageCF[]
   const query = `SELECT
@@ -486,6 +486,8 @@ ORDER BY date, app_id`
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading bandwidth usage', error: serializeError(e), query })
+    if (options.throwOnError)
+      throw e
   }
   return [] as BandwidthUsageCF[]
 }

--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -143,7 +143,8 @@ export function readStatsMau(c: Context, app_id: string, start_date: string, end
 export function readStatsBandwidth(c: Context, app_id: string, start_date: string, end_date: string) {
   if (!c.env.BANDWIDTH_USAGE)
     return readBandwidthUsageSB(c, app_id, start_date, end_date)
-  return readBandwidthUsageCF(c, app_id, start_date, end_date)
+  assertAnalyticsEngineReadConfig(c, 'bandwidth usage')
+  return readBandwidthUsageCF(c, app_id, start_date, end_date, { throwOnError: true })
 }
 
 export function readStatsStorage(c: Context, app_id: string, start_date: string, end_date: string) {
@@ -162,14 +163,23 @@ export function readNativeVersionUsage(c: Context, app_id: string, start_date: s
     return readNativeVersionUsageSB(c, app_id, start_date, end_date, supabase)
   return readNativeVersionUsageCF(c, app_id, start_date, end_date)
 }
+function hasAnalyticsEngineReadConfig(c: Context): boolean {
+  const token = getEnv(c, 'CF_ANALYTICS_TOKEN')
+  const accountId = getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID')
+  return Boolean(token && accountId)
+}
 
 function shouldUseAnalyticsEngine(c: Context): boolean {
   if (getRuntimeKey() !== 'workerd' || !c.env.DEVICE_INFO)
     return false
   // Analytics reads require API access; fall back to Supabase when tokens are missing.
-  const token = getEnv(c, 'CF_ANALYTICS_TOKEN')
-  const accountId = getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID')
-  return Boolean(token && accountId)
+  return hasAnalyticsEngineReadConfig(c)
+}
+
+function assertAnalyticsEngineReadConfig(c: Context, metricName: string): void {
+  if (!hasAnalyticsEngineReadConfig(c)) {
+    throw simpleError('analytics_engine_unavailable', `Cannot read ${metricName} without Analytics Engine read configuration`)
+  }
 }
 
 export function readDeviceVersionCounts(c: Context, app_id: string, channelName?: string): Promise<Record<string, number>> {

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { createClient } from '@supabase/supabase-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { buildReadDevicesCFQuery, countDevicesCF, countInstallSourcesCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { buildReadDevicesCFQuery, countDevicesCF, countInstallSourcesCF, readBandwidthUsageCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
 import { readDevicesSB } from '../supabase/functions/_backend/utils/supabase.ts'
 
 vi.mock('@supabase/supabase-js', () => ({
@@ -32,6 +32,7 @@ function createContextMock() {
       SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
       CF_ANALYTICS_TOKEN: 'cf-analytics-token',
       CF_ACCOUNT_ANALYTICS_ID: 'cf-account-id',
+      BANDWIDTH_USAGE: {},
     },
     req: { url: 'http://localhost/private/devices' },
     get: vi.fn((key: string) => key === 'requestId' ? 'test-request' : undefined),
@@ -115,7 +116,7 @@ describe('buildReadDevicesCFQuery', () => {
     const groupByIndex = query.indexOf('GROUP BY blob1')
     const installSourceFilterIndex = query.indexOf(`install_source IN ('app_store', 'amazon_appstore')`)
 
-    expect(query).toContain("argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source")
+    expect(query).toContain(`argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source`)
     expect(installSourceFilterIndex).toBeGreaterThan(groupByIndex)
     expect(query).not.toContain(`WHERE index1 = 'com.example.app' AND blob9 IN`)
     expect(query).toContain(`WHERE device_id > '11111111-1111-4111-8111-111111111111' AND install_source IN ('app_store', 'amazon_appstore')`)
@@ -146,6 +147,25 @@ describe('countDevicesCF', () => {
     expect(query).toContain('COUNT(DISTINCT blob1) AS total')
     expect(query).not.toContain('blob9')
     expect(query).not.toContain('install_source')
+  })
+})
+
+describe('readBandwidthUsageCF', () => {
+  it('throws strict bandwidth read failures instead of returning empty usage', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('analytics unavailable')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(readBandwidthUsageCF(
+      createContextMock() as unknown as Context,
+      'com.example.app',
+      '2026-06-01',
+      '2026-07-01',
+      { throwOnError: true },
+    )).rejects.toThrow('runQueryToCFA encountered an error')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -239,5 +259,4 @@ describe('readDevicesSB', () => {
 
     expect(query.in).toHaveBeenCalledWith('install_source', ['app_store', 'testflight'])
   })
-
 })

--- a/tests/stats-device-count.unit.test.ts
+++ b/tests/stats-device-count.unit.test.ts
@@ -1,9 +1,9 @@
 import type { Context } from 'hono'
 import { getRuntimeKey } from 'hono/adapter'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { countDevicesCF, countInstallSourcesCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
-import { countInstallSources } from '../supabase/functions/_backend/utils/stats.ts'
-import { countDevicesSB, countInstallSourcesSB } from '../supabase/functions/_backend/utils/supabase.ts'
+import { countDevicesCF, countInstallSourcesCF, readBandwidthUsageCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { countInstallSources, readStatsBandwidth } from '../supabase/functions/_backend/utils/stats.ts'
+import { countDevicesSB, countInstallSourcesSB, readBandwidthUsageSB } from '../supabase/functions/_backend/utils/supabase.ts'
 
 vi.mock('hono/adapter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('hono/adapter')>()
@@ -17,18 +17,22 @@ vi.mock('hono/adapter', async (importOriginal) => {
 vi.mock('../supabase/functions/_backend/utils/cloudflare.ts', () => ({
   countDevicesCF: vi.fn(),
   countInstallSourcesCF: vi.fn(),
+  readBandwidthUsageCF: vi.fn(),
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
   countDevicesSB: vi.fn(),
   countInstallSourcesSB: vi.fn(),
+  readBandwidthUsageSB: vi.fn(),
 }))
+
 function createContextMock(env: Record<string, unknown>) {
   return {
     env,
     get: vi.fn((key: string) => key === 'requestId' ? 'test-request' : undefined),
   } as unknown as Context
 }
+
 describe('countInstallSources routing', () => {
   beforeEach(() => {
     vi.mocked(getRuntimeKey).mockReset()
@@ -36,6 +40,8 @@ describe('countInstallSources routing', () => {
     vi.mocked(countDevicesSB).mockReset()
     vi.mocked(countInstallSourcesCF).mockReset()
     vi.mocked(countInstallSourcesSB).mockReset()
+    vi.mocked(readBandwidthUsageCF).mockReset()
+    vi.mocked(readBandwidthUsageSB).mockReset()
   })
 
   it('fails install-source counts when Worker writes use Analytics Engine but read config is missing', () => {
@@ -67,5 +73,48 @@ describe('countInstallSources routing', () => {
     expect(countInstallSourcesSB).not.toHaveBeenCalled()
     expect(countDevicesCF).not.toHaveBeenCalled()
     expect(countDevicesSB).not.toHaveBeenCalled()
+  })
+})
+
+describe('readStatsBandwidth routing', () => {
+  beforeEach(() => {
+    vi.mocked(readBandwidthUsageCF).mockReset()
+    vi.mocked(readBandwidthUsageSB).mockReset()
+  })
+
+  it('fails when Worker bandwidth writes use Analytics Engine but read config is missing', () => {
+    expect(() => readStatsBandwidth(
+      createContextMock({ BANDWIDTH_USAGE: {} }),
+      'com.example.app',
+      '2026-06-01',
+      '2026-07-01',
+    )).toThrow('Cannot read bandwidth usage without Analytics Engine read configuration')
+
+    expect(readBandwidthUsageCF).not.toHaveBeenCalled()
+    expect(readBandwidthUsageSB).not.toHaveBeenCalled()
+  })
+
+  it('uses Analytics Engine for bandwidth reads when read config is available', async () => {
+    vi.mocked(readBandwidthUsageCF).mockResolvedValue([{ date: '2026-06-20', bandwidth: 4096, app_id: 'com.example.app' }])
+
+    await expect(readStatsBandwidth(
+      createContextMock({
+        BANDWIDTH_USAGE: {},
+        CF_ANALYTICS_TOKEN: 'token',
+        CF_ACCOUNT_ANALYTICS_ID: 'account',
+      }),
+      'com.example.app',
+      '2026-06-01',
+      '2026-07-01',
+    )).resolves.toEqual([{ date: '2026-06-20', bandwidth: 4096, app_id: 'com.example.app' }])
+
+    expect(readBandwidthUsageCF).toHaveBeenCalledWith(
+      expect.anything(),
+      'com.example.app',
+      '2026-06-01',
+      '2026-07-01',
+      { throwOnError: true },
+    )
+    expect(readBandwidthUsageSB).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- require Analytics Engine read config before cron reads bandwidth from Cloudflare
- make strict bandwidth Analytics reads throw instead of returning empty usage on query failure
- add regression tests for missing read config and strict Cloudflare read failures

## Root cause
`cron_stat_app` read bandwidth through `readStatsBandwidth()`. When `BANDWIDTH_USAGE` existed, the code assumed Cloudflare Analytics Engine was readable. If the Analytics API env was missing or the query failed, `readBandwidthUsageCF()` swallowed the error and returned `[]`, so cron could materialize an empty `daily_bandwidth` result instead of retrying.

## Tests
- `bunx vitest run tests/stats-device-count.unit.test.ts tests/cloudflare-device-pagination.unit.test.ts`
- `bunx eslint tests/stats-device-count.unit.test.ts tests/cloudflare-device-pagination.unit.test.ts`
- `bun lint:backend`
- `bun typecheck:backend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `cron_stat_app` bandwidth materialization from silent empty data to hard failures on misconfiguration or Analytics API errors, which is correct but can surface more cron retries until env/API issues are fixed.
> 
> **Overview**
> **Bandwidth stats from Cloudflare Analytics Engine now fail loudly instead of looking like zero usage.**
> 
> When `BANDWIDTH_USAGE` is bound (Worker path), `readStatsBandwidth` **requires** `CF_ANALYTICS_TOKEN` and `CF_ACCOUNT_ANALYTICS_ID` via a new `assertAnalyticsEngineReadConfig` helper (shared with the existing install-source read guard pattern). Missing config throws `analytics_engine_unavailable` rather than attempting a read that would fail or mis-route.
> 
> `readBandwidthUsageCF` gains an optional `{ throwOnError: true }` flag; `readStatsBandwidth` uses it so Analytics SQL/API failures **propagate** instead of being logged and converted to `[]`. That stops `cron_stat_app` from persisting empty `daily_bandwidth` when reads are broken.
> 
> Unit tests cover missing read config, successful CF routing with `throwOnError`, and strict throw behavior on query failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7725932839d9d54f3265162ad5b7ca71079c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->