### PR TITLE
fix(billing): sync Bento tags for billing emails

### DIFF
--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -5,18 +5,19 @@ import type { StripeData, StripeWebhookStatus } from '../utils/stripe.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
-import { addTagBento, trackBentoEvent } from '../utils/bento.ts'
+import { isBentoConfigured, syncBentoSubscriberTags, trackBentoEvent } from '../utils/bento.ts'
 import { getFallbackCreditProductId } from '../utils/credits.ts'
 import { BRES, quickError, simpleError } from '../utils/hono.ts'
 import { middlewareStripeWebhook } from '../utils/hono_middleware_stripe.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
+import { getOrgAdminMemberEmailsForTags } from '../utils/org_email_notifications.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import * as schema from '../utils/postgres_schema.ts'
 import { groupIdentifyPosthog } from '../utils/posthog.ts'
-import { ensureCustomerMetadata, getCreditCheckoutDetails, syncStripeCustomerCountry } from '../utils/stripe.ts'
+import { ensureCustomerMetadata, getCreditCheckoutDetails, getStripe, syncStripeCustomerCountry } from '../utils/stripe.ts'
 import { customerToSegmentOrg, supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
-import { backgroundTask } from '../utils/utils.ts'
+import { backgroundTask, isStripeConfigured } from '../utils/utils.ts'
 
 export const app = new Hono<MiddlewareKeyVariablesStripe>()
 
@@ -57,6 +58,8 @@ interface RevenueMovement {
 }
 
 type PersistRevenueMovementResult = 'applied' | 'duplicate' | 'missing' | 'stale'
+type BentoSegmentUpdate = { segments: string[], deleteSegments: string[] }
+type BentoSubscriberTagUpdate = { email: string, segments: string[], deleteSegments: string[] }
 
 const ZERO_REVENUE_MOVEMENT: RevenueMovement = {
   currentMrr: 0,
@@ -114,6 +117,34 @@ function isSubscriptionUpdateStatus(
   status: StripeWebhookStatus | null | undefined,
 ): status is StripeWebhookStatus {
   return Boolean(status && SUBSCRIPTION_UPDATE_STATUSES.has(status))
+}
+
+function normalizeBillingEmail(email: string | null | undefined) {
+  const normalized = email?.trim().toLowerCase()
+  return normalized || null
+}
+
+function buildBillingBentoTagUpdates(
+  emails: Array<string | null | undefined>,
+  segments: BentoSegmentUpdate,
+): BentoSubscriberTagUpdate[] {
+  const emailSet = new Set<string>()
+  const updates: BentoSubscriberTagUpdate[] = []
+
+  for (const email of emails) {
+    const normalizedEmail = normalizeBillingEmail(email)
+    if (!normalizedEmail || emailSet.has(normalizedEmail))
+      continue
+
+    emailSet.add(normalizedEmail)
+    updates.push({
+      email: normalizedEmail,
+      segments: [...segments.segments],
+      deleteSegments: [...segments.deleteSegments],
+    })
+  }
+
+  return updates
 }
 
 function getPaidAtUpdate(
@@ -243,6 +274,123 @@ function getPlanByProductId(plans: RevenuePlanRow[], productId: string | null | 
     return null
 
   return plans.find(plan => plan.stripe_id === productId) ?? null
+}
+
+async function lookupOrgCreatorEmail(
+  c: Context,
+  drizzleClient: ReturnType<typeof getDrizzleClient>,
+  org: Org,
+): Promise<string | null> {
+  try {
+    const users = await drizzleClient
+      .select({ email: schema.users.email })
+      .from(schema.users)
+      .where(eq(schema.users.id, org.created_by))
+      .limit(1)
+
+    return users[0]?.email ?? null
+  }
+  catch (error) {
+    cloudlog({ requestId: c.get('requestId'), message: 'lookupOrgCreatorEmail failed', orgId: org.id, userId: org.created_by, error })
+    return null
+  }
+}
+
+async function getStripeCustomerBillingEmail(c: Context, customerId: string): Promise<string | null> {
+  if (!customerId || !isStripeConfigured(c))
+    return null
+
+  try {
+    const customer = await getStripe(c).customers.retrieve(customerId)
+    if ('deleted' in customer && customer.deleted)
+      return null
+
+    return normalizeBillingEmail(customer.email)
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getStripeCustomerBillingEmail error', customerId, error })
+    return null
+  }
+}
+
+async function getBillingBentoEmails(c: Context, org: Org, customerId: string) {
+  const emails: Array<string | null | undefined> = [org.management_email]
+  const pgClient = getPgClient(c, true)
+
+  try {
+    const drizzleClient = getDrizzleClient(pgClient)
+    const { emails: billingMemberEmails } = await getOrgAdminMemberEmailsForTags(c, org.id, drizzleClient, 'billing')
+    emails.push(...billingMemberEmails)
+
+    const creatorEmail = await lookupOrgCreatorEmail(c, drizzleClient, org)
+    emails.push(creatorEmail)
+  }
+  finally {
+    closeClient(c, pgClient)
+  }
+
+  emails.push(await getStripeCustomerBillingEmail(c, customerId))
+
+  return emails
+}
+
+async function syncBillingBentoTags(
+  c: Context,
+  org: Org,
+  customerId: string,
+  segment: BentoSegmentUpdate,
+) {
+  if (!isBentoConfigured(c))
+    return
+
+  const updates = buildBillingBentoTagUpdates(await getBillingBentoEmails(c, org, customerId), segment)
+  if (updates.length === 0)
+    return
+
+  const synced = await syncBentoSubscriberTags(c, updates)
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'syncBillingBentoTags',
+    orgId: org.id,
+    customerId,
+    recipientCount: updates.length,
+    synced: synced !== false,
+  })
+}
+
+async function syncBillingBentoTagsFromStoredStripeInfo(c: Context, org: Org, customerId: string) {
+  if (!isBentoConfigured(c))
+    return
+
+  const { data: stripeInfo, error: stripeInfoError } = await supabaseAdmin(c)
+    .from('stripe_info')
+    .select('price_id, product_id')
+    .eq('customer_id', customerId)
+    .maybeSingle()
+
+  if (stripeInfoError) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'syncBillingBentoTagsFromStoredStripeInfo stripe_info error', customerId, error: stripeInfoError })
+    return
+  }
+  if (!stripeInfo)
+    return
+
+  let plan: PlanRow | null = null
+  if (stripeInfo.product_id) {
+    const { data: planData, error: planError } = await supabaseAdmin(c)
+      .from('plans')
+      .select()
+      .eq('stripe_id', stripeInfo.product_id)
+      .maybeSingle()
+
+    if (planError)
+      cloudlogErr({ requestId: c.get('requestId'), message: 'syncBillingBentoTagsFromStoredStripeInfo plan error', customerId, productId: stripeInfo.product_id, error: planError })
+
+    plan = planData ?? null
+  }
+
+  const segment = await customerToSegmentOrg(c, org.id, stripeInfo.price_id, plan)
+  await syncBillingBentoTags(c, org, customerId, segment)
 }
 
 function getSubscriptionPlan(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
@@ -958,7 +1106,7 @@ async function createdOrUpdated(
     const isMonthly = plan.price_m_id === stripeData.data.price_id
     const eventName = `user:subscribe_${statusName}:${isMonthly ? 'monthly' : 'yearly'}`
     const subscriptionMetadata = buildSubscriptionEventMetadata(stripeData, plan, previousPlan)
-    await addTagBento(c, org.management_email, segment)
+    await syncBillingBentoTags(c, org, stripeData.data.customer_id, segment)
     const isNewSubscription = status === 'created'
     await sendEventToTracking(c, {
       bento: {
@@ -992,7 +1140,7 @@ async function createdOrUpdated(
   }
   else {
     const segment = await customerToSegmentOrg(c, org.id, stripeData.data.price_id)
-    await addTagBento(c, org.management_email, segment)
+    await syncBillingBentoTags(c, org, stripeData.data.customer_id, segment)
   }
 }
 
@@ -1008,9 +1156,9 @@ async function updateStripeInfo(c: Context, stripeData: StripeData) {
   return false
 }
 
-async function didCancel(c: Context, org: Org) {
+async function didCancel(c: Context, org: Org, customerId: string) {
   const segment = await customerToSegmentOrg(c, org.id, 'canceled')
-  await addTagBento(c, org.management_email, segment)
+  await syncBillingBentoTags(c, org, customerId, segment)
   await sendEventToTracking(c, {
     bento: {
       cron: '* * * * *',
@@ -1039,18 +1187,26 @@ async function didCancel(c: Context, org: Org) {
   }))
 }
 
-async function getOrg(c: Context, stripeData: StripeData) {
+async function getOrgForCustomerId(c: Context, customerId: string): Promise<Org | null> {
   const { error: dbError, data: org } = await supabaseAdmin(c)
     .from('orgs')
-    .select('id, management_email, created_by, name')
-    .eq('customer_id', stripeData.data.customer_id)
-    .single()
+    .select('id, management_email, created_by, name, customer_id')
+    .eq('customer_id', customerId)
+    .maybeSingle()
+
   if (dbError) {
-    throw simpleError('webhook_error_no_org_found', 'Webhook Error: no org found')
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getOrgForCustomerId error', customerId, error: dbError })
+    return null
   }
-  if (!org) {
+
+  return org ?? null
+}
+
+async function getOrg(c: Context, stripeData: StripeData) {
+  const org = await getOrgForCustomerId(c, stripeData.data.customer_id)
+  if (!org)
     throw simpleError('webhook_error_no_org_found', 'Webhook Error: no org found')
-  }
+
   return org
 }
 
@@ -1120,6 +1276,11 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
 
   if (isCustomerProfileEvent(stripeEvent)) {
     await syncStripeCustomerCountry(c, stripeData.data.customer_id)
+    const org = await getOrgForCustomerId(c, stripeData.data.customer_id)
+    if (org) {
+      await ensureCustomerMetadata(c, stripeData.data.customer_id, org.id, org.created_by)
+      await syncBillingBentoTagsFromStoredStripeInfo(c, org, stripeData.data.customer_id)
+    }
     return c.json(BRES)
   }
 
@@ -1232,7 +1393,7 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
         return quickError(404, 'canceled_customer_id_not_found', `canceled: customer_id not found`, { stripeData })
 
       // This is the known subscription being cancelled.
-      await didCancel(c, org)
+      await didCancel(c, org, stripeData.data.customer_id)
     }
     // If it's a different subscription (not the one in DB), ignore it
     // This prevents old subscription webhooks from overwriting newer active subscriptions
@@ -1244,6 +1405,7 @@ app.post('/', middlewareStripeWebhook(), async (c) => {
 })
 
 export const stripeEventTestUtils = {
+  buildBillingBentoTagUpdates,
   buildSubscriptionEventMetadata,
   classifyRevenueMovement,
   getEventDateId,

--- a/tests/stripe-billing-bento-tags.unit.test.ts
+++ b/tests/stripe-billing-bento-tags.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { stripeEventTestUtils } from '../supabase/functions/_backend/triggers/stripe_event.ts'
+
+describe('stripe billing Bento tag updates', () => {
+  it.concurrent('normalizes and deduplicates every billing-linked email', () => {
+    const segment = {
+      segments: ['capgo', 'paying', 'plan:Solo'],
+      deleteSegments: ['trial', 'trial0', 'canceled'],
+    }
+
+    expect(stripeEventTestUtils.buildBillingBentoTagUpdates([
+      'Owner@Example.com ',
+      'owner@example.com',
+      'billing@stripe.example',
+      null,
+      '',
+      ' Billing@Stripe.Example ',
+      'creator@example.com',
+    ], segment)).toEqual([
+      { email: 'owner@example.com', segments: segment.segments, deleteSegments: segment.deleteSegments },
+      { email: 'billing@stripe.example', segments: segment.segments, deleteSegments: segment.deleteSegments },
+      { email: 'creator@example.com', segments: segment.segments, deleteSegments: segment.deleteSegments },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- sync Bento subscription tags to every billing-linked email, not only the org management email
- include billing audience members, the org creator email, and the Stripe customer email when billing differs from the Capgo account email
- add unit coverage for billing email normalization and deduplication

## Tests
- bun run lint:backend
- bun run typecheck:backend
- bun lint
- bunx vitest run tests/stripe-billing-bento-tags.unit.test.ts tests/stripe-event-paid-at.unit.test.ts tests/stripe-country.unit.test.ts tests/stripe-revenue-movement.unit.test.ts tests/stripe-subscription-events.unit.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live in the Stripe webhook path with extra email/Stripe lookups and broader Bento updates, but core subscription persistence and revenue logic are unchanged.
> 
> **Overview**
> Stripe webhook handling now applies subscription/cancel Bento segment tags to **every billing-related email**, not only `management_email`. Subscription create/update, cancel, and the no-plan branch call `syncBillingBentoTags`, which gathers org management email, org members with billing notification prefs, the org creator, and the Stripe customer email (when Stripe is configured), then batch-syncs via `syncBentoSubscriberTags` after normalize/dedupe.
> 
> **Customer created/updated** webhooks additionally run `syncBillingBentoTagsFromStoredStripeInfo` so tag state can refresh when the Stripe profile changes without a subscription event. Org lookup is split into `getOrgForCustomerId` (`maybeSingle`, log-and-null on error) for those optional paths while `getOrg` still fails the webhook when no org exists.
> 
> Unit coverage was added for `buildBillingBentoTagUpdates` (trim, lower-case, dedupe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e635681f1d0813a52571508c52bf64f4507adeb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->