### PR TITLE
fix(api): stabilize manifest size queue processing

### DIFF
--- a/supabase/functions/_backend/triggers/on_manifest_create.ts
+++ b/supabase/functions/_backend/triggers/on_manifest_create.ts
@@ -46,6 +46,54 @@ function shouldRetryManifestSizeLookup(size: number, currentFileSize: number | n
   return size <= 0 && !(currentFileSize && currentFileSize > 0)
 }
 
+async function shouldSkipManifestSizeRetry(c: Context, record: Database['public']['Tables']['manifest']['Row'], queue: QueueLogMetadata): Promise<boolean> {
+  if (!record.id)
+    return false
+
+  const { data: currentManifest, error: manifestError } = await supabaseAdmin(c)
+    .from('manifest')
+    .select('file_size, app_version_id')
+    .eq('id', record.id)
+    .maybeSingle()
+
+  if (manifestError) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'error reading current manifest before retry', id: record.id, app_version_id: record.app_version_id, queue, error: manifestError })
+    return false
+  }
+
+  if (!currentManifest) {
+    cloudlog({ requestId: c.get('requestId'), message: 'manifest row already gone, skipping size retry', id: record.id, app_version_id: record.app_version_id, queue })
+    return true
+  }
+
+  if (currentManifest.file_size && currentManifest.file_size > 0) {
+    cloudlog({ requestId: c.get('requestId'), message: 'manifest row already sized, skipping stale queue retry', id: record.id, app_version_id: currentManifest.app_version_id, file_size: currentManifest.file_size, queue })
+    return true
+  }
+
+  const appVersionId = currentManifest.app_version_id ?? record.app_version_id
+  if (!appVersionId)
+    return false
+
+  const { data: appVersion, error: appVersionError } = await supabaseAdmin(c)
+    .from('app_versions')
+    .select('deleted, deleted_at')
+    .eq('id', appVersionId)
+    .maybeSingle()
+
+  if (appVersionError) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'error reading app version before manifest retry', id: record.id, app_version_id: appVersionId, queue, error: appVersionError })
+    return false
+  }
+
+  if (appVersion?.deleted || appVersion?.deleted_at) {
+    cloudlog({ requestId: c.get('requestId'), message: 'app version deleted, skipping manifest size retry', id: record.id, app_version_id: appVersionId, queue })
+    return true
+  }
+
+  return false
+}
+
 async function runManifestUpdateWithRetry(
   c: Context,
   operation: () => Promise<RetryableResult>,
@@ -97,6 +145,8 @@ export async function updateManifestSize(c: Context, record: Database['public'][
     cloudlogErr({ requestId: c.get('requestId'), message: 'getSize failed after retries', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, attempts, queue, error: lastError, storageDiagnostics: diagnostics })
   }
   if (shouldRetryManifestSizeLookup(size, record.file_size)) {
+    if (await shouldSkipManifestSizeRetry(c, record, queue))
+      return c.json(BRES)
     cloudlogErr({ requestId: c.get('requestId'), message: 'getSize returned 0 after retries', id: record.id, app_version_id: record.app_version_id, file_name: record.file_name, s3_path: record.s3_path, attempts, queue, storageDiagnostics: diagnostics })
     // Return non-2xx so queue_consumer keeps the message and applies its 5-read retry budget.
     throw quickError(503, 'manifest_size_not_found', 'Manifest file size metadata was not found', { attempts, file_name: record.file_name, id: record.id, queue, s3_path: record.s3_path, storageDiagnostics: diagnostics }, lastError, { alert: false })
@@ -139,5 +189,6 @@ export const onManifestCreateTestUtils = {
   isRetryablePostgrestResult,
   runManifestUpdateWithRetry,
   shouldRetryManifestSizeLookup,
+  shouldSkipManifestSizeRetry,
   sizeRetryAttempts: SIZE_RETRY_ATTEMPTS,
 }

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -64,6 +64,21 @@ function versionUpdateLogFields(
   }
 }
 
+type DeletedVersionAction = 'continue' | 'delete' | 'cleanup_manifest' | 'skip'
+
+function getDeletedVersionAction(
+  record: Database['public']['Tables']['app_versions']['Row'],
+  oldRecord?: Database['public']['Tables']['app_versions']['Row'] | null,
+): DeletedVersionAction {
+  if (!record.deleted_at)
+    return 'continue'
+  if (record.deleted_at !== oldRecord?.deleted_at)
+    return 'delete'
+  if (record.manifest || (record.manifest_count ?? 0) > 0)
+    return 'cleanup_manifest'
+  return 'skip'
+}
+
 function getMetadataBranch(storageProvider: string | null, resolvedR2Path: string | null) {
   if (storageProvider === 'r2' && resolvedR2Path)
     return 'r2_bundle_size'
@@ -337,7 +352,7 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
       const updatePgClient = getPgClient(c, false)
       try {
         await updatePgClient.query(
-          `UPDATE app_versions SET manifest_count = 0 WHERE id = $1`,
+          `UPDATE app_versions SET manifest_count = 0, manifest = NULL WHERE id = $1`,
           [record.id],
         )
 
@@ -418,7 +433,7 @@ export async function deleteIt(c: Context, record: Database['public']['Tables'][
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
-app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (c) => {
+app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['app_versions']['Row']
   const oldRecord = c.get('oldRecord') as Database['public']['Tables']['app_versions']['Row']
   cloudlog({ requestId: c.get('requestId'), message: 'on_version_update received', ...versionUpdateLogFields(record, oldRecord) })
@@ -428,9 +443,17 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
     cloudlog({ requestId: c.get('requestId'), message: 'no app_id', record })
     return c.json(BRES)
   }
-  // check if version was soft-deleted (deleted_at was set)
-  if (record.deleted_at && record.deleted_at !== oldRecord.deleted_at)
+
+  const deletedVersionAction = getDeletedVersionAction(record, oldRecord)
+  if (deletedVersionAction === 'delete')
     return deleteIt(c, record)
+  if (deletedVersionAction === 'cleanup_manifest') {
+    cloudlog({ requestId: c.get('requestId'), message: 'cleaning manifest for already deleted version', ...versionUpdateLogFields(record, oldRecord) })
+    await deleteManifest(c, record)
+    return c.json(BRES)
+  }
+  if (deletedVersionAction === 'skip')
+    return c.json(BRES)
 
   if (!record.r2_path && !record.manifest) {
     cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', ...versionUpdateLogFields(record, oldRecord) })
@@ -440,3 +463,7 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), (
   cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted', ...versionUpdateLogFields(record, oldRecord) })
   return updateIt(c, record)
 })
+
+export const onVersionUpdateTestUtils = {
+  getDeletedVersionAction,
+}

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -16,6 +16,7 @@ import { updateManifestSize } from './on_manifest_create.ts'
 const DEFAULT_BATCH_SIZE = 950 // Default batch size for queue reads limit of CF is 1000 fetches so we take a safe margin
 const DEFAULT_QUEUE_HTTP_CONCURRENCY = 25
 const MANIFEST_QUEUE_HTTP_CONCURRENCY = 100
+const MANIFEST_QUEUE_ACK_CHUNK_SIZE = 100
 const DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 120
 const MANIFEST_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 900
 const QUEUE_HTTP_TIMEOUT_MS = 15_000
@@ -76,6 +77,7 @@ interface ProcessedQueueMessage extends Message {
   cfId: string
   payloadSize: number
   durationMs: number
+  deletedFromQueue?: boolean
   targetUrl: string | null
 }
 
@@ -481,6 +483,20 @@ function getQueueVisibilityTimeout(queueName: string): number {
   return DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SECONDS
 }
 
+function getQueueAckChunkSize(queueName: string): number | null {
+  if (queueName === 'on_manifest_create')
+    return MANIFEST_QUEUE_ACK_CHUNK_SIZE
+  return null
+}
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += chunkSize) {
+    chunks.push(items.slice(i, i + chunkSize))
+  }
+  return chunks
+}
+
 async function mapWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
@@ -499,6 +515,203 @@ async function mapWithConcurrency<T, R>(
   const workerCount = Math.min(Math.max(1, concurrency), items.length)
   await Promise.all(Array.from({ length: workerCount }, () => worker()))
   return results
+}
+
+function isSuccessfulQueueResult(result: ProcessedQueueMessage): boolean {
+  return result.httpResponse.status >= 200 && result.httpResponse.status < 300
+}
+
+async function deleteSuccessfulChunkMessages(
+  c: Context,
+  db: ReturnType<typeof getPgClient>,
+  queueName: string,
+  chunkResults: ProcessedQueueMessage[],
+): Promise<void> {
+  const successfulChunkMessages = chunkResults.filter(isSuccessfulQueueResult)
+  if (successfulChunkMessages.length === 0)
+    return
+
+  cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Deleting ${successfulChunkMessages.length} successful messages from queue checkpoint.` })
+  await delete_queue_message_batch(c, db, queueName, successfulChunkMessages.map(msg => msg.msg_id))
+  for (const result of successfulChunkMessages) {
+    result.deletedFromQueue = true
+  }
+}
+
+async function processQueueMessageChunks(
+  c: Context,
+  db: ReturnType<typeof getPgClient>,
+  queueName: string,
+  messagesToProcess: Message[],
+  processConcurrency: number,
+): Promise<ProcessedQueueMessage[]> {
+  const ackChunkSize = getQueueAckChunkSize(queueName)
+  const processChunks = ackChunkSize ? chunkArray(messagesToProcess, ackChunkSize) : [messagesToProcess]
+  const results: ProcessedQueueMessage[] = []
+
+  for (const chunk of processChunks) {
+    const chunkResults = await mapWithConcurrency(chunk, processConcurrency, async message => processQueueMessage(c, queueName, message))
+    results.push(...chunkResults)
+
+    if (ackChunkSize) {
+      await deleteSuccessfulChunkMessages(c, db, queueName, chunkResults)
+    }
+  }
+
+  return results
+}
+
+async function persistQueueCfIds(
+  c: Context,
+  db: ReturnType<typeof getPgClient>,
+  queueName: string,
+  results: ProcessedQueueMessage[],
+): Promise<void> {
+  const cfIdUpdates = results.map(result => ({
+    msg_id: result.msg_id,
+    cf_id: result.cfId,
+    queue: queueName,
+  }))
+
+  if (cfIdUpdates.length === 0)
+    return
+
+  cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Updating ${cfIdUpdates.length} messages with CF IDs.` })
+  try {
+    await mass_edit_queue_messages_cf_ids(c, db, cfIdUpdates)
+  }
+  catch (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Failed to persist queue CF IDs. Continuing queue cleanup.`,
+      error: serializeError(error),
+      queueName,
+      updateCount: cfIdUpdates.length,
+    })
+  }
+}
+
+async function deleteUncheckpointedSuccessMessages(
+  c: Context,
+  db: ReturnType<typeof getPgClient>,
+  queueName: string,
+  successMessages: ProcessedQueueMessage[],
+): Promise<void> {
+  const successMessagesPendingDelete = successMessages.filter(msg => !msg.deletedFromQueue)
+  if (successMessagesPendingDelete.length === 0)
+    return
+
+  cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Deleting ${successMessagesPendingDelete.length} successful messages from queue.` })
+  await delete_queue_message_batch(c, db, queueName, successMessagesPendingDelete.map(msg => msg.msg_id))
+}
+
+async function reportQueueFailures(c: Context, queueName: string, messagesFailed: ProcessedQueueMessage[]): Promise<number> {
+  if (messagesFailed.length === 0)
+    return 0
+
+  cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Failed to process ${messagesFailed.length} messages.` })
+
+  const timestamp = new Date().toISOString()
+  const failureDetails = messagesFailed.map(msg => ({
+    function_name: msg.message?.function_name ?? 'unknown',
+    function_type: msg.message?.function_type ?? 'supabase',
+    msg_id: msg.msg_id,
+    read_count: msg.read_ct,
+    status: msg.httpResponse.status,
+    status_text: msg.httpResponse.statusText,
+    error_code: msg.errorDetails.errorCode ?? undefined,
+    error_message: msg.errorDetails.errorMessage ?? undefined,
+    response_body: msg.errorDetails.bodyPreview ?? undefined,
+    payload_size: msg.payloadSize,
+    cf_id: msg.cfId,
+    duration_ms: msg.durationMs,
+    target_url: msg.targetUrl ?? undefined,
+  }))
+
+  const actionableFailures = getActionableQueueFailures(failureDetails)
+  const groupedByFunction = actionableFailures.reduce((acc, detail) => {
+    const key = detail.function_name
+    acc[key] ??= []
+    acc[key].push(detail)
+    return acc
+  }, {} as Record<string, typeof actionableFailures>)
+
+  if (actionableFailures.length > 0) {
+    await sendDiscordAlert(c, {
+      content: `🚨 **Queue Processing Failures** - ${queueName}`,
+      embeds: [
+        {
+          title: `❌ ${actionableFailures.length} Messages Failed Processing`,
+          description: `**Queue:** ${queueName}\n**Failed Functions:** ${Object.keys(groupedByFunction).length}\n**Total Failures:** ${actionableFailures.length}`,
+          color: 0xFF6B35, // Orange color for warnings
+          timestamp,
+          fields: [
+            {
+              name: '📊 Failure Summary',
+              value: Object.entries(groupedByFunction)
+                .map(([funcName, failures]) =>
+                  `**${funcName}** (${failures[0].function_type}): ${failures.length} failures`,
+                )
+                .join('\n'),
+              inline: false,
+            },
+            {
+              name: '🔍 Detailed Failures',
+              value: truncateDiscordField(actionableFailures.slice(0, 10).map((detail) => {
+                const cfLogUrl = `https://dash.cloudflare.com/${getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID')}/workers/services/view/capgo_api-prod/production/observability/logs?workers-observability-view=%22invocations%22&filters=%5B%7B%22key%22%3A%22%24workers.event.request.headers.x-capgo-cf-id%22%2C%22type%22%3A%22string%22%2C%22value%22%3A%22${detail.cf_id}%22%2C%22operation%22%3A%22eq%22%7D%5D`
+                const errorInfo = detail.error_code ? ` | Error: ${detail.error_code}` : ''
+                const messageInfo = detail.error_message ? ` | ${truncateDiscordField(detail.error_message.replace(/\s+/g, ' ').trim(), 180)}` : ''
+                const durationInfo = typeof detail.duration_ms === 'number' ? ` | ${detail.duration_ms}ms` : ''
+                const targetInfo = detail.target_url ? ` | Target: ${truncateDiscordField(detail.target_url, 120)}` : ''
+                return `**${detail.function_name}** | Status: ${detail.status} | Read: ${detail.read_count}/${MAX_QUEUE_READS}${durationInfo}${errorInfo}${messageInfo}${targetInfo} | [CF Logs](${cfLogUrl})`
+              }).join('\n')),
+              inline: false,
+            },
+            {
+              name: '📈 Status Code Distribution',
+              value: Object.entries(
+                actionableFailures.reduce((acc, detail) => {
+                  acc[detail.status] = (acc[detail.status] ?? 0) + 1
+                  return acc
+                }, {} as Record<number, number>),
+              ).map(([status, count]) => `**${status}:** ${count}`).join(' | '),
+              inline: false,
+            },
+            {
+              name: '⚠️ Retry Analysis',
+              value: `**Retry Budget Exhausted:** ${actionableFailures.length}\n**Will Archive:** ${actionableFailures.length}`,
+              inline: true,
+            },
+            {
+              name: '📦 Payload Info',
+              value: `**Avg Size:** ${Math.round(actionableFailures.reduce((sum, d) => sum + d.payload_size, 0) / actionableFailures.length)} bytes\n**Max Size:** ${Math.max(...actionableFailures.map(d => d.payload_size))} bytes`,
+              inline: true,
+            },
+            {
+              name: '🧾 Sanitized Response Body',
+              value: truncateDiscordField(actionableFailures
+                .map(detail => detail.response_body ? `**${detail.function_name}:** ${sanitizeDiscordResponseBody(detail.response_body)}` : `**${detail.function_name}:** (empty)`)
+                .join('\n')),
+              inline: false,
+            },
+          ],
+          footer: {
+            text: `Queue: ${queueName} | Environment: ${getEnv(c, 'ENVIRONMENT') ?? 'unknown'}`,
+          },
+        },
+      ],
+    })
+  }
+  else {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: `[${queueName}] Suppressed Discord alert for retryable or ignored queue failures.`,
+      retryingFailures: failureDetails.filter(detail => detail.read_count < MAX_QUEUE_READS).length,
+      ignoredErrors: Array.from(DISCORD_IGNORED_ERROR_CODES),
+    })
+  }
+
+  return actionableFailures.length
 }
 
 async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queueName: string, batchSize: number = DEFAULT_BATCH_SIZE): Promise<QueueProcessResult> {
@@ -550,149 +763,17 @@ async function processQueue(c: Context, db: ReturnType<typeof getPgClient>, queu
     await archive_queue_messages(c, db, queueName, messagesToSkip.map(msg => msg.msg_id))
   }
 
-  // Process messages that are still within the retry budget.
-  const results = await mapWithConcurrency(messagesToProcess, processConcurrency, async message => processQueueMessage(c, queueName, message))
-  let actionableFailureCount = 0
+  const results = await processQueueMessageChunks(c, db, queueName, messagesToProcess, processConcurrency)
+  await persistQueueCfIds(c, db, queueName, results)
 
-  // Update all messages with their CF IDs
-  const cfIdUpdates = results.map(result => ({
-    msg_id: result.msg_id,
-    cf_id: result.cfId,
-    queue: queueName,
-  }))
-
-  if (cfIdUpdates.length > 0) {
-    cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Updating ${cfIdUpdates.length} messages with CF IDs.` })
-    try {
-      await mass_edit_queue_messages_cf_ids(c, db, cfIdUpdates)
-    }
-    catch (error) {
-      cloudlogErr({
-        requestId: c.get('requestId'),
-        message: `[${queueName}] Failed to persist queue CF IDs. Continuing queue cleanup.`,
-        error: serializeError(error),
-        queueName,
-        updateCount: cfIdUpdates.length,
-      })
-    }
-  }
-
-  // Batch remove all messages that have succeeded
-  // const successMessages = results.filter(result => result.httpResponse.status >= 200 && result.httpResponse.status < 300)
+  // Batch remove all messages that have succeeded.
   const [successMessages, messagesFailed] = results.reduce((acc, result) => {
-    acc[(result.httpResponse.status >= 200 && result.httpResponse.status < 300) ? 0 : 1].push(result)
+    acc[isSuccessfulQueueResult(result) ? 0 : 1].push(result)
     return acc
   }, [[], []] as [typeof results, typeof results])
-  if (successMessages.length > 0) {
-    cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Deleting ${successMessages.length} successful messages from queue.` })
-    await delete_queue_message_batch(c, db, queueName, successMessages.map(msg => msg.msg_id))
-  }
-  if (messagesFailed.length > 0) {
-    cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] Failed to process ${messagesFailed.length} messages.` })
 
-    const timestamp = new Date().toISOString()
-    const failureDetails = messagesFailed.map(msg => ({
-      function_name: msg.message?.function_name ?? 'unknown',
-      function_type: msg.message?.function_type ?? 'supabase',
-      msg_id: msg.msg_id,
-      read_count: msg.read_ct,
-      status: msg.httpResponse.status,
-      status_text: msg.httpResponse.statusText,
-      error_code: msg.errorDetails.errorCode ?? undefined,
-      error_message: msg.errorDetails.errorMessage ?? undefined,
-      response_body: msg.errorDetails.bodyPreview ?? undefined,
-      payload_size: msg.payloadSize,
-      cf_id: msg.cfId,
-      duration_ms: msg.durationMs,
-      target_url: msg.targetUrl ?? undefined,
-    }))
-
-    const actionableFailures = getActionableQueueFailures(failureDetails)
-    actionableFailureCount = actionableFailures.length
-
-    const groupedByFunction = actionableFailures.reduce((acc, detail) => {
-      const key = detail.function_name
-      acc[key] ??= []
-      acc[key].push(detail)
-      return acc
-    }, {} as Record<string, typeof actionableFailures>)
-
-    if (actionableFailures.length > 0) {
-      await sendDiscordAlert(c, {
-        content: `🚨 **Queue Processing Failures** - ${queueName}`,
-        embeds: [
-          {
-            title: `❌ ${actionableFailures.length} Messages Failed Processing`,
-            description: `**Queue:** ${queueName}\n**Failed Functions:** ${Object.keys(groupedByFunction).length}\n**Total Failures:** ${actionableFailures.length}`,
-            color: 0xFF6B35, // Orange color for warnings
-            timestamp,
-            fields: [
-              {
-                name: '📊 Failure Summary',
-                value: Object.entries(groupedByFunction)
-                  .map(([funcName, failures]) =>
-                    `**${funcName}** (${failures[0].function_type}): ${failures.length} failures`,
-                  )
-                  .join('\n'),
-                inline: false,
-              },
-              {
-                name: '🔍 Detailed Failures',
-                value: truncateDiscordField(actionableFailures.slice(0, 10).map((detail) => {
-                  const cfLogUrl = `https://dash.cloudflare.com/${getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID')}/workers/services/view/capgo_api-prod/production/observability/logs?workers-observability-view=%22invocations%22&filters=%5B%7B%22key%22%3A%22%24workers.event.request.headers.x-capgo-cf-id%22%2C%22type%22%3A%22string%22%2C%22value%22%3A%22${detail.cf_id}%22%2C%22operation%22%3A%22eq%22%7D%5D`
-                  const errorInfo = detail.error_code ? ` | Error: ${detail.error_code}` : ''
-                  const messageInfo = detail.error_message ? ` | ${truncateDiscordField(detail.error_message.replace(/\s+/g, ' ').trim(), 180)}` : ''
-                  const durationInfo = typeof detail.duration_ms === 'number' ? ` | ${detail.duration_ms}ms` : ''
-                  const targetInfo = detail.target_url ? ` | Target: ${truncateDiscordField(detail.target_url, 120)}` : ''
-                  return `**${detail.function_name}** | Status: ${detail.status} | Read: ${detail.read_count}/${MAX_QUEUE_READS}${durationInfo}${errorInfo}${messageInfo}${targetInfo} | [CF Logs](${cfLogUrl})`
-                }).join('\n')),
-                inline: false,
-              },
-              {
-                name: '📈 Status Code Distribution',
-                value: Object.entries(
-                  actionableFailures.reduce((acc, detail) => {
-                    acc[detail.status] = (acc[detail.status] ?? 0) + 1
-                    return acc
-                  }, {} as Record<number, number>),
-                ).map(([status, count]) => `**${status}:** ${count}`).join(' | '),
-                inline: false,
-              },
-              {
-                name: '⚠️ Retry Analysis',
-                value: `**Retry Budget Exhausted:** ${actionableFailures.length}\n**Will Archive:** ${actionableFailures.length}`,
-                inline: true,
-              },
-              {
-                name: '📦 Payload Info',
-                value: `**Avg Size:** ${Math.round(actionableFailures.reduce((sum, d) => sum + d.payload_size, 0) / actionableFailures.length)} bytes\n**Max Size:** ${Math.max(...actionableFailures.map(d => d.payload_size))} bytes`,
-                inline: true,
-              },
-              {
-                name: '🧾 Sanitized Response Body',
-                value: truncateDiscordField(actionableFailures
-                  .map(detail => detail.response_body ? `**${detail.function_name}:** ${sanitizeDiscordResponseBody(detail.response_body)}` : `**${detail.function_name}:** (empty)`)
-                  .join('\n')),
-                inline: false,
-              },
-            ],
-            footer: {
-              text: `Queue: ${queueName} | Environment: ${getEnv(c, 'ENVIRONMENT') ?? 'unknown'}`,
-            },
-          },
-        ],
-      })
-    }
-    else {
-      cloudlog({
-        requestId: c.get('requestId'),
-        message: `[${queueName}] Suppressed Discord alert for retryable or ignored queue failures.`,
-        retryingFailures: failureDetails.filter(detail => detail.read_count < MAX_QUEUE_READS).length,
-        ignoredErrors: Array.from(DISCORD_IGNORED_ERROR_CODES),
-      })
-    }
-    // set visibility timeout to random number to prevent Auto DDOS
-  }
+  await deleteUncheckpointedSuccessMessages(c, db, queueName, successMessages)
+  const actionableFailureCount = await reportQueueFailures(c, queueName, messagesFailed)
 
   if (successMessages.length !== messagesToProcess.length) {
     cloudlog({ requestId: c.get('requestId'), message: `[${queueName}] ${successMessages.length} messages were processed successfully, ${messagesToProcess.length - successMessages.length} messages failed.` })
@@ -1084,6 +1165,7 @@ export const __queueConsumerTestUtils__ = {
   getActionableQueueFailures,
   getCronHealthcheckStartUrl,
   getQueueBatchSize,
+  getQueueAckChunkSize,
   getQueueHttpConcurrency,
   httpExceptionToQueueResponse,
   getQueueVisibilityTimeout,

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -168,7 +168,7 @@ describe('on_version_update deleted version cleanup', () => {
     expect(response.status).toBe(200)
     expect(moveObjectToTrash).toHaveBeenCalledWith(expect.anything(), 'orgs/org-1/apps/com.cleanup.test/manifest/index.js')
     expect(deleteObject).not.toHaveBeenCalled()
-    expect(pgQuery).toHaveBeenCalledWith('UPDATE app_versions SET manifest_count = 0 WHERE id = $1', [123])
+    expect(pgQuery).toHaveBeenCalledWith('UPDATE app_versions SET manifest_count = 0, manifest = NULL WHERE id = $1', [123])
     expect(pgQuery).toHaveBeenCalledWith(expect.stringContaining('manifest_bundle_count = GREATEST(manifest_bundle_count - 1, 0)'), ['com.cleanup.test'])
   })
 

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -2,6 +2,7 @@ import { HTTPException } from 'hono/http-exception'
 import { describe, expect, it, vi } from 'vitest'
 import { __queueConsumerTestUtils__, MAX_QUEUE_READS, messagesArraySchema } from '../supabase/functions/_backend/triggers/queue_consumer.ts'
 import { onManifestCreateTestUtils } from '../supabase/functions/_backend/triggers/on_manifest_create.ts'
+import { onVersionUpdateTestUtils } from '../supabase/functions/_backend/triggers/on_version_update.ts'
 import { s3TestUtils } from '../supabase/functions/_backend/utils/s3.ts'
 import { parseSchema } from '../supabase/functions/_backend/utils/ark_validation.ts'
 
@@ -145,16 +146,39 @@ describe('queue_consumer legacy message compatibility', () => {
       },
     ])).toEqual([])
   })
