### PR TITLE
fix(cli): require explicit --icon on app set

### DIFF
--- a/cli/src/api/app.ts
+++ b/cli/src/api/app.ts
@@ -214,6 +214,12 @@ export type { AppOptions as Options } from '../schemas/app'
 export const newIconPath = 'assets/icon.png'
 export const defaultAppIconPath = 'public/capgo.png'
 
+export function resolveAppSetIconPath(explicitIcon?: string): string | undefined {
+  if (explicitIcon === undefined)
+    return undefined
+  return explicitIcon
+}
+
 export function getAppIconStoragePath(organizationUid: string, appId: string) {
   return `org/${organizationUid}/${appId}/icon`
 }

--- a/cli/src/api/app.ts
+++ b/cli/src/api/app.ts
@@ -215,8 +215,6 @@ export const newIconPath = 'assets/icon.png'
 export const defaultAppIconPath = 'public/capgo.png'
 
 export function resolveAppSetIconPath(explicitIcon?: string): string | undefined {
-  if (explicitIcon === undefined)
-    return undefined
   return explicitIcon
 }
 

--- a/cli/src/app/set.ts
+++ b/cli/src/app/set.ts
@@ -3,7 +3,7 @@ import type { Options } from '../api/app'
 import type { Database } from '../types/supabase.types'
 import { existsSync, readFileSync } from 'node:fs'
 import { intro, log, outro } from '@clack/prompts'
-import { checkAppExistsAndHasPermissionOrgErr, defaultAppIconPath, getAppIconStoragePath, newIconPath } from '../api/app'
+import { checkAppExistsAndHasPermissionOrgErr, defaultAppIconPath, getAppIconStoragePath, resolveAppSetIconPath } from '../api/app'
 import { assertChannelExists, disableDownloadChannels as disableAllDownloadChannels, setDefaultDownloadChannel } from './default-channels'
 import { normalizeStoreUrl } from './store-url'
 import {
@@ -113,22 +113,19 @@ export async function setAppInternal(appId: string, options: Options, silent = f
   const iconPath = getAppIconStoragePath(organizationUid, appId)
   let iconUrl: string | undefined = defaultAppIconPath
 
-  if (icon && existsSync(icon)) {
-    iconBuff = readFileSync(icon)
-    const contentType = getContentType(icon)
+  const iconToUpload = resolveAppSetIconPath(icon)
+  if (iconToUpload) {
+    if (!existsSync(iconToUpload)) {
+      if (!silent)
+        log.error(`Cannot find app icon at ${iconToUpload}`)
+      throw new Error(`Cannot find app icon at ${iconToUpload}`)
+    }
+
+    iconBuff = readFileSync(iconToUpload)
+    const contentType = getContentType(iconToUpload)
     iconType = contentType || 'image/png'
     if (!silent)
-      log.warn(`Found app icon ${icon}`)
-  }
-  else if (existsSync(newIconPath)) {
-    iconBuff = readFileSync(newIconPath)
-    const contentType = getContentType(newIconPath)
-    iconType = contentType || 'image/png'
-    if (!silent)
-      log.warn(`Found app icon ${newIconPath}`)
-  }
-  else if (!silent) {
-    log.warn(`Cannot find app icon in any of the following locations: ${icon}, ${newIconPath}`)
+      log.warn(`Found app icon ${iconToUpload}`)
   }
 
   if (iconBuff && iconType) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -455,7 +455,7 @@ Example: npx @capgo/cli@latest app set com.example.app --name "Updated App" --re
     await setApp(appId, options)
   })
   .option('-n, --name <name>', `App name for display in Capgo Cloud`)
-  .option('-i, --icon <icon>', `App icon path to upload. Only updates the icon when this flag is passed`)
+  .option('-i, --icon <icon>', `Local image file path (png, jpg, webp, svg) used as the app icon in Capgo Cloud`)
   .option('-a, --apikey <apikey>', optionDescriptions.apikey)
   .option('-r, --retention <retention>', `Days to keep old bundles (0 = infinite, default: 0)`)
   .option('--expose-metadata <exposeMetadata>', `Expose bundle metadata (link and comment) to the plugin (true/false, default: false)`)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -455,7 +455,7 @@ Example: npx @capgo/cli@latest app set com.example.app --name "Updated App" --re
     await setApp(appId, options)
   })
   .option('-n, --name <name>', `App name for display in Capgo Cloud`)
