### PR TITLE
ci: guard release on read replica schema

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -96,6 +96,12 @@ jobs:
         run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_TOKEN }}
+      - name: Check read-replica schema through Hyperdrive
+        if: env.SUPA_ENV == 'PROD'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bun run readreplicate:check-hyperdrive-schema
       - name: Apply Supabase Migrations
         run: supabase db push
       - name: Update functions

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Disable flaky runner apt sources
+        run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-prod.sources
+
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -262,6 +262,7 @@ jobs:
           if command -v pg_dump-17 >/dev/null 2>&1 && command -v pg_restore-17 >/dev/null 2>&1 && command -v psql-17 >/dev/null 2>&1; then
             exit 0
           fi
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-prod.sources
           sudo apt-get update
           sudo apt-get install -y ca-certificates postgresql-common
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
@@ -377,6 +378,8 @@ jobs:
         run: bash scripts/setup-bun.sh
       - name: Install dependencies
         run: bun install
+      - name: Disable flaky runner apt sources
+        run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-prod.sources
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium
       - name: Install Supabase CLI

--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -2,7 +2,8 @@ import { Pool } from 'pg'
 import { readReplicaSchemaCatalog, stableStringify } from '../../read_replicate/schema_catalog.ts'
 
 interface Env {
-  HYPERDRIVE_CAPGO_READ_EU: Hyperdrive
+  HYPERDRIVE_CAPGO_READ_EU?: Hyperdrive
+  READ_REPLICA_SCHEMA_CHECK_TOKEN?: string
 }
 
 export default {
@@ -15,8 +16,19 @@ export default {
     if (pathname !== '/catalog')
       return Response.json({ error: 'not_found' }, { status: 404 })
 
+    const expectedToken = env.READ_REPLICA_SCHEMA_CHECK_TOKEN
+    if (!expectedToken)
+      return Response.json({ error: 'missing_schema_check_token' }, { status: 500 })
+
+    if (request.headers.get('authorization') !== `Bearer ${expectedToken}`)
+      return Response.json({ error: 'unauthorized' }, { status: 401 })
+
+    const hyperdrive = env.HYPERDRIVE_CAPGO_READ_EU
+    if (!hyperdrive?.connectionString)
+      return Response.json({ error: 'missing_hyperdrive_binding' }, { status: 500 })
+
     const pool = new Pool({
-      connectionString: env.HYPERDRIVE_CAPGO_READ_EU.connectionString,
+      connectionString: hyperdrive.connectionString,
       max: 1,
       connectionTimeoutMillis: 10000,
     })

--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -1,0 +1,40 @@
+import { Pool } from 'pg'
+import { readReplicaSchemaCatalog, stableStringify } from '../../read_replicate/schema_catalog.ts'
+
+interface Env {
+  HYPERDRIVE_CAPGO_READ_EU: Hyperdrive
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const { pathname } = new URL(request.url)
+
+    if (pathname === '/ok')
+      return Response.json({ status: 'ok' })
+
+    if (pathname !== '/catalog')
+      return Response.json({ error: 'not_found' }, { status: 404 })
+
+    const pool = new Pool({
+      connectionString: env.HYPERDRIVE_CAPGO_READ_EU.connectionString,
+      max: 1,
+      connectionTimeoutMillis: 10000,
+    })
+
+    try {
+      const catalog = await readReplicaSchemaCatalog(pool)
+      return new Response(`${stableStringify(catalog)}\n`, {
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+        },
+      })
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return Response.json({ error: 'catalog_query_failed', message }, { status: 500 })
+    }
+    finally {
+      await pool.end()
+    }
+  },
+}

