### PR TITLE
fix: posthog

### DIFF
--- a/src/services/posthog.ts
+++ b/src/services/posthog.ts
@@ -5,48 +5,7 @@ import { isLocal } from '~/services/supabase'
 export function posthogLoader(supaHost: string) {
   if (isLocal(supaHost))
     return
-  !(function (t, e) {
-    let o, n, p, r
-    e.__SV
-      || ((window.posthog = e),
-        (e._i = []),
-        (e.init = function (i, s, a) {
-          function g(t, e) {
-            let o = e.split('.')
-              ; (o.length == 2 && ((t = t[o[0]]), (e = o[1])),
-                (t[e] = function () {
-                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
-                }))
-          }
-          ; (((p = t.createElement('script')).type = 'text/javascript'),
-            (p.crossOrigin = 'anonymous'),
-            (p.async = !0),
-            (p.src = `${s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com')}/static/array.js`),
-            (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r))
-          let u = e
-          for (
-            void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-            u.people = u.people || [],
-            u.toString = function (t) {
-              let e = 'posthog'
-              return (a !== 'posthog' && (e += `.${a}`), t || (e += ' (stub)'), e)
-            },
-            u.people.toString = function () {
-              return `${u.toString(1)}.people (stub)`
-            },
-            o
-            = 'init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session js getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ps opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric'.split(
-              ' ',
-            ),
-            n = 0;
-            n < o.length;
-            n++
-          )
-            g(u, o[n])
-          e._i.push([i, s, a])
-        }),
-        (e.__SV = 1))
-  })(document, window.posthog || [])
+  !function (t, e) { var o, n, p, r; e.__SV || (window.posthog && window.posthog.__loaded) || (window.posthog = e, e._i = [], e.init = function (i, s, a) { function g(t, e) { var o = e.split("."); 2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))) } } (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r); var u = e; for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) { var e = "posthog"; return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e }, u.people.toString = function () { return u.toString(1) + ".people (stub)" }, o = "ki Ci init qi Hi pr Bi zi Di capture calculateEventProperties Qi register register_once register_for_session unregister unregister_for_session Ki getFeatureFlag getFeatureFlagPayload getFeatureFlagResult getAllFeatureFlags isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Xi identify setPersonProperties unsetPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset shutdown setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Ji Gi createPersonProfile setInternalOrTestUser Yi Ai rn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Vi debug mr it getPageViewId captureTraceFeedback captureTraceMetric Oi".split(" "), n = 0; n < o.length; n++)g(u, o[n]); e._i.push([i, s, a]) }, e.__SV = 1) }(document, window.posthog || []);
   posthog.init('phc_NXDyDajQaTQVwb25DEhIVZfxVUn4R0Y348Z7vWYHZUi', {
     api_host: 'https://psthg.capgo.app',
     ui_host: 'https://eu.posthog.com',

--- a/src/services/posthog.ts
+++ b/src/services/posthog.ts
@@ -8,47 +8,47 @@ export function posthogLoader(supaHost: string) {
   !(function (t, e) {
     let o, n, p, r
     e.__SV
-    || ((window.posthog = e),
-    (e._i = []),
-    (e.init = function (i, s, a) {
-      function g(t, e) {
-        let o = e.split('.')
-          ;(o.length == 2 && ((t = t[o[0]]), (e = o[1])),
-        (t[e] = function () {
-          t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
-        }))
-      }
-      ;(((p = t.createElement('script')).type = 'text/javascript'),
-      (p.crossOrigin = 'anonymous'),
-      (p.async = !0),
-      (p.src = `${s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com')}/static/array.js`),
-      (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r))
-      let u = e
-      for (
-        void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-        u.people = u.people || [],
-        u.toString = function (t) {
-          let e = 'posthog'
-          return (a !== 'posthog' && (e += `.${a}`), t || (e += ' (stub)'), e)
-        },
-        u.people.toString = function () {
-          return `${u.toString(1)}.people (stub)`
-        },
-        o
-          = 'init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session js getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ps opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric'.split(
-            ' ',
-          ),
-        n = 0;
-        n < o.length;
-        n++
-      )
-        g(u, o[n])
-      e._i.push([i, s, a])
-    }),
-    (e.__SV = 1))
+      || ((window.posthog = e),
+        (e._i = []),
+        (e.init = function (i, s, a) {
+          function g(t, e) {
+            let o = e.split('.')
+              ; (o.length == 2 && ((t = t[o[0]]), (e = o[1])),
+                (t[e] = function () {
+                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
+                }))
+          }
+          ; (((p = t.createElement('script')).type = 'text/javascript'),
+            (p.crossOrigin = 'anonymous'),
+            (p.async = !0),
+            (p.src = `${s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com')}/static/array.js`),
+            (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r))
+          let u = e
+          for (
+            void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+            u.people = u.people || [],
+            u.toString = function (t) {
+              let e = 'posthog'
+              return (a !== 'posthog' && (e += `.${a}`), t || (e += ' (stub)'), e)
+            },
+            u.people.toString = function () {
+              return `${u.toString(1)}.people (stub)`
+            },
+            o
+            = 'init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session js getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ps opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric'.split(
+              ' ',
+            ),
+            n = 0;
+            n < o.length;
+            n++
+          )
+            g(u, o[n])
+          e._i.push([i, s, a])
+        }),
+        (e.__SV = 1))
   })(document, window.posthog || [])
   posthog.init('phc_NXDyDajQaTQVwb25DEhIVZfxVUn4R0Y348Z7vWYHZUi', {
-    api_host: 'https://psthg.digitalshift-ee.workers.dev/',
+    api_host: 'https://psthg.capgo.app',
     ui_host: 'https://eu.posthog.com',
     person_profiles: 'identified_only',
     defaults: '2025-11-30',

--- a/src/services/posthog.ts
+++ b/src/services/posthog.ts
@@ -51,7 +51,7 @@ export function posthogLoader(supaHost: string) {
     api_host: 'https://psthg.capgo.app',
     ui_host: 'https://eu.posthog.com',
     person_profiles: 'identified_only',
-    defaults: '2025-11-30',
+    defaults: '2026-05-30',
     before_send: (event) => {
       if (shouldSuppressPostHogExceptionEvent(event))
         return false


### PR DESCRIPTION
move from old worker to new managed proxy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All non-local analytics traffic depends on the new proxy host and SDK snippet; misconfiguration could drop events until verified, though app logic and auth are untouched.
> 
> **Overview**
> Switches client-side PostHog ingestion from the old Cloudflare worker (`psthg.digitalshift-ee.workers.dev`) to the **managed proxy** at `https://psthg.capgo.app`, matching the PR goal of moving off the legacy worker.
> 
> The inline PostHog loader snippet is **replaced** with a newer minified build: it adds a guard so init is skipped when `window.posthog.__loaded` is already set, and the stub method list is expanded (e.g. feature flags, surveys, exception autocapture). **`posthog.init` config** keeps the same project key, `ui_host`, `person_profiles`, and `before_send` filtering via `shouldSuppressPostHogExceptionEvent`; only **`defaults`** moves from `2025-11-30` to `2026-05-30`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80faa8910220f8dc281f9c53009dd34b787caf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the analytics service endpoint to a new host, improving tracking connectivity.
  * Adjusted analytics default date configuration to a newer value.
  * Kept the existing analytics initialization behavior and user-facing setup flow unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->