### PR TITLE
fix(api): raise upload API key rate limit

### DIFF
--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -1036,7 +1036,7 @@ async function checkWriteAppAccess(c: Context, next: Next) {
 }
 
 app.options(`/upload/${ATTACHMENT_PREFIX}`, optionsHandler)
-app.post(`/upload/${ATTACHMENT_PREFIX}`, middlewareKey(['all', 'write', 'upload'], true, false), setKeyFromMetadata, checkWriteAppAccess, (c) => {
+app.post(`/upload/${ATTACHMENT_PREFIX}`, middlewareKey(['all', 'write', 'upload'], true, false, 'upload'), setKeyFromMetadata, checkWriteAppAccess, (c) => {
   if (getRuntimeKey() !== 'workerd') {
     return supabaseTusCreateHandler(c)
   }
@@ -1047,7 +1047,7 @@ app.options(`/upload/${ATTACHMENT_PREFIX}/:id{.+}`, optionsHandler)
 // Combined GET/HEAD handler for TUS uploads - Hono tiny routes HEAD to GET
 app.get(
   `/upload/${ATTACHMENT_PREFIX}/:id{.+}`,
-  middlewareKey(['all', 'write', 'upload'], true, false),
+  middlewareKey(['all', 'write', 'upload'], true, false, 'upload'),
   setKeyFromIdParam,
   checkWriteAppAccess,
   (c) => {
@@ -1069,7 +1069,7 @@ app.get(
   },
 )
 app.get(`/read/${ATTACHMENT_PREFIX}/:id{.+}`, setKeyFromIdParam, getHandler)
-app.patch(`/upload/${ATTACHMENT_PREFIX}/:id{.+}`, middlewareKey(['all', 'write', 'upload'], true, false), setKeyFromIdParam, checkWriteAppAccess, (c) => {
+app.patch(`/upload/${ATTACHMENT_PREFIX}/:id{.+}`, middlewareKey(['all', 'write', 'upload'], true, false, 'upload'), setKeyFromIdParam, checkWriteAppAccess, (c) => {
   if (getRuntimeKey() !== 'workerd') {
     return supabaseTusPatchHandler(c)
   }

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -5,6 +5,7 @@ import { getClaimsFromJWT, honoFactory, quickError, simpleRateLimit } from './ho
 import { cloudlog } from './logging.ts'
 import { closeClient, getDrizzleClient, getPgClient, logPgError } from './pg.ts'
 import * as schema from './postgres_schema.ts'
+import type { APIKeyRateLimitScope } from './rate_limit.ts'
 import { isAPIKeyRateLimited, isIPRateLimited, recordAPIKeyUsage, recordFailedAuth } from './rate_limit.ts'
 import { buildRateLimitInfo } from './rateLimitInfo.ts'
 import { checkKey, checkKeyById, supabaseAdmin } from './supabase.ts'
@@ -678,8 +679,9 @@ export function middlewareV2(rights: Database['public']['Enums']['key_mode'][]) 
  * @param rights - Required key modes for the route.
  * @param usePostgres - When true, performs key lookups via Postgres instead of Supabase client.
  * @param readOnly - When using Postgres, choose replica-safe read-only connections by default; latency-sensitive write flows can force primary auth.
+ * @param rateLimitScope - Selects the API-key rate-limit bucket for this route.
  */
-export function middlewareKey(rights: Database['public']['Enums']['key_mode'][], usePostgres = false, readOnly = true) {
+export function middlewareKey(rights: Database['public']['Enums']['key_mode'][], usePostgres = false, readOnly = true, rateLimitScope: APIKeyRateLimitScope = 'default') {
   const subMiddlewareKey = honoFactory.createMiddleware(async (c, next) => {
     // Check if IP is rate limited due to failed auth attempts
     const ipRateLimited = await isIPRateLimited(c)
@@ -717,12 +719,13 @@ export function middlewareKey(rights: Database['public']['Enums']['key_mode'][],
     }
 
     // Record API usage first, then check if rate limited
-    await recordAPIKeyUsage(c, apikey.id)
+    await recordAPIKeyUsage(c, apikey.id, rateLimitScope)
 
     // Check if API key is rate limited after recording usage
-    const apiKeyRateLimited = await isAPIKeyRateLimited(c, apikey.id)
+    const apiKeyRateLimited = await isAPIKeyRateLimited(c, apikey.id, rateLimitScope)
     if (apiKeyRateLimited.limited) {
-      return simpleRateLimit({ reason: 'api_key_rate_limit_exceeded', apikey_id: apikey.id, ...buildRateLimitInfo(apiKeyRateLimited.resetAt) })
+      const reason = rateLimitScope === 'upload' ? 'api_key_upload_rate_limit_exceeded' : 'api_key_rate_limit_exceeded'
+      return simpleRateLimit({ reason, apikey_id: apikey.id, ...buildRateLimitInfo(apiKeyRateLimited.resetAt) })
     }
 
     // Set auth context for RBAC (can be overridden by subkey below)

--- a/supabase/functions/_backend/utils/rate_limit.ts
+++ b/supabase/functions/_backend/utils/rate_limit.ts
@@ -10,9 +10,11 @@ const API_KEY_RATE_LIMIT_TTL = 60 // 1 minute window for API key rate limiting
 // Default limits - set high to catch only severe abuse, not normal usage
 const DEFAULT_FAILED_AUTH_LIMIT = 20 // 20 failed attempts before blocking (catches brute force, allows mistakes)
 const DEFAULT_API_KEY_RATE_LIMIT = 2000 // 2000 requests per minute per API key (catches infinite loops)
+const DEFAULT_UPLOAD_API_KEY_RATE_LIMIT = 20000 // 20000 upload requests per minute per API key (supports large bundles)
 const FAILED_AUTH_PATH = '/rate-limit/failed-auth'
 const FAILED_ACCOUNT_AUTH_PATH = '/rate-limit/failed-auth-account'
 const API_KEY_RATE_LIMIT_PATH = '/rate-limit/apikey'
+const UPLOAD_API_KEY_RATE_LIMIT_PATH = '/rate-limit/apikey-upload'
 
 interface RateLimitData {
   count: number
@@ -23,6 +25,8 @@ export interface RateLimitStatus {
   limited: boolean
   resetAt?: number
 }
+
+export type APIKeyRateLimitScope = 'default' | 'upload'
 
 /**
  * Get the client IP address from the request.
@@ -263,16 +267,16 @@ export async function clearFailedAccountAuth(c: Context, accountIdentifier: stri
  * Returns true if the API key has exceeded its configured rate limit.
  * Note: If cache is unavailable, rate limiting fails open (returns false).
  */
-export async function isAPIKeyRateLimited(c: Context, apiKeyId: number): Promise<RateLimitStatus> {
+export async function isAPIKeyRateLimited(c: Context, apiKeyId: number, scope: APIKeyRateLimitScope = 'default'): Promise<RateLimitStatus> {
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest(API_KEY_RATE_LIMIT_PATH, { id: String(apiKeyId) })
+  const cacheKey = cacheHelper.buildRequest(getAPIKeyRateLimitPath(scope), { id: String(apiKeyId) })
   const data = await cacheHelper.matchJson<RateLimitData>(cacheKey)
 
   // If no data or cache unavailable, fail open (don't block)
   if (!data)
     return { limited: false }
 
-  const limit = getAPIKeyRateLimit(c)
+  const limit = getAPIKeyRateLimit(c, scope)
   const isLimited = data.count >= limit
 
   if (isLimited) {
@@ -280,6 +284,7 @@ export async function isAPIKeyRateLimited(c: Context, apiKeyId: number): Promise
       requestId: c.get('requestId'),
       message: 'API key rate limited',
       apiKeyId,
+      scope,
       count: data.count,
       limit,
     })
@@ -293,9 +298,9 @@ export async function isAPIKeyRateLimited(c: Context, apiKeyId: number): Promise
  * Tracks the number of calls per API key within the configured time window.
  * This should be awaited to ensure accurate counting before checking limits.
  */
-export async function recordAPIKeyUsage(c: Context, apiKeyId: number): Promise<void> {
+export async function recordAPIKeyUsage(c: Context, apiKeyId: number, scope: APIKeyRateLimitScope = 'default'): Promise<void> {
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest(API_KEY_RATE_LIMIT_PATH, { id: String(apiKeyId) })
+  const cacheKey = cacheHelper.buildRequest(getAPIKeyRateLimitPath(scope), { id: String(apiKeyId) })
   const existingData = await cacheHelper.matchJson<RateLimitData>(cacheKey)
 
   const newData: RateLimitData = {
@@ -319,15 +324,20 @@ function getFailedAuthLimit(c: Context): number {
   return DEFAULT_FAILED_AUTH_LIMIT
 }
 
+function getAPIKeyRateLimitPath(scope: APIKeyRateLimitScope) {
+  return scope === 'upload' ? UPLOAD_API_KEY_RATE_LIMIT_PATH : API_KEY_RATE_LIMIT_PATH
+}
+
 /**
  * Get the API key rate limit from environment or use default (2000/minute).
  */
-function getAPIKeyRateLimit(c: Context): number {
-  const envLimit = getEnv(c, 'RATE_LIMIT_API_KEY')
+function getAPIKeyRateLimit(c: Context, scope: APIKeyRateLimitScope): number {
+  const envKey = scope === 'upload' ? 'RATE_LIMIT_API_KEY_UPLOAD' : 'RATE_LIMIT_API_KEY'
+  const envLimit = getEnv(c, envKey)
   if (envLimit) {
     const parsed = Number.parseInt(envLimit, 10)
     if (!Number.isNaN(parsed) && parsed > 0)
       return parsed
   }
-  return DEFAULT_API_KEY_RATE_LIMIT
+  return scope === 'upload' ? DEFAULT_UPLOAD_API_KEY_RATE_LIMIT : DEFAULT_API_KEY_RATE_LIMIT
 }

--- a/tests/files-upload-auth-primary.unit.test.ts
+++ b/tests/files-upload-auth-primary.unit.test.ts
@@ -5,6 +5,8 @@ const getPgClientMock = vi.fn((_c: unknown, _readOnly?: boolean) => ({}))
 const getDrizzleClientMock = vi.fn(() => ({
   execute: executeMock,
 }))
+const isAPIKeyRateLimitedMock = vi.fn<(_c: unknown, _apiKeyId: number, _scope?: string) => Promise<{ limited: boolean }>>(async () => ({ limited: false }))
+const recordAPIKeyUsageMock = vi.fn<(_c: unknown, _apiKeyId: number, _scope?: string) => Promise<void>>(async () => undefined)
 
 vi.mock('hono/adapter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('hono/adapter')>()
@@ -33,9 +35,9 @@ vi.mock('../supabase/functions/_backend/utils/pg_files.ts', () => ({
 }))
 
 vi.mock('../supabase/functions/_backend/utils/rate_limit.ts', () => ({
-  isAPIKeyRateLimited: vi.fn(async () => ({ limited: false })),
+  isAPIKeyRateLimited: isAPIKeyRateLimitedMock,
   isIPRateLimited: vi.fn(async () => ({ limited: false })),
-  recordAPIKeyUsage: vi.fn(async () => undefined),
+  recordAPIKeyUsage: recordAPIKeyUsageMock,
   recordFailedAuth: vi.fn(async () => undefined),
 }))
 
@@ -81,5 +83,24 @@ describe('files upload auth', () => {
     expect(response.status).toBe(404)
     expect(getPgClientMock).toHaveBeenCalledTimes(1)
     expect(getPgClientMock.mock.calls[0][1]).toBe(false)
+  })
+
+  it('uses the upload API-key rate-limit scope for upload creation', async () => {
+    const { app: files } = await import('../supabase/functions/_backend/files/files.ts')
+
+    const response = await files.fetch(
+      new Request('http://localhost/upload/attachments', {
+        method: 'POST',
+        headers: {
+          Authorization: 'valid-upload-key',
+        },
+      }),
+      {},
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(404)
+    expect(recordAPIKeyUsageMock).toHaveBeenCalledWith(expect.anything(), 123, 'upload')
+    expect(isAPIKeyRateLimitedMock).toHaveBeenCalledWith(expect.anything(), 123, 'upload')
   })
 })


### PR DESCRIPTION
## Summary
- add an upload-specific API-key rate-limit bucket with a 20k/min default
- route TUS upload create/read-offset/patch requests through the upload bucket only
- keep the default API-key bucket unchanged and return a distinct upload 429 reason

## Tests
- bun lint
- bun typecheck
- bunx vitest run tests/files-upload-auth-primary.unit.test.ts tests/account-rate-limit.unit.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped limiter change on upload auth paths only; default limits and non-upload routes are unchanged, with a targeted unit test.
> 
> **Overview**
> Introduces a separate **upload** API-key rate-limit bucket (default **20k requests/min**, configurable via `RATE_LIMIT_API_KEY_UPLOAD`) with its own cache key, so high-volume TUS chunk traffic does not consume the general **2k/min** bucket.
> 
> `middlewareKey` gains an optional `rateLimitScope` (`default` | `upload`) passed through to `recordAPIKeyUsage` and `isAPIKeyRateLimited`. Attachment **POST / PATCH** and authenticated **GET/HEAD** TUS upload routes now pass `'upload'`; other routes keep the default scope. Upload throttling returns **`api_key_upload_rate_limit_exceeded`** instead of the generic API-key 429 reason.
> 
> A unit test asserts upload creation records and checks limits with the `'upload'` scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3150c5d52aa6f4b88b2199bd893e454e85f26d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->