--- a/cloudflare_workers/read-replica-schema-check/wrangler.jsonc
+++ b/cloudflare_workers/read-replica-schema-check/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "name": "capgo_read_replica_schema_check",
+  "main": "./index.ts",
+  "compatibility_date": "2026-04-21",
+  "compatibility_flags": [
+    "nodejs_compat",
+    "nodejs_compat_populate_process_env"
+  ],
+  "workers_dev": true,
+  "env": {
+    "prod": {
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE_CAPGO_READ_EU",
+          "id": "d5aae8be75f446868352110502fa9a1e"
+        }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "readreplicate:indexes": "bash read_replicate/replicate_ensure_indexes.sh",
     "readreplicate:status": "bash read_replicate/replicate_status.sh",
     "readreplicate:check-schema": "bash scripts/check-read-replica-schema.sh",
+    "readreplicate:check-target-schema": "bun run readreplicate:check-hyperdrive-schema",
+    "readreplicate:check-hyperdrive-schema": "bash scripts/check-read-replica-hyperdrive-schema.sh",
     "supabase:reset-postgres-config": "bash scripts/reset_supabase_postgres_config_defaults.sh",
     "cloudsql:allow-cloudflare": "bash scripts/update_cloudsql_authorized_networks.sh",
     "supabase:start": "bun scripts/supabase-worktree.ts start",

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -48,6 +48,13 @@ Check that the committed replica schema matches the current database schema:
 bun run readreplicate:check-schema
 ```
 
+Check that the live read replica visible through Hyperdrive matches the committed
+replica schema catalog:
+
+```bash
+bun run readreplicate:check-hyperdrive-schema
+```
+
 Recreate the Google subscription:
 
 ```bash
@@ -88,3 +95,9 @@ READ_REPLICA_PASSWORD='new-password' bash read_replicate/update_readreplica_pass
   false`, then re-enables the subscription.
 - `schema_replicate.sql` is intentionally limited to tables replicated into the
   Google subscriber. It excludes foreign keys, triggers, and RLS policies.
+- `schema_replicate.catalog.json` is the machine-readable catalog snapshot used
+  by release CI to compare the committed schema against the live read replica
+  through Hyperdrive.
+- Production Supabase deploys run `bun run readreplicate:check-hyperdrive-schema`
+  before migrations, functions, or workers publish. If it fails, update the
+  Google subscriber schema before retrying the release.

--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -98,6 +98,12 @@ ensure_connect_timeout() {
 
 normalize_cloudsql_ssl() {
   local url="$1"
+  if [[ "$url" == *"sslmode=no-verify"* ]]; then
+    echo "==> WARNING: PostgreSQL 17 rejects sslmode=no-verify." >&2
+    echo "==> Downgrading this connection to sslmode=require for this command." >&2
+    printf "%s" "${url/sslmode=no-verify/sslmode=require}"
+    return 0
+  fi
   if [[ "$url" == *"sslmode=verify-full"* ]]; then
     echo "==> WARNING: Google Cloud SQL URLs using IP hosts usually fail with sslmode=verify-full." >&2
     echo "==> Downgrading this connection to sslmode=require for this command." >&2
@@ -156,6 +162,7 @@ load_source_db_url() {
   fi
 
   db_url="${db_url//ssl=false/sslmode=disable}"
+  db_url="$(normalize_cloudsql_ssl "$db_url")"
   printf "%s" "$db_url"
 }
 

--- a/read_replicate/replicate_prepare.sh
+++ b/read_replicate/replicate_prepare.sh
@@ -8,7 +8,8 @@ source "${SCRIPT_DIR}/common.sh"
 DUMP_FILE="schema_replicate.dump"
 LIST_FILE="schema_replicate.list"
 FILTERED_LIST="schema_replicate.filtered.list"
-OUT_SQL="read_replicate/schema_replicate.sql"
+OUT_SQL="${OUT_SQL:-read_replicate/schema_replicate.sql}"
+CATALOG_FILE="${CATALOG_FILE:-read_replicate/schema_replicate.catalog.json}"
 
 PSQL_BIN="${PSQL_BIN:-$(command -v psql-17 || command -v psql || true)}"
 PG_DUMP_BIN="${PG_DUMP_BIN:-$(command -v pg_dump-17 || command -v pg_dump || true)}"
@@ -18,6 +19,32 @@ if [[ -z "$PSQL_BIN" || -z "$PG_DUMP_BIN" || -z "$PG_RESTORE_BIN" ]]; then
   echo "Error: psql, pg_dump, and pg_restore are required to prepare read-replica schema."
   exit 1
 fi
+
+replica_config_pattern() {
+  local export_name="$1"
+
+  REPLICA_SCHEMA_EXPORT="$export_name" bun --silent -e '
+    import {
+      REPLICA_EXCLUDED_INDEXES,
+      REPLICA_FUNCTIONS,
+      REPLICA_TYPES,
+      replicaConfigPattern,
+    } from "./read_replicate/schema_catalog.ts"
+
+    const configs = {
+      REPLICA_EXCLUDED_INDEXES,
+      REPLICA_FUNCTIONS,
+      REPLICA_TYPES,
+    }
+    const name = process.env.REPLICA_SCHEMA_EXPORT
+    const values = name ? configs[name] : undefined
+    if (!values) {
+      console.error("Unknown read-replica schema config")
+      process.exit(1)
+    }
+    console.log(replicaConfigPattern(values))
+  '
+}
 
 DB_SB="$(load_source_db_url)"
 echo "==> Dumping replica schema from Supabase source"
@@ -63,12 +90,14 @@ TYPES_DUMP="types_replicate.dump"
 #    - TRIGGER: remove triggers
 #    - POLICY: remove RLS policies
 #    - ROW SECURITY: removes ALTER TABLE ... ENABLE ROW LEVEL SECURITY (wording varies by pg_dump version)
+REPLICA_EXCLUDED_INDEX_PATTERN="$(replica_config_pattern REPLICA_EXCLUDED_INDEXES)"
+export REPLICA_EXCLUDED_INDEX_PATTERN
 perl -ne '
   next if /\bFK CONSTRAINT\b/;
   next if /\bTRIGGER\b/;
   next if /\bPOLICY\b/;
   next if /\bROW SECURITY\b/;
-  next if /\bINDEX\b/ && /\bidx_stripe_info_customer_id\b/;
+  next if /\bINDEX\b/ && ($ENV{REPLICA_EXCLUDED_INDEX_PATTERN} // "") ne "" && /$ENV{REPLICA_EXCLUDED_INDEX_PATTERN}/;
   print;
 ' "$LIST_FILE" > "$FILTERED_LIST"
 
@@ -89,13 +118,16 @@ if [[ -f "$TYPES_DUMP" ]]; then
   
   # Filter to only include the types and functions we need
   if [[ -f "$TYPES_LIST" ]]; then
+    REPLICA_TYPE_PATTERN="$(replica_config_pattern REPLICA_TYPES)"
+    REPLICA_FUNCTION_PATTERN="$(replica_config_pattern REPLICA_FUNCTIONS)"
+
     # Extract types
     grep -E '\bTYPE\b' "$TYPES_LIST" | \
-      grep -E 'manifest_entry|disable_update|user_min_right|stripe_status' > "$TYPES_FILTERED_LIST" || true
+      grep -E "$REPLICA_TYPE_PATTERN" > "$TYPES_FILTERED_LIST" || true
     
-    # Also extract the one_month_ahead function (required by stripe_info table)
+    # Also extract the functions required by replica table defaults
     grep -E '\bFUNCTION\b' "$TYPES_LIST" | \
-      grep -E 'one_month_ahead' >> "$TYPES_FILTERED_LIST" || true
+      grep -E "$REPLICA_FUNCTION_PATTERN" >> "$TYPES_FILTERED_LIST" || true
     
     if [[ -s "$TYPES_FILTERED_LIST" ]]; then
       # Restore only the filtered types and functions to SQL
@@ -146,8 +178,9 @@ grep -nE 'CREATE POLICY|ROW LEVEL SECURITY|FK CONSTRAINT|FOREIGN KEY|CREATE TRIG
 
 echo "==> Index count:"
 grep -cE '^\s*CREATE (UNIQUE )?INDEX\b' "$OUT_SQL" || true
-
 # 8) Cleanup temporary files
 echo "==> Cleaning up temporary files..."
 rm -f "$DUMP_FILE" "$LIST_FILE" "$FILTERED_LIST" "$TYPES_DUMP" "$TYPES_SQL" 2>/dev/null || true
+echo "==> Writing catalog snapshot..."
+MAIN_SUPABASE_DB_URL="$DB_SB" bun scripts/write-read-replica-schema-catalog.ts "$CATALOG_FILE"
 echo "==> Done. Output: $OUT_SQL"

--- a/read_replicate/replicate_prepare.sh
+++ b/read_replicate/replicate_prepare.sh
@@ -122,12 +122,18 @@ if [[ -f "$TYPES_DUMP" ]]; then
     REPLICA_FUNCTION_PATTERN="$(replica_config_pattern REPLICA_FUNCTIONS)"
 
     # Extract types
-    grep -E '\bTYPE\b' "$TYPES_LIST" | \
-      grep -E "$REPLICA_TYPE_PATTERN" > "$TYPES_FILTERED_LIST" || true
+    if [[ -n "$REPLICA_TYPE_PATTERN" ]]; then
+      grep -E '\bTYPE\b' "$TYPES_LIST" | \
+        grep -E "$REPLICA_TYPE_PATTERN" > "$TYPES_FILTERED_LIST" || true
+    else
+      : > "$TYPES_FILTERED_LIST"
+    fi
     
     # Also extract the functions required by replica table defaults
-    grep -E '\bFUNCTION\b' "$TYPES_LIST" | \
-      grep -E "$REPLICA_FUNCTION_PATTERN" >> "$TYPES_FILTERED_LIST" || true
+    if [[ -n "$REPLICA_FUNCTION_PATTERN" ]]; then
+      grep -E '\bFUNCTION\b' "$TYPES_LIST" | \
+        grep -E "$REPLICA_FUNCTION_PATTERN" >> "$TYPES_FILTERED_LIST" || true
+    fi
     
     if [[ -s "$TYPES_FILTERED_LIST" ]]; then
       # Restore only the filtered types and functions to SQL

--- a/read_replicate/schema_catalog.ts
+++ b/read_replicate/schema_catalog.ts
@@ -41,7 +41,7 @@ export function replicaConfigPattern(values: readonly string[]): string {
 }
 
 function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 }
 
 export interface Queryable {

--- a/read_replicate/schema_catalog.ts
+++ b/read_replicate/schema_catalog.ts
@@ -1,0 +1,290 @@
+export const REPLICA_TABLES = [
+  'orgs',
+  'stripe_info',
+  'org_users',
+  'apps',
+  'app_versions',
+  'channels',
+  'channel_devices',
+  'manifest',
+  'notifications',
+  'onboarding_demo_data',
+] as const
+
+export const REPLICA_TYPES = [
+  'disable_update',
+  'manifest_entry',
+  'stripe_status',
+  'user_min_right',
+] as const
+
+const REPLICA_SEQUENCES = [
+  'app_versions_id_seq',
+  'channel_devices_id_seq',
+  'channel_id_seq',
+  'manifest_id_seq',
+  'org_users_id_seq',
+  'stripe_info_id_seq',
+] as const
+
+export const REPLICA_FUNCTIONS = [
+  'one_month_ahead',
+] as const
+
+export const REPLICA_EXCLUDED_INDEXES = [
+  // replicate_prepare.sh intentionally omits this source-only customer lookup index from the replica DDL.
+  'idx_stripe_info_customer_id',
+] as const
+
+export function replicaConfigPattern(values: readonly string[]): string {
+  return values.map(escapeRegex).join('|')
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export interface Queryable {
+  query: (queryText: string, values?: unknown[]) => Promise<{ rows: Record<string, any>[] }>
+}
+
+export const READ_REPLICA_SCHEMA_CATALOG_SQL = `
+WITH replica_tables(table_name) AS (
+  SELECT unnest($1::text[])
+),
+replica_types(type_name) AS (
+  SELECT unnest($2::text[])
+),
+replica_sequences(sequence_name) AS (
+  SELECT unnest($3::text[])
+),
+replica_functions(function_name) AS (
+  SELECT unnest($4::text[])
+),
+replica_excluded_indexes(index_name) AS (
+  SELECT unnest($5::text[])
+),
+tables AS (
+  SELECT
+    c.oid AS table_oid,
+    c.relname AS table_name,
+    c.relkind,
+    COALESCE((
+      SELECT jsonb_agg(option ORDER BY option)
+      FROM unnest(c.reloptions) AS option
+    ), '[]'::jsonb) AS reloptions
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  JOIN replica_tables rt ON rt.table_name = c.relname
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+),
+columns AS (
+  SELECT
+    t.table_name,
+    row_number() OVER (PARTITION BY t.table_name ORDER BY a.attnum)::int AS position,
+    a.attname AS column_name,
+    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+    a.attnotnull AS not_null,
+    a.attidentity AS identity_kind,
+    a.attgenerated AS generated_kind,
+    pg_get_expr(d.adbin, d.adrelid) AS default_expr
+  FROM tables t
+  JOIN pg_attribute a ON a.attrelid = t.table_oid
+  LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+  WHERE a.attnum > 0
+    AND NOT a.attisdropped
+),
+constraints AS (
+  SELECT
+    t.table_name,
+    con.conname AS constraint_name,
+    con.contype AS constraint_type,
+    pg_get_constraintdef(con.oid, true) AS definition
+  FROM tables t
+  JOIN pg_constraint con ON con.conrelid = t.table_oid
+  WHERE con.contype IN ('p', 'u', 'c')
+),
+indexes AS (
+  SELECT
+    t.table_name,
+    idx.relname AS index_name,
+    pg_get_indexdef(idx.oid) AS definition
+  FROM tables t
+  JOIN pg_index ix ON ix.indrelid = t.table_oid
+  JOIN pg_class idx ON idx.oid = ix.indexrelid
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM replica_excluded_indexes rei
+    WHERE rei.index_name = idx.relname
+  )
+),
+types AS (
+  SELECT
+    typ.typname AS type_name,
+    typ.typtype AS type_kind,
+    CASE
+      WHEN typ.typtype = 'e' THEN (
+        SELECT jsonb_agg(e.enumlabel ORDER BY e.enumsortorder)
+        FROM pg_enum e
+        WHERE e.enumtypid = typ.oid
+      )
+      WHEN typ.typtype = 'c' THEN (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'position', a.attnum,
+            'name', a.attname,
+            'type', pg_catalog.format_type(a.atttypid, a.atttypmod)
+          )
+          ORDER BY a.attnum
+        )
+        FROM pg_attribute a
+        WHERE a.attrelid = typ.typrelid
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+      )
+      ELSE NULL
+    END AS definition
+  FROM pg_type typ
+  JOIN pg_namespace n ON n.oid = typ.typnamespace
+  JOIN replica_types rt ON rt.type_name = typ.typname
+  WHERE n.nspname = 'public'
+),
+sequences AS (
+  SELECT
+    seq.relname AS sequence_name,
+    pg_catalog.format_type(s.seqtypid, NULL) AS data_type,
+    s.seqstart::text AS start_value,
+    s.seqincrement::text AS increment_by,
+    s.seqmin::text AS min_value,
+    s.seqmax::text AS max_value,
+    s.seqcache::text AS cache_size,
+    s.seqcycle AS cycle,
+    owned_table.relname AS owned_table,
+    owned_attr.attname AS owned_column
+  FROM pg_class seq
+  JOIN pg_namespace n ON n.oid = seq.relnamespace
+  JOIN pg_sequence s ON s.seqrelid = seq.oid
+  JOIN replica_sequences rs ON rs.sequence_name = seq.relname
+  LEFT JOIN pg_depend dep ON dep.objid = seq.oid AND dep.deptype = 'a'
+  LEFT JOIN pg_class owned_table ON owned_table.oid = dep.refobjid
+  LEFT JOIN pg_attribute owned_attr ON owned_attr.attrelid = dep.refobjid AND owned_attr.attnum = dep.refobjsubid
+  WHERE n.nspname = 'public'
+    AND seq.relkind = 'S'
+),
+functions AS (
+  SELECT
+    p.proname AS function_name,
+    pg_get_function_identity_arguments(p.oid) AS arguments,
+    pg_get_functiondef(p.oid) AS definition
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  JOIN replica_functions rf ON rf.function_name = p.proname
+  WHERE n.nspname = 'public'
+)
+SELECT jsonb_build_object(
+  'version', 1,
+  'tables', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'name', table_name,
+      'kind', relkind,
+      'reloptions', reloptions
+    ) ORDER BY table_name)
+    FROM tables
+  ), '[]'::jsonb),
+  'columns', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'table', table_name,
+      'position', position,
+      'name', column_name,
+      'type', data_type,
+      'notNull', not_null,
+      'default', default_expr,
+      'identity', identity_kind,
+      'generated', generated_kind
+    ) ORDER BY table_name, position)
+    FROM columns
+  ), '[]'::jsonb),
+  'constraints', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'table', table_name,
+      'name', constraint_name,
+      'type', constraint_type,
+      'definition', definition
+    ) ORDER BY table_name, constraint_name)
+    FROM constraints
+  ), '[]'::jsonb),
+  'indexes', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'table', table_name,
+      'name', index_name,
+      'definition', definition
+    ) ORDER BY table_name, index_name)
+    FROM indexes
+  ), '[]'::jsonb),
+  'types', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'name', type_name,
+      'kind', type_kind,
+      'definition', definition
+    ) ORDER BY type_name)
+    FROM types
+  ), '[]'::jsonb),
+  'sequences', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'name', sequence_name,
+      'type', data_type,
+      'start', start_value,
+      'increment', increment_by,
+      'min', min_value,
+      'max', max_value,
+      'cache', cache_size,
+      'cycle', cycle,
+      'ownedTable', owned_table,
+      'ownedColumn', owned_column
+    ) ORDER BY sequence_name)
+    FROM sequences
+  ), '[]'::jsonb),
+  'functions', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'name', function_name,
+      'arguments', arguments,
+      'definition', definition
+    ) ORDER BY function_name, arguments)
+    FROM functions
+  ), '[]'::jsonb)
+) AS catalog
+`
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJson(value), null, 2)
+}
+
+export async function readReplicaSchemaCatalog(client: Queryable): Promise<unknown> {
+  const result = await client.query(READ_REPLICA_SCHEMA_CATALOG_SQL, [
+    REPLICA_TABLES,
+    REPLICA_TYPES,
+    REPLICA_SEQUENCES,
+    REPLICA_FUNCTIONS,
+    REPLICA_EXCLUDED_INDEXES,
+  ])
+  const catalog = result.rows[0]?.catalog
+  if (!catalog)
+    throw new Error('Read-replica schema catalog query returned no rows')
+
+  return sortJson(catalog)
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value))
+    return value.map(sortJson)
+
+  if (!value || typeof value !== 'object')
+    return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => [key, sortJson(child)]),
+  )
+}

--- a/read_replicate/schema_replicate.catalog.json
+++ b/read_replicate/schema_replicate.catalog.json
@@ -1,0 +1,2471 @@
+{
+  "columns": [
+    {
+      "default": null,
+      "generated": "",
+      "identity": "d",
+      "name": "id",
+      "notNull": true,
+      "position": 1,
+      "table": "app_versions",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": false,
+      "position": 2,
+      "table": "app_versions",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_id",
+      "notNull": true,
+      "position": 3,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "name",
+      "notNull": true,
+      "position": 4,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": false,
+      "position": 5,
+      "table": "app_versions",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "deleted",
+      "notNull": true,
+      "position": 6,
+      "table": "app_versions",
+      "type": "boolean"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "external_url",
+      "notNull": false,
+      "position": 7,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "checksum",
+      "notNull": false,
+      "position": 8,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "session_key",
+      "notNull": false,
+      "position": 9,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": "'r2'::text",
+      "generated": "",
+      "identity": "",
+      "name": "storage_provider",
+      "notNull": true,
+      "position": 10,
+      "table": "app_versions",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "min_update_version",
+      "notNull": false,
+      "position": 11,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "native_packages",
+      "notNull": false,
+      "position": 12,
+      "table": "app_versions",
+      "type": "jsonb[]"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "owner_org",
+      "notNull": true,
+      "position": 13,
+      "table": "app_versions",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "user_id",
+      "notNull": false,
+      "position": 14,
+      "table": "app_versions",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "r2_path",
+      "notNull": false,
+      "position": 15,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "manifest",
+      "notNull": false,
+      "position": 16,
+      "table": "app_versions",
+      "type": "manifest_entry[]"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "link",
+      "notNull": false,
+      "position": 17,
+      "table": "app_versions",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "comment",
+      "notNull": false,
+      "position": 18,
+      "table": "app_versions",
+      "type": "text"
+    },
+    {
+      "default": "0",
+      "generated": "",
+      "identity": "",
+      "name": "manifest_count",
+      "notNull": true,
+      "position": 19,
+      "table": "app_versions",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "key_id",
+      "notNull": false,
+      "position": 20,
+      "table": "app_versions",
+      "type": "character varying(20)"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "cli_version",
+      "notNull": false,
+      "position": 21,
+      "table": "app_versions",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "deleted_at",
+      "notNull": false,
+      "position": 22,
+      "table": "app_versions",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": false,
+      "position": 1,
+      "table": "apps",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_id",
+      "notNull": true,
+      "position": 2,
+      "table": "apps",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "icon_url",
+      "notNull": true,
+      "position": 3,
+      "table": "apps",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "user_id",
+      "notNull": false,
+      "position": 4,
+      "table": "apps",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "name",
+      "notNull": false,
+      "position": 5,
+      "table": "apps",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "last_version",
+      "notNull": false,
+      "position": 6,
+      "table": "apps",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": false,
+      "position": 7,
+      "table": "apps",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "gen_random_uuid()",
+      "generated": "",
+      "identity": "",
+      "name": "id",
+      "notNull": false,
+      "position": 8,
+      "table": "apps",
+      "type": "uuid"
+    },
+    {
+      "default": "'2592000'::bigint",
+      "generated": "",
+      "identity": "",
+      "name": "retention",
+      "notNull": true,
+      "position": 9,
+      "table": "apps",
+      "type": "bigint"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "owner_org",
+      "notNull": true,
+      "position": 10,
+      "table": "apps",
+      "type": "uuid"
+    },
+    {
+      "default": "'production'::character varying",
+      "generated": "",
+      "identity": "",
+      "name": "default_upload_channel",
+      "notNull": true,
+      "position": 11,
+      "table": "apps",
+      "type": "character varying"
+    },
+    {
+      "default": "'{}'::jsonb[]",
+      "generated": "",
+      "identity": "",
+      "name": "transfer_history",
+      "notNull": false,
+      "position": 12,
+      "table": "apps",
+      "type": "jsonb[]"
+    },
+    {
+      "default": "0",
+      "generated": "",
+      "identity": "",
+      "name": "channel_device_count",
+      "notNull": true,
+      "position": 13,
+      "table": "apps",
+      "type": "bigint"
+    },
+    {
+      "default": "0",
+      "generated": "",
+      "identity": "",
+      "name": "manifest_bundle_count",
+      "notNull": true,
+      "position": 14,
+      "table": "apps",
+      "type": "bigint"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "expose_metadata",
+      "notNull": true,
+      "position": 15,
+      "table": "apps",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "allow_preview",
+      "notNull": true,
+      "position": 16,
+      "table": "apps",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "allow_device_custom_id",
+      "notNull": true,
+      "position": 17,
+      "table": "apps",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "need_onboarding",
+      "notNull": true,
+      "position": 18,
+      "table": "apps",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "existing_app",
+      "notNull": true,
+      "position": 19,
+      "table": "apps",
+      "type": "boolean"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "ios_store_url",
+      "notNull": false,
+      "position": 20,
+      "table": "apps",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "android_store_url",
+      "notNull": false,
+      "position": 21,
+      "table": "apps",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "stats_updated_at",
+      "notNull": false,
+      "position": 22,
+      "table": "apps",
+      "type": "timestamp without time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "stats_refresh_requested_at",
+      "notNull": false,
+      "position": 23,
+      "table": "apps",
+      "type": "timestamp without time zone"
+    },
+    {
+      "default": "900",
+      "generated": "",
+      "identity": "",
+      "name": "build_timeout_seconds",
+      "notNull": true,
+      "position": 24,
+      "table": "apps",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "build_timeout_updated_at",
+      "notNull": true,
+      "position": 25,
+      "table": "apps",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "block_provider_infra_requests",
+      "notNull": true,
+      "position": 26,
+      "table": "apps",
+      "type": "boolean"
+    },
+    {
+      "default": "0",
+      "generated": "",
+      "identity": "",
+      "name": "rollout_channel_count",
+      "notNull": true,
+      "position": 27,
+      "table": "apps",
+      "type": "bigint"
+    },
+    {
+      "default": "'{}'::character varying[]",
+      "generated": "",
+      "identity": "",
+      "name": "rollout_paused_version_names",
+      "notNull": true,
+      "position": 28,
+      "table": "apps",
+      "type": "character varying[]"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": false,
+      "position": 1,
+      "table": "channel_devices",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "channel_id",
+      "notNull": true,
+      "position": 2,
+      "table": "channel_devices",
+      "type": "bigint"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_id",
+      "notNull": true,
+      "position": 3,
+      "table": "channel_devices",
+      "type": "character varying"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": true,
+      "position": 4,
+      "table": "channel_devices",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "device_id",
+      "notNull": true,
+      "position": 5,
+      "table": "channel_devices",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "d",
+      "name": "id",
+      "notNull": true,
+      "position": 6,
+      "table": "channel_devices",
+      "type": "bigint"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "owner_org",
+      "notNull": true,
+      "position": 7,
+      "table": "channel_devices",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "d",
+      "name": "id",
+      "notNull": true,
+      "position": 1,
+      "table": "channels",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": true,
+      "position": 2,
+      "table": "channels",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "name",
+      "notNull": true,
+      "position": 3,
+      "table": "channels",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_id",
+      "notNull": true,
+      "position": 4,
+      "table": "channels",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "version",
+      "notNull": false,
+      "position": 5,
+      "table": "channels",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": true,
+      "position": 6,
+      "table": "channels",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "public",
+      "notNull": true,
+      "position": 7,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "disable_auto_update_under_native",
+      "notNull": true,
+      "position": 8,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "ios",
+      "notNull": true,
+      "position": 9,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "android",
+      "notNull": true,
+      "position": 10,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "allow_device_self_set",
+      "notNull": true,
+      "position": 11,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "allow_emulator",
+      "notNull": true,
+      "position": 12,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "allow_device",
+      "notNull": true,
+      "position": 13,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "allow_dev",
+      "notNull": true,
+      "position": 14,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "allow_prod",
+      "notNull": true,
+      "position": 15,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "'major'::disable_update",
+      "generated": "",
+      "identity": "",
+      "name": "disable_auto_update",
+      "notNull": true,
+      "position": 16,
+      "table": "channels",
+      "type": "disable_update"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "owner_org",
+      "notNull": true,
+      "position": 17,
+      "table": "channels",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "created_by",
+      "notNull": true,
+      "position": 18,
+      "table": "channels",
+      "type": "uuid"
+    },
+    {
+      "default": "gen_random_uuid()",
+      "generated": "",
+      "identity": "",
+      "name": "rbac_id",
+      "notNull": true,
+      "position": 19,
+      "table": "channels",
+      "type": "uuid"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "electron",
+      "notNull": true,
+      "position": 20,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "rollout_version",
+      "notNull": false,
+      "position": 21,
+      "table": "channels",
+      "type": "bigint"
+    },
+    {
+      "default": "0",
+      "generated": "",
+      "identity": "",
+      "name": "rollout_percentage_bps",
+      "notNull": true,
+      "position": 22,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "rollout_enabled",
+      "notNull": true,
+      "position": 23,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "gen_random_uuid()",
+      "generated": "",
+      "identity": "",
+      "name": "rollout_id",
+      "notNull": true,
+      "position": 24,
+      "table": "channels",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "rollout_paused_at",
+      "notNull": false,
+      "position": 25,
+      "table": "channels",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "rollout_pause_reason",
+      "notNull": false,
+      "position": 26,
+      "table": "channels",
+      "type": "text"
+    },
+    {
+      "default": "2592000",
+      "generated": "",
+      "identity": "",
+      "name": "rollout_cache_ttl_seconds",
+      "notNull": true,
+      "position": 27,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_enabled",
+      "notNull": true,
+      "position": 28,
+      "table": "channels",
+      "type": "boolean"
+    },
+    {
+      "default": "60",
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_window_minutes",
+      "notNull": true,
+      "position": 29,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_failure_rate_bps",
+      "notNull": false,
+      "position": 30,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": "0.9500",
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_confidence",
+      "notNull": true,
+      "position": 31,
+      "table": "channels",
+      "type": "numeric(5,4)"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_min_attempts",
+      "notNull": false,
+      "position": 32,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_min_failures",
+      "notNull": false,
+      "position": 33,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": "'pause'::text",
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_action",
+      "notNull": true,
+      "position": 34,
+      "table": "channels",
+      "type": "text"
+    },
+    {
+      "default": "60",
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_cooldown_minutes",
+      "notNull": true,
+      "position": 35,
+      "table": "channels",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_last_triggered_at",
+      "notNull": false,
+      "position": 36,
+      "table": "channels",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "auto_pause_last_checked_at",
+      "notNull": false,
+      "position": 37,
+      "table": "channels",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "nextval('manifest_id_seq'::regclass)",
+      "generated": "",
+      "identity": "",
+      "name": "id",
+      "notNull": true,
+      "position": 1,
+      "table": "manifest",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_version_id",
+      "notNull": true,
+      "position": 2,
+      "table": "manifest",
+      "type": "bigint"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "file_name",
+      "notNull": true,
+      "position": 3,
+      "table": "manifest",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "s3_path",
+      "notNull": true,
+      "position": 4,
+      "table": "manifest",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "file_hash",
+      "notNull": true,
+      "position": 5,
+      "table": "manifest",
+      "type": "character varying"
+    },
+    {
+      "default": "0",
+      "generated": "",
+      "identity": "",
+      "name": "file_size",
+      "notNull": false,
+      "position": 6,
+      "table": "manifest",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": false,
+      "position": 1,
+      "table": "notifications",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": false,
+      "position": 2,
+      "table": "notifications",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "last_send_at",
+      "notNull": true,
+      "position": 3,
+      "table": "notifications",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "'1'::bigint",
+      "generated": "",
+      "identity": "",
+      "name": "total_send",
+      "notNull": true,
+      "position": 4,
+      "table": "notifications",
+      "type": "bigint"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "owner_org",
+      "notNull": true,
+      "position": 5,
+      "table": "notifications",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "event",
+      "notNull": true,
+      "position": 6,
+      "table": "notifications",
+      "type": "character varying(255)"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "uniq_id",
+      "notNull": true,
+      "position": 7,
+      "table": "notifications",
+      "type": "character varying(255)"
+    },
+    {
+      "default": "gen_random_uuid()",
+      "generated": "",
+      "identity": "",
+      "name": "id",
+      "notNull": true,
+      "position": 1,
+      "table": "onboarding_demo_data",
+      "type": "uuid"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": true,
+      "position": 2,
+      "table": "onboarding_demo_data",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_id",
+      "notNull": true,
+      "position": 3,
+      "table": "onboarding_demo_data",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "owner_org",
+      "notNull": true,
+      "position": 4,
+      "table": "onboarding_demo_data",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "relation_name",
+      "notNull": true,
+      "position": 5,
+      "table": "onboarding_demo_data",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "row_key",
+      "notNull": true,
+      "position": 6,
+      "table": "onboarding_demo_data",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "seed_id",
+      "notNull": true,
+      "position": 7,
+      "table": "onboarding_demo_data",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "d",
+      "name": "id",
+      "notNull": true,
+      "position": 1,
+      "table": "org_users",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": false,
+      "position": 2,
+      "table": "org_users",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": false,
+      "position": 3,
+      "table": "org_users",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "user_id",
+      "notNull": true,
+      "position": 4,
+      "table": "org_users",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "org_id",
+      "notNull": true,
+      "position": 5,
+      "table": "org_users",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "app_id",
+      "notNull": false,
+      "position": 6,
+      "table": "org_users",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "channel_id",
+      "notNull": false,
+      "position": 7,
+      "table": "org_users",
+      "type": "bigint"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "user_right",
+      "notNull": false,
+      "position": 8,
+      "table": "org_users",
+      "type": "user_min_right"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "rbac_role_name",
+      "notNull": false,
+      "position": 9,
+      "table": "org_users",
+      "type": "text"
+    },
+    {
+      "default": "gen_random_uuid()",
+      "generated": "",
+      "identity": "",
+      "name": "id",
+      "notNull": true,
+      "position": 1,
+      "table": "orgs",
+      "type": "uuid"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "created_by",
+      "notNull": true,
+      "position": 2,
+      "table": "orgs",
+      "type": "uuid"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": false,
+      "position": 3,
+      "table": "orgs",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": false,
+      "position": 4,
+      "table": "orgs",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "logo",
+      "notNull": false,
+      "position": 5,
+      "table": "orgs",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "name",
+      "notNull": true,
+      "position": 6,
+      "table": "orgs",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "management_email",
+      "notNull": true,
+      "position": 7,
+      "table": "orgs",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "customer_id",
+      "notNull": false,
+      "position": 8,
+      "table": "orgs",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "stats_updated_at",
+      "notNull": false,
+      "position": 9,
+      "table": "orgs",
+      "type": "timestamp without time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "last_stats_updated_at",
+      "notNull": false,
+      "position": 10,
+      "table": "orgs",
+      "type": "timestamp without time zone"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "use_new_rbac",
+      "notNull": true,
+      "position": 11,
+      "table": "orgs",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "enforcing_2fa",
+      "notNull": true,
+      "position": 12,
+      "table": "orgs",
+      "type": "boolean"
+    },
+    {
+      "default": "'{\"onboarding\": true, \"usage_limit\": true, \"credit_usage\": true, \"device_error\": true, \"weekly_stats\": true, \"monthly_stats\": true, \"bundle_created\": true, \"bundle_deployed\": true, \"deploy_stats_24h\": true, \"billing_period_stats\": true, \"channel_self_rejected\": true}'::jsonb",
+      "generated": "",
+      "identity": "",
+      "name": "email_preferences",
+      "notNull": true,
+      "position": 13,
+      "table": "orgs",
+      "type": "jsonb"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "enforce_hashed_api_keys",
+      "notNull": true,
+      "position": 14,
+      "table": "orgs",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "require_apikey_expiration",
+      "notNull": true,
+      "position": 15,
+      "table": "orgs",
+      "type": "boolean"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "max_apikey_expiration_days",
+      "notNull": false,
+      "position": 16,
+      "table": "orgs",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "password_policy_config",
+      "notNull": false,
+      "position": 17,
+      "table": "orgs",
+      "type": "jsonb"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "enforce_encrypted_bundles",
+      "notNull": true,
+      "position": 18,
+      "table": "orgs",
+      "type": "boolean"
+    },
+    {
+      "default": "NULL::character varying",
+      "generated": "",
+      "identity": "",
+      "name": "required_encryption_key",
+      "notNull": false,
+      "position": 19,
+      "table": "orgs",
+      "type": "character varying(21)"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "has_usage_credits",
+      "notNull": true,
+      "position": 20,
+      "table": "orgs",
+      "type": "boolean"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "website",
+      "notNull": false,
+      "position": 21,
+      "table": "orgs",
+      "type": "text"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "stats_refresh_requested_at",
+      "notNull": false,
+      "position": 22,
+      "table": "orgs",
+      "type": "timestamp without time zone"
+    },
+    {
+      "default": "'{\"intent\": \"unknown\"}'::jsonb",
+      "generated": "",
+      "identity": "",
+      "name": "onboarding",
+      "notNull": true,
+      "position": 23,
+      "table": "orgs",
+      "type": "jsonb"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "created_at",
+      "notNull": true,
+      "position": 1,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "updated_at",
+      "notNull": true,
+      "position": 2,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "subscription_id",
+      "notNull": false,
+      "position": 3,
+      "table": "stripe_info",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "customer_id",
+      "notNull": true,
+      "position": 4,
+      "table": "stripe_info",
+      "type": "character varying"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "status",
+      "notNull": false,
+      "position": 5,
+      "table": "stripe_info",
+      "type": "stripe_status"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "product_id",
+      "notNull": true,
+      "position": 6,
+      "table": "stripe_info",
+      "type": "character varying"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "trial_at",
+      "notNull": true,
+      "position": 7,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "price_id",
+      "notNull": false,
+      "position": 8,
+      "table": "stripe_info",
+      "type": "character varying"
+    },
+    {
+      "default": "true",
+      "generated": "",
+      "identity": "",
+      "name": "is_good_plan",
+      "notNull": false,
+      "position": 9,
+      "table": "stripe_info",
+      "type": "boolean"
+    },
+    {
+      "default": "'0'::bigint",
+      "generated": "",
+      "identity": "",
+      "name": "plan_usage",
+      "notNull": false,
+      "position": 10,
+      "table": "stripe_info",
+      "type": "bigint"
+    },
+    {
+      "default": "now()",
+      "generated": "",
+      "identity": "",
+      "name": "subscription_anchor_start",
+      "notNull": true,
+      "position": 11,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "one_month_ahead()",
+      "generated": "",
+      "identity": "",
+      "name": "subscription_anchor_end",
+      "notNull": true,
+      "position": 12,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "canceled_at",
+      "notNull": false,
+      "position": 13,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "mau_exceeded",
+      "notNull": false,
+      "position": 14,
+      "table": "stripe_info",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "storage_exceeded",
+      "notNull": false,
+      "position": 15,
+      "table": "stripe_info",
+      "type": "boolean"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "bandwidth_exceeded",
+      "notNull": false,
+      "position": 16,
+      "table": "stripe_info",
+      "type": "boolean"
+    },
+    {
+      "default": "nextval('stripe_info_id_seq'::regclass)",
+      "generated": "",
+      "identity": "",
+      "name": "id",
+      "notNull": true,
+      "position": 17,
+      "table": "stripe_info",
+      "type": "integer"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "plan_calculated_at",
+      "notNull": false,
+      "position": 18,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": "false",
+      "generated": "",
+      "identity": "",
+      "name": "build_time_exceeded",
+      "notNull": false,
+      "position": 19,
+      "table": "stripe_info",
+      "type": "boolean"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "upgraded_at",
+      "notNull": false,
+      "position": 20,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "paid_at",
+      "notNull": false,
+      "position": 21,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "customer_country",
+      "notNull": false,
+      "position": 22,
+      "table": "stripe_info",
+      "type": "character varying(2)"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "last_stripe_event_at",
+      "notNull": false,
+      "position": 23,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "past_due_at",
+      "notNull": false,
+      "position": 24,
+      "table": "stripe_info",
+      "type": "timestamp with time zone"
+    },
+    {
+      "default": null,
+      "generated": "",
+      "identity": "",
+      "name": "churn_reason",
+      "notNull": false,
+      "position": 25,
+      "table": "stripe_info",
+      "type": "text"
+    }
+  ],
+  "constraints": [
+    {
+      "definition": "UNIQUE (name, app_id)",
+      "name": "app_versions_name_app_id_key",
+      "table": "app_versions",
+      "type": "u"
+    },
+    {
+      "definition": "PRIMARY KEY (id)",
+      "name": "app_versions_pkey",
+      "table": "app_versions",
+      "type": "p"
+    },
+    {
+      "definition": "CHECK (build_timeout_seconds >= 300 AND build_timeout_seconds <= 21600)",
+      "name": "apps_build_timeout_seconds_check",
+      "table": "apps",
+      "type": "c"
+    },
+    {
+      "definition": "UNIQUE (id)",
+      "name": "apps_id_unique",
+      "table": "apps",
+      "type": "u"
+    },
+    {
+      "definition": "PRIMARY KEY (app_id)",
+      "name": "apps_pkey",
+      "table": "apps",
+      "type": "p"
+    },
+    {
+      "definition": "UNIQUE (app_id, device_id)",
+      "name": "channel_devices_app_id_device_id_key",
+      "table": "channel_devices",
+      "type": "u"
+    },
+    {
+      "definition": "PRIMARY KEY (id)",
+      "name": "channel_pkey",
+      "table": "channels",
+      "type": "p"
+    },
+    {
+      "definition": "CHECK (auto_pause_action = ANY (ARRAY['pause'::text, 'rollback'::text, 'notify'::text]))",
+      "name": "channels_auto_pause_action_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (auto_pause_confidence > 0::numeric AND auto_pause_confidence < 1::numeric)",
+      "name": "channels_auto_pause_confidence_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (auto_pause_cooldown_minutes >= 0 AND auto_pause_cooldown_minutes <= 10080)",
+      "name": "channels_auto_pause_cooldown_minutes_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (auto_pause_failure_rate_bps IS NULL OR auto_pause_failure_rate_bps >= 0 AND auto_pause_failure_rate_bps <= 10000)",
+      "name": "channels_auto_pause_failure_rate_bps_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (auto_pause_min_attempts IS NULL OR auto_pause_min_attempts >= 0)",
+      "name": "channels_auto_pause_min_attempts_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (auto_pause_min_failures IS NULL OR auto_pause_min_failures >= 0)",
+      "name": "channels_auto_pause_min_failures_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (auto_pause_window_minutes > 0 AND auto_pause_window_minutes <= 10080)",
+      "name": "channels_auto_pause_window_minutes_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "UNIQUE (rbac_id)",
+      "name": "channels_rbac_id_key",
+      "table": "channels",
+      "type": "u"
+    },
+    {
+      "definition": "CHECK (rollout_cache_ttl_seconds >= 60 AND rollout_cache_ttl_seconds <= 31536000)",
+      "name": "channels_rollout_cache_ttl_seconds_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (rollout_percentage_bps >= 0 AND rollout_percentage_bps <= 10000)",
+      "name": "channels_rollout_percentage_bps_check",
+      "table": "channels",
+      "type": "c"
+    },
+    {
+      "definition": "UNIQUE (name, app_id)",
+      "name": "unique_name_app_id",
+      "table": "channels",
+      "type": "u"
+    },
+    {
+      "definition": "PRIMARY KEY (id)",
+      "name": "manifest_pkey",
+      "table": "manifest",
+      "type": "p"
+    },
+    {
+      "definition": "PRIMARY KEY (owner_org, event, uniq_id)",
+      "name": "notifications_pkey",
+      "table": "notifications",
+      "type": "p"
+    },
+    {
+      "definition": "PRIMARY KEY (id)",
+      "name": "onboarding_demo_data_pkey",
+      "table": "onboarding_demo_data",
+      "type": "p"
+    },
+    {
+      "definition": "CHECK (relation_name = ANY (ARRAY['app_versions'::text, 'app_versions_meta'::text, 'manifest'::text, 'channels'::text, 'channel_devices'::text, 'deploy_history'::text, 'devices'::text, 'build_requests'::text]))",
+      "name": "onboarding_demo_data_relation_name_check",
+      "table": "onboarding_demo_data",
+      "type": "c"
+    },
+    {
+      "definition": "PRIMARY KEY (id)",
+      "name": "org_users_pkey",
+      "table": "org_users",
+      "type": "p"
+    },
+    {
+      "definition": "CHECK (max_apikey_expiration_days IS NULL OR max_apikey_expiration_days >= 1 AND max_apikey_expiration_days <= 365)",
+      "name": "orgs_max_apikey_expiration_days_valid",
+      "table": "orgs",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (jsonb_typeof(onboarding) = 'object'::text AND (NOT onboarding ? 'intent'::text OR ((onboarding ->> 'intent'::text) = ANY (ARRAY['unknown'::text, 'ota'::text, 'builder'::text, 'both'::text, 'exploring'::text]))))",
+      "name": "orgs_onboarding_valid",
+      "table": "orgs",
+      "type": "c"
+    },
+    {
+      "definition": "CHECK (password_policy_config IS NULL OR jsonb_typeof(password_policy_config) = 'object'::text AND (NOT password_policy_config ? 'min_length'::text OR jsonb_typeof(password_policy_config -> 'min_length'::text) = 'number'::text AND ((password_policy_config ->> 'min_length'::text)::numeric) = trunc((password_policy_config ->> 'min_length'::text)::numeric) AND ((password_policy_config ->> 'min_length'::text)::numeric) >= 6::numeric AND ((password_policy_config ->> 'min_length'::text)::numeric) <= 72::numeric))",
+      "name": "orgs_password_policy_config_min_length_check",
+      "table": "orgs",
+      "type": "c"
+    },
+    {
+      "definition": "PRIMARY KEY (id)",
+      "name": "orgs_pkey",
+      "table": "orgs",
+      "type": "p"
+    },
+    {
+      "definition": "CHECK (required_encryption_key IS NULL OR (length(required_encryption_key::text) = ANY (ARRAY[20, 21])))",
+      "name": "orgs_required_encryption_key_valid",
+      "table": "orgs",
+      "type": "c"
+    },
+    {
+      "definition": "UNIQUE (customer_id)",
+      "name": "unique customer_id on orgs",
+      "table": "orgs",
+      "type": "u"
+    },
+    {
+      "definition": "UNIQUE (name, created_by)",
+      "name": "unique_name_created_by",
+      "table": "orgs",
+      "type": "u"
+    },
+    {
+      "definition": "PRIMARY KEY (customer_id)",
+      "name": "stripe_info_pkey",
+      "table": "stripe_info",
+      "type": "p"
+    }
+  ],
+  "functions": [
+    {
+      "arguments": "",
+      "definition": "CREATE OR REPLACE FUNCTION public.one_month_ahead()\n RETURNS timestamp without time zone\n LANGUAGE plpgsql\n SET search_path TO ''\nAS $function$\nBEGIN\n   RETURN NOW() + INTERVAL '1 month';\nEND;\n$function$\n",
+      "name": "one_month_ahead"
+    }
+  ],
+  "indexes": [
+    {
+      "definition": "CREATE INDEX app_versions_cli_version_idx ON public.app_versions USING btree (cli_version)",
+      "name": "app_versions_cli_version_idx",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX app_versions_name_app_id_key ON public.app_versions USING btree (name, app_id)",
+      "name": "app_versions_name_app_id_key",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX app_versions_pkey ON public.app_versions USING btree (id)",
+      "name": "app_versions_pkey",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX app_versions_r2_path_idx ON public.app_versions USING btree (r2_path)",
+      "name": "app_versions_r2_path_idx",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX finx_app_versions_owner_org ON public.app_versions USING btree (owner_org)",
+      "name": "finx_app_versions_owner_org",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_id_app_versions ON public.app_versions USING btree (app_id)",
+      "name": "idx_app_id_app_versions",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_id_name_app_versions ON public.app_versions USING btree (app_id, name)",
+      "name": "idx_app_id_name_app_versions",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_created_at ON public.app_versions USING btree (created_at)",
+      "name": "idx_app_versions_created_at",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_created_at_app_id ON public.app_versions USING btree (created_at, app_id)",
+      "name": "idx_app_versions_created_at_app_id",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_deleted ON public.app_versions USING btree (deleted)",
+      "name": "idx_app_versions_deleted",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_deleted_at ON public.app_versions USING btree (deleted_at) WHERE (deleted_at IS NOT NULL)",
+      "name": "idx_app_versions_deleted_at",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_id ON public.app_versions USING btree (id)",
+      "name": "idx_app_versions_id",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_key_id ON public.app_versions USING btree (key_id) WHERE (key_id IS NOT NULL)",
+      "name": "idx_app_versions_key_id",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_name ON public.app_versions USING btree (name)",
+      "name": "idx_app_versions_name",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_owner_org_not_deleted ON public.app_versions USING btree (owner_org) WHERE (deleted = false)",
+      "name": "idx_app_versions_owner_org_not_deleted",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_versions_retention_cleanup ON public.app_versions USING btree (deleted, created_at, app_id) WHERE (deleted = false)",
+      "name": "idx_app_versions_retention_cleanup",
+      "table": "app_versions"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX apps_id_unique ON public.apps USING btree (id)",
+      "name": "apps_id_unique",
+      "table": "apps"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX apps_pkey ON public.apps USING btree (app_id)",
+      "name": "apps_pkey",
+      "table": "apps"
+    },
+    {
+      "definition": "CREATE INDEX finx_apps_owner_org ON public.apps USING btree (owner_org)",
+      "name": "finx_apps_owner_org",
+      "table": "apps"
+    },
+    {
+      "definition": "CREATE INDEX finx_apps_user_id ON public.apps USING btree (user_id)",
+      "name": "finx_apps_user_id",
+      "table": "apps"
+    },
+    {
+      "definition": "CREATE INDEX idx_apps_default_upload_channel ON public.apps USING btree (default_upload_channel)",
+      "name": "idx_apps_default_upload_channel",
+      "table": "apps"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX idx_apps_owner_org_app_id ON public.apps USING btree (owner_org, app_id)",
+      "name": "idx_apps_owner_org_app_id",
+      "table": "apps"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX channel_devices_app_id_device_id_key ON public.channel_devices USING btree (app_id, device_id)",
+      "name": "channel_devices_app_id_device_id_key",
+      "table": "channel_devices"
+    },
+    {
+      "definition": "CREATE INDEX channel_devices_device_id_idx ON public.channel_devices USING btree (device_id)",
+      "name": "channel_devices_device_id_idx",
+      "table": "channel_devices"
+    },
+    {
+      "definition": "CREATE INDEX finx_channel_devices_app_id ON public.channel_devices USING btree (app_id)",
+      "name": "finx_channel_devices_app_id",
+      "table": "channel_devices"
+    },
+    {
+      "definition": "CREATE INDEX finx_channel_devices_channel_id ON public.channel_devices USING btree (channel_id)",
+      "name": "finx_channel_devices_channel_id",
+      "table": "channel_devices"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX idx_app_id_device_id_channel_id_channel_devices ON public.channel_devices USING btree (app_id, device_id, channel_id)",
+      "name": "idx_app_id_device_id_channel_id_channel_devices",
+      "table": "channel_devices"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX channel_pkey ON public.channels USING btree (id)",
+      "name": "channel_pkey",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX channels_one_public_android_per_app_key ON public.channels USING btree (app_id) WHERE ((public = true) AND (android = true))",
+      "name": "channels_one_public_android_per_app_key",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX channels_one_public_electron_per_app_key ON public.channels USING btree (app_id) WHERE ((public = true) AND (electron = true))",
+      "name": "channels_one_public_electron_per_app_key",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX channels_one_public_ios_per_app_key ON public.channels USING btree (app_id) WHERE ((public = true) AND (ios = true))",
+      "name": "channels_one_public_ios_per_app_key",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX channels_rbac_id_key ON public.channels USING btree (rbac_id)",
+      "name": "channels_rbac_id_key",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX finx_channels_app_id ON public.channels USING btree (app_id)",
+      "name": "finx_channels_app_id",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX finx_channels_owner_org ON public.channels USING btree (owner_org)",
+      "name": "finx_channels_owner_org",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX finx_channels_version ON public.channels USING btree (version)",
+      "name": "finx_channels_version",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_app_id_public_channel ON public.channels USING btree (app_id, public)",
+      "name": "idx_app_id_public_channel",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_channels_app_id_name ON public.channels USING btree (app_id, name)",
+      "name": "idx_channels_app_id_name",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_channels_app_id_version ON public.channels USING btree (app_id, version)",
+      "name": "idx_channels_app_id_version",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_channels_public_app_id_android ON public.channels USING btree (public, app_id, android)",
+      "name": "idx_channels_public_app_id_android",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_channels_public_app_id_ios ON public.channels USING btree (public, app_id, ios)",
+      "name": "idx_channels_public_app_id_ios",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_channels_rollout_targets ON public.channels USING btree (app_id, rollout_version) WHERE (rollout_version IS NOT NULL)",
+      "name": "idx_channels_rollout_targets",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_channels_rollout_version ON public.channels USING btree (rollout_version) WHERE (rollout_version IS NOT NULL)",
+      "name": "idx_channels_rollout_version",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX unique_name_app_id ON public.channels USING btree (name, app_id)",
+      "name": "unique_name_app_id",
+      "table": "channels"
+    },
+    {
+      "definition": "CREATE INDEX idx_manifest_app_version_id ON public.manifest USING btree (app_version_id)",
+      "name": "idx_manifest_app_version_id",
+      "table": "manifest"
+    },
+    {
+      "definition": "CREATE INDEX idx_manifest_file_hash ON public.manifest USING btree (file_hash)",
+      "name": "idx_manifest_file_hash",
+      "table": "manifest"
+    },
+    {
+      "definition": "CREATE INDEX idx_manifest_file_name ON public.manifest USING btree (file_name)",
+      "name": "idx_manifest_file_name",
+      "table": "manifest"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX manifest_pkey ON public.manifest USING btree (id)",
+      "name": "manifest_pkey",
+      "table": "manifest"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX notifications_pkey ON public.notifications USING btree (owner_org, event, uniq_id)",
+      "name": "notifications_pkey",
+      "table": "notifications"
+    },
+    {
+      "definition": "CREATE INDEX notifications_uniq_id_idx ON public.notifications USING btree (uniq_id)",
+      "name": "notifications_uniq_id_idx",
+      "table": "notifications"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX onboarding_demo_data_app_relation_row_key_idx ON public.onboarding_demo_data USING btree (app_id, relation_name, row_key)",
+      "name": "onboarding_demo_data_app_relation_row_key_idx",
+      "table": "onboarding_demo_data"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX onboarding_demo_data_pkey ON public.onboarding_demo_data USING btree (id)",
+      "name": "onboarding_demo_data_pkey",
+      "table": "onboarding_demo_data"
+    },
+    {
+      "definition": "CREATE INDEX onboarding_demo_data_seed_id_idx ON public.onboarding_demo_data USING btree (seed_id)",
+      "name": "onboarding_demo_data_seed_id_idx",
+      "table": "onboarding_demo_data"
+    },
+    {
+      "definition": "CREATE INDEX finx_org_users_channel_id ON public.org_users USING btree (channel_id)",
+      "name": "finx_org_users_channel_id",
+      "table": "org_users"
+    },
+    {
+      "definition": "CREATE INDEX finx_org_users_org_id ON public.org_users USING btree (org_id)",
+      "name": "finx_org_users_org_id",
+      "table": "org_users"
+    },
+    {
+      "definition": "CREATE INDEX finx_org_users_user_id ON public.org_users USING btree (user_id)",
+      "name": "finx_org_users_user_id",
+      "table": "org_users"
+    },
+    {
+      "definition": "CREATE INDEX org_users_app_id_idx ON public.org_users USING btree (app_id)",
+      "name": "org_users_app_id_idx",
+      "table": "org_users"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX org_users_pkey ON public.org_users USING btree (id)",
+      "name": "org_users_pkey",
+      "table": "org_users"
+    },
+    {
+      "definition": "CREATE INDEX finx_orgs_created_by ON public.orgs USING btree (created_by)",
+      "name": "finx_orgs_created_by",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE INDEX idx_orgs_customer_id ON public.orgs USING btree (customer_id)",
+      "name": "idx_orgs_customer_id",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE INDEX idx_orgs_email_preferences ON public.orgs USING gin (email_preferences)",
+      "name": "idx_orgs_email_preferences",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE INDEX orgs_enforce_hashed_api_keys_true_idx ON public.orgs USING btree (id) WHERE (enforce_hashed_api_keys = true)",
+      "name": "orgs_enforce_hashed_api_keys_true_idx",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX orgs_pkey ON public.orgs USING btree (id)",
+      "name": "orgs_pkey",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE INDEX orgs_updated_at_id_idx ON public.orgs USING btree (updated_at DESC) INCLUDE (id) WHERE (customer_id IS NOT NULL)",
+      "name": "orgs_updated_at_id_idx",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX \"unique customer_id on orgs\" ON public.orgs USING btree (customer_id)",
+      "name": "unique customer_id on orgs",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX unique_name_created_by ON public.orgs USING btree (name, created_by)",
+      "name": "unique_name_created_by",
+      "table": "orgs"
+    },
+    {
+      "definition": "CREATE INDEX finx_orgs_stripe_info ON public.stripe_info USING btree (product_id)",
+      "name": "finx_orgs_stripe_info",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE INDEX idx_stripe_info_customer_covering ON public.stripe_info USING btree (customer_id) INCLUDE (product_id, subscription_anchor_start, subscription_anchor_end)",
+      "name": "idx_stripe_info_customer_covering",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE INDEX idx_stripe_info_past_due_at ON public.stripe_info USING btree (past_due_at) WHERE (past_due_at IS NOT NULL)",
+      "name": "idx_stripe_info_past_due_at",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE INDEX idx_stripe_info_status_plan ON public.stripe_info USING btree (status, is_good_plan) WHERE ((status = 'succeeded'::stripe_status) AND (is_good_plan = true))",
+      "name": "idx_stripe_info_status_plan",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE INDEX idx_stripe_info_trial ON public.stripe_info USING btree (trial_at) WHERE (trial_at IS NOT NULL)",
+      "name": "idx_stripe_info_trial",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE INDEX si_customer_status_trial_idx ON public.stripe_info USING btree (customer_id, status, trial_at) INCLUDE (mau_exceeded, storage_exceeded, bandwidth_exceeded)",
+      "name": "si_customer_status_trial_idx",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE INDEX stripe_info_paid_at_idx ON public.stripe_info USING btree (paid_at) WHERE (paid_at IS NOT NULL)",
+      "name": "stripe_info_paid_at_idx",
+      "table": "stripe_info"
+    },
+    {
+      "definition": "CREATE UNIQUE INDEX stripe_info_pkey ON public.stripe_info USING btree (customer_id)",
+      "name": "stripe_info_pkey",
+      "table": "stripe_info"
+    }
+  ],
+  "sequences": [
+    {
+      "cache": "1",
+      "cycle": false,
+      "increment": "1",
+      "max": "9223372036854775807",
+      "min": "1",
+      "name": "app_versions_id_seq",
+      "ownedColumn": null,
+      "ownedTable": null,
+      "start": "1",
+      "type": "bigint"
+    },
+    {
+      "cache": "1",
+      "cycle": false,
+      "increment": "1",
+      "max": "9223372036854775807",
+      "min": "1",
+      "name": "channel_devices_id_seq",
+      "ownedColumn": null,
+      "ownedTable": null,
+      "start": "1",
+      "type": "bigint"
+    },
+    {
+      "cache": "1",
+      "cycle": false,
+      "increment": "1",
+      "max": "9223372036854775807",
+      "min": "1",
+      "name": "channel_id_seq",
+      "ownedColumn": null,
+      "ownedTable": null,
+      "start": "1",
+      "type": "bigint"
+    },
+    {
+      "cache": "1",
+      "cycle": false,
+      "increment": "1",
+      "max": "2147483647",
+      "min": "1",
+      "name": "manifest_id_seq",
+      "ownedColumn": "id",
+      "ownedTable": "manifest",
+      "start": "1",
+      "type": "integer"
+    },
+    {
+      "cache": "1",
+      "cycle": false,
+      "increment": "1",
+      "max": "9223372036854775807",
+      "min": "1",
+      "name": "org_users_id_seq",
+      "ownedColumn": null,
+      "ownedTable": null,
+      "start": "1",
+      "type": "bigint"
+    },
+    {
+      "cache": "1",
+      "cycle": false,
+      "increment": "1",
+      "max": "2147483647",
+      "min": "1",
+      "name": "stripe_info_id_seq",
+      "ownedColumn": "id",
+      "ownedTable": "stripe_info",
+      "start": "1",
+      "type": "integer"
+    }
+  ],
+  "tables": [
+    {
+      "kind": "r",
+      "name": "app_versions",
+      "reloptions": [
+        "autovacuum_analyze_scale_factor=0.02",
+        "autovacuum_vacuum_scale_factor=0.05"
+      ]
+    },
+    {
+      "kind": "r",
+      "name": "apps",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "channel_devices",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "channels",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "manifest",
+      "reloptions": [
+        "autovacuum_analyze_scale_factor=0.02",
+        "autovacuum_vacuum_scale_factor=0.05"
+      ]
+    },
+    {
+      "kind": "r",
+      "name": "notifications",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "onboarding_demo_data",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "org_users",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "orgs",
+      "reloptions": []
+    },
+    {
+      "kind": "r",
+      "name": "stripe_info",
+      "reloptions": []
+    }
+  ],
+  "types": [
+    {
+      "definition": [
+        "major",
+        "minor",
+        "patch",
+        "version_number",
+        "none"
+      ],
+      "kind": "e",
+      "name": "disable_update"
+    },
+    {
+      "definition": [
+        {
+          "name": "file_name",
+          "position": 1,
+          "type": "character varying"
+        },
+        {
+          "name": "s3_path",
+          "position": 2,
+          "type": "character varying"
+        },
+        {
+          "name": "file_hash",
+          "position": 3,
+          "type": "character varying"
+        }
+      ],
+      "kind": "c",
+      "name": "manifest_entry"
+    },
+    {
+      "definition": [
+        "created",
+        "succeeded",
+        "updated",
+        "failed",
+        "deleted",
+        "canceled"
+      ],
+      "kind": "e",
+      "name": "stripe_status"
+    },
+    {
+      "definition": [
+        "invite_read",
+        "invite_upload",
+        "invite_write",
+        "invite_admin",
+        "invite_super_admin",
+        "read",
+        "upload",
+        "write",
+        "admin",
+        "super_admin"
+      ],
+      "kind": "e",
+      "name": "user_min_right"
+    }
+  ],
+  "version": 1
+}

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+EXPECTED_SCHEMA_CATALOG='read_replicate/schema_replicate.catalog.json'
+ACTUAL_SCHEMA_CATALOG="$(mktemp)"
+WRANGLER_LOG="$(mktemp)"
+PORT="${READ_REPLICA_SCHEMA_CHECK_PORT:-8799}"
+WORKER_PID=''
+
+cleanup() {
+  if [[ -n "$WORKER_PID" ]] && kill -0 "$WORKER_PID" 2>/dev/null; then
+    kill "$WORKER_PID" 2>/dev/null || true
+    wait "$WORKER_PID" 2>/dev/null || true
+  fi
+  rm -f "$ACTUAL_SCHEMA_CATALOG" "$WRANGLER_LOG"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$EXPECTED_SCHEMA_CATALOG" ]]; then
+  echo "::error title=Missing read-replica schema catalog::${EXPECTED_SCHEMA_CATALOG} does not exist."
+  exit 1
+fi
+
+bunx wrangler dev \
+  --remote \
+  --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc \
+  --env=prod \
+  --ip 127.0.0.1 \
+  --port "$PORT" \
+  --log-level warn \
+  --show-interactive-dev-session=false \
+  > "$WRANGLER_LOG" 2>&1 &
+WORKER_PID=$!
+
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
+    break
+  fi
+
+  if ! kill -0 "$WORKER_PID" 2>/dev/null; then
+    echo "::error title=Read-replica schema checker failed to start::wrangler dev exited before the health check passed."
+    cat "$WRANGLER_LOG"
+    exit 1
+  fi
+
+  sleep 2
+done
+
+if ! curl -fsS "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
+  echo "::error title=Read-replica schema checker did not become ready::Timed out waiting for the Hyperdrive checker worker."
+  cat "$WRANGLER_LOG"
+  exit 1
+fi
+
+HTTP_STATUS="$(curl -sS -w '%{http_code}' -o "$ACTUAL_SCHEMA_CATALOG" "http://127.0.0.1:${PORT}/catalog" || true)"
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "::error title=Failed to fetch read-replica schema catalog::Worker /catalog returned HTTP ${HTTP_STATUS}."
+  cat "$ACTUAL_SCHEMA_CATALOG"
+  cat "$WRANGLER_LOG"
+  exit 1
+fi
+
+bun scripts/compare-read-replica-schema-catalog.ts "$EXPECTED_SCHEMA_CATALOG" "$ACTUAL_SCHEMA_CATALOG"

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -10,6 +10,7 @@ ACTUAL_SCHEMA_CATALOG="$(mktemp)"
 WRANGLER_LOG="$(mktemp)"
 PORT="${READ_REPLICA_SCHEMA_CHECK_PORT:-8799}"
 WORKER_PID=''
+SCHEMA_CHECK_TOKEN="$(bun --silent -e 'const bytes = crypto.getRandomValues(new Uint8Array(32)); console.log(Buffer.from(bytes).toString("hex"))')"
 
 cleanup() {
   if [[ -n "$WORKER_PID" ]] && kill -0 "$WORKER_PID" 2>/dev/null; then
@@ -33,11 +34,12 @@ bunx wrangler dev \
   --port "$PORT" \
   --log-level warn \
   --show-interactive-dev-session=false \
+  --var "READ_REPLICA_SCHEMA_CHECK_TOKEN:${SCHEMA_CHECK_TOKEN}" \
   > "$WRANGLER_LOG" 2>&1 &
 WORKER_PID=$!
 
 for _ in $(seq 1 60); do
-  if curl -fsS "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
+  if curl -fsS --connect-timeout 5 --max-time 5 "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
     break
   fi
 
@@ -50,13 +52,13 @@ for _ in $(seq 1 60); do
   sleep 2
 done
 
-if ! curl -fsS "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
+if ! curl -fsS --connect-timeout 5 --max-time 5 "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
   echo "::error title=Read-replica schema checker did not become ready::Timed out waiting for the Hyperdrive checker worker."
   cat "$WRANGLER_LOG"
   exit 1
 fi
 
-HTTP_STATUS="$(curl -sS -w '%{http_code}' -o "$ACTUAL_SCHEMA_CATALOG" "http://127.0.0.1:${PORT}/catalog" || true)"
+HTTP_STATUS="$(curl -sS --connect-timeout 5 --max-time 30 --header "authorization: Bearer ${SCHEMA_CHECK_TOKEN}" -w '%{http_code}' -o "$ACTUAL_SCHEMA_CATALOG" "http://127.0.0.1:${PORT}/catalog" || true)"
 if [[ "$HTTP_STATUS" != "200" ]]; then
   echo "::error title=Failed to fetch read-replica schema catalog::Worker /catalog returned HTTP ${HTTP_STATUS}."
   cat "$ACTUAL_SCHEMA_CATALOG"

--- a/scripts/check-read-replica-schema.sh
+++ b/scripts/check-read-replica-schema.sh
@@ -2,24 +2,27 @@
 
 set -euo pipefail
 
-SCHEMA_FILE='read_replicate/schema_replicate.sql'
+SCHEMA_FILES=(
+  'read_replicate/schema_replicate.sql'
+  'read_replicate/schema_replicate.catalog.json'
+)
 
-echo "Generating ${SCHEMA_FILE} from the current database schema..."
+echo "Generating read-replica schema snapshots from the current database schema..."
 bash read_replicate/replicate_prepare.sh
 
-if git diff --quiet -- "${SCHEMA_FILE}"; then
-  echo "Read-replica schema is up to date."
+if git diff --quiet -- "${SCHEMA_FILES[@]}"; then
+  echo "Read-replica schema snapshots are up to date."
   exit 0
 fi
 
-echo "::error title=Read-replica schema is out of date::${SCHEMA_FILE} changed after running bun run readreplicate:prepare."
+echo "::error title=Read-replica schema is out of date::Read-replica snapshots changed after running bun run readreplicate:prepare."
 echo ''
 echo "The PR changes the schema replicated to Google read replicas."
 echo "Before merge:"
 echo "  1. Run: bun run readreplicate:prepare"
 echo "  2. Apply the matching migration to the Google read replica."
-echo "  3. Commit the updated ${SCHEMA_FILE}."
+echo "  3. Commit the updated read_replicate/schema_replicate.sql and read_replicate/schema_replicate.catalog.json."
 echo ''
 echo "Diff:"
-git --no-pager diff -- "${SCHEMA_FILE}"
+git --no-pager diff -- "${SCHEMA_FILES[@]}"
 exit 1

--- a/scripts/compare-read-replica-schema-catalog.ts
+++ b/scripts/compare-read-replica-schema-catalog.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { stableStringify } from '../read_replicate/schema_catalog.ts'
+
+const [expectedPath, actualPath] = process.argv.slice(2)
+
+async function main() {
+  if (!expectedPath || !actualPath) {
+    console.error('Usage: bun scripts/compare-read-replica-schema-catalog.ts <expected-json> <actual-json>')
+    process.exitCode = 1
+    return
+  }
+
+  const tempDir = await mkdtemp(join(tmpdir(), 'read-replica-schema-'))
+
+  try {
+    const expected = JSON.parse(await readFile(expectedPath, 'utf8'))
+    const actual = JSON.parse(await readFile(actualPath, 'utf8'))
+    const expectedText = `${stableStringify(expected)}\n`
+    const actualText = `${stableStringify(actual)}\n`
+
+    if (expectedText === actualText) {
+      console.log('Read-replica schema catalog matches the committed snapshot.')
+      return
+    }
+
+    const normalizedExpectedPath = join(tempDir, 'expected.json')
+    const normalizedActualPath = join(tempDir, 'actual.json')
+    await writeFile(normalizedExpectedPath, expectedText)
+    await writeFile(normalizedActualPath, actualText)
+
+    console.error('::error title=Read-replica schema is out of date::Hyperdrive read replica does not match read_replicate/schema_replicate.catalog.json.')
+    console.error('')
+    console.error('The production source schema was updated, but the read replica visible through Hyperdrive still differs from the committed replica schema catalog.')
+    console.error('Apply the matching read-replica DDL or maintenance flow, then retry the release.')
+    console.error('')
+    console.error('Diff:')
+
+    const diff = spawnSync('diff', ['-u', normalizedExpectedPath, normalizedActualPath], {
+      encoding: 'utf8',
+    })
+    if (diff.stdout)
+      console.error(diff.stdout)
+    if (diff.stderr)
+      console.error(diff.stderr)
+
+    process.exitCode = 1
+  }
+  finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+await main()

--- a/scripts/write-read-replica-schema-catalog.ts
+++ b/scripts/write-read-replica-schema-catalog.ts
@@ -1,0 +1,34 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { Pool } from 'pg'
+import { readReplicaSchemaCatalog, stableStringify } from '../read_replicate/schema_catalog.ts'
+
+const firstArg = process.argv[2]
+const secondArg = process.argv[3]
+const defaultOutputPath = 'read_replicate/schema_replicate.catalog.json'
+const firstArgIsPostgresUrl = Boolean(firstArg?.startsWith('postgres://') || firstArg?.startsWith('postgresql://'))
+const connectionString = firstArgIsPostgresUrl ? firstArg : process.env.MAIN_SUPABASE_DB_URL
+const outputPath = firstArgIsPostgresUrl
+  ? (secondArg || defaultOutputPath)
+  : (firstArg || defaultOutputPath)
+if (!connectionString) {
+  console.error('Usage: MAIN_SUPABASE_DB_URL=<postgres-url> bun scripts/write-read-replica-schema-catalog.ts [output-path]')
+  console.error('   or: bun scripts/write-read-replica-schema-catalog.ts <postgres-url> [output-path]')
+  process.exit(1)
+}
+
+const pool = new Pool({
+  connectionString,
+  max: 1,
+  connectionTimeoutMillis: 10000,
+})
+
+try {
+  const catalog = await readReplicaSchemaCatalog(pool)
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${stableStringify(catalog)}\n`)
+  console.log(`Wrote read-replica schema catalog to ${outputPath}`)
+}
+finally {
+  await pool.end()
+}


