### PR TITLE
perf(cloudflare): enable Workers Cache for files worker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -204,12 +204,12 @@
         "vite-plugin-webfont-dl": "^3.12.0",
         "vitest": "^4.1.9",
         "vue-tsc": "3.3.5",
-        "wrangler": "^4.101.0",
+        "wrangler": "^4.107.0",
       },
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "8.24.5",
+      "version": "8.25.1",
       "bin": {
         "capgo": "dist/index.js",
       },
@@ -277,7 +277,7 @@
     },
     "packages/capacitor-notifications": {
       "name": "@capgo/capacitor-notifications",
-      "version": "0.0.1-private.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",
         "@capacitor/ios": "^8.0.0",
@@ -656,15 +656,15 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260616.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260701.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260616.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260701.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260616.1", "", { "os": "linux", "cpu": "x64" }, "sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260701.1", "", { "os": "linux", "cpu": "x64" }, "sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260616.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260701.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260616.1", "", { "os": "win32", "cpu": "x64" }, "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260616.1", "", {}, "sha512-AHyA0NC2/gNOHiMN6vzS25xenMaQ0XTzfw+MUQSQHXQDjLldxCBwjjtbNfKhBg540qGXIEx31kM1+L84GyECJw=="],
 
@@ -2328,7 +2328,7 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "miniflare": ["miniflare@4.20260616.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.24.8", "workerd": "1.20260616.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw=="],
+    "miniflare": ["miniflare@4.20260701.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260701.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -2742,7 +2742,7 @@
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -2854,9 +2854,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20260616.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260616.1", "@cloudflare/workerd-darwin-arm64": "1.20260616.1", "@cloudflare/workerd-linux-64": "1.20260616.1", "@cloudflare/workerd-linux-arm64": "1.20260616.1", "@cloudflare/workerd-windows-64": "1.20260616.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg=="],
+    "workerd": ["workerd@1.20260701.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260701.1", "@cloudflare/workerd-darwin-arm64": "1.20260701.1", "@cloudflare/workerd-linux-64": "1.20260701.1", "@cloudflare/workerd-linux-arm64": "1.20260701.1", "@cloudflare/workerd-windows-64": "1.20260701.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ=="],
 
-    "wrangler": ["wrangler@4.101.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260616.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260616.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260616.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g=="],
+    "wrangler": ["wrangler@4.107.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260701.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260701.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260701.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
@@ -3206,8 +3206,6 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
-
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -3267,6 +3265,8 @@
     "vue-router/@vue/devtools-api": ["@vue/devtools-api@8.1.2", "", { "dependencies": { "@vue/devtools-kit": "^8.1.2" } }, "sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg=="],
 
     "vue-router/unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
+
+    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
@@ -3533,6 +3533,58 @@
     "vue-router/@vue-macros/common/magic-string-ast": ["magic-string-ast@1.0.3", "", { "dependencies": { "magic-string": "^0.30.19" } }, "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA=="],
 
     "vue-router/@vue/devtools-api/@vue/devtools-kit": ["@vue/devtools-kit@8.1.2", "", { "dependencies": { "@vue/devtools-shared": "^8.1.2", "birpc": "^2.6.1", "hookable": "^5.5.3", "perfect-debounce": "^2.0.0" } }, "sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ=="],
+
+    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/cloudflare_workers/files/index.ts
+++ b/cloudflare_workers/files/index.ts
@@ -1,3 +1,4 @@
+import { WorkerEntrypoint } from 'cloudflare:workers'
 import { app as files } from '../../supabase/functions/_backend/files/files.ts'
 import { handlePreviewRequest, isPreviewSubdomain } from '../../supabase/functions/_backend/files/preview.ts'
 import { app as download_link } from '../../supabase/functions/_backend/private/download_link.ts'
@@ -10,6 +11,70 @@ export { AttachmentUploadHandler, UploadHandler } from '../../supabase/functions
 
 const functionName = 'files'
 const app = createHono(functionName, version)
+const TRACKING_QUERY_PARAMS = ['device_id'] as const
+
+type CachedFilesLoopback = {
+  fetch: (request: Request, init?: { cf?: { cacheKey: string } }) => Promise<Response>
+}
+
+type FilesExecutionContext = ExecutionContext & {
+  exports?: {
+    CachedFiles?: CachedFilesLoopback
+  }
+}
+
+function getRequestHostname(request: Request): string {
+  return request.headers.get('host') || new URL(request.url).hostname
+}
+
+function hasAttachmentReadPath(pathname: string): boolean {
+  return pathname.startsWith('/files/read/attachments/') || pathname.startsWith('/private/files/read/attachments/')
+}
+
+function normalizeSearch(url: URL, ignoredParams: readonly string[] = []): string {
+  const searchParams = new URLSearchParams(url.search)
+  for (const param of ignoredParams) {
+    searchParams.delete(param)
+  }
+  searchParams.sort()
+  const search = searchParams.toString()
+  return search ? `?${search}` : ''
+}
+
+function isCacheableAttachmentRead(request: Request): boolean {
+  if (request.method !== 'GET' || request.headers.has('range'))
+    return false
+
+  return hasAttachmentReadPath(new URL(request.url).pathname)
+}
+
+function isCacheablePreviewRead(request: Request): boolean {
+  if (request.method !== 'GET' || request.headers.has('range'))
+    return false
+
+  const hostname = getRequestHostname(request).toLowerCase()
+  if (!isPreviewSubdomain(hostname))
+    return false
+
+  const firstLabel = hostname.split('.', 1)[0]
+  if (/^c\d+-/.test(firstLabel))
+    return false
+
+  return new URL(request.url).pathname !== '/.capgo/preview.json'
+}
+
+function buildWorkersCacheKey(request: Request): string | null {
+  const url = new URL(request.url)
+  if (isCacheableAttachmentRead(request))
+    return `/files-cache${url.pathname}${normalizeSearch(url, TRACKING_QUERY_PARAMS)}`
+
+  if (isCacheablePreviewRead(request)) {
+    const hostname = getRequestHostname(request).toLowerCase()
+    return `/preview-cache/${hostname}${url.pathname}${normalizeSearch(url)}`
+  }
+
+  return null
+}
 
 // Middleware to route preview subdomain requests
 app.use('/*', async (c, next) => {
@@ -31,6 +96,23 @@ app.route('/private/upload_link', upload_link)
 app.route('/private/files', files)
 createAllCatch(app, functionName)
 
+export class CachedFiles extends WorkerEntrypoint {
+  fetch(request: Request): Response | Promise<Response> {
+    return app.fetch(request, this.env, this.ctx)
+  }
+}
+
+export const filesWorkerCacheTestUtils = {
+  buildWorkersCacheKey,
+}
+
 export default {
-  fetch: app.fetch,
+  async fetch(request: Request, env: Cloudflare.Env, ctx: FilesExecutionContext): Promise<Response> {
+    const cacheKey = buildWorkersCacheKey(request)
+    const cachedFiles = ctx.exports?.CachedFiles
+    if (cacheKey && cachedFiles)
+      return cachedFiles.fetch(request, { cf: { cacheKey } })
+
+    return app.fetch(request, env, ctx)
+  },
 }

--- a/cloudflare_workers/files/wrangler.jsonc
+++ b/cloudflare_workers/files/wrangler.jsonc
@@ -9,6 +9,9 @@
   ],
   "workers_dev": false,
   "upload_source_maps": true,
+  "cache": {
+    "enabled": false
+  },
   "migrations": [
     {
       "tag": "v1",
@@ -29,6 +32,9 @@
   "env": {
     "prod": {
       "name": "capgo_files-prod",
+      "cache": {
+        "enabled": true
+      },
       "vars": {
         "ENV_NAME": "capgo_files-prod"
       },

--- a/cloudflare_workers/files/wrangler.jsonc
+++ b/cloudflare_workers/files/wrangler.jsonc
@@ -36,6 +36,10 @@
         "enabled": true,
         "cross_version_cache": true
       },
+      "exports": {
+        "default": { "type": "worker", "cache": { "enabled": false } },
+        "CachedFiles": { "type": "worker", "cache": { "enabled": true } }
+      },
       "vars": {
         "ENV_NAME": "capgo_files-prod"
       },

--- a/cloudflare_workers/files/wrangler.jsonc
+++ b/cloudflare_workers/files/wrangler.jsonc
@@ -33,7 +33,8 @@
     "prod": {
       "name": "capgo_files-prod",
       "cache": {
-        "enabled": true
+        "enabled": true,
+        "cross_version_cache": true
       },
       "vars": {
         "ENV_NAME": "capgo_files-prod"

--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
     "vite-plugin-webfont-dl": "^3.12.0",
     "vitest": "^4.1.9",
     "vue-tsc": "3.3.5",
-    "wrangler": "^4.101.0"
+    "wrangler": "^4.107.0"
   },
   "gitmoji": {
     "autoAdd": false,

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -21,7 +21,7 @@ import { app as files_config } from './files_config.ts'
 import { parseUploadMetadata } from './parse.ts'
 import { DEFAULT_RETRY_PARAMS, RetryBucket } from './retry.ts'
 import { supabaseTusCreateHandler, supabaseTusHeadHandler, supabaseTusPatchHandler } from './supabaseTusProxy.ts'
-import { ALLOWED_HEADERS, ALLOWED_METHODS, buildFileHttpMetadata, EXPOSED_HEADERS, getSafeAttachmentReadCandidateKeys, headFirstExistingAttachmentCandidate, isRetryableDurableObjectResetError, MAX_UPLOAD_LENGTH_BYTES, parseAppScopedAttachmentPath, toBase64, TUS_EXTENSIONS, TUS_VERSION, withNoTransformCacheControl, X_CHECKSUM_SHA256, X_UPLOAD_HANDLER_RETRYABLE } from './util.ts'
+import { ALLOWED_HEADERS, ALLOWED_METHODS, buildFileHttpMetadata, EXPOSED_HEADERS, getSafeAttachmentReadCandidateKeys, headFirstExistingAttachmentCandidate, isRetryableDurableObjectResetError, MAX_UPLOAD_LENGTH_BYTES, NO_TRANSFORM_CACHE_CONTROL, parseAppScopedAttachmentPath, toBase64, TUS_EXTENSIONS, TUS_VERSION, withNoTransformCacheControl, X_CHECKSUM_SHA256, X_UPLOAD_HANDLER_RETRYABLE } from './util.ts'
 
 const DO_CALL_TIMEOUT = 1000 * 60 * 30 // 30 minutes
 const DO_FETCH_RETRY_ATTEMPTS = 3
@@ -30,6 +30,8 @@ const DO_FETCH_RETRY_DELAY_MS = 250
 const ATTACHMENT_PREFIX = 'attachments'
 const ATTACHMENT_PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth', 'storage']
 const TUS_UPLOAD_CONTENT_TYPE = 'application/offset+octet-stream'
+const FILE_READ_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+const TRACKING_QUERY_PARAMS = ['device_id']
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -254,8 +256,17 @@ async function fetchUploadHandlerWithRetry(
   throw lastError ?? new Error('Durable Object upload fetch failed')
 }
 
+function withFileReadCacheControl(cacheControl: string | null | undefined): string {
+  const normalizedCacheControl = cacheControl?.trim().toLowerCase()
+  if (!normalizedCacheControl || normalizedCacheControl === NO_TRANSFORM_CACHE_CONTROL) {
+    return withNoTransformCacheControl(FILE_READ_CACHE_CONTROL)
+  }
+
+  return withNoTransformCacheControl(cacheControl)
+}
+
 function ensureNoTransformResponse(response: Response): Response {
-  const cacheControl = withNoTransformCacheControl(response.headers.get('cache-control'))
+  const cacheControl = withFileReadCacheControl(response.headers.get('cache-control'))
   if (cacheControl === response.headers.get('cache-control')) {
     return response
   }
@@ -271,7 +282,7 @@ function ensureNoTransformResponse(response: Response): Response {
 
 function withAttachmentResponseHeaders(response: Response, fileId: string): Response {
   const headers = new Headers(response.headers)
-  headers.set('cache-control', withNoTransformCacheControl(headers.get('cache-control')))
+  headers.set('cache-control', withFileReadCacheControl(headers.get('cache-control')))
   headers.set('content-disposition', `attachment; filename="${fileId}"`)
 
   return new Response(response.body, {
@@ -417,7 +428,11 @@ async function getHandler(c: Context): Promise<Response> {
   const rawFileId = getRawAttachmentRouteId(c)
   const candidateKeys = getSafeAttachmentReadCandidateKeys(fileId, rawFileId)
   const cacheUrl = new URL(c.req.url)
+  for (const queryParam of TRACKING_QUERY_PARAMS) {
+    cacheUrl.searchParams.delete(queryParam)
+  }
   cacheUrl.searchParams.set('range', c.req.header('range') || '')
+  cacheUrl.searchParams.sort()
   const cacheKey = new Request(cacheUrl, c.req)
   let response = await cache.match(cacheKey)
   if (response != null) {
@@ -517,7 +532,7 @@ function objectHeaders(object: R2Object): Headers {
   object.writeHttpMetadata(headers)
   // Prevent CDN transformations (auto-minify, email obfuscation, etc.) that modify
   // bytes in transit, breaking checksum verification on devices.
-  headers.set('cache-control', withNoTransformCacheControl(headers.get('cache-control')))
+  headers.set('cache-control', withFileReadCacheControl(headers.get('cache-control')))
   headers.set('etag', object.httpEtag)
 
   // the sha256 checksum was provided to R2 in the upload

--- a/tests/files-r2-error.test.ts
+++ b/tests/files-r2-error.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from 'vitest'
 const retryGetMock = vi.fn()
 const retryHeadMock = vi.fn()
 
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class DurableObjectMock {},
+  WorkerEntrypoint: class WorkerEntrypointMock {},
+}))
 vi.mock('hono/adapter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('hono/adapter')>()
   return {
@@ -65,18 +69,26 @@ describe('files R2 error handling', () => {
     expect(data.error).toBe('upstream_unavailable')
   })
 
-  it('should add no-transform on cached responses', async () => {
+  it('should add immutable cache control and strip tracking params on cached responses', async () => {
     vi.resetModules()
     retryHeadMock.mockResolvedValue(null)
     retryGetMock.mockResolvedValue(null)
 
+    const matchMock = vi.fn(async (request: Request) => {
+      const cacheUrl = new URL(request.url)
+      expect(cacheUrl.searchParams.get('device_id')).toBeNull()
+      expect(cacheUrl.searchParams.get('key')).toBe('checksum')
+      expect(cacheUrl.searchParams.get('range')).toBe('')
+      return new Response('cached zip bytes', {
+        headers: {
+          'content-type': 'application/zip',
+        },
+      })
+    })
+
     globalThis.caches = {
       default: {
-        match: async () => new Response('cached zip bytes', {
-          headers: {
-            'content-type': 'application/zip',
-          },
-        }),
+        match: matchMock,
         put: async () => { },
       },
     } as any
@@ -89,7 +101,7 @@ describe('files R2 error handling', () => {
     appGlobal.route('/', files)
     createAllCatch(appGlobal, 'files')
 
-    const request = new Request('http://localhost/read/attachments/test.zip')
+    const request = new Request('http://localhost/read/attachments/test.zip?device_id=device-1&key=checksum')
     const response = await appGlobal.fetch(
       request,
       {
@@ -99,7 +111,8 @@ describe('files R2 error handling', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('cache-control')).toBe('no-transform')
+    expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable, no-transform')
+    expect(matchMock).toHaveBeenCalledTimes(1)
   })
 
   it('should persist no-transform in file metadata written to R2', async () => {
@@ -114,5 +127,38 @@ describe('files R2 error handling', () => {
       cacheControl: 'public, max-age=3600, no-transform',
       contentType: 'application/zip',
     })
+  })
+})
+
+describe('files worker cache keys', () => {
+  it('should strip tracking params and preserve file identity params', async () => {
+    const { filesWorkerCacheTestUtils } = await import('../cloudflare_workers/files/index.ts')
+
+    const cacheKey = filesWorkerCacheTestUtils.buildWorkersCacheKey(
+      new Request('https://api.capgo.app/files/read/attachments/orgs/test/apps/app/bundle.zip?device_id=device-1&key=checksum'),
+    )
+
+    expect(cacheKey).toBe('/files-cache/files/read/attachments/orgs/test/apps/app/bundle.zip?key=checksum')
+  })
+
+  it('should include preview host in cache keys', async () => {
+    const { filesWorkerCacheTestUtils } = await import('../cloudflare_workers/files/index.ts')
+
+    const cacheKey = filesWorkerCacheTestUtils.buildWorkersCacheKey(
+      new Request('https://app-123.preview.capgo.app/index.html?b=2&a=1'),
+    )
+
+    expect(cacheKey).toBe('/preview-cache/app-123.preview.capgo.app/index.html?a=1&b=2')
+  })
+
+  it('should bypass channel preview and range requests', async () => {
+    const { filesWorkerCacheTestUtils } = await import('../cloudflare_workers/files/index.ts')
+
+    expect(filesWorkerCacheTestUtils.buildWorkersCacheKey(
+      new Request('https://c12-app.preview.capgo.app/index.html'),
+    )).toBeNull()
+    expect(filesWorkerCacheTestUtils.buildWorkersCacheKey(
+      new Request('https://api.capgo.app/files/read/attachments/test.zip', { headers: { range: 'bytes=0-99' } }),
+    )).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Enable Cloudflare Workers Cache for the production files Worker, but opt the default router entrypoint out so auth/routing-sensitive paths still run normally.
- Add a `CachedFiles` entrypoint for reusable file/preview reads and forward to it with `cf.cacheKey` so file downloads strip `device_id` while preview cache keys include the preview hostname.
- Make attachment read responses default to `public, max-age=31536000, immutable, no-transform` when object metadata has no cache policy or only legacy `no-transform`.
- Keep non-production files Worker cache disabled to avoid confusing local/staging validation.
- Bump Wrangler to 4.107.0, which is required for the Workers Cache config.

## Scope note
- The existing Cloudflare snippet cache for plugin on-prem/plan-upgrade responses stays unchanged. Cloudflare Workers Cache does not store POST/PUT/PATCH/DELETE requests, while those plugin hot paths rely on synthetic snippet cache keys and non-GET traffic.
- Range requests bypass the new Workers Cache entrypoint so byte-range responses do not share the same key as full-file responses.

## References
- Cloudflare announcement: https://blog.cloudflare.com/workers-cache/
- Cloudflare config docs: https://developers.cloudflare.com/workers/cache/configuration/
- Cloudflare cache key docs: https://developers.cloudflare.com/workers/cache/cache-keys/

## Tests
- `bun lint` (passes with existing unrelated Vue newline warnings in admin dashboard files)
- `bun typecheck`
- `bunx vitest run tests/files-r2-error.test.ts tests/files-local-read-proxy.unit.test.ts tests/preview-response-headers.unit.test.ts tests/cloudflare-snippet.unit.test.ts`
- `bunx wrangler deploy --config cloudflare_workers/files/wrangler.jsonc --env=prod --dry-run --outdir /tmp/capgo-files-worker-cache --minify`
- pre-commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path file and preview delivery and CDN caching behavior; mis-keyed cache entries could serve wrong assets, though scope is limited to defined GET paths with explicit bypass rules.
> 
> **Overview**
> Turns on **Cloudflare Workers Cache** for the production files worker while keeping the default fetch handler uncached so uploads, auth, and other sensitive routes behave as before.
> 
> Eligible **GET** attachment reads (no `Range`) and most preview subdomain reads are routed through a new **`CachedFiles`** entrypoint with custom **`cf.cacheKey`** values: file paths use `/files-cache…` and drop **`device_id`** from the key; preview paths use `/preview-cache/{host}…`. Channel previews (`c\d+-…`), **`/.capgo/preview.json`**, and range requests skip Workers Cache.
> 
> Attachment read responses now default to **`public, max-age=31536000, immutable, no-transform`** when R2 metadata is empty or only legacy `no-transform`, and the in-worker **`caches.default`** lookup normalizes query params the same way (strip tracking, sort).
> 
> **Wrangler** is bumped to **4.107.0** (required for Workers Cache config); non-prod files worker keeps cache disabled. Tests cover cache headers, cache key building, and a **`cloudflare:workers`** mock for vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05581bdd618771be92024a6f7a10d44c8479e84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->