### PR TITLE
fix(api): validate Analytics Engine SQL and repair invalid queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,9 @@
     "deploy:supabase_env:prod": "bunx supabase secrets set --project-ref xvwzpoazmxkqosrdewyv --env-file internal/cloudflare/.env.prod",
     "deploy:supabase_env:preprod": "bunx supabase secrets set --project-ref ibwjdnhknbkcqfbabwei --env-file internal/cloudflare/.env.preprod",
     "deploy:supabase_env:dev": "bunx supabase secrets set --project-ref aucsybvnhavogdmzwtcw --env-file internal/cloudflare/.env.alpha",
-    "size": "bunx vite-bundle-visualizer"
+    "size": "bunx vite-bundle-visualizer",
+    "test:analytics-sql": "vitest run tests/analytics-engine-sql.unit.test.ts",
+    "test:analytics-sql:live": "bun --env-file=internal/cloudflare/.env.prod scripts/validate-analytics-engine-sql.ts"
   },
   "dependencies": {
     "@bradenmacdonald/s3-lite-client": "npm:@jsr/bradenmacdonald__s3-lite-client@0.9.6",

--- a/scripts/validate-analytics-engine-sql.ts
+++ b/scripts/validate-analytics-engine-sql.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+import {
+  lintAnalyticsEngineSql,
+  prepareAnalyticsEngineSqlForLiveValidation,
+  validateAnalyticsEngineSqlLive,
+} from '../supabase/functions/_backend/utils/analyticsEngineSqlLint.ts'
+import { collectAnalyticsEngineSqlFixtures } from '../tests/helpers/collectAnalyticsEngineSqlFixtures.ts'
+
+const accountId = process.env.CF_ACCOUNT_ANALYTICS_ID
+const token = process.env.CF_ANALYTICS_TOKEN
+
+if (!accountId || !token) {
+  console.error('Missing CF_ACCOUNT_ANALYTICS_ID or CF_ANALYTICS_TOKEN')
+  process.exit(1)
+}
+
+const fixtures = await collectAnalyticsEngineSqlFixtures()
+const lintFailures = fixtures.flatMap((fixture) => {
+  return lintAnalyticsEngineSql(fixture.query).map(issue => `${fixture.name}: ${issue.rule} - ${issue.message}`)
+})
+
+if (lintFailures.length > 0) {
+  console.error('Static Analytics Engine SQL lint failures:')
+  for (const failure of lintFailures)
+    console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+const liveFailures: string[] = []
+
+for (const fixture of fixtures) {
+  const prepared = prepareAnalyticsEngineSqlForLiveValidation(fixture.query)
+  if (!prepared)
+    continue
+
+  const result = await validateAnalyticsEngineSqlLive(accountId, token, fixture.query)
+  if (!result.ok)
+    liveFailures.push(`${fixture.name} (${result.status}): ${result.body.trim()}`)
+}
+
+if (liveFailures.length > 0) {
+  console.error('Live Analytics Engine SQL validation failures:')
+  for (const failure of liveFailures)
+    console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(`Validated ${fixtures.length} Analytics Engine SQL queries against Cloudflare`)

--- a/scripts/validate-analytics-engine-sql.ts
+++ b/scripts/validate-analytics-engine-sql.ts
@@ -33,7 +33,7 @@ for (const fixture of fixtures) {
   if (!prepared)
     continue
 
-  const result = await validateAnalyticsEngineSqlLive(accountId, token, fixture.query)
+  const result = await validateAnalyticsEngineSqlLive(accountId, token, fixture.query, prepared)
   if (!result.ok)
     liveFailures.push(`${fixture.name} (${result.status}): ${result.body.trim()}`)
 }

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -37,7 +37,7 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   },
   {
     id: 'no-from-table-alias',
-    test: sql => /\b(?:FROM|JOIN)\s+[\w.]+\s+(?:AS\s+)?[a-z][\w]*\s+(?:,|WHERE|LEFT|RIGHT|INNER|JOIN|GROUP|ORDER|LIMIT|$)/i.test(sql),
+    test: sql => /\b(?:FROM|JOIN)\s+[\w.]+\s+(?:AS\s+)?[a-z]\w*\s+(?:,|WHERE|LEFT|RIGHT|INNER|JOIN|GROUP|ORDER|LIMIT|$)/i.test(sql),
     message: 'Table aliases in FROM/JOIN are unsupported by Analytics Engine SQL',
   },
 ]
@@ -92,8 +92,9 @@ export async function validateAnalyticsEngineSqlLive(
   accountId: string,
   token: string,
   sql: string,
+  preparedSql?: string,
 ): Promise<AnalyticsEngineSqlLiveValidationResult | AnalyticsEngineSqlLiveValidationFailure> {
-  const prepared = prepareAnalyticsEngineSqlForLiveValidation(sql)
+  const prepared = preparedSql ?? prepareAnalyticsEngineSqlForLiveValidation(sql)
   if (!prepared)
     return { ok: true }
 
@@ -104,6 +105,7 @@ export async function validateAnalyticsEngineSqlLive(
       'Content-Type': 'text/plain; charset=utf-8',
     },
     body: prepared,
+    signal: AbortSignal.timeout(30000),
   })
 
   const body = await response.text()

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -1,0 +1,118 @@
+export interface AnalyticsEngineSqlLintIssue {
+  rule: string
+  message: string
+}
+
+interface AnalyticsEngineSqlLintRule {
+  id: string
+  test: (sql: string) => boolean
+  message: string
+}
+
+export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
+  {
+    id: 'no-count-star',
+    test: sql => /\bCOUNT\s*\(\s*\*\s*\)/i.test(sql),
+    message: 'Analytics Engine SQL requires COUNT() or COUNT(DISTINCT column), not COUNT(*)',
+  },
+  {
+    id: 'no-case-in-argmax',
+    test: sql => /\bargMax\s*\([^)]*CASE\s+WHEN/i.test(sql),
+    message: 'CASE WHEN inside argMax is unsupported by Analytics Engine SQL',
+  },
+  {
+    id: 'no-join',
+    test: sql => /\bJOIN\b/i.test(sql),
+    message: 'JOIN clauses are unsupported by Analytics Engine SQL',
+  },
+  {
+    id: 'no-multiif',
+    test: sql => /\bmultiIf\b/i.test(sql),
+    message: 'multiIf is unsupported by Analytics Engine SQL; use nested if() instead',
+  },
+  {
+    id: 'no-select-alias-dependency',
+    test: sql => /\bif\(\s*(?:installs|failures|fails)\s*\+/i.test(sql),
+    message: 'Analytics Engine SQL cannot reference SELECT aliases inside other projected expressions',
+  },
+  {
+    id: 'no-from-table-alias',
+    test: sql => /\b(?:FROM|JOIN)\s+[\w.]+\s+(?:AS\s+)?[a-z][\w]*\s+(?:,|WHERE|LEFT|RIGHT|INNER|JOIN|GROUP|ORDER|LIMIT|$)/i.test(sql),
+    message: 'Table aliases in FROM/JOIN are unsupported by Analytics Engine SQL',
+  },
+]
+
+export function lintAnalyticsEngineSql(sql: string): AnalyticsEngineSqlLintIssue[] {
+  const normalized = sql.trim()
+  if (!normalized)
+    return []
+
+  return ANALYTICS_ENGINE_SQL_LINT_RULES
+    .filter(rule => rule.test(normalized))
+    .map(rule => ({ rule: rule.id, message: rule.message }))
+}
+
+export function assertAnalyticsEngineSqlValid(sql: string, queryName?: string): void {
+  const issues = lintAnalyticsEngineSql(sql)
+  if (issues.length === 0)
+    return
+
+  const prefix = queryName ? `[${queryName}] ` : ''
+  const details = issues.map(issue => `${issue.rule}: ${issue.message}`).join('; ')
+  throw new Error(`${prefix}Invalid Analytics Engine SQL: ${details}`)
+}
+
+const CLOUDFLARE_ANALYTICS_SQL_URL = 'https://api.cloudflare.com/client/v4/accounts'
+
+export function prepareAnalyticsEngineSqlForLiveValidation(sql: string): string | null {
+  const trimmed = sql.trim()
+  if (!trimmed)
+    return null
+
+  if (/^\s*(INSERT|UPDATE|DELETE)\b/i.test(trimmed))
+    return null
+
+  if (/\bLIMIT\s+\d+/i.test(trimmed))
+    return trimmed
+
+  return `${trimmed}\nLIMIT 1`
+}
+
+export interface AnalyticsEngineSqlLiveValidationResult {
+  ok: true
+}
+
+export interface AnalyticsEngineSqlLiveValidationFailure {
+  ok: false
+  status: number
+  body: string
+}
+
+export async function validateAnalyticsEngineSqlLive(
+  accountId: string,
+  token: string,
+  sql: string,
+): Promise<AnalyticsEngineSqlLiveValidationResult | AnalyticsEngineSqlLiveValidationFailure> {
+  const prepared = prepareAnalyticsEngineSqlForLiveValidation(sql)
+  if (!prepared)
+    return { ok: true }
+
+  const response = await fetch(`${CLOUDFLARE_ANALYTICS_SQL_URL}/${accountId}/analytics_engine/sql`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+    body: prepared,
+  })
+
+  const body = await response.text()
+  if (!response.ok)
+    return { ok: false, status: response.status, body }
+
+  return { ok: true }
+}
+
+export function hasAnalyticsEngineLiveValidationConfig(): boolean {
+  return Boolean(process.env.CF_ANALYTICS_TOKEN && process.env.CF_ACCOUNT_ANALYTICS_ID)
+}

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -598,7 +598,7 @@ FROM (
     argMax(blob7, timestamp) AS default_channel,
     blob1 AS device_id
   FROM device_info
-  WHERE index1 = '${escapeSqlString(app_id)}'
+  WHERE index1 = '${escapeSqlString(app_id)}' AND blob9 != ''
   GROUP BY blob1
 )
 WHERE version_name != '' ${channelFilter}
@@ -621,6 +621,26 @@ GROUP BY version_name`
 function buildInstallSourceList(installSources: string[]) {
   return installSources.map(source => `'${escapeSqlString(source)}'`).join(', ')
 }
+export function buildDeviceIdsByInstallSourcesQuery(app_id: string, installSources: string[]) {
+  return `SELECT blob1 AS device_id
+FROM (
+  SELECT
+    blob1,
+    argMax(blob9, timestamp) AS install_source
+  FROM device_info
+  WHERE index1 = '${escapeSqlString(app_id)}' AND blob9 != ''
+  GROUP BY blob1
+)
+WHERE install_source IN (${buildInstallSourceList(installSources)})`
+}
+
+async function readDeviceIdsByInstallSourcesCF(c: Context, app_id: string, installSources: string[]): Promise<string[]> {
+  const query = buildDeviceIdsByInstallSourcesQuery(app_id, installSources)
+  cloudlog({ requestId: c.get('requestId'), message: 'readDeviceIdsByInstallSourcesCF query', query })
+  const res = await runQueryToCFA<{ device_id: string }>(c, query)
+  return res.map(row => row.device_id)
+}
+
 export async function countInstallSourcesCF(c: Context, app_id: string): Promise<Record<string, number>> {
   const cache = new CacheHelper(c)
   const cacheKey = cache.buildRequest('/internal/install-source-counts', { app_id })
@@ -750,10 +770,6 @@ function buildReadDevicesCFCursorCondition(cursor: string | undefined, devicesOr
 
 function buildReadDevicesCFOuterConditions(params: ReadDevicesParams, devicesOrder: DevicesOrderCF | null) {
   const conditions = [buildReadDevicesCFCursorCondition(params.cursor, devicesOrder)]
-
-  if (params.installSources?.length)
-    conditions.push(`install_source IN (${buildInstallSourceList(params.installSources)})`)
-
   return conditions.filter(Boolean)
 }
 
@@ -790,7 +806,6 @@ export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode:
   }
 
   const devicesOrder = getReadDevicesCFOrder(params)
-  const includeInstallSource = Boolean(params.installSources?.length)
   const outerConditions = buildReadDevicesCFOuterConditions(params, devicesOrder)
   const outerFilter = outerConditions.length ? `WHERE ${outerConditions.join(' AND ')}` : ''
   let orderBy = 'device_id ASC'
@@ -811,7 +826,6 @@ export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode:
     '    argMax(blob6, timestamp) AS version_build,',
     '    argMax(blob7, timestamp) AS default_channel,',
     '    argMax(blob8, timestamp) AS key_id,',
-    includeInstallSource ? '    argMax(blob9, timestamp) AS install_source,' : '',
     '    argMax(double1, timestamp) AS platform,',
     '    argMax(double2, timestamp) AS is_prod,',
     '    argMax(double3, timestamp) AS is_emulator,',
@@ -844,7 +858,26 @@ export async function readDevicesCF(c: Context, params: ReadDevicesParams, custo
     cloudlog({ requestId: c.get('requestId'), message: 'search', searchLength: params.search.length })
   }
 
-  const query = buildReadDevicesCFQuery(params, customIdMode)
+  let readParams = params
+  if (params.installSources?.length) {
+    const sourceDeviceIds = await readDeviceIdsByInstallSourcesCF(c, params.app_id, params.installSources)
+    if (!sourceDeviceIds.length)
+      return [] as DeviceRes[]
+
+    const deviceIds = params.deviceIds?.length
+      ? params.deviceIds.filter(deviceId => sourceDeviceIds.includes(deviceId))
+      : sourceDeviceIds
+    if (!deviceIds.length)
+      return [] as DeviceRes[]
+
+    readParams = {
+      ...params,
+      deviceIds,
+      installSources: undefined,
+    }
+  }
+
+  const query = buildReadDevicesCFQuery(readParams, customIdMode)
 
   cloudlog({ requestId: c.get('requestId'), message: 'readDevicesCF query', query })
   try {
@@ -1875,13 +1908,8 @@ export async function getAdminOrgMetrics(
         bandwidthByOrg.set(orgId, current)
       }
 
-      const bandwidthResult = [...bandwidthByOrg.entries()]
-        .map(([org_id, metrics]) => ({ org_id, ...metrics }))
-        .sort((a, b) => b.bandwidth - a.bandwidth)
-        .slice(0, safeLimit)
-
       // Merge results
-      const bandwidthMap = new Map(bandwidthResult.map(b => [b.org_id, b]))
+      const bandwidthMap = bandwidthByOrg
 
       return orgMau.map(org => ({
         org_id: org.org_id,

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -864,8 +864,9 @@ export async function readDevicesCF(c: Context, params: ReadDevicesParams, custo
     if (!sourceDeviceIds.length)
       return [] as DeviceRes[]
 
+    const sourceDeviceIdSet = new Set(sourceDeviceIds)
     const deviceIds = params.deviceIds?.length
-      ? params.deviceIds.filter(deviceId => sourceDeviceIds.includes(deviceId))
+      ? params.deviceIds.filter(deviceId => sourceDeviceIdSet.has(deviceId))
       : sourceDeviceIds
     if (!deviceIds.length)
       return [] as DeviceRes[]
@@ -1908,15 +1909,12 @@ export async function getAdminOrgMetrics(
         bandwidthByOrg.set(orgId, current)
       }
 
-      // Merge results
-      const bandwidthMap = bandwidthByOrg
-
       return orgMau.map(org => ({
         org_id: org.org_id,
         mau: org.mau,
         apps_count: org.apps_count,
-        bandwidth: bandwidthMap.get(org.org_id)?.bandwidth || 0,
-        updates: bandwidthMap.get(org.org_id)?.updates || 0,
+        bandwidth: bandwidthByOrg.get(org.org_id)?.bandwidth || 0,
+        updates: bandwidthByOrg.get(org.org_id)?.updates || 0,
       }))
     }
 

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -561,7 +561,7 @@ export async function readNativeVersionUsageCF(c: Context, app_id: string, perio
 
   const query = `SELECT
   formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS date,