### PR DESCRIPTION
## Summary

- Add a Hyperdrive-backed read-replica schema check Worker and release script that compares the live subscriber catalog with the committed `read_replicate/schema_replicate.catalog.json` snapshot.
- Run the production release guard before `supabase db push`, so a stale read replica blocks the release before production schema changes are applied.
- Extend read-replica snapshot generation so the SQL snapshot and JSON catalog use the same allowlist source, and keep the snapshot check covered in CI.
- Document the required Worker binding, token secret, and local verification flow in `read_replicate/README.md`.

## Test plan

- `bash -n scripts/check-read-replica-hyperdrive-schema.sh scripts/check-read-replica-schema.sh read_replicate/replicate_prepare.sh read_replicate/common.sh`
- `bun scripts/compare-read-replica-schema-catalog.ts read_replicate/schema_replicate.catalog.json read_replicate/schema_replicate.catalog.json`
- `bun --silent -e 'import worker from "./cloudflare_workers/read-replica-schema-check/index.ts"; const missingToken = await worker.fetch(new Request("http://local/catalog"), {}); console.log(missingToken.status, await missingToken.text()); const missingBinding = await worker.fetch(new Request("http://local/catalog", { headers: { authorization: "Bearer test" } }), { READ_REPLICA_SCHEMA_CHECK_TOKEN: "test" }); console.log(missingBinding.status, await missingBinding.text()); const unauthorized = await worker.fetch(new Request("http://local/catalog"), { READ_REPLICA_SCHEMA_CHECK_TOKEN: "test" }); console.log(unauthorized.status, await unauthorized.text());'`
- `bun typecheck`
- `bun lint:backend`
- `bun lint`
- `MAIN_SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:61302/postgres bun run readreplicate:check-schema`
- `bunx wrangler deploy --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc --env=prod --dry-run --outdir /tmp/capgo-read-replica-schema-check-dry-run`
- GitHub CI is passing on `7e7666f3b4944d7ff7ca258f308b54196acbc1f6`; CodeRabbit approved; unresolved review threads: 0.

## Screenshots

Not applicable. This is backend/CI release-guard work with no UI change.

## Checklist

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests
