### PR TITLE
feat(read-replica): auto-sync additive schema drift

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -96,7 +96,7 @@ jobs:
         run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_TOKEN }}
-      - name: Check read-replica schema through Hyperdrive
+      - name: Sync and check read-replica schema through Hyperdrive
         if: env.SUPA_ENV == 'PROD'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -9,6 +9,7 @@ interface Env {
 }
 
 const textEncoder = new TextEncoder()
+const SCHEMA_SYNC_STATEMENT_TIMEOUT_MS = 550_000
 
 type SchemaRoute = 'catalog' | 'sync-additive'
 
@@ -93,6 +94,7 @@ async function handleAdditiveSync(request: Request, pool: Pool): Promise<Respons
     return Response.json({ error: 'invalid_schema_catalog_json' }, { status: 400 })
   }
 
+  await pool.query(`SET statement_timeout = ${SCHEMA_SYNC_STATEMENT_TIMEOUT_MS}`)
   const result = await applyReadReplicaAdditiveSchemaSync(pool, expectedCatalog)
   return Response.json(result)
 }

--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -10,6 +10,7 @@ interface Env {
 
 const textEncoder = new TextEncoder()
 const SCHEMA_SYNC_STATEMENT_TIMEOUT_MS = 550_000
+const SCHEMA_SYNC_MAX_DURATION_HEADER = 'x-schema-sync-max-duration-ms'
 
 type SchemaRoute = 'catalog' | 'sync-additive'
 
@@ -94,9 +95,27 @@ async function handleAdditiveSync(request: Request, pool: Pool): Promise<Respons
     return Response.json({ error: 'invalid_schema_catalog_json' }, { status: 400 })
   }
 
-  await pool.query(`SET statement_timeout = ${SCHEMA_SYNC_STATEMENT_TIMEOUT_MS}`)
-  const result = await applyReadReplicaAdditiveSchemaSync(pool, expectedCatalog)
+  const maxDurationMs = schemaSyncMaxDurationMs(request)
+  if (maxDurationMs instanceof Response)
+    return maxDurationMs
+
+  const result = await applyReadReplicaAdditiveSchemaSync(pool, expectedCatalog, {
+    maxDurationMs,
+    statementTimeoutMs: SCHEMA_SYNC_STATEMENT_TIMEOUT_MS,
+  })
   return Response.json(result)
