### PR TITLE
fix(build): enrich support log metadata

### DIFF
--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -525,7 +525,7 @@ function readInitInternalLogLines(): string[] {
 // .log.gz path → reveal in Finder (macOS) → open a pre-filled mailto. There's
 // no build log in init, so the support bundle carries diagnostics + the
 // internal log only. Every step but "write the bundle" is best-effort.
-async function runInitContactSupport(failureText: string): Promise<void> {
+async function runInitContactSupport(failureText: string, supportPlatform?: PlatformChoice): Promise<void> {
   await contactSupport({
     subject: `Capgo Builder onboarding support — ${globalAppId ?? 'unknown'}`,
     body: `Hi Capgo team,\n\nI hit an error during Capgo Builder onboarding.\n\nApp: ${globalAppId ?? 'unknown'}\nError: ${failureText}`,
@@ -566,7 +566,7 @@ async function runInitContactSupport(failureText: string): Promise<void> {
         return null
       const spinner = pSpinner()
       spinner.start('Uploading your logs to Capgo support…')
-      const r = await uploadSupportLogs({ apiHost: globalSupaHost ?? defaultApiHost, apikey: key, appId: globalAppId, gzPath })
+      const r = await uploadSupportLogs({ apiHost: globalSupaHost ?? defaultApiHost, apikey: key, appId: globalAppId, platform: supportPlatform, gzPath })
       spinner.stop(r ? 'Logs uploaded.' : 'Logs upload unavailable — falling back to attaching the file.')
       return r
     },
@@ -1246,6 +1246,7 @@ async function selectRecoveryOption<T extends string>(
   message: string,
   options: RecoveryOption<T>[],
   failureText = message,
+  supportPlatform?: PlatformChoice,
 ): Promise<T> {
   type RecoveryChoice = T | '__doctor__' | '__email_support__' | '__support__' | '__cancel__'
 
@@ -1278,7 +1279,7 @@ async function selectRecoveryOption<T extends string>(
     }
 
     if (choice === '__email_support__') {
-      await runInitContactSupport(failureText)
+      await runInitContactSupport(failureText, supportPlatform)
       continue
     }
 
@@ -2339,7 +2340,7 @@ async function waitForVerifiedUpdaterInstall(
   packageJsonPath: string,
   pm: PackageManagerInfo,
   versionToInstall: string,
-  options: { allowAutoRetry?: boolean, failureText?: string } = {},
+  options: { allowAutoRetry?: boolean, failureText?: string, supportPlatform?: PlatformChoice } = {},
 ) {
   const manualCommand = getUpdaterInstallCommand(pm, versionToInstall)
 
@@ -2356,8 +2357,7 @@ async function waitForVerifiedUpdaterInstall(
       const recoveryChoice = await selectRecoveryOption(orgId, apikey, 'Updater install is not complete yet. What do you want to do?', [
         { value: 'retry-auto', label: 'Retry automatic updater install' },
         { value: 'manual', label: 'Install it manually, then continue' },
-      ], options.failureText ?? state.details.join('\n'))
-
+      ], options.failureText ?? state.details.join('\n'), options.supportPlatform)
       if (recoveryChoice === 'retry-auto') {
         const s = pSpinner()
         try {
@@ -3113,6 +3113,7 @@ async function handleBuildAndSyncFailure(
     const versionToInstall = await getCompatibleUpdaterVersionForPackage(packageJsonPath, pm)
     await waitForVerifiedUpdaterInstall(orgId, apikey, packageJsonPath, pm, versionToInstall, {
       failureText: formattedError,
+      supportPlatform: platform,
     })
     return 'retry'
   }
@@ -3120,7 +3121,7 @@ async function handleBuildAndSyncFailure(
   const recoveryChoice = await selectRecoveryOption(orgId, apikey, 'Build or sync failed. What do you want to do?', [
     { value: 'retry', label: 'Retry build and sync' },
     { value: 'manual', label: 'Fix it manually, then continue' },
-  ], formattedError)
+  ], formattedError, platform)
 
   if (recoveryChoice === 'retry')
     return 'retry'
@@ -4273,7 +4274,7 @@ async function maybeOfferAutoTestCleanup(orgId: string, apikey: string, appId: s
   pLog.warn(`Do not run "${pm.runner} cap sync ${platform}" before this cleanup upload.`)
 }
 
-async function uploadStep(orgId: string, apikey: string, appId: string, newVersion: string, delta: boolean) {
+async function uploadStep(orgId: string, apikey: string, appId: string, newVersion: string, delta: boolean, supportPlatform: PlatformChoice) {
   const pm = getPMAndCommand()
   const selectedPackageJsonPath = globalPathToPackageJson ? path.resolve(globalPathToPackageJson) : undefined
   const selectedProjectDir = selectedPackageJsonPath ? dirname(selectedPackageJsonPath) : cwd()
@@ -4326,14 +4327,14 @@ async function uploadStep(orgId: string, apikey: string, appId: string, newVersi
         pLog.error(formatError(error))
         await selectRecoveryOption(orgId, apikey, 'Bundle upload failed. What do you want to do?', [
           { value: 'retry', label: 'Retry bundle upload' },
-        ], formatError(error))
+        ], formatError(error), supportPlatform)
         continue
       }
       if (!uploadRes?.success) {
         s.stop('Upload failed ❌')
         await selectRecoveryOption(orgId, apikey, 'Bundle upload failed. What do you want to do?', [
           { value: 'retry', label: 'Retry bundle upload' },
-        ], 'Bundle upload did not complete successfully.')
+        ], 'Bundle upload did not complete successfully.', supportPlatform)
         continue
       }
 
@@ -4898,7 +4899,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
 
     if (stepToSkip < 10) {
       renderCurrentStep(10)
-      await uploadStep(orgId, options.apikey, appId, currentVersion, delta)
+      await uploadStep(orgId, options.apikey, appId, currentVersion, delta, platform)
       markStepDone(10)
     }
 

--- a/cli/src/support/support-upload.ts
+++ b/cli/src/support/support-upload.ts
@@ -6,6 +6,7 @@ export interface SupportUploadInput {
   apikey: string
   appId?: string
   jobId?: string
+  platform?: 'ios' | 'android'
   // Path to the already-gzipped bundle (the .log.gz writeSupportBundleFiles produced).
   gzPath: string
 }
@@ -35,7 +36,7 @@ export async function uploadSupportLogs(input: SupportUploadInput): Promise<Supp
         'capgkey': input.apikey,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ appId: input.appId, jobId: input.jobId, gzB64 }),
+      body: JSON.stringify({ appId: input.appId, jobId: input.jobId, platform: input.platform, gzB64 }),
       // Short timeout: this is an optional nicety; the attach fallback always works.
       signal: AbortSignal.timeout(15_000),
     })

--- a/cli/test/test-cicd-failure-help.mjs
+++ b/cli/test/test-cicd-failure-help.mjs
@@ -110,6 +110,7 @@ await test('uploadSupportLogs returns {id,url} on a 200 with a valid body', asyn
       apikey: 'apikey-abc',
       appId: 'com.app',
       jobId: 'job-1',
+      platform: 'ios',
       gzPath,
     })
     assert.deepEqual(r, { id: 'sup-123', url: 'https://capgo.app/logs/sup-123' })