-
-  it.concurrent('keeps manifest queue batches out of Cloudflare waitUntil', () => {
+  it.concurrent('checkpoints manifest queue deletes without reducing read batch size', () => {
     expect(__queueConsumerTestUtils__.getQueueBatchSize('on_manifest_create', 950)).toBe(950)
     expect(__queueConsumerTestUtils__.getQueueBatchSize('cron_email', 950)).toBe(950)
+    expect(__queueConsumerTestUtils__.getQueueAckChunkSize('on_manifest_create')).toBe(100)
+    expect(__queueConsumerTestUtils__.getQueueAckChunkSize('cron_email')).toBeNull()
     expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('on_manifest_create')).toBe(100)
     expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('cron_email')).toBe(25)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_manifest_create')).toBe(900)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('cron_email')).toBe(120)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('on_manifest_create')).toBe(false)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('cron_email')).toBe(true)
+  })
+
+  it.concurrent('does not reprocess manifests for already deleted versions', () => {
+    const deletedAt = '2026-07-07T00:40:00.096Z'
+    const appVersionRow = (value: Record<string, unknown>) => value as Parameters<typeof onVersionUpdateTestUtils.getDeletedVersionAction>[0]
+
+    expect(onVersionUpdateTestUtils.getDeletedVersionAction(
+      appVersionRow({ deleted_at: deletedAt, manifest: [{ file_name: 'index.html' }], manifest_count: 1 }),
+      appVersionRow({ deleted_at: deletedAt }),
+    )).toBe('cleanup_manifest')
+    expect(onVersionUpdateTestUtils.getDeletedVersionAction(
+      appVersionRow({ deleted_at: deletedAt, manifest: null, manifest_count: 0 }),
+      appVersionRow({ deleted_at: deletedAt }),
+    )).toBe('skip')
+    expect(onVersionUpdateTestUtils.getDeletedVersionAction(
+      appVersionRow({ deleted_at: deletedAt, manifest: null, manifest_count: 0 }),
+      appVersionRow({ deleted_at: null }),
+    )).toBe('delete')
+    expect(onVersionUpdateTestUtils.getDeletedVersionAction(
+      appVersionRow({ deleted_at: null, manifest: [{ file_name: 'index.html' }], manifest_count: 0 }),
+      appVersionRow({ deleted_at: null }),
+    )).toBe('continue')
   })
 
   it.concurrent('alerts Discord after retry budget is exhausted', () => {


### PR DESCRIPTION
## Summary
- checkpoint successful `on_manifest_create` messages every 100 processed rows while keeping the 950-message read batch
- prevent already-deleted app versions from reprocessing stale manifest payloads
- make stale manifest-size retry messages no-op when the manifest row is already sized, gone, or tied to a deleted app version

## Root cause
`on_manifest_create` was processing 950-message batches but only deleting successful messages after the entire batch completed. The database caller gives that awaited request 60s, so large manifest batches could update `manifest.file_size` and still time out before queue deletion, causing the same messages to retry and eventually archive. Separately, already-deleted `app_versions` updates with unchanged `deleted_at` could fall through to `updateIt()` and reinsert manifest rows for R2 objects that had already been moved/deleted.

## Validation
- `bun test tests/queue-consumer-message-shape.unit.test.ts`
- `bunx vitest run tests/queue-consumer-message-shape.unit.test.ts`
- `bunx oxlint tests/queue-consumer-message-shape.unit.test.ts`
- `bun run lint:backend`
- `bun run typecheck:backend`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches queue ack timing, manifest/version delete paths, and storage cleanup; wrong skip/ack logic could drop work or leave stale manifest rows, but behavior is covered by targeted unit tests.
> 
> **Overview**
> Stabilizes **`on_manifest_create`** queue handling and stops stale manifest work on deleted app versions.
> 
> **Queue consumer:** For `on_manifest_create`, successful messages are **deleted every 100 rows** while reads stay at 950, so a long batch is less likely to time out before acks and re-deliver the same work. Processing is refactored into chunked helpers (CF ID persistence, failure reporting, final delete for successes not already checkpointed).
> 
> **Manifest size retries:** Before returning 503 for a zero-size lookup, **`shouldSkipManifestSizeRetry`** re-reads the manifest and app version and **no-ops with 2xx** when the row is gone, already has `file_size`, or the parent version is deleted.
> 
> **Version updates:** **`getDeletedVersionAction`** routes soft-deleted versions: first transition → full delete; unchanged `deleted_at` with leftover manifest → **`cleanup_manifest`** only; otherwise skip instead of falling through to **`updateIt`**. Manifest cleanup SQL also sets **`manifest = NULL`** on `app_versions`.
> 
> Unit tests cover ack chunk size, deleted-version routing, and the updated cleanup SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9351913f0c14d13adbd4021903a4ed154ffd177e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->