+}
+
+function schemaSyncMaxDurationMs(request: Request): number | Response {
+  const value = request.headers.get(SCHEMA_SYNC_MAX_DURATION_HEADER)
+  if (!value)
+    return SCHEMA_SYNC_STATEMENT_TIMEOUT_MS
+
+  const durationMs = Number(value)
+  if (!Number.isSafeInteger(durationMs) || durationMs <= 0)
+    return Response.json({ error: 'invalid_schema_sync_max_duration' }, { status: 400 })
+
+  return durationMs
 }
 
 function hasExpectedAuthorization(request: Request, expectedToken: string): boolean {

--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -10,67 +10,91 @@ interface Env {
 
 const textEncoder = new TextEncoder()
 
+type SchemaRoute = 'catalog' | 'sync-additive'
+
 export default {
   async fetch(request: Request, env: Env) {
     const { pathname } = new URL(request.url)
+    const route = schemaRoute(pathname, request.method)
 
-    if (pathname === '/ok')
+    if (route instanceof Response)
+      return route
+
+    if (route === 'ok')
       return Response.json({ status: 'ok' })
 
-    if (pathname !== '/catalog' && pathname !== '/sync-additive')
-      return Response.json({ error: 'not_found' }, { status: 404 })
-
-    if (pathname === '/catalog' && request.method !== 'GET')
-      return Response.json({ error: 'method_not_allowed' }, { status: 405 })
-
-    if (pathname === '/sync-additive' && request.method !== 'POST')
-      return Response.json({ error: 'method_not_allowed' }, { status: 405 })
-
-    const expectedToken = env.READ_REPLICA_SCHEMA_CHECK_TOKEN
-    if (!expectedToken)
-      return Response.json({ error: 'missing_schema_check_token' }, { status: 500 })
-    if (!hasExpectedAuthorization(request, expectedToken))
-      return Response.json({ error: 'unauthorized' }, { status: 401 })
-    const hyperdrive = env.HYPERDRIVE_CAPGO_READ_EU
-    if (!hyperdrive?.connectionString)
-      return Response.json({ error: 'missing_hyperdrive_binding' }, { status: 500 })
+    const setup = schemaCheckSetup(request, env)
+    if (setup instanceof Response)
+      return setup
 
     const pool = new Pool({
-      connectionString: hyperdrive.connectionString,
+      connectionString: setup.connectionString,
       max: 1,
       connectionTimeoutMillis: 10000,
     })
 
     try {
-      if (pathname === '/sync-additive') {
-        let expectedCatalog: unknown
-        try {
-          expectedCatalog = await request.json()
-        }
-        catch {
-          return Response.json({ error: 'invalid_schema_catalog_json' }, { status: 400 })
-        }
-
-        const result = await applyReadReplicaAdditiveSchemaSync(pool, expectedCatalog)
-        return Response.json(result)
-      }
-
-      const catalog = await readReplicaSchemaCatalog(pool)
-      return new Response(`${stableStringify(catalog)}\n`, {
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-        },
-      })
+      return await handleSchemaRoute(route, request, pool)
     }
     catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      const code = pathname === '/sync-additive' ? 'schema_sync_failed' : 'catalog_query_failed'
+      const code = route === 'sync-additive' ? 'schema_sync_failed' : 'catalog_query_failed'
       return Response.json({ error: code, message }, { status: 500 })
     }
     finally {
       await pool.end()
     }
   },
+}
+
+function schemaRoute(pathname: string, method: string): SchemaRoute | 'ok' | Response {
+  if (pathname === '/ok')
+    return 'ok'
+  if (pathname === '/catalog')
+    return method === 'GET' ? 'catalog' : Response.json({ error: 'method_not_allowed' }, { status: 405 })
+  if (pathname === '/sync-additive')
+    return method === 'POST' ? 'sync-additive' : Response.json({ error: 'method_not_allowed' }, { status: 405 })
+
+  return Response.json({ error: 'not_found' }, { status: 404 })
+}
+
+function schemaCheckSetup(request: Request, env: Env): { connectionString: string } | Response {
+  const expectedToken = env.READ_REPLICA_SCHEMA_CHECK_TOKEN
+  if (!expectedToken)
+    return Response.json({ error: 'missing_schema_check_token' }, { status: 500 })
+  if (!hasExpectedAuthorization(request, expectedToken))
+    return Response.json({ error: 'unauthorized' }, { status: 401 })
+
+  const connectionString = env.HYPERDRIVE_CAPGO_READ_EU?.connectionString
+  if (!connectionString)
+    return Response.json({ error: 'missing_hyperdrive_binding' }, { status: 500 })
+
+  return { connectionString }
+}
+
+async function handleSchemaRoute(route: SchemaRoute, request: Request, pool: Pool): Promise<Response> {
+  if (route === 'sync-additive')
+    return handleAdditiveSync(request, pool)
+
+  const catalog = await readReplicaSchemaCatalog(pool)
+  return new Response(`${stableStringify(catalog)}\n`, {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+  })
+}
+
+async function handleAdditiveSync(request: Request, pool: Pool): Promise<Response> {
+  let expectedCatalog: unknown
+  try {
+    expectedCatalog = await request.json()
+  }
+  catch {
+    return Response.json({ error: 'invalid_schema_catalog_json' }, { status: 400 })
+  }
+
+  const result = await applyReadReplicaAdditiveSchemaSync(pool, expectedCatalog)
+  return Response.json(result)
 }
 
 function hasExpectedAuthorization(request: Request, expectedToken: string): boolean {

--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -1,10 +1,14 @@
 import { Pool } from 'pg'
+import { timingSafeEqual } from 'node:crypto'
+import { applyReadReplicaAdditiveSchemaSync } from '../../read_replicate/schema_additive_sync.ts'
 import { readReplicaSchemaCatalog, stableStringify } from '../../read_replicate/schema_catalog.ts'
 
 interface Env {
   HYPERDRIVE_CAPGO_READ_EU?: Hyperdrive
   READ_REPLICA_SCHEMA_CHECK_TOKEN?: string
 }
+
+const textEncoder = new TextEncoder()
 
 export default {
   async fetch(request: Request, env: Env) {
@@ -13,16 +17,20 @@ export default {
     if (pathname === '/ok')
       return Response.json({ status: 'ok' })
 
-    if (pathname !== '/catalog')
+    if (pathname !== '/catalog' && pathname !== '/sync-additive')
       return Response.json({ error: 'not_found' }, { status: 404 })
+
+    if (pathname === '/catalog' && request.method !== 'GET')
+      return Response.json({ error: 'method_not_allowed' }, { status: 405 })
+
+    if (pathname === '/sync-additive' && request.method !== 'POST')
+      return Response.json({ error: 'method_not_allowed' }, { status: 405 })
 
     const expectedToken = env.READ_REPLICA_SCHEMA_CHECK_TOKEN
     if (!expectedToken)
       return Response.json({ error: 'missing_schema_check_token' }, { status: 500 })
-
-    if (request.headers.get('authorization') !== `Bearer ${expectedToken}`)
+    if (!hasExpectedAuthorization(request, expectedToken))
       return Response.json({ error: 'unauthorized' }, { status: 401 })
-
     const hyperdrive = env.HYPERDRIVE_CAPGO_READ_EU
     if (!hyperdrive?.connectionString)
       return Response.json({ error: 'missing_hyperdrive_binding' }, { status: 500 })
@@ -34,6 +42,19 @@ export default {
     })
 
     try {
+      if (pathname === '/sync-additive') {
+        let expectedCatalog: unknown
+        try {
+          expectedCatalog = await request.json()
+        }
+        catch {
+          return Response.json({ error: 'invalid_schema_catalog_json' }, { status: 400 })
+        }
+
+        const result = await applyReadReplicaAdditiveSchemaSync(pool, expectedCatalog)
+        return Response.json(result)
+      }
+
       const catalog = await readReplicaSchemaCatalog(pool)
       return new Response(`${stableStringify(catalog)}\n`, {
         headers: {
@@ -43,10 +64,20 @@ export default {
     }
     catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      return Response.json({ error: 'catalog_query_failed', message }, { status: 500 })
+      const code = pathname === '/sync-additive' ? 'schema_sync_failed' : 'catalog_query_failed'
+      return Response.json({ error: code, message }, { status: 500 })
     }
     finally {
       await pool.end()
     }
   },
+}
+
+function hasExpectedAuthorization(request: Request, expectedToken: string): boolean {
+  const actual = request.headers.get('authorization') ?? ''
+  const expected = `Bearer ${expectedToken}`
+  const actualBytes = textEncoder.encode(actual)
+  const expectedBytes = textEncoder.encode(expected)
+
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes)
 }

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -23,7 +23,7 @@ Optional overrides:
 | `READ_REPLICA_SLOT_NAME` | Slot name on Supabase |
 | `READ_REPLICA_FULL_RESET=1` | Allow full target reset in `replicate_to_replica.sh` |
 | `READ_REPLICA_SUBSCRIPTION_ONLY=1` | Recreate only the subscription |
-| `READ_REPLICA_SCHEMA_SYNC_MAX_TIME` | Max seconds for the Hyperdrive additive schema sync call |
+| `READ_REPLICA_SCHEMA_SYNC_MAX_TIME` | Max seconds for the Hyperdrive additive schema sync call; defaults to `1800` and the worker deadline is 15s shorter |
 
 If subscription name is not provided, scripts discover it from `pg_subscription`.
 If exactly one subscription exists, it is used. If multiple subscriptions exist,

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -101,5 +101,6 @@ READ_REPLICA_PASSWORD='new-password' bash read_replicate/update_readreplica_pass
   schema against the live read replica through Hyperdrive.
 - Production Supabase deploys run `bun run readreplicate:check-hyperdrive-schema`
   before migrations, functions, or workers publish. The check first applies safe
-  missing columns and indexes on the Google subscriber, then fails if any
+  missing columns and indexes on the Google subscriber, retries invalid
+  same-name indexes left by interrupted concurrent builds, then fails if any
   unsupported drift remains.

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -101,6 +101,6 @@ READ_REPLICA_PASSWORD='new-password' bash read_replicate/update_readreplica_pass
   schema against the live read replica through Hyperdrive.
 - Production Supabase deploys run `bun run readreplicate:check-hyperdrive-schema`
   before migrations, functions, or workers publish. The check first applies safe
-  missing columns and indexes on the Google subscriber, retries invalid
+  missing columns and indexes on the Google subscriber, reindexes invalid
   same-name indexes left by interrupted concurrent builds, then fails if any
   unsupported drift remains.

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -23,6 +23,7 @@ Optional overrides:
 | `READ_REPLICA_SLOT_NAME` | Slot name on Supabase |
 | `READ_REPLICA_FULL_RESET=1` | Allow full target reset in `replicate_to_replica.sh` |
 | `READ_REPLICA_SUBSCRIPTION_ONLY=1` | Recreate only the subscription |
+| `READ_REPLICA_SCHEMA_SYNC_MAX_TIME` | Max seconds for the Hyperdrive additive schema sync call |
 
 If subscription name is not provided, scripts discover it from `pg_subscription`.
 If exactly one subscription exists, it is used. If multiple subscriptions exist,
@@ -48,8 +49,8 @@ Check that the committed replica schema matches the current database schema:
 bun run readreplicate:check-schema
 ```
 
-Check that the live read replica visible through Hyperdrive matches the committed
-replica schema catalog:
+Sync safe additive changes through Hyperdrive, then check that the live read
+replica matches the committed replica schema catalog:
 
 ```bash
 bun run readreplicate:check-hyperdrive-schema
@@ -96,8 +97,9 @@ READ_REPLICA_PASSWORD='new-password' bash read_replicate/update_readreplica_pass
 - `schema_replicate.sql` is intentionally limited to tables replicated into the
   Google subscriber. It excludes foreign keys, triggers, and RLS policies.
 - `schema_replicate.catalog.json` is the machine-readable catalog snapshot used
-  by release CI to compare the committed schema against the live read replica
-  through Hyperdrive.
+  by release CI to sync missing additive schema changes and compare the committed
+  schema against the live read replica through Hyperdrive.
 - Production Supabase deploys run `bun run readreplicate:check-hyperdrive-schema`
-  before migrations, functions, or workers publish. If it fails, update the
-  Google subscriber schema before retrying the release.
+  before migrations, functions, or workers publish. The check first applies safe
+  missing columns and indexes on the Google subscriber, then fails if any
+  unsupported drift remains.

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -71,7 +71,7 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
   const actualColumns = new Set((actualCatalog.columns ?? []).map(column => columnKey(column)))
   const actualIndexByName = new Map((actualCatalog.indexes ?? []).map(index => [index.name, index]))
   const expectedConstraintIndexes = new Set((expectedCatalog.constraints ?? []).map(constraint => constraint.name))
-  const tablesWithSkippedColumns = new Set<string>()
+  const skippedColumnsByTable = new Map<string, Set<string>>()
   const statements: SyncStatement[] = []
   const skipped: SkippedChange[] = []
 
@@ -81,7 +81,7 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
 
     const addColumnSql = buildAddColumnStatement(column, actualTables)
     if (!addColumnSql) {
-      tablesWithSkippedColumns.add(column.table)
+      trackSkippedColumn(skippedColumnsByTable, column)
       skipped.push({
         kind: 'column',
         table: column.table,
@@ -104,7 +104,7 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
     if (actualIndex?.valid)
       continue
 
-    if (tablesWithSkippedColumns.has(index.table)) {
+    if (hasUnresolvedColumnDependency(index, skippedColumnsByTable)) {
       skipped.push({
         kind: 'index',
         table: index.table,
@@ -120,6 +120,16 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
         table: index.table,
         name: index.name,
         reason: 'constraint_owned_index',
+      })
+      continue
+    }
+
+    if (actualIndex && actualIndex.table !== index.table) {
+      skipped.push({
+        kind: 'index',
+        table: index.table,
+        name: index.name,
+        reason: 'index_name_conflict',
       })
       continue
     }
@@ -140,8 +150,9 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
         kind: 'invalid_index',
         table: index.table,
         name: index.name,
-        sql: buildDropIndexStatement(index),
+        sql: buildReindexIndexStatement(index),
       })
+      continue
     }
 
     statements.push({
@@ -271,8 +282,8 @@ function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>
   return `CREATE ${unique}INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteQualifiedTable(index.table)} ${indexTail}`
 }
 
-function buildDropIndexStatement(index: SchemaIndex): string {
-  return `DROP INDEX CONCURRENTLY IF EXISTS public.${quoteIdent(index.name)}`
+function buildReindexIndexStatement(index: SchemaIndex): string {
+  return `REINDEX INDEX CONCURRENTLY public.${quoteIdent(index.name)}`
 }
 
 function parseCreateIndexDefinition(definition: string): { unique: string, indexName: string, tableName: string, indexTail: string } | null {
@@ -316,8 +327,40 @@ function isSafeReplicaTable(table: string, actualTables: Set<string>): boolean {
   return REPLICA_TABLE_SET.has(table) && actualTables.has(table) && isSafeIdentifier(table)
 }
 
+function trackSkippedColumn(skippedColumnsByTable: Map<string, Set<string>>, column: SchemaColumn): void {
+  const tableColumns = skippedColumnsByTable.get(column.table) ?? new Set<string>()
+  tableColumns.add(column.name)
+  skippedColumnsByTable.set(column.table, tableColumns)
+}
+
+function hasUnresolvedColumnDependency(index: SchemaIndex, skippedColumnsByTable: Map<string, Set<string>>): boolean {
+  const skippedColumns = skippedColumnsByTable.get(index.table)
+  if (!skippedColumns?.size)
+    return false
+
+  const parsedDefinition = parseCreateIndexDefinition(index.definition)
+  if (!parsedDefinition)
+    return false
+
+  for (const column of skippedColumns) {
+    if (indexTailReferencesColumn(parsedDefinition.indexTail, column))
+      return true
+  }
+
+  return false
+}
+
+function indexTailReferencesColumn(indexTail: string, column: string): boolean {
+  return indexTail.includes(quoteIdent(column))
+    || new RegExp(`(^|[^A-Za-z0-9_"])${escapeRegExp(column)}($|[^A-Za-z0-9_"])`).test(indexTail)
+}
+
 function isSafeIdentifier(value: string): boolean {
   return SAFE_IDENTIFIER_RE.test(value)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 }
 
 function isSafeSqlFragment(value: string): boolean {

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -114,22 +114,43 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
       continue
     }
 
-    if (expectedConstraintIndexes.has(index.name)) {
-      skipped.push({
-        kind: 'index',
-        table: index.table,
-        name: index.name,
-        reason: 'constraint_owned_index',
-      })
-      continue
-    }
-
     if (actualIndex && actualIndex.table !== index.table) {
       skipped.push({
         kind: 'index',
         table: index.table,
         name: index.name,
         reason: 'index_name_conflict',
+      })
+      continue
+    }
+
+    if (actualIndex) {
+      const reindexSql = buildReindexIndexStatement(index, actualTables)
+      if (!reindexSql) {
+        skipped.push({
+          kind: 'index',
+          table: index.table,
+          name: index.name,
+          reason: 'unsupported_additive_index',
+        })
+        continue
+      }
+
+      statements.push({
+        kind: 'invalid_index',
+        table: index.table,
+        name: index.name,
+        sql: reindexSql,
+      })
+      continue
+    }
+
+    if (expectedConstraintIndexes.has(index.name)) {
+      skipped.push({
+        kind: 'index',
+        table: index.table,
+        name: index.name,
+        reason: 'constraint_owned_index',
       })
       continue
     }
@@ -141,16 +162,6 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
         table: index.table,
         name: index.name,
         reason: 'unsupported_additive_index',
-      })
-      continue
-    }
-
-    if (actualIndex) {
-      statements.push({
-        kind: 'invalid_index',
-        table: index.table,
-        name: index.name,
-        sql: buildReindexIndexStatement(index),
       })
       continue
     }
@@ -282,7 +293,10 @@ function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>
   return `CREATE ${unique}INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteQualifiedTable(index.table)} ${indexTail}`
 }
 
-function buildReindexIndexStatement(index: SchemaIndex): string {
+function buildReindexIndexStatement(index: SchemaIndex, actualTables: Set<string>): string | null {
+  if (!isSafeReplicaTable(index.table, actualTables) || !isSafeIdentifier(index.name))
+    return null
+
   return `REINDEX INDEX CONCURRENTLY public.${quoteIdent(index.name)}`
 }
 

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -59,8 +59,8 @@ export interface AdditiveSchemaSyncResult {
   skipped: SkippedChange[]
 }
 
-const SAFE_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
-const SAFE_SQL_FRAGMENT_RE = /^[A-Za-z0-9_ .()[\],:'"{}+\-=<>!]+$/
+const SAFE_IDENTIFIER_RE = /^[A-Za-z_]\w*$/
+const SAFE_SQL_FRAGMENT_RE = /^[\w .()[\],:'"{}+\-=<>!]+$/
 const REPLICA_TABLE_SET = new Set<string>(REPLICA_TABLES)
 
 export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unknown): AdditiveSchemaSyncPlan {
@@ -197,15 +197,52 @@ function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>
   if (!isSafeSqlFragment(index.definition))
     return null
 
-  const match = index.definition.match(/^CREATE (UNIQUE )?INDEX ([A-Za-z_][A-Za-z0-9_]*) ON public\.([A-Za-z_][A-Za-z0-9_]*) (.+)$/s)
-  if (!match)
+  const parsedDefinition = parseCreateIndexDefinition(index.definition)
+  if (!parsedDefinition)
     return null
 
-  const [, unique = '', indexName, tableName, indexTail] = match
+  const { unique, indexName, tableName, indexTail } = parsedDefinition
   if (indexName !== index.name || tableName !== index.table)
     return null
 
   return `CREATE ${unique}INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteQualifiedTable(index.table)} ${indexTail}`
+}
+
+function parseCreateIndexDefinition(definition: string): { unique: string, indexName: string, tableName: string, indexTail: string } | null {
+  let rest = definition
+  if (!rest.startsWith('CREATE '))
+    return null
+  rest = rest.slice('CREATE '.length)
+
+  const unique = rest.startsWith('UNIQUE ') ? 'UNIQUE ' : ''
+  if (unique)
+    rest = rest.slice(unique.length)
+
+  if (!rest.startsWith('INDEX '))
+    return null
+  rest = rest.slice('INDEX '.length)
+
+  const indexNameEnd = rest.indexOf(' ')
+  if (indexNameEnd === -1)
+    return null
+  const indexName = rest.slice(0, indexNameEnd)
+  rest = rest.slice(indexNameEnd + 1)
+
+  const tablePrefix = 'ON public.'
+  if (!rest.startsWith(tablePrefix))
+    return null
+  rest = rest.slice(tablePrefix.length)
+
+  const tableNameEnd = rest.indexOf(' ')
+  if (tableNameEnd === -1)
+    return null
+
+  return {
+    unique,
+    indexName,
+    tableName: rest.slice(0, tableNameEnd),
+    indexTail: rest.slice(tableNameEnd + 1),
+  }
 }
 
 function isSafeReplicaTable(table: string, actualTables: Set<string>): boolean {
@@ -225,7 +262,36 @@ function isSafeSqlFragment(value: string): boolean {
 }
 
 function isSafeConstantDefault(value: string): boolean {
-  return !/[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(value)
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== '(')
+      continue
+
+    const previous = previousNonWhitespace(value, index)
+    if (previous && (isIdentifierChar(previous) || previous === '"'))
+      return false
+  }
+
+  return true
+}
+
+function previousNonWhitespace(value: string, index: number): string | null {
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    if (!isWhitespace(value[cursor]))
+      return value[cursor]
+  }
+
+  return null
+}
+
+function isWhitespace(value: string): boolean {
+  return value === ' ' || value === '\n' || value === '\r' || value === '\t' || value === '\f'
+}
+
+function isIdentifierChar(value: string): boolean {
+  return value === '_'
+    || (value >= 'A' && value <= 'Z')
+    || (value >= 'a' && value <= 'z')
+    || (value >= '0' && value <= '9')
 }
 
 function isNullDefault(value: string): boolean {

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -60,9 +60,17 @@ export interface AdditiveSchemaSyncResult {
   skipped: SkippedChange[]
 }
 
+export interface AdditiveSchemaSyncOptions {
+  statementTimeoutMs?: number
+  maxDurationMs?: number
+}
+
 const SAFE_IDENTIFIER_RE = /^[A-Za-z_]\w*$/
 const SAFE_SQL_FRAGMENT_RE = /^[\w .()[\],:'"{}+\-=<>!]+$/
 const REPLICA_TABLE_SET = new Set<string>(REPLICA_TABLES)
+const DEFAULT_SCHEMA_SYNC_STATEMENT_TIMEOUT_MS = 550_000
+const DEFAULT_SCHEMA_SYNC_MAX_DURATION_MS = 585_000
+const SCHEMA_SYNC_RESPONSE_BUFFER_MS = 5_000
 
 export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unknown): AdditiveSchemaSyncPlan {
   const expectedCatalog = assertSchemaCatalog(expected)
@@ -177,17 +185,41 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
   return { statements, skipped }
 }
 
-export async function applyReadReplicaAdditiveSchemaSync(client: Queryable, expected: unknown): Promise<AdditiveSchemaSyncResult> {
+export async function applyReadReplicaAdditiveSchemaSync(client: Queryable, expected: unknown, options: AdditiveSchemaSyncOptions = {}): Promise<AdditiveSchemaSyncResult> {
   const actual = await readReplicaSchemaCatalog(client)
   const plan = planReadReplicaAdditiveSchemaSync(expected, actual)
+  const statementTimeoutMs = positiveIntegerOrDefault(options.statementTimeoutMs, DEFAULT_SCHEMA_SYNC_STATEMENT_TIMEOUT_MS)
+  const deadline = Date.now() + positiveIntegerOrDefault(options.maxDurationMs, DEFAULT_SCHEMA_SYNC_MAX_DURATION_MS)
 
-  for (const statement of plan.statements)
-    await client.query(statement.sql)
+  try {
+    for (const statement of plan.statements) {
+      await setStatementTimeoutForRemainingBudget(client, statementTimeoutMs, deadline, statement)
+      await client.query(statement.sql)
+    }
+  }
+  finally {
+    await client.query('RESET statement_timeout')
+  }
 
   return {
     applied: plan.statements.map(({ kind, table, name }) => ({ kind, table, name })),
     skipped: plan.skipped,
   }
+}
+
+async function setStatementTimeoutForRemainingBudget(client: Queryable, maxStatementTimeoutMs: number, deadline: number, statement: SyncStatement): Promise<void> {
+  const remainingMs = deadline - Date.now() - SCHEMA_SYNC_RESPONSE_BUFFER_MS
+  if (remainingMs <= 0)
+    throw new Error(`Read-replica additive schema sync exceeded max duration before ${statement.kind} ${statement.table}.${statement.name}`)
+
+  await client.query(`SET statement_timeout = ${Math.min(maxStatementTimeoutMs, remainingMs)}`)
+}
+
+function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0)
+    return fallback
+
+  return Math.trunc(value)
 }
 
 function assertSchemaCatalog(value: unknown): SchemaCatalog {
@@ -294,7 +326,7 @@ function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>
 }
 
 function buildReindexIndexStatement(index: SchemaIndex, actualTables: Set<string>): string | null {
-  if (!isSafeReplicaTable(index.table, actualTables) || !isSafeIdentifier(index.name))
+  if (!isSafeReplicaTable(index.table, actualTables) || !isSafeQuotedIdentifier(index.name))
     return null
 
   return `REINDEX INDEX CONCURRENTLY public.${quoteIdent(index.name)}`
@@ -371,6 +403,10 @@ function indexTailReferencesColumn(indexTail: string, column: string): boolean {
 
 function isSafeIdentifier(value: string): boolean {
   return SAFE_IDENTIFIER_RE.test(value)
+}
+
+function isSafeQuotedIdentifier(value: string): boolean {
+  return value.length > 0 && !value.includes('\0')
 }
 
 function escapeRegExp(value: string): string {

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -36,7 +36,7 @@ interface SchemaCatalog {
 }
 
 interface SyncStatement {
-  kind: 'column' | 'index' | 'not_null'
+  kind: 'column' | 'index'
   table: string
   name: string
   sql: string
@@ -70,6 +70,7 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
   const actualColumns = new Set((actualCatalog.columns ?? []).map(column => columnKey(column)))
   const actualIndexes = new Set((actualCatalog.indexes ?? []).map(index => index.name))
   const expectedConstraintIndexes = new Set((expectedCatalog.constraints ?? []).map(constraint => constraint.name))
+  const tablesWithSkippedColumns = new Set<string>()
   const statements: SyncStatement[] = []
   const skipped: SkippedChange[] = []
 
@@ -79,6 +80,7 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
 
     const addColumnSql = buildAddColumnStatement(column, actualTables)
     if (!addColumnSql) {
+      tablesWithSkippedColumns.add(column.table)
       skipped.push({
         kind: 'column',
         table: column.table,
@@ -94,20 +96,21 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
       name: column.name,
       sql: addColumnSql,
     })
-
-    if (column.notNull) {
-      statements.push({
-        kind: 'not_null',
-        table: column.table,
-        name: column.name,
-        sql: `ALTER TABLE ${quoteQualifiedTable(column.table)} ALTER COLUMN ${quoteIdent(column.name)} SET NOT NULL`,
-      })
-    }
   }
 
   for (const index of expectedCatalog.indexes ?? []) {
     if (actualIndexes.has(index.name))
       continue
+
+    if (tablesWithSkippedColumns.has(index.table)) {
+      skipped.push({
+        kind: 'index',
+        table: index.table,
+        name: index.name,
+        reason: 'unresolved_column_dependency',
+      })
+      continue
+    }
 
     if (expectedConstraintIndexes.has(index.name)) {
       skipped.push({
@@ -168,7 +171,53 @@ function assertSchemaCatalog(value: unknown): SchemaCatalog {
   if (catalog.tables && !Array.isArray(catalog.tables))
     throw new Error('Read-replica schema catalog tables must be an array')
 
+  for (const column of catalog.columns ?? [])
+    assertSchemaColumn(column)
+  for (const constraint of catalog.constraints ?? [])
+    assertSchemaConstraint(constraint)
+  for (const index of catalog.indexes ?? [])
+    assertSchemaIndex(index)
+  for (const table of catalog.tables ?? [])
+    assertSchemaTable(table)
+
   return catalog
+}
+
+function assertSchemaColumn(value: unknown): asserts value is SchemaColumn {
+  const column = assertCatalogObject(value, 'columns') as Partial<SchemaColumn>
+  if (typeof column.table !== 'string' || typeof column.name !== 'string' || typeof column.type !== 'string')
+    throw new Error('Read-replica schema catalog columns must include string table, name, and type')
+  if (typeof column.notNull !== 'boolean')
+    throw new Error('Read-replica schema catalog columns must include boolean notNull')
+  if (column.default !== null && typeof column.default !== 'string')
+    throw new Error('Read-replica schema catalog column defaults must be strings or null')
+  if (typeof column.identity !== 'string' || typeof column.generated !== 'string')
+    throw new Error('Read-replica schema catalog columns must include string identity and generated fields')
+}
+
+function assertSchemaConstraint(value: unknown): asserts value is SchemaConstraint {
+  const constraint = assertCatalogObject(value, 'constraints') as Partial<SchemaConstraint>
+  if (typeof constraint.name !== 'string')
+    throw new Error('Read-replica schema catalog constraints must include string names')
+}
+
+function assertSchemaIndex(value: unknown): asserts value is SchemaIndex {
+  const index = assertCatalogObject(value, 'indexes') as Partial<SchemaIndex>
+  if (typeof index.table !== 'string' || typeof index.name !== 'string' || typeof index.definition !== 'string')
+    throw new Error('Read-replica schema catalog indexes must include string table, name, and definition')
+}
+
+function assertSchemaTable(value: unknown): asserts value is SchemaTable {
+  const table = assertCatalogObject(value, 'tables') as Partial<SchemaTable>
+  if (typeof table.name !== 'string')
+    throw new Error('Read-replica schema catalog tables must include string names')
+}
+
+function assertCatalogObject(value: unknown, collection: string): object {
+  if (!value || typeof value !== 'object')
+    throw new Error(`Read-replica schema catalog ${collection} must contain objects`)
+
+  return value
 }
 
 function buildAddColumnStatement(column: SchemaColumn, actualTables: Set<string>): string | null {
@@ -186,7 +235,8 @@ function buildAddColumnStatement(column: SchemaColumn, actualTables: Set<string>
     return null
 
   const defaultSql = column.default === null ? '' : ` DEFAULT ${column.default}`
-  return `ALTER TABLE ${quoteQualifiedTable(column.table)} ADD COLUMN IF NOT EXISTS ${quoteIdent(column.name)} ${column.type}${defaultSql}`
+  const notNullSql = column.notNull ? ' NOT NULL' : ''
+  return `ALTER TABLE ${quoteQualifiedTable(column.table)} ADD COLUMN IF NOT EXISTS ${quoteIdent(column.name)} ${column.type}${defaultSql}${notNullSql}`
 }
 
 function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>): string | null {

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -22,6 +22,7 @@ interface SchemaIndex {
   table: string
   name: string
   definition: string
+  valid: boolean
 }
 
 interface SchemaTable {
@@ -36,7 +37,7 @@ interface SchemaCatalog {
 }
 
 interface SyncStatement {
-  kind: 'column' | 'index'
+  kind: 'column' | 'index' | 'invalid_index'
   table: string
   name: string
   sql: string
@@ -68,7 +69,7 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
   const actualCatalog = assertSchemaCatalog(actual)
   const actualTables = new Set((actualCatalog.tables ?? []).map(table => table.name))
   const actualColumns = new Set((actualCatalog.columns ?? []).map(column => columnKey(column)))
-  const actualIndexes = new Set((actualCatalog.indexes ?? []).map(index => index.name))
+  const actualIndexByName = new Map((actualCatalog.indexes ?? []).map(index => [index.name, index]))
   const expectedConstraintIndexes = new Set((expectedCatalog.constraints ?? []).map(constraint => constraint.name))
   const tablesWithSkippedColumns = new Set<string>()
   const statements: SyncStatement[] = []
@@ -99,7 +100,8 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
   }
 
   for (const index of expectedCatalog.indexes ?? []) {
-    if (actualIndexes.has(index.name))
+    const actualIndex = actualIndexByName.get(index.name)
+    if (actualIndex?.valid)
       continue
 
     if (tablesWithSkippedColumns.has(index.table)) {
@@ -131,6 +133,15 @@ export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unk
         reason: 'unsupported_additive_index',
       })
       continue
+    }
+
+    if (actualIndex) {
+      statements.push({
+        kind: 'invalid_index',
+        table: index.table,
+        name: index.name,
+        sql: buildDropIndexStatement(index),
+      })
     }
 
     statements.push({
@@ -205,6 +216,8 @@ function assertSchemaIndex(value: unknown): asserts value is SchemaIndex {
   const index = assertCatalogObject(value, 'indexes') as Partial<SchemaIndex>
   if (typeof index.table !== 'string' || typeof index.name !== 'string' || typeof index.definition !== 'string')
     throw new Error('Read-replica schema catalog indexes must include string table, name, and definition')
+  if (typeof index.valid !== 'boolean')
+    throw new Error('Read-replica schema catalog indexes must include boolean valid')
 }
 
 function assertSchemaTable(value: unknown): asserts value is SchemaTable {
@@ -256,6 +269,10 @@ function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>
     return null
 
   return `CREATE ${unique}INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteQualifiedTable(index.table)} ${indexTail}`
+}
+
+function buildDropIndexStatement(index: SchemaIndex): string {
+  return `DROP INDEX CONCURRENTLY IF EXISTS public.${quoteIdent(index.name)}`
 }
 
 function parseCreateIndexDefinition(definition: string): { unique: string, indexName: string, tableName: string, indexTail: string } | null {

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -1,0 +1,245 @@
+import {
+  REPLICA_TABLES,
+  readReplicaSchemaCatalog,
+  type Queryable,
+} from './schema_catalog.ts'
+
+interface SchemaColumn {
+  table: string
+  name: string
+  type: string
+  notNull: boolean
+  default: string | null
+  identity: string
+  generated: string
+}
+
+interface SchemaConstraint {
+  name: string
+}
+
+interface SchemaIndex {
+  table: string
+  name: string
+  definition: string
+}
+
+interface SchemaTable {
+  name: string
+}
+
+interface SchemaCatalog {
+  columns?: SchemaColumn[]
+  constraints?: SchemaConstraint[]
+  indexes?: SchemaIndex[]
+  tables?: SchemaTable[]
+}
+
+interface SyncStatement {
+  kind: 'column' | 'index' | 'not_null'
+  table: string
+  name: string
+  sql: string
+}
+
+interface SkippedChange {
+  kind: 'column' | 'index'
+  table: string
+  name: string
+  reason: string
+}
+
+export interface AdditiveSchemaSyncPlan {
+  statements: SyncStatement[]
+  skipped: SkippedChange[]
+}
+
+export interface AdditiveSchemaSyncResult {
+  applied: Array<Omit<SyncStatement, 'sql'>>
+  skipped: SkippedChange[]
+}
+
+const SAFE_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const SAFE_SQL_FRAGMENT_RE = /^[A-Za-z0-9_ .()[\],:'"{}+\-=<>!]+$/
+const REPLICA_TABLE_SET = new Set<string>(REPLICA_TABLES)
+
+export function planReadReplicaAdditiveSchemaSync(expected: unknown, actual: unknown): AdditiveSchemaSyncPlan {
+  const expectedCatalog = assertSchemaCatalog(expected)
+  const actualCatalog = assertSchemaCatalog(actual)
+  const actualTables = new Set((actualCatalog.tables ?? []).map(table => table.name))
+  const actualColumns = new Set((actualCatalog.columns ?? []).map(column => columnKey(column)))
+  const actualIndexes = new Set((actualCatalog.indexes ?? []).map(index => index.name))
+  const expectedConstraintIndexes = new Set((expectedCatalog.constraints ?? []).map(constraint => constraint.name))
+  const statements: SyncStatement[] = []
+  const skipped: SkippedChange[] = []
+
+  for (const column of expectedCatalog.columns ?? []) {
+    if (actualColumns.has(columnKey(column)))
+      continue
+
+    const addColumnSql = buildAddColumnStatement(column, actualTables)
+    if (!addColumnSql) {
+      skipped.push({
+        kind: 'column',
+        table: column.table,
+        name: column.name,
+        reason: 'unsupported_additive_column',
+      })
+      continue
+    }
+
+    statements.push({
+      kind: 'column',
+      table: column.table,
+      name: column.name,
+      sql: addColumnSql,
+    })
+
+    if (column.notNull) {
+      statements.push({
+        kind: 'not_null',
+        table: column.table,
+        name: column.name,
+        sql: `ALTER TABLE ${quoteQualifiedTable(column.table)} ALTER COLUMN ${quoteIdent(column.name)} SET NOT NULL`,
+      })
+    }
+  }
+
+  for (const index of expectedCatalog.indexes ?? []) {
+    if (actualIndexes.has(index.name))
+      continue
+
+    if (expectedConstraintIndexes.has(index.name)) {
+      skipped.push({
+        kind: 'index',
+        table: index.table,
+        name: index.name,
+        reason: 'constraint_owned_index',
+      })
+      continue
+    }
+
+    const addIndexSql = buildCreateIndexStatement(index, actualTables)
+    if (!addIndexSql) {
+      skipped.push({
+        kind: 'index',
+        table: index.table,
+        name: index.name,
+        reason: 'unsupported_additive_index',
+      })
+      continue
+    }
+
+    statements.push({
+      kind: 'index',
+      table: index.table,
+      name: index.name,
+      sql: addIndexSql,
+    })
+  }
+
+  return { statements, skipped }
+}
+
+export async function applyReadReplicaAdditiveSchemaSync(client: Queryable, expected: unknown): Promise<AdditiveSchemaSyncResult> {
+  const actual = await readReplicaSchemaCatalog(client)
+  const plan = planReadReplicaAdditiveSchemaSync(expected, actual)
+
+  for (const statement of plan.statements)
+    await client.query(statement.sql)
+
+  return {
+    applied: plan.statements.map(({ kind, table, name }) => ({ kind, table, name })),
+    skipped: plan.skipped,
+  }
+}
+
+function assertSchemaCatalog(value: unknown): SchemaCatalog {
+  if (!value || typeof value !== 'object')
+    throw new Error('Expected read-replica schema catalog JSON object')
+
+  const catalog = value as SchemaCatalog
+  if (catalog.columns && !Array.isArray(catalog.columns))
+    throw new Error('Read-replica schema catalog columns must be an array')
+  if (catalog.constraints && !Array.isArray(catalog.constraints))
+    throw new Error('Read-replica schema catalog constraints must be an array')
+  if (catalog.indexes && !Array.isArray(catalog.indexes))
+    throw new Error('Read-replica schema catalog indexes must be an array')
+  if (catalog.tables && !Array.isArray(catalog.tables))
+    throw new Error('Read-replica schema catalog tables must be an array')
+
+  return catalog
+}
+
+function buildAddColumnStatement(column: SchemaColumn, actualTables: Set<string>): string | null {
+  if (!isSafeReplicaTable(column.table, actualTables))
+    return null
+  if (!isSafeIdentifier(column.name))
+    return null
+  if (column.identity || column.generated)
+    return null
+  if (!isSafeSqlFragment(column.type))
+    return null
+  if (column.default !== null && (!isSafeSqlFragment(column.default) || !isSafeConstantDefault(column.default)))
+    return null
+  if (column.notNull && (column.default === null || isNullDefault(column.default)))
+    return null
+
+  const defaultSql = column.default === null ? '' : ` DEFAULT ${column.default}`
+  return `ALTER TABLE ${quoteQualifiedTable(column.table)} ADD COLUMN IF NOT EXISTS ${quoteIdent(column.name)} ${column.type}${defaultSql}`
+}
+
+function buildCreateIndexStatement(index: SchemaIndex, actualTables: Set<string>): string | null {
+  if (!isSafeReplicaTable(index.table, actualTables))
+    return null
+  if (!isSafeIdentifier(index.name))
+    return null
+  if (!isSafeSqlFragment(index.definition))
+    return null
+
+  const match = index.definition.match(/^CREATE (UNIQUE )?INDEX ([A-Za-z_][A-Za-z0-9_]*) ON public\.([A-Za-z_][A-Za-z0-9_]*) (.+)$/s)
+  if (!match)
+    return null
+
+  const [, unique = '', indexName, tableName, indexTail] = match
+  if (indexName !== index.name || tableName !== index.table)
+    return null
+
+  return `CREATE ${unique}INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteQualifiedTable(index.table)} ${indexTail}`
+}
+
+function isSafeReplicaTable(table: string, actualTables: Set<string>): boolean {
+  return REPLICA_TABLE_SET.has(table) && actualTables.has(table) && isSafeIdentifier(table)
+}
+
+function isSafeIdentifier(value: string): boolean {
+  return SAFE_IDENTIFIER_RE.test(value)
+}
+
+function isSafeSqlFragment(value: string): boolean {
+  return SAFE_SQL_FRAGMENT_RE.test(value)
+    && !value.includes(';')
+    && !value.includes('--')
+    && !value.includes('/*')
+    && !value.includes('*/')
+}
+
+function isSafeConstantDefault(value: string): boolean {
+  return !/[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(value)
+}
+
+function isNullDefault(value: string): boolean {
+  return /^NULL\b/i.test(value)
+}
+
+function quoteQualifiedTable(table: string): string {
+  return `public.${quoteIdent(table)}`
+}
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function columnKey(column: Pick<SchemaColumn, 'table' | 'name'>): string {
+  return `${column.table}.${column.name}`
+}

--- a/read_replicate/schema_catalog.ts
+++ b/read_replicate/schema_catalog.ts
@@ -109,7 +109,8 @@ indexes AS (
   SELECT
     t.table_name,
     idx.relname AS index_name,
-    pg_get_indexdef(idx.oid) AS definition
+    pg_get_indexdef(idx.oid) AS definition,
+    ix.indisvalid AS is_valid
   FROM tables t
   JOIN pg_index ix ON ix.indrelid = t.table_oid
   JOIN pg_class idx ON idx.oid = ix.indexrelid
@@ -218,7 +219,8 @@ SELECT jsonb_build_object(
     SELECT jsonb_agg(jsonb_build_object(
       'table', table_name,
       'name', index_name,
-      'definition', definition
+      'definition', definition,
+      'valid', is_valid
     ) ORDER BY table_name, index_name)
     FROM indexes
   ), '[]'::jsonb),

--- a/read_replicate/schema_replicate.catalog.json
+++ b/read_replicate/schema_replicate.catalog.json
@@ -1910,367 +1910,440 @@
     {
       "definition": "CREATE INDEX app_versions_cli_version_idx ON public.app_versions USING btree (cli_version)",
       "name": "app_versions_cli_version_idx",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX app_versions_name_app_id_key ON public.app_versions USING btree (name, app_id)",
       "name": "app_versions_name_app_id_key",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX app_versions_pkey ON public.app_versions USING btree (id)",
       "name": "app_versions_pkey",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX app_versions_r2_path_idx ON public.app_versions USING btree (r2_path)",
       "name": "app_versions_r2_path_idx",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_app_versions_owner_org ON public.app_versions USING btree (owner_org)",
       "name": "finx_app_versions_owner_org",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_id_app_versions ON public.app_versions USING btree (app_id)",
       "name": "idx_app_id_app_versions",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_id_name_app_versions ON public.app_versions USING btree (app_id, name)",
       "name": "idx_app_id_name_app_versions",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_created_at ON public.app_versions USING btree (created_at)",
       "name": "idx_app_versions_created_at",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_created_at_app_id ON public.app_versions USING btree (created_at, app_id)",
       "name": "idx_app_versions_created_at_app_id",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_deleted ON public.app_versions USING btree (deleted)",
       "name": "idx_app_versions_deleted",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_deleted_at ON public.app_versions USING btree (deleted_at) WHERE (deleted_at IS NOT NULL)",
       "name": "idx_app_versions_deleted_at",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_id ON public.app_versions USING btree (id)",
       "name": "idx_app_versions_id",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_key_id ON public.app_versions USING btree (key_id) WHERE (key_id IS NOT NULL)",
       "name": "idx_app_versions_key_id",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_name ON public.app_versions USING btree (name)",
       "name": "idx_app_versions_name",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_owner_org_not_deleted ON public.app_versions USING btree (owner_org) WHERE (deleted = false)",
       "name": "idx_app_versions_owner_org_not_deleted",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_versions_retention_cleanup ON public.app_versions USING btree (deleted, created_at, app_id) WHERE (deleted = false)",
       "name": "idx_app_versions_retention_cleanup",
-      "table": "app_versions"
+      "table": "app_versions",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX apps_id_unique ON public.apps USING btree (id)",
       "name": "apps_id_unique",
-      "table": "apps"
+      "table": "apps",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX apps_pkey ON public.apps USING btree (app_id)",
       "name": "apps_pkey",
-      "table": "apps"
+      "table": "apps",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_apps_owner_org ON public.apps USING btree (owner_org)",
       "name": "finx_apps_owner_org",
-      "table": "apps"
+      "table": "apps",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_apps_user_id ON public.apps USING btree (user_id)",
       "name": "finx_apps_user_id",
-      "table": "apps"
+      "table": "apps",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_apps_default_upload_channel ON public.apps USING btree (default_upload_channel)",
       "name": "idx_apps_default_upload_channel",
-      "table": "apps"
+      "table": "apps",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX idx_apps_owner_org_app_id ON public.apps USING btree (owner_org, app_id)",
       "name": "idx_apps_owner_org_app_id",
-      "table": "apps"
+      "table": "apps",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX channel_devices_app_id_device_id_key ON public.channel_devices USING btree (app_id, device_id)",
       "name": "channel_devices_app_id_device_id_key",
-      "table": "channel_devices"
+      "table": "channel_devices",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX channel_devices_device_id_idx ON public.channel_devices USING btree (device_id)",
       "name": "channel_devices_device_id_idx",
-      "table": "channel_devices"
+      "table": "channel_devices",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_channel_devices_app_id ON public.channel_devices USING btree (app_id)",
       "name": "finx_channel_devices_app_id",
-      "table": "channel_devices"
+      "table": "channel_devices",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_channel_devices_channel_id ON public.channel_devices USING btree (channel_id)",
       "name": "finx_channel_devices_channel_id",
-      "table": "channel_devices"
+      "table": "channel_devices",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX idx_app_id_device_id_channel_id_channel_devices ON public.channel_devices USING btree (app_id, device_id, channel_id)",
       "name": "idx_app_id_device_id_channel_id_channel_devices",
-      "table": "channel_devices"
+      "table": "channel_devices",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX channel_pkey ON public.channels USING btree (id)",
       "name": "channel_pkey",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX channels_one_public_android_per_app_key ON public.channels USING btree (app_id) WHERE ((public = true) AND (android = true))",
       "name": "channels_one_public_android_per_app_key",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX channels_one_public_electron_per_app_key ON public.channels USING btree (app_id) WHERE ((public = true) AND (electron = true))",
       "name": "channels_one_public_electron_per_app_key",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX channels_one_public_ios_per_app_key ON public.channels USING btree (app_id) WHERE ((public = true) AND (ios = true))",
       "name": "channels_one_public_ios_per_app_key",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX channels_rbac_id_key ON public.channels USING btree (rbac_id)",
       "name": "channels_rbac_id_key",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_channels_app_id ON public.channels USING btree (app_id)",
       "name": "finx_channels_app_id",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_channels_owner_org ON public.channels USING btree (owner_org)",
       "name": "finx_channels_owner_org",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_channels_version ON public.channels USING btree (version)",
       "name": "finx_channels_version",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_app_id_public_channel ON public.channels USING btree (app_id, public)",
       "name": "idx_app_id_public_channel",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_channels_app_id_name ON public.channels USING btree (app_id, name)",
       "name": "idx_channels_app_id_name",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_channels_app_id_version ON public.channels USING btree (app_id, version)",
       "name": "idx_channels_app_id_version",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_channels_public_app_id_android ON public.channels USING btree (public, app_id, android)",
       "name": "idx_channels_public_app_id_android",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_channels_public_app_id_ios ON public.channels USING btree (public, app_id, ios)",
       "name": "idx_channels_public_app_id_ios",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_channels_rollout_targets ON public.channels USING btree (app_id, rollout_version) WHERE (rollout_version IS NOT NULL)",
       "name": "idx_channels_rollout_targets",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_channels_rollout_version ON public.channels USING btree (rollout_version) WHERE (rollout_version IS NOT NULL)",
       "name": "idx_channels_rollout_version",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX unique_name_app_id ON public.channels USING btree (name, app_id)",
       "name": "unique_name_app_id",
-      "table": "channels"
+      "table": "channels",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_manifest_app_version_id ON public.manifest USING btree (app_version_id)",
       "name": "idx_manifest_app_version_id",
-      "table": "manifest"
+      "table": "manifest",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_manifest_file_hash ON public.manifest USING btree (file_hash)",
       "name": "idx_manifest_file_hash",
-      "table": "manifest"
+      "table": "manifest",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_manifest_file_name ON public.manifest USING btree (file_name)",
       "name": "idx_manifest_file_name",
-      "table": "manifest"
+      "table": "manifest",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX manifest_pkey ON public.manifest USING btree (id)",
       "name": "manifest_pkey",
-      "table": "manifest"
+      "table": "manifest",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX notifications_pkey ON public.notifications USING btree (owner_org, event, uniq_id)",
       "name": "notifications_pkey",
-      "table": "notifications"
+      "table": "notifications",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX notifications_uniq_id_idx ON public.notifications USING btree (uniq_id)",
       "name": "notifications_uniq_id_idx",
-      "table": "notifications"
+      "table": "notifications",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX onboarding_demo_data_app_relation_row_key_idx ON public.onboarding_demo_data USING btree (app_id, relation_name, row_key)",
       "name": "onboarding_demo_data_app_relation_row_key_idx",
-      "table": "onboarding_demo_data"
+      "table": "onboarding_demo_data",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX onboarding_demo_data_pkey ON public.onboarding_demo_data USING btree (id)",
       "name": "onboarding_demo_data_pkey",
-      "table": "onboarding_demo_data"
+      "table": "onboarding_demo_data",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX onboarding_demo_data_seed_id_idx ON public.onboarding_demo_data USING btree (seed_id)",
       "name": "onboarding_demo_data_seed_id_idx",
-      "table": "onboarding_demo_data"
+      "table": "onboarding_demo_data",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_org_users_channel_id ON public.org_users USING btree (channel_id)",
       "name": "finx_org_users_channel_id",
-      "table": "org_users"
+      "table": "org_users",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_org_users_org_id ON public.org_users USING btree (org_id)",
       "name": "finx_org_users_org_id",
-      "table": "org_users"
+      "table": "org_users",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_org_users_user_id ON public.org_users USING btree (user_id)",
       "name": "finx_org_users_user_id",
-      "table": "org_users"
+      "table": "org_users",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX org_users_app_id_idx ON public.org_users USING btree (app_id)",
       "name": "org_users_app_id_idx",
-      "table": "org_users"
+      "table": "org_users",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX org_users_pkey ON public.org_users USING btree (id)",
       "name": "org_users_pkey",
-      "table": "org_users"
+      "table": "org_users",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_orgs_created_by ON public.orgs USING btree (created_by)",
       "name": "finx_orgs_created_by",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_orgs_customer_id ON public.orgs USING btree (customer_id)",
       "name": "idx_orgs_customer_id",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_orgs_email_preferences ON public.orgs USING gin (email_preferences)",
       "name": "idx_orgs_email_preferences",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX orgs_enforce_hashed_api_keys_true_idx ON public.orgs USING btree (id) WHERE (enforce_hashed_api_keys = true)",
       "name": "orgs_enforce_hashed_api_keys_true_idx",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX orgs_pkey ON public.orgs USING btree (id)",
       "name": "orgs_pkey",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX orgs_updated_at_id_idx ON public.orgs USING btree (updated_at DESC) INCLUDE (id) WHERE (customer_id IS NOT NULL)",
       "name": "orgs_updated_at_id_idx",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX \"unique customer_id on orgs\" ON public.orgs USING btree (customer_id)",
       "name": "unique customer_id on orgs",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX unique_name_created_by ON public.orgs USING btree (name, created_by)",
       "name": "unique_name_created_by",
-      "table": "orgs"
+      "table": "orgs",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX finx_orgs_stripe_info ON public.stripe_info USING btree (product_id)",
       "name": "finx_orgs_stripe_info",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_stripe_info_customer_covering ON public.stripe_info USING btree (customer_id) INCLUDE (product_id, subscription_anchor_start, subscription_anchor_end)",
       "name": "idx_stripe_info_customer_covering",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_stripe_info_past_due_at ON public.stripe_info USING btree (past_due_at) WHERE (past_due_at IS NOT NULL)",
       "name": "idx_stripe_info_past_due_at",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_stripe_info_status_plan ON public.stripe_info USING btree (status, is_good_plan) WHERE ((status = 'succeeded'::stripe_status) AND (is_good_plan = true))",
       "name": "idx_stripe_info_status_plan",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX idx_stripe_info_trial ON public.stripe_info USING btree (trial_at) WHERE (trial_at IS NOT NULL)",
       "name": "idx_stripe_info_trial",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX si_customer_status_trial_idx ON public.stripe_info USING btree (customer_id, status, trial_at) INCLUDE (mau_exceeded, storage_exceeded, bandwidth_exceeded)",
       "name": "si_customer_status_trial_idx",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE INDEX stripe_info_paid_at_idx ON public.stripe_info USING btree (paid_at) WHERE (paid_at IS NOT NULL)",
       "name": "stripe_info_paid_at_idx",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     },
     {
       "definition": "CREATE UNIQUE INDEX stripe_info_pkey ON public.stripe_info USING btree (customer_id)",
       "name": "stripe_info_pkey",
-      "table": "stripe_info"
+      "table": "stripe_info",
+      "valid": true
     }
   ],
   "sequences": [

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -7,8 +7,10 @@ cd "$REPO_ROOT"
 
 EXPECTED_SCHEMA_CATALOG='read_replicate/schema_replicate.catalog.json'
 ACTUAL_SCHEMA_CATALOG="$(mktemp)"
+SYNC_RESPONSE="$(mktemp)"
 WRANGLER_LOG="$(mktemp)"
 PORT="${READ_REPLICA_SCHEMA_CHECK_PORT:-8799}"
+SYNC_MAX_TIME="${READ_REPLICA_SCHEMA_SYNC_MAX_TIME:-600}"
 WORKER_PID=''
 SCHEMA_CHECK_TOKEN="$(bun --silent -e 'const bytes = crypto.getRandomValues(new Uint8Array(32)); console.log(Buffer.from(bytes).toString("hex"))')"
 
@@ -17,7 +19,7 @@ cleanup() {
     kill "$WORKER_PID" 2>/dev/null || true
     wait "$WORKER_PID" 2>/dev/null || true
   fi
-  rm -f "$ACTUAL_SCHEMA_CATALOG" "$WRANGLER_LOG"
+  rm -f "$ACTUAL_SCHEMA_CATALOG" "$SYNC_RESPONSE" "$WRANGLER_LOG"
 }
 trap cleanup EXIT
 
@@ -57,6 +59,24 @@ if ! curl -fsS --connect-timeout 5 --max-time 5 "http://127.0.0.1:${PORT}/ok" >/
   cat "$WRANGLER_LOG"
   exit 1
 fi
+
+SYNC_STATUS="$(curl -sS --connect-timeout 10 --max-time "$SYNC_MAX_TIME" \
+  --header "authorization: Bearer ${SCHEMA_CHECK_TOKEN}" \
+  --header 'content-type: application/json' \
+  --data-binary "@${EXPECTED_SCHEMA_CATALOG}" \
+  -w '%{http_code}' \
+  -o "$SYNC_RESPONSE" \
+  "http://127.0.0.1:${PORT}/sync-additive" || true)"
+if [[ "$SYNC_STATUS" != "200" ]]; then
+  echo "::error title=Failed to sync additive read-replica schema::Worker /sync-additive returned HTTP ${SYNC_STATUS}."
+  cat "$SYNC_RESPONSE"
+  cat "$WRANGLER_LOG"
+  exit 1
+fi
+
+echo 'Read-replica additive schema sync result:'
+cat "$SYNC_RESPONSE"
+echo
 
 HTTP_STATUS="$(curl -sS --connect-timeout 5 --max-time 30 --header "authorization: Bearer ${SCHEMA_CHECK_TOKEN}" -w '%{http_code}' -o "$ACTUAL_SCHEMA_CATALOG" "http://127.0.0.1:${PORT}/catalog" || true)"
 if [[ "$HTTP_STATUS" != "200" ]]; then

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -10,7 +10,12 @@ ACTUAL_SCHEMA_CATALOG="$(mktemp)"
 SYNC_RESPONSE="$(mktemp)"
 WRANGLER_LOG="$(mktemp)"
 PORT="${READ_REPLICA_SCHEMA_CHECK_PORT:-8799}"
-SYNC_MAX_TIME="${READ_REPLICA_SCHEMA_SYNC_MAX_TIME:-600}"
+SYNC_MAX_TIME="${READ_REPLICA_SCHEMA_SYNC_MAX_TIME:-1800}"
+if ! [[ "$SYNC_MAX_TIME" =~ ^[0-9]+$ ]] || (( SYNC_MAX_TIME <= 30 )); then
+  echo '::error title=Invalid read-replica schema sync timeout::READ_REPLICA_SCHEMA_SYNC_MAX_TIME must be an integer greater than 30 seconds.'
+  exit 1
+fi
+SYNC_MAX_DURATION_MS="$(( (SYNC_MAX_TIME - 15) * 1000 ))"
 WORKER_PID=''
 SCHEMA_CHECK_TOKEN="$(bun --silent -e 'const bytes = crypto.getRandomValues(new Uint8Array(32)); console.log(Buffer.from(bytes).toString("hex"))')"
 
@@ -63,6 +68,7 @@ fi
 SYNC_STATUS="$(curl -sS --connect-timeout 10 --max-time "$SYNC_MAX_TIME" \
   --header "authorization: Bearer ${SCHEMA_CHECK_TOKEN}" \
   --header 'content-type: application/json' \
+  --header "x-schema-sync-max-duration-ms: ${SYNC_MAX_DURATION_MS}" \
   --data-binary "@${EXPECTED_SCHEMA_CATALOG}" \
   -w '%{http_code}' \
   -o "$SYNC_RESPONSE" \

--- a/scripts/compare-read-replica-schema-catalog.ts
+++ b/scripts/compare-read-replica-schema-catalog.ts
@@ -31,10 +31,10 @@ async function main() {
     await writeFile(normalizedExpectedPath, expectedText)
     await writeFile(normalizedActualPath, actualText)
 
-    console.error('::error title=Read-replica schema is out of date::Hyperdrive read replica does not match read_replicate/schema_replicate.catalog.json.')
+    console.error('::error title=Read-replica schema is out of date::Hyperdrive read replica does not match read_replicate/schema_replicate.catalog.json after additive sync.')
     console.error('')
     console.error('The production source schema was updated, but the read replica visible through Hyperdrive still differs from the committed replica schema catalog.')
-    console.error('Apply the matching read-replica DDL or maintenance flow, then retry the release.')
+    console.error('Automatic sync only applies safe missing columns and indexes. Apply any remaining non-additive DDL or maintenance flow, then retry the release.')
     console.error('')
     console.error('Diff:')
 


### PR DESCRIPTION
## Summary

- Add an authenticated `/sync-additive` Hyperdrive Worker endpoint that compares the committed replica catalog with the live subscriber and applies safe missing additive DDL.
- Update `bun run readreplicate:check-hyperdrive-schema` to call `/sync-additive` before fetching `/catalog`, so production release preflight can add missing columns/indexes before the final drift check.
- Keep the automation conservative: it only adds supported missing columns and non-constraint indexes; unsupported drift still fails with the existing catalog diff.
- Document the new flow and timeout override in `read_replicate/README.md`.

## Test plan

- `bash -n scripts/check-read-replica-hyperdrive-schema.sh scripts/check-read-replica-schema.sh read_replicate/replicate_prepare.sh read_replicate/common.sh`
- `bun --silent - <<'TS' ...planner assertions for nullable columns, constant-default columns, volatile-default skips, regular indexes, and constraint-owned index skips... TS`
- `bun --silent -e 'import worker from "./cloudflare_workers/read-replica-schema-check/index.ts"; ...sync-additive auth/method smoke checks...'`
- `bun scripts/compare-read-replica-schema-catalog.ts read_replicate/schema_replicate.catalog.json read_replicate/schema_replicate.catalog.json`
- `bun typecheck`
- `bun lint:backend`
- `bun lint` (passes with existing Vue single-line HTML warnings in admin dashboard pages)
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build_and_deploy.yml`
- `bunx wrangler deploy --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc --env=prod --dry-run --outdir /tmp/capgo-read-replica-additive-sync-dry-run`

## Screenshots

Not applicable. This is backend/CI release-guard work with no UI change.

## Checklist

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Preflight now executes live DDL on the production read replica before Supabase migrations; guards are conservative but mis-sync or timeout could still affect release timing or subscriber schema.
> 
> **Overview**
> Production read-replica preflight **syncs safe additive DDL** on the Google subscriber (via Hyperdrive) before the existing catalog diff, instead of only comparing schemas.
> 
> A new **`POST /sync-additive`** route on the read-replica schema-check worker accepts the committed catalog JSON, runs **`applyReadReplicaAdditiveSchemaSync`**, and returns what was applied vs skipped. Sync is limited to supported missing columns, non–constraint-owned indexes (`CREATE INDEX CONCURRENTLY`), and **concurrent reindex** for invalid same-name indexes; volatile defaults, generated/identity columns, and constraint-owned indexes are skipped.
> 
> The Hyperdrive check script now **calls `/sync-additive` first** (configurable **`READ_REPLICA_SCHEMA_SYNC_MAX_TIME`**, deadline header), then fetches `/catalog` and compares. The schema catalog snapshot gains per-index **`valid`** flags; deploy workflow step text reflects sync-then-check. Bearer auth uses **timing-safe** comparison; `/catalog` is GET-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94662b77cba118f35f44b03694f8843ccb43599e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additive schema sync flow for read replicas, applying safe missing columns/indexes (including reindexing invalid same-name indexes) before final validation.
  * Added a sync endpoint and updated the deploy/read-replica check to use it, with configurable sync timeout.
* **Bug Fixes**
  * Improved authorization robustness and tightened request routing/error responses (method/route handling and clearer sync failure codes).
* **Documentation**
  * Updated setup and deploy guidance to describe the sync-and-verify behavior and the new timeout environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->