@@ -119,6 +120,7 @@ await test('uploadSupportLogs returns {id,url} on a 200 with a valid body', asyn
     const body = JSON.parse(captured.init.body)
     assert.equal(body.appId, 'com.app')
     assert.equal(body.jobId, 'job-1')
+    assert.equal(body.platform, 'ios')
     assert.ok(typeof body.gzB64 === 'string' && body.gzB64.length > 0, 'sends base64 bundle')
   }
   finally {

--- a/supabase/functions/_backend/public/build/index.ts
+++ b/supabase/functions/_backend/public/build/index.ts
@@ -1,6 +1,7 @@
 import type { Database } from '../../utils/supabase.types.ts'
 import type { RequestBuildBody } from './request.ts'
 import type { BuildStatusParams } from './status.ts'
+import type { SupportLogsBody } from './support_logs.ts'
 import {
   ALLOWED_HEADERS,
   ALLOWED_METHODS,
@@ -91,7 +92,7 @@ app.post('/ai_analyze_stream', middlewareKey(['all', 'write']), async (c) => {
 // (No app-ownership check on purpose: onboarding failures can reference apps that
 // were never registered — the authenticated account is the abuse anchor.)
 app.post('/support_logs', middlewareKey(['all', 'write']), async (c) => {
-  const body = await getBodyOrQuery<{ appId?: string, jobId?: string, gzB64: string }>(c)
+  const body = await getBodyOrQuery<SupportLogsBody>(c)
   if (!body || typeof body.gzB64 !== 'string' || body.gzB64.length === 0) {
     throw new Error('gzB64 is required in request body')
   }

--- a/supabase/functions/_backend/public/build/support_logs.ts
+++ b/supabase/functions/_backend/public/build/support_logs.ts
@@ -3,6 +3,7 @@ import type { Database } from '../../utils/supabase.types.ts'
 import { CacheHelper } from '../../utils/cache.ts'
 import { quickError, simpleError } from '../../utils/hono.ts'
 import { cloudlogErr } from '../../utils/logging.ts'
+import { supabaseAdmin } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
 
 // Proxy for the CLI's "Email Capgo support" logs upload — forwards gzipped text
@@ -29,6 +30,24 @@ interface RateWindow {
   resetAt: number
 }
 
+export type SupportLogPlatform = 'ios' | 'android'
+
+export interface SupportLogsBody {
+  appId?: string
+  jobId?: string
+  platform?: SupportLogPlatform
+  gzB64: string
+}
+
+function parseSupportLogPlatform(platform: unknown): SupportLogPlatform | undefined {
+  if (typeof platform !== 'string')
+    return undefined
+  const normalized = platform.trim().toLowerCase()
+  if (normalized === 'ios' || normalized === 'android')
+    return normalized
+  return undefined
+}
+
 // Returns false when the window is exhausted. Fails open on cache errors,
 // matching the behavior of the rest of utils/rate_limit.ts.
 async function bumpWindow(c: Context, path: string, userId: string, limit: number, ttlSeconds: number): Promise<boolean> {
@@ -49,10 +68,58 @@ async function bumpWindow(c: Context, path: string, userId: string, limit: numbe
   }
 }
 
+async function getSupportUploadEmail(c: Context, userId: string): Promise<string | undefined> {
+  const { data, error } = await supabaseAdmin(c)
+    .from('users')
+    .select('email')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'support-logs user email lookup failed', userId, error })
+    return undefined
+  }
+
+  return data?.email?.trim() || undefined
+}
+
+async function getSupportUploadPlatform(c: Context, body: SupportLogsBody, userId: string): Promise<SupportLogPlatform | undefined> {
+  const requestPlatform = parseSupportLogPlatform(body.platform)
+  if (requestPlatform)
+    return requestPlatform
+  if (!body.jobId)
+    return undefined
+
+  const buildRequestQuery = supabaseAdmin(c)
+    .from('build_requests')
+    .select('platform')
+    .eq('builder_job_id', body.jobId)
+    .eq('requested_by', userId)
+
+  if (body.appId)
+    buildRequestQuery.eq('app_id', body.appId)
+
+  const { data, error } = await buildRequestQuery.maybeSingle()
+
+  if (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'support-logs platform lookup failed',
+      jobId: body.jobId,
+      appId: body.appId,
+      userId,
+      error,
+    })
+    return undefined
+  }
+
+  return parseSupportLogPlatform(data?.platform)
+}
+
 export async function uploadSupportLogs(
   c: Context,
   apikey: Database['public']['Tables']['apikeys']['Row'],
-  body: { appId?: string, jobId?: string, gzB64: string },
+  body: SupportLogsBody,
 ): Promise<Response> {
   // Deliberately NO app-ownership permission check: onboarding failures can
   // reference apps that were never registered, and these are the caller's own
@@ -71,6 +138,11 @@ export async function uploadSupportLogs(
   if (!builderUrl || !builderApiKey)
     throw simpleError('config_error', 'Builder service not configured')
 
+  const [email, platform] = await Promise.all([
+    getSupportUploadEmail(c, userId),
+    getSupportUploadPlatform(c, body, userId),
+  ])
+
   let builderResp: Response
   try {
     builderResp = await fetch(`${builderUrl}/support-logs`, {
@@ -79,7 +151,7 @@ export async function uploadSupportLogs(
         'x-api-key': builderApiKey,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ gzB64: body.gzB64, appId: body.appId, jobId: body.jobId, userId }),
+      body: JSON.stringify({ gzB64: body.gzB64, appId: body.appId, jobId: body.jobId, userId, email, platform }),
       signal: AbortSignal.timeout(60_000),
     })
   }

--- a/tests/build-support-logs.unit.test.ts
+++ b/tests/build-support-logs.unit.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSupabaseAdmin } = vi.hoisted(() => ({
+  mockSupabaseAdmin: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin: mockSupabaseAdmin,
+}))
+
+import { uploadSupportLogs } from '../supabase/functions/_backend/public/build/support_logs.ts'
+
+const apikey = { user_id: 'user-1' } as any
+
+function createContext() {
+  return {
+    req: { url: 'http://localhost/build/support_logs' },
+    env: {
+      BUILDER_URL: 'https://builder.test',
+      BUILDER_API_KEY: 'builder-key',
+    },
+    get: vi.fn((key: string) => key === 'requestId' ? 'req-test' : undefined),
+    json: vi.fn((data: unknown, status = 200) => new Response(JSON.stringify(data), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })),
+  } as any
+}
+
+function makeSelectResult(data: unknown, error: unknown = null) {
+  const query = {
+    eq: vi.fn(),
+    maybeSingle: vi.fn(async () => ({ data, error })),
+  }
+  query.eq.mockReturnValue(query)
+  return { select: vi.fn(() => query), query }
+}
+
+function mockAdminRows(rows: { user?: unknown, buildRequest?: unknown }) {
+  const userResult = makeSelectResult(rows.user ?? null)
+  const buildRequestResult = makeSelectResult(rows.buildRequest ?? null)
+  const from = vi.fn((table: string) => {
+    if (table === 'users')
+      return userResult
+    if (table === 'build_requests')
+      return buildRequestResult
+    throw new Error(`unexpected table ${table}`)
+  })
+  mockSupabaseAdmin.mockReturnValue({ from })
+  return { from, userQuery: userResult.query, buildRequestQuery: buildRequestResult.query }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockSupabaseAdmin.mockReset()
+  vi.stubEnv('BUILDER_URL', 'https://builder.test')
+  vi.stubEnv('BUILDER_API_KEY', 'builder-key')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+describe('uploadSupportLogs metadata forwarding', () => {
+  it('forwards user email and derives platform from the build request job id', async () => {
+    const { buildRequestQuery } = mockAdminRows({
+      user: { email: 'dev@capgo.app' },
+      buildRequest: { platform: 'ios' },
+    })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ id: 'log-1', url: 'https://api.test/log-1' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await uploadSupportLogs(createContext(), apikey, {
+      appId: 'com.test.app',
+      jobId: 'job-1',
+      gzB64: 'not-empty',
+    })
+
+    expect(res.status).toBe(200)
+    expect(buildRequestQuery.eq).toHaveBeenCalledWith('builder_job_id', 'job-1')
+    expect(buildRequestQuery.eq).toHaveBeenCalledWith('requested_by', 'user-1')
+    expect(buildRequestQuery.eq).toHaveBeenCalledWith('app_id', 'com.test.app')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      appId: 'com.test.app',
+      jobId: 'job-1',
+      userId: 'user-1',
+      email: 'dev@capgo.app',
+      platform: 'ios',
+    })
+  })
+
+  it('forwards the caller supplied platform when there is no job lookup path', async () => {
+    const { from } = mockAdminRows({ user: { email: 'dev@capgo.app' } })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ id: 'log-2', url: 'https://api.test/log-2' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await uploadSupportLogs(createContext(), apikey, {
+      appId: 'com.test.app',
+      platform: 'android',
+      gzB64: 'not-empty',
+    })
+
+    expect(from).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      email: 'dev@capgo.app',
+      platform: 'android',
+    })
+  })
+
+  it('ignores unsupported caller supplied platform values', async () => {
+    const { from } = mockAdminRows({ user: { email: 'dev@capgo.app' } })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ id: 'log-3', url: 'https://api.test/log-3' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await uploadSupportLogs(createContext(), apikey, {
+      appId: 'com.test.app',
+      platform: 'web' as never,
+      gzB64: 'not-empty',
+    })
+
+    expect(from).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.email).toBe('dev@capgo.app')
+    expect(body.platform).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- forward CLI platform metadata with support log uploads
- enrich the support-log builder proxy with the API key owner email
- derive platform from `build_requests.builder_job_id` when older clients only send a job id

## Why
The builder worker already accepts `email` and `platform`, but the Capgo API proxy only sent `gzB64`, `appId`, `jobId`, and `userId`. That made Discord support webhooks fall back to `unknown` for email/platform. The job fallback uses the existing `idx_build_requests_job` index.

## Tests
- `bunx vitest run tests/build-support-logs.unit.test.ts`
- `bun run --cwd cli test:cicd-failure-help`
- `bun run lint:backend`
- `bun run cli:lint`
- `bun run typecheck:backend`
- `bun run cli:typecheck`
- `bun run cli:build`
- pre-commit: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata on an existing authenticated upload path; lookups fail open and unsupported platform values are ignored.
> 
> **Overview**
> Support log uploads now carry **iOS/Android platform** end-to-end so Discord/webhook tooling stops showing `unknown` for that field.
> 
> **CLI:** Init onboarding threads the selected test platform through recovery and “Email Capgo support” paths (`runInitContactSupport`, `selectRecoveryOption`, build/sync/upload failure handlers). `uploadSupportLogs` accepts optional `platform` and sends it in the `POST /build/support_logs` JSON body.
> 
> **API proxy:** `uploadSupportLogs` loads the API key owner’s **email** from `users`, accepts optional `platform` on the request (normalized to `ios` | `android`), and when only `jobId` is present looks up **platform** on `build_requests` (`builder_job_id`, scoped to the caller). Those fields are forwarded to the builder worker along with the existing bundle metadata. Invalid platform values are dropped rather than failing the upload.
> 
> **Tests:** CLI upload test asserts `platform` in the body; new backend unit tests cover email forwarding, job-based platform derivation, and caller-supplied platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38774604af9fb41129b82e9205552aba4e62d9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support log uploads now carry mobile platform details (iOS/Android) to provide more context.
  * When available, uploads also include the uploader’s email address to improve attribution.
* **Bug Fixes**
  * Platform selection is now propagated through support-log upload and recovery flows so metadata stays consistent.
* **Tests**
  * Added/updated unit tests to verify platform and email metadata are included in the upload request body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->