-  .option('-i, --icon <icon>', `App icon path for display in Capgo Cloud`)
+  .option('-i, --icon <icon>', `App icon path to upload. Only updates the icon when this flag is passed`)
   .option('-a, --apikey <apikey>', optionDescriptions.apikey)
   .option('-r, --retention <retention>', `Days to keep old bundles (0 = infinite, default: 0)`)
   .option('--expose-metadata <exposeMetadata>', `Expose bundle metadata (link and comment) to the plugin (true/false, default: false)`)

--- a/cli/test/test-app-set-options.mjs
+++ b/cli/test/test-app-set-options.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict'
+import { resolveAppSetIconPath } from '../src/api/app.ts'
 import { normalizeStoreUrl } from '../src/app/store-url.ts'
 
 let failures = 0
@@ -43,6 +44,14 @@ await test('rejects invalid store hosts', () => {
     () => normalizeStoreUrl('https://example.com/app', 'apps.apple.com'),
     /apps\.apple\.com/,
   )
+})
+
+await test('does not resolve app set icon without --icon', () => {
+  assert.equal(resolveAppSetIconPath(undefined), undefined)
+})
+
+await test('resolves app set icon only when --icon is passed', () => {
+  assert.equal(resolveAppSetIconPath('./assets/capgo-icon.png'), './assets/capgo-icon.png')
 })
 
 if (failures > 0) {

--- a/cli/webdocs/app.mdx
+++ b/cli/webdocs/app.mdx
@@ -150,7 +150,7 @@ npx @capgo/cli@latest app set com.example.app --name "Updated App" --retention 3
 | Param          | Type          | Description          |
 | -------------- | ------------- | -------------------- |
 | **-n** | <code>string</code> | App name for display in Capgo Cloud |
-| **-i** | <code>string</code> | App icon path for display in Capgo Cloud |
+| **-i** | <code>string</code> | App icon path to upload. Only updates the icon when this flag is passed |
 | **-a** | <code>string</code> | API key to link to your account |
 | **-r** | <code>string</code> | Days to keep old bundles (0 = infinite, default: 0) |
 | **--expose-metadata** | <code>string</code> | Expose bundle metadata (link and comment) to the plugin (true/false, default: false) |

--- a/cli/webdocs/app.mdx
+++ b/cli/webdocs/app.mdx
@@ -150,7 +150,7 @@ npx @capgo/cli@latest app set com.example.app --name "Updated App" --retention 3
 | Param          | Type          | Description          |
 | -------------- | ------------- | -------------------- |
 | **-n** | <code>string</code> | App name for display in Capgo Cloud |
-| **-i** | <code>string</code> | App icon path to upload. Only updates the icon when this flag is passed |
+| **-i** | <code>string</code> | Local image file path (png, jpg, webp, svg) used as the app icon in Capgo Cloud |
 | **-a** | <code>string</code> | API key to link to your account |
 | **-r** | <code>string</code> | Days to keep old bundles (0 = infinite, default: 0) |
 | **--expose-metadata** | <code>string</code> | Expose bundle metadata (link and comment) to the plugin (true/false, default: false) |


### PR DESCRIPTION
## Summary (AI generated)

- `app set` no longer auto-uploads `assets/icon.png` from the current directory
- Icon uploads now happen only when `--icon` is explicitly passed
- Updated CLI help/docs and added unit tests for the new behavior

## Motivation (AI generated)

Running `capgo app set <id> --name "..."` from an example-app folder silently uploaded that folder's icon for every app. A batch rename overwrote ~106 plugin app logos with the same Transitions icon.

## Business Impact (AI generated)

Prevents accidental mass icon overwrites during routine app setting updates. Operators can safely rename or update app settings from any working directory without risking logo corruption.

## Test Plan (AI generated)

- [x] `bun run test:app-set-options` in `cli/`
- [x] `bun run build` and `bun run lint` in `cli/`
- [ ] CI passes

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clarified the `app set --icon` / `-i` option: it accepts a local image path and is used as the app icon in Capgo Cloud.
* **Bug Fixes**
  * Improved icon path handling and validation: icon upload now happens only when an icon is explicitly provided and the resolved file exists.
* **Documentation**
  * Updated CLI help text and web docs to match the new icon behavior and supported formats.
* **Tests**
  * Added coverage for icon path resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->