-  multiIf(blob4 != '', blob4, double1 = 1, 'ios', double1 = 2, 'electron', double1 = 0, 'android', 'unknown') AS platform,
+  if(blob4 != '', blob4, if(double1 = 1, 'ios', if(double1 = 2, 'electron', if(double1 = 0, 'android', 'unknown')))) AS platform,
   if(blob3 = '', 'unknown', blob3) AS version_build,
   COUNT(DISTINCT blob1) AS devices
 FROM device_usage
@@ -630,11 +630,11 @@ export async function countInstallSourcesCF(c: Context, app_id: string): Promise
 
   const query = `SELECT
   install_source,
-  COUNT(*) AS total
+  COUNT() AS total
 FROM (
   SELECT
     blob1 AS device_id,
-    argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source
+    argMax(blob9, timestamp) AS install_source
   FROM device_info
   WHERE index1 = '${escapeSqlString(app_id)}'
   GROUP BY blob1
@@ -811,7 +811,7 @@ export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode:
     '    argMax(blob6, timestamp) AS version_build,',
     '    argMax(blob7, timestamp) AS default_channel,',
     '    argMax(blob8, timestamp) AS key_id,',
-    includeInstallSource ? '    argMax(blob9, CASE WHEN blob9 != \'\' THEN timestamp ELSE toDateTime(\'1970-01-01 00:00:00\') END) AS install_source,' : '',
+    includeInstallSource ? '    argMax(blob9, timestamp) AS install_source,' : '',
     '    argMax(double1, timestamp) AS platform,',
     '    argMax(double2, timestamp) AS is_prod,',
     '    argMax(double3, timestamp) AS is_emulator,',
@@ -1624,8 +1624,7 @@ export async function getAdminFailureMetrics(
   const query = `SELECT
     formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS date,
     sum(if(blob3 = 'fail', 1, 0)) AS failures,
-    sum(if(blob3 = 'install', 1, 0)) AS installs,
-    if(installs + failures > 0, (failures / (installs + failures)) * 100, 0) AS failure_rate
+    sum(if(blob3 = 'install', 1, 0)) AS installs
     ${app_id ? `, blob1 AS app_id` : ''}
   FROM version_usage
   WHERE timestamp >= toDateTime('${formatDateCF(start_date)}')
@@ -1637,7 +1636,16 @@ export async function getAdminFailureMetrics(
   cloudlog({ requestId: c.get('requestId'), message: 'getAdminFailureMetrics query', query })
 
   try {
-    return await runQueryToCFA<AdminFailureMetrics>(c, query)
+    const rows = await runQueryToCFA<{ date: string, failures: number, installs: number, app_id?: string }>(c, query)
+    return rows.map((row) => {
+      const total = (row.failures || 0) + (row.installs || 0)
+      return {
+        date: row.date,
+        failures: row.failures || 0,
+        app_id: row.app_id,
+        failure_rate: total > 0 ? ((row.failures || 0) / total) * 100 : 0,
+      }
+    })
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error in getAdminFailureMetrics', error: serializeError(e), query })
@@ -1662,9 +1670,7 @@ export async function getAdminSuccessRate(
 
   const query = `SELECT
     sum(if(blob3 = 'install', 1, 0)) AS installs,
-    sum(if(blob3 = 'fail', 1, 0)) AS fails,
-    if(installs + fails > 0, (installs / (installs + fails)) * 100, 0) AS success_rate,
-    installs + fails AS total_actions
+    sum(if(blob3 = 'fail', 1, 0)) AS fails
   FROM version_usage
   WHERE timestamp >= toDateTime('${formatDateCF(start_date)}')
     AND timestamp < toDateTime('${formatDateCF(end_date)}')
@@ -1673,8 +1679,18 @@ export async function getAdminSuccessRate(
   cloudlog({ requestId: c.get('requestId'), message: 'getAdminSuccessRate query', query })
 
   try {
-    const result = await runQueryToCFA<AdminSuccessRate>(c, query)
-    return result[0] || null
+    const result = await runQueryToCFA<{ installs: number, fails: number }>(c, query)
+    const row = result[0]
+    if (!row)
+      return null
+
+    const totalActions = (row.installs || 0) + (row.fails || 0)
+    return {
+      installs: row.installs || 0,
+      fails: row.fails || 0,
+      total_actions: totalActions,
+      success_rate: totalActions > 0 ? ((row.installs || 0) / totalActions) * 100 : 0,
+    }
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error in getAdminSuccessRate', error: serializeError(e), query })
@@ -1823,20 +1839,46 @@ export async function getAdminOrgMetrics(
 
     // Get bandwidth per org
     if (c.env.BANDWIDTH_USAGE) {
-      const bandwidthQuery = `SELECT
-        du.blob2 AS org_id,
-        sum(bu.double1) AS bandwidth,
-        COUNT(*) AS updates
-      FROM bandwidth_usage bu
-      LEFT JOIN device_usage du ON bu.blob1 = du.blob1
-      WHERE bu.timestamp >= toDateTime('${formatDateCF(start_date)}')
-        AND bu.timestamp < toDateTime('${formatDateCF(end_date)}')
-        AND du.blob2 != ''
-      GROUP BY org_id
-      ORDER BY bandwidth DESC
-      LIMIT ${safeLimit}`
+      const periodStart = formatDateCF(start_date)
+      const periodEnd = formatDateCF(end_date)
+      const deviceOrgQuery = `SELECT
+        blob1 AS device_id,
+        argMax(blob2, timestamp) AS org_id
+      FROM device_usage
+      WHERE timestamp >= toDateTime('${periodStart}')
+        AND timestamp < toDateTime('${periodEnd}')
+        AND blob2 != ''
+      GROUP BY blob1`
+      const bandwidthByDeviceQuery = `SELECT
+        blob1 AS device_id,
+        sum(double1) AS bandwidth,
+        COUNT() AS updates
+      FROM bandwidth_usage
+      WHERE timestamp >= toDateTime('${periodStart}')
+        AND timestamp < toDateTime('${periodEnd}')
+      GROUP BY blob1`
 
-      const bandwidthResult = await runQueryToCFA<{ org_id: string, bandwidth: number, updates: number }>(c, bandwidthQuery)
+      const [deviceOrgRows, bandwidthByDeviceRows] = await Promise.all([
+        runQueryToCFA<{ device_id: string, org_id: string }>(c, deviceOrgQuery),
+        runQueryToCFA<{ device_id: string, bandwidth: number, updates: number }>(c, bandwidthByDeviceQuery),
+      ])
+
+      const orgByDevice = new Map(deviceOrgRows.map(row => [row.device_id, row.org_id]))
+      const bandwidthByOrg = new Map<string, { bandwidth: number, updates: number }>()
+      for (const row of bandwidthByDeviceRows) {
+        const orgId = orgByDevice.get(row.device_id)
+        if (!orgId)
+          continue
+        const current = bandwidthByOrg.get(orgId) ?? { bandwidth: 0, updates: 0 }
+        current.bandwidth += row.bandwidth || 0
+        current.updates += row.updates || 0
+        bandwidthByOrg.set(orgId, current)
+      }
+
+      const bandwidthResult = [...bandwidthByOrg.entries()]
+        .map(([org_id, metrics]) => ({ org_id, ...metrics }))
+        .sort((a, b) => b.bandwidth - a.bandwidth)
+        .slice(0, safeLimit)
 
       // Merge results
       const bandwidthMap = new Map(bandwidthResult.map(b => [b.org_id, b]))

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { lintAnalyticsEngineSql } from '../supabase/functions/_backend/utils/analyticsEngineSqlLint.ts'
+import { collectAnalyticsEngineSqlFixtures } from './helpers/collectAnalyticsEngineSqlFixtures.ts'
+
+describe('analytics engine sql lint rules', () => {
+  it.concurrent('flags COUNT(*)', () => {
+    expect(lintAnalyticsEngineSql('SELECT COUNT(*) AS total FROM device_info')).toEqual([
+      expect.objectContaining({ rule: 'no-count-star' }),
+    ])
+  })
+
+  it.concurrent('flags CASE WHEN inside argMax', () => {
+    expect(lintAnalyticsEngineSql(
+      "SELECT argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) FROM device_info",
+    )).toEqual([
+      expect.objectContaining({ rule: 'no-case-in-argmax' }),
+    ])
+  })
+
+  it.concurrent('flags JOIN clauses', () => {
+    const issues = lintAnalyticsEngineSql(
+      'SELECT 1 FROM bandwidth_usage LEFT JOIN device_usage ON bandwidth_usage.blob1 = device_usage.blob1',
+    )
+    expect(issues.map(issue => issue.rule)).toContain('no-join')
+  })
+
+  it.concurrent('flags multiIf', () => {
+    expect(lintAnalyticsEngineSql("SELECT multiIf(blob4 != '', blob4, 1, 'ios') FROM device_usage").map(issue => issue.rule)).toContain('no-multiif')
+  })
+
+  it.concurrent('accepts supported COUNT() and COUNT(DISTINCT) forms', () => {
+    expect(lintAnalyticsEngineSql('SELECT COUNT() AS total FROM device_info')).toEqual([])
+    expect(lintAnalyticsEngineSql('SELECT COUNT(DISTINCT blob1) AS total FROM device_info')).toEqual([])
+  })
+})
+
+describe('analytics engine sql fixtures', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('generates lint-clean queries for every Analytics Engine read path', async () => {
+    const fixtures = await collectAnalyticsEngineSqlFixtures()
+
+    expect(fixtures.length).toBeGreaterThan(30)
+
+    const offenders = fixtures.flatMap((fixture) => {
+      const issues = lintAnalyticsEngineSql(fixture.query)
+      return issues.map(issue => ({ fixture: fixture.name, issue }))
+    })
+
+    expect(offenders, offenders.map(entry => `${entry.fixture}: ${entry.issue.rule}`).join('\n')).toEqual([])
+  })
+})

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -109,7 +109,7 @@ describe('buildReadDevicesCFQuery', () => {
     const query = buildDeviceIdsByInstallSourcesQuery('com.example.app', ['app_store', 'amazon_appstore'])
 
     expect(query).toContain(`WHERE index1 = 'com.example.app' AND blob9 != ''`)
-    expect(query).toContain(`WHERE index1 = 'com.example.app' AND blob9 != ''`)
+    expect(query).toContain('GROUP BY blob1')
     expect(query).toContain(`install_source IN ('app_store', 'amazon_appstore')`)
   })
 })

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { createClient } from '@supabase/supabase-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { buildReadDevicesCFQuery, countDevicesCF, countInstallSourcesCF, readBandwidthUsageCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { buildDeviceIdsByInstallSourcesQuery, buildReadDevicesCFQuery, countDevicesCF, countInstallSourcesCF, readBandwidthUsageCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
 import { readDevicesSB } from '../supabase/functions/_backend/utils/supabase.ts'
 
 vi.mock('@supabase/supabase-js', () => ({
@@ -105,21 +105,12 @@ describe('buildReadDevicesCFQuery', () => {
     expect(query).toContain(`ORDER BY updated_at ASC, device_id ASC`)
   })
 
-  it.concurrent('filters install sources after device grouping', () => {
-    const query = buildReadDevicesCFQuery({
-      app_id: 'com.example.app',
-      installSources: ['app_store', 'amazon_appstore'],
-      cursor: '2026-04-04 03:05:59|11111111-1111-4111-8111-111111111111',
-      limit: 1,
-    }, false)
+  it.concurrent('builds install source device lookup from non-empty blob9 rows', () => {
+    const query = buildDeviceIdsByInstallSourcesQuery('com.example.app', ['app_store', 'amazon_appstore'])
 
-    const groupByIndex = query.indexOf('GROUP BY blob1')
-    const installSourceFilterIndex = query.indexOf(`install_source IN ('app_store', 'amazon_appstore')`)
-
-    expect(query).toContain('argMax(blob9, timestamp) AS install_source')
-    expect(installSourceFilterIndex).toBeGreaterThan(groupByIndex)
-    expect(query).not.toContain(`WHERE index1 = 'com.example.app' AND blob9 IN`)
-    expect(query).toContain(`WHERE device_id > '11111111-1111-4111-8111-111111111111' AND install_source IN ('app_store', 'amazon_appstore')`)
+    expect(query).toContain(`WHERE index1 = 'com.example.app' AND blob9 != ''`)
+    expect(query).toContain(`WHERE index1 = 'com.example.app' AND blob9 != ''`)
+    expect(query).toContain(`install_source IN ('app_store', 'amazon_appstore')`)
   })
 })
 describe('countDevicesCF', () => {

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -116,7 +116,7 @@ describe('buildReadDevicesCFQuery', () => {
     const groupByIndex = query.indexOf('GROUP BY blob1')
     const installSourceFilterIndex = query.indexOf(`install_source IN ('app_store', 'amazon_appstore')`)
 
-    expect(query).toContain(`argMax(blob9, CASE WHEN blob9 != '' THEN timestamp ELSE toDateTime('1970-01-01 00:00:00') END) AS install_source`)
+    expect(query).toContain('argMax(blob9, timestamp) AS install_source')
     expect(installSourceFilterIndex).toBeGreaterThan(groupByIndex)
     expect(query).not.toContain(`WHERE index1 = 'com.example.app' AND blob9 IN`)
     expect(query).toContain(`WHERE device_id > '11111111-1111-4111-8111-111111111111' AND install_source IN ('app_store', 'amazon_appstore')`)
@@ -195,8 +195,10 @@ describe('countInstallSourcesCF', () => {
     expect(counts).toEqual({ app_store: 3, testflight: 2 })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(query).toContain('GROUP BY install_source')
-    expect(query).toContain('argMax(blob9')
+    expect(query).toContain('argMax(blob9, timestamp) AS install_source')
+    expect(query).toContain('COUNT() AS total')
     expect(query).not.toContain('COUNT(DISTINCT blob1) AS total')
+    expect(query).not.toContain('CASE WHEN blob9')
   })
 
   it('reuses cached install source counts for the same app', async () => {

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -43,12 +43,88 @@ const SAMPLE_START = '2026-06-01 00:00:00'
 const SAMPLE_END = '2026-07-01 00:00:00'
 const SAMPLE_REFERENCE_DATE = new Date('2026-07-01T00:00:00.000Z')
 
-function createAnalyticsEngineSqlResponse() {
+function createAnalyticsEngineSqlResponse(query: string) {
+  const lowerQuery = query.toLowerCase()
+  const fields = new Set<string>()
+
+  for (const match of query.matchAll(/\bAS\s+(\w+)\b/g)) {
+    fields.add(match[1])
+  }
+
+  const scalarDefaults: Record<string, string> = {
+    count: '0',
+    total: '0',
+    mau: '0',
+    installs: '0',
+    fails: '0',
+    failures: '0',
+    bandwidth: '0',
+    updates: '0',
+    apps_count: '0',
+    active_apps: '0',
+    total_bandwidth: '0',
+    android_devices: '0',
+    ios_devices: '0',
+    electron_devices: '0',
+    total_devices: '0',
+    active_orgs: '0',
+    success_rate: '0',
+    failure_rate: '0',
+    total_actions: '0',
+    device_count: '0',
+    failed: '0',
+    set: '0',
+    get: '0',
+    downloads: '0',
+    storage_bytes: '0',
+    bandwidth_bytes: '0',
+    bundles_created: '0',
+    apps_created: '0',
+    uploads: '0',
+    date: '2026-01-01',
+    app_id: 'com.example.app',
+    org_id: 'org-id',
+    device_id: '11111111-1111-4111-8111-111111111111',
+    version_name: '1.0.0',
+    install_source: 'app_store',
+    plugin_version: '8.0.0',
+    platform: 'android',
+    version_build: '1',
+    action: 'get',
+    metadata: '{}',
+    created_at: '2026-01-01 00:00:00',
+  }
+
+  for (const name of Object.keys(scalarDefaults)) {
+    if (lowerQuery.includes(name))
+      fields.add(name)
+  }
+
+  if (fields.size === 0)
+    fields.add('count')
+
+  const row: Record<string, string> = {}
+  const meta = [...fields].map((name) => {
+    row[name] = scalarDefaults[name] ?? '0'
+    const stringField = name.includes('id')
+      || name.includes('source')
+      || name.includes('name')
+      || name.includes('version')
+      || name.includes('date')
+      || name.includes('platform')
+      || name.includes('action')
+      || name.includes('metadata')
+      || name.includes('created_at')
+      || name.includes('app_id')
+      || name.includes('org_id')
+    return { name, type: stringField ? 'String' : 'UInt64' }
+  })
+
   return new Response(JSON.stringify({
-    meta: [],
-    data: [],
-    rows: 0,
-    rows_before_limit_at_least: 0,
+    meta,
+    data: [row],
+    rows: 1,
+    rows_before_limit_at_least: 1,
   }), {
     status: 200,
     headers: { 'content-type': 'application/json' },
@@ -98,7 +174,7 @@ export function installAnalyticsEngineSqlCapture(): AnalyticsEngineSqlCapture {
       const name = count === 0 ? state.pendingName : `${state.pendingName}[${count}]`
       fixtures.push({ name, query })
     }
-    return createAnalyticsEngineSqlResponse()
+    return createAnalyticsEngineSqlResponse(query)
   }) as typeof fetch
 
   globalThis.caches = {

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -1,0 +1,210 @@
+import type { Context } from 'hono'
+import {
+  buildReadDevicesCFQuery,
+  countDevicesCF,
+  countInstallSourcesCF,
+  countUpdatesFromLogsCF,
+  countUpdatesFromLogsExternalCF,
+  getAdminAppsTrend,
+  getAdminBandwidthTrend,
+  getAdminBundlesTrend,
+  getAdminDistributionMetrics,
+  getAdminFailureMetrics,
+  getAdminMauTrend,
+  getAdminOrgMetrics,
+  getAdminPlatformOverview,
+  getAdminStorageTrend,
+  getAdminSuccessRate,
+  getAdminSuccessRateTrend,
+  getAdminUploadMetrics,
+  getPluginBreakdownCF,
+  getUpdateStatsCF,
+  readActiveAppsCF,
+  readBandwidthUsageCF,
+  readDeviceUsageCF,
+  readDeviceVersionCountsCF,
+  readDevicesCF,
+  readLastMonthDevicesByPlatformCF,
+  readLastMonthDevicesCF,
+  readLastMonthUpdatesCF,
+  readNativeVersionUsageCF,
+  readStatsCF,
+  readStatsVersionCF,
+} from '../../supabase/functions/_backend/utils/cloudflare.ts'
+
+export interface AnalyticsEngineSqlFixture {
+  name: string
+  query: string
+}
+
+const SAMPLE_APP_ID = 'com.example.app'
+const SAMPLE_DEVICE_ID = '11111111-1111-4111-8111-111111111111'
+const SAMPLE_START = '2026-06-01 00:00:00'
+const SAMPLE_END = '2026-07-01 00:00:00'
+const SAMPLE_REFERENCE_DATE = new Date('2026-07-01T00:00:00.000Z')
+
+function createAnalyticsEngineSqlResponse() {
+  return new Response(JSON.stringify({
+    meta: [],
+    data: [],
+    rows: 0,
+    rows_before_limit_at_least: 0,
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function createMockContext() {
+  return {
+    env: {
+      SUPABASE_URL: 'http://localhost:54321',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+      CF_ANALYTICS_TOKEN: 'cf-analytics-token',
+      CF_ACCOUNT_ANALYTICS_ID: 'cf-account-id',
+      DEVICE_INFO: {},
+      DEVICE_USAGE: {},
+      BANDWIDTH_USAGE: {},
+      VERSION_USAGE: {},
+      APP_LOG: {},
+      APP_LOG_EXTERNAL: {},
+    },
+    req: {
+      url: 'http://localhost/private/devices',
+      raw: { cf: { country: 'US' }, headers: new Headers() },
+    },
+    get: (key: string) => key === 'requestId' ? 'analytics-sql-fixture' : undefined,
+  } as unknown as Context
+}
+
+export interface AnalyticsEngineSqlCapture {
+  fixtures: AnalyticsEngineSqlFixture[]
+  setPendingName: (name: string) => void
+  restore: () => void
+}
+
+export function installAnalyticsEngineSqlCapture(): AnalyticsEngineSqlCapture {
+  const fixtures: AnalyticsEngineSqlFixture[] = []
+  const pendingCounts = new Map<string, number>()
+  const state = { pendingName: 'unknown' }
+  const originalFetch = globalThis.fetch
+  const originalCaches = globalThis.caches
+
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    const query = String(init?.body ?? '').trim()
+    if (query) {
+      const count = pendingCounts.get(state.pendingName) ?? 0
+      pendingCounts.set(state.pendingName, count + 1)
+      const name = count === 0 ? state.pendingName : `${state.pendingName}[${count}]`
+      fixtures.push({ name, query })
+    }
+    return createAnalyticsEngineSqlResponse()
+  }) as typeof fetch
+
+  globalThis.caches = {
+    open: async () => ({
+      match: async () => null,
+      put: async () => undefined,
+    }),
+  } as unknown as CacheStorage
+
+  return {
+    fixtures,
+    setPendingName: (name: string) => {
+      state.pendingName = name
+    },
+    restore: () => {
+      globalThis.fetch = originalFetch
+      globalThis.caches = originalCaches
+    },
+  }
+}
+
+export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngineSqlFixture[]> {
+  const capture = installAnalyticsEngineSqlCapture()
+
+  try {
+    const context = createMockContext()
+
+    async function captureCall(name: string, fn: () => Promise<unknown>) {
+      capture.setPendingName(name)
+      await fn()
+    }
+
+    const staticFixtures: AnalyticsEngineSqlFixture[] = [
+      {
+        name: 'buildReadDevicesCFQuery.default',
+        query: buildReadDevicesCFQuery({ app_id: SAMPLE_APP_ID, limit: 10 }, false),
+      },
+      {
+        name: 'buildReadDevicesCFQuery.installSources',
+        query: buildReadDevicesCFQuery({
+          app_id: SAMPLE_APP_ID,
+          installSources: ['app_store', 'testflight'],
+          cursor: `${SAMPLE_START}|${SAMPLE_DEVICE_ID}`,
+          limit: 10,
+        }, false),
+      },
+      {
+        name: 'buildReadDevicesCFQuery.customIdMode',
+        query: buildReadDevicesCFQuery({
+          app_id: SAMPLE_APP_ID,
+          search: 'demo',
+          version_name: '1.0.0',
+          deviceIds: [SAMPLE_DEVICE_ID],
+          order: [{ key: 'updated_at', sortable: 'desc' }],
+          limit: 10,
+        }, true),
+      },
+    ]
+
+    await captureCall('readDeviceUsageCF', () => readDeviceUsageCF(context, SAMPLE_APP_ID, SAMPLE_START, SAMPLE_END))
+    await captureCall('readBandwidthUsageCF', () => readBandwidthUsageCF(context, SAMPLE_APP_ID, SAMPLE_START, SAMPLE_END))
+    await captureCall('readStatsVersionCF', () => readStatsVersionCF(context, SAMPLE_APP_ID, SAMPLE_START, SAMPLE_END))
+    await captureCall('readNativeVersionUsageCF', () => readNativeVersionUsageCF(context, SAMPLE_APP_ID, SAMPLE_START, SAMPLE_END))
+    await captureCall('readDeviceVersionCountsCF', () => readDeviceVersionCountsCF(context, SAMPLE_APP_ID, 'production'))
+    await captureCall('countInstallSourcesCF', () => countInstallSourcesCF(context, SAMPLE_APP_ID))
+    await captureCall('countDevicesCF', () => countDevicesCF(context, SAMPLE_APP_ID, false, [SAMPLE_DEVICE_ID], '1.0.0', 'demo'))
+    await captureCall('readDevicesCF', () => readDevicesCF(context, {
+      app_id: SAMPLE_APP_ID,
+      installSources: ['app_store'],
+      search: 'demo',
+      limit: 10,
+    }, false))
+    await captureCall('readStatsCF', () => readStatsCF(context, {
+      app_id: SAMPLE_APP_ID,
+      start_date: SAMPLE_START,
+      end_date: SAMPLE_END,
+      search: 'demo',
+      actions: ['get', 'set'],
+      deviceIds: [SAMPLE_DEVICE_ID],
+      order: [{ key: 'created_at', sortable: 'desc' }],
+      limit: 10,
+    }))
+    await captureCall('countUpdatesFromLogsCF', () => countUpdatesFromLogsCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('countUpdatesFromLogsExternalCF', () => countUpdatesFromLogsExternalCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('readActiveAppsCF', () => readActiveAppsCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('readLastMonthUpdatesCF', () => readLastMonthUpdatesCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('readLastMonthDevicesCF', () => readLastMonthDevicesCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('readLastMonthDevicesByPlatformCF', () => readLastMonthDevicesByPlatformCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('getUpdateStatsCF', () => getUpdateStatsCF(context))
+    await captureCall('getAdminUploadMetrics', () => getAdminUploadMetrics(context, SAMPLE_START, SAMPLE_END, SAMPLE_APP_ID))
+    await captureCall('getAdminDistributionMetrics', () => getAdminDistributionMetrics(context, SAMPLE_START, SAMPLE_END, SAMPLE_APP_ID))
+    await captureCall('getAdminFailureMetrics', () => getAdminFailureMetrics(context, SAMPLE_START, SAMPLE_END, SAMPLE_APP_ID))
+    await captureCall('getAdminSuccessRate', () => getAdminSuccessRate(context, SAMPLE_START, SAMPLE_END, SAMPLE_APP_ID))
+    await captureCall('getAdminPlatformOverview', () => getAdminPlatformOverview(context, SAMPLE_START, SAMPLE_END, 'org-id'))
+    await captureCall('getAdminOrgMetrics', () => getAdminOrgMetrics(context, SAMPLE_START, SAMPLE_END, 10))
+    await captureCall('getAdminMauTrend', () => getAdminMauTrend(context, SAMPLE_START, SAMPLE_END))
+    await captureCall('getAdminSuccessRateTrend', () => getAdminSuccessRateTrend(context, SAMPLE_START, SAMPLE_END))
+    await captureCall('getAdminAppsTrend', () => getAdminAppsTrend(context, SAMPLE_START, SAMPLE_END))
+    await captureCall('getAdminBundlesTrend', () => getAdminBundlesTrend(context, SAMPLE_START, SAMPLE_END))
+    await captureCall('getAdminStorageTrend', () => getAdminStorageTrend(context, SAMPLE_START, SAMPLE_END))
+    await captureCall('getAdminBandwidthTrend', () => getAdminBandwidthTrend(context, SAMPLE_START, SAMPLE_END))
+    await captureCall('getPluginBreakdownCF', () => getPluginBreakdownCF(context, SAMPLE_REFERENCE_DATE))
+
+    return [...staticFixtures, ...capture.fixtures]
+  }
+  finally {
+    capture.restore()
+  }
+}


### PR DESCRIPTION
## Summary (AI generated)

- Fix production failures on `POST /private/devices` with `installSourceCounts: true` caused by invalid Analytics Engine SQL (`COUNT(*)`, unsupported `CASE WHEN` in `argMax`)
- Add static linting plus fixture collection for all Analytics Engine read queries, with an optional live validation script against Cloudflare
- Repair additional invalid queries found during live validation (`multiIf`, admin success/failure rate alias usage, org bandwidth JOIN)

## Motivation (AI generated)

Cloudflare Analytics Engine SQL is not Postgres and has no local emulator. Invalid syntax only surfaced in production as generic `runQueryToCFA encountered an error` alerts. We need CI coverage that catches these before deploy.

## Business Impact (AI generated)

- Stops recurring API error alerts when console users load install-source device stats
- Prevents similar silent Analytics Engine query regressions across admin metrics and device analytics
- Reduces time-to-diagnose for future SQL changes with explicit lint failures instead of opaque 422s

## Test Plan (AI generated)

- [x] `bun run test:analytics-sql`
- [x] `bunx vitest run tests/cloudflare-device-pagination.unit.test.ts tests/stats-device-count.unit.test.ts`
- [x] `bun run test:analytics-sql:live` (40 queries validated against Cloudflare)
- [ ] CI backend/unit tests pass

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Analytics Engine SQL linter with optional live validation to detect unsupported SQL constructs early.
  * Added new test commands for analytics SQL, including a live validation mode.
* **Bug Fixes**
  * Improved Analytics Engine query generation for install-source/device filtering and updated admin/org metrics calculations for more accurate results.
* **Tests**
  * Added a comprehensive linter test suite with fixture coverage and updated SQL expectations to match the new query generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->