### PR TITLE
fix(auth): keep email for password reset

### DIFF
--- a/playwright/e2e/auth.spec.ts
+++ b/playwright/e2e/auth.spec.ts
@@ -49,10 +49,12 @@ test.describe('Authentication', () => {
     await page.waitForURL(/\/(apps|dashboard)(\/|$)/)
   })
 
-  test('should navigate to forgot password page', async ({ page }) => {
-    await continueToPasswordStep(page, 'test@capgo.app')
+  test('should keep email when navigating to forgot password page', async ({ page }) => {
+    const email = 'test@capgo.app'
+    await continueToPasswordStep(page, email)
     await page.click('[data-test="forgot-password"]')
-    await expect(page).toHaveURL('/forgot_password')
+    await expect(page).toHaveURL(`/forgot_password?email=${email}`)
+    await expect(page.locator('[data-test="email"]')).toHaveValue(email)
   })
 
   test('should navigate to registration page', async ({ page }) => {

--- a/playwright/e2e/auth.spec.ts
+++ b/playwright/e2e/auth.spec.ts
@@ -53,7 +53,7 @@ test.describe('Authentication', () => {
     const email = 'test@capgo.app'
     await continueToPasswordStep(page, email)
     await page.click('[data-test="forgot-password"]')
-    await expect(page).toHaveURL(`/forgot_password?email=${email}`)
+    await expect(page).toHaveURL('/forgot_password')
     await expect(page.locator('[data-test="email"]')).toHaveValue(email)
   })
 

--- a/src/pages/forgot_password.vue
+++ b/src/pages/forgot_password.vue
@@ -21,14 +21,23 @@ const dialogStore = useDialogV2Store()
 const step = ref(1)
 const turnstileToken = ref('')
 const mfaCode = ref('')
+const forgotPasswordEmailStorageKey = 'capgo:forgot-password-email'
 
 const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
 
 const isLoading = ref(false)
 const isLoadingMain = ref(true)
-const initialEmail = computed(() => typeof route.query.email === 'string' ? route.query.email : '')
+const initialEmail = ref('')
 const initialFormValue = computed(() => ({ email: initialEmail.value }))
 const cardDescription = computed(() => step.value === 1 ? t('enter-your-email-add') : t('enter-your-new-passw'))
+
+if (typeof sessionStorage !== 'undefined') {
+  const storedEmail = sessionStorage.getItem(forgotPasswordEmailStorageKey)
+  if (storedEmail) {
+    initialEmail.value = storedEmail
+    sessionStorage.removeItem(forgotPasswordEmailStorageKey)
+  }
+}
 
 function getRecoveryParams() {
   const hashParams = new URLSearchParams(route.hash.replace('#', ''))

--- a/src/pages/forgot_password.vue
+++ b/src/pages/forgot_password.vue
@@ -26,6 +26,8 @@ const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
 
 const isLoading = ref(false)
 const isLoadingMain = ref(true)
+const initialEmail = computed(() => typeof route.query.email === 'string' ? route.query.email : '')
+const initialFormValue = computed(() => ({ email: initialEmail.value }))
 const cardDescription = computed(() => step.value === 1 ? t('enter-your-email-add') : t('enter-your-new-passw'))
 
 function getRecoveryParams() {
@@ -184,7 +186,7 @@ watchEffect(() => {
       <Spinner size="w-14 h-14" class="my-auto" />
     </div>
 
-    <FormKit v-else id="forgot-password" type="form" :actions="false" @submit="submit">
+    <FormKit v-else id="forgot-password" type="form" :actions="false" :value="initialFormValue" @submit="submit">
       <div class="space-y-5 text-slate-500 dark:text-slate-300">
         <div v-if="step === 1">
           <FormKit

--- a/src/pages/forgot_password.vue
+++ b/src/pages/forgot_password.vue
@@ -21,7 +21,7 @@ const dialogStore = useDialogV2Store()
 const step = ref(1)
 const turnstileToken = ref('')
 const mfaCode = ref('')
-const forgotPasswordEmailStorageKey = 'capgo:forgot-password-email'
+const resetEmailStorageKey = 'capgo:reset-email'
 
 const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
 
@@ -32,10 +32,10 @@ const initialFormValue = computed(() => ({ email: initialEmail.value }))
 const cardDescription = computed(() => step.value === 1 ? t('enter-your-email-add') : t('enter-your-new-passw'))
 
 if (typeof sessionStorage !== 'undefined') {
-  const storedEmail = sessionStorage.getItem(forgotPasswordEmailStorageKey)
+  const storedEmail = sessionStorage.getItem(resetEmailStorageKey)
   if (storedEmail) {
     initialEmail.value = storedEmail
-    sessionStorage.removeItem(forgotPasswordEmailStorageKey)
+    sessionStorage.removeItem(resetEmailStorageKey)
   }
 }
 

--- a/src/pages/forgot_password.vue
+++ b/src/pages/forgot_password.vue
@@ -21,7 +21,6 @@ const dialogStore = useDialogV2Store()
 const step = ref(1)
 const turnstileToken = ref('')
 const mfaCode = ref('')
-const resetEmailStorageKey = 'capgo:reset-email'
 
 const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
 
@@ -31,11 +30,13 @@ const initialEmail = ref('')
 const initialFormValue = computed(() => ({ email: initialEmail.value }))
 const cardDescription = computed(() => step.value === 1 ? t('enter-your-email-add') : t('enter-your-new-passw'))
 
-if (typeof sessionStorage !== 'undefined') {
-  const storedEmail = sessionStorage.getItem(resetEmailStorageKey)
-  if (storedEmail) {
-    initialEmail.value = storedEmail
-    sessionStorage.removeItem(resetEmailStorageKey)
+if (typeof history !== 'undefined') {
+  const currentHistoryState = history.state as Record<string, unknown> | null
+  if (typeof currentHistoryState?.resetEmail === 'string') {
+    initialEmail.value = currentHistoryState.resetEmail
+    const nextHistoryState = { ...currentHistoryState }
+    delete nextHistoryState.resetEmail
+    history.replaceState(nextHistoryState, '')
   }
 }
 

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -65,6 +65,10 @@ const loginHeroHighlights = computed(() => [
     description: t('login-highlight-team-description'),
   },
 ])
+const forgotPasswordRoute = computed(() => ({
+  path: '/forgot_password',
+  query: emailForLogin.value ? { email: emailForLogin.value } : undefined,
+}))
 const authCardShellClass = [
   'rounded-none border-0 bg-transparent p-0 shadow-none backdrop-blur-0',
   'sm:rounded-[1.75rem] sm:border sm:border-slate-200/75 sm:bg-[linear-gradient(180deg,rgba(255,255,255,0.94)_0%,rgba(255,255,255,0.84)_100%)]',
@@ -995,7 +999,7 @@ onMounted(checkLogin)
                             {{ t('create-a-free-account') }}
                           </a>
                           <router-link
-                            to="/forgot_password"
+                            :to="forgotPasswordRoute"
                             data-test="forgot-password"
                             :class="authInlineLinkClass"
                           >

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -42,7 +42,7 @@ const isDomainChecking = ref(false)
 const isCheckingSavedSession = ref(true)
 const captchaStatus = ref<'disabled' | 'loading' | 'ready' | 'unavailable'>(captchaKey.value ? 'loading' : 'disabled')
 let captchaInitTimeout: ReturnType<typeof setTimeout> | null = null
-const forgotPasswordEmailStorageKey = 'capgo:forgot-password-email'
+const resetEmailStorageKey = 'capgo:reset-email'
 
 const version = import.meta.env.VITE_APP_VERSION
 const isEmailStepBusy = computed(() => isDomainChecking.value || isCheckingSavedSession.value)
@@ -450,9 +450,9 @@ async function goBackToEmail() {
 async function goToForgotPassword() {
   if (typeof sessionStorage !== 'undefined') {
     if (emailForLogin.value)
-      sessionStorage.setItem(forgotPasswordEmailStorageKey, emailForLogin.value)
+      sessionStorage.setItem(resetEmailStorageKey, emailForLogin.value)
     else
-      sessionStorage.removeItem(forgotPasswordEmailStorageKey)
+      sessionStorage.removeItem(resetEmailStorageKey)
   }
 
   await router.push('/forgot_password')

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -42,6 +42,7 @@ const isDomainChecking = ref(false)
 const isCheckingSavedSession = ref(true)
 const captchaStatus = ref<'disabled' | 'loading' | 'ready' | 'unavailable'>(captchaKey.value ? 'loading' : 'disabled')
 let captchaInitTimeout: ReturnType<typeof setTimeout> | null = null
+const forgotPasswordEmailStorageKey = 'capgo:forgot-password-email'
 
 const version = import.meta.env.VITE_APP_VERSION
 const isEmailStepBusy = computed(() => isDomainChecking.value || isCheckingSavedSession.value)
@@ -65,10 +66,6 @@ const loginHeroHighlights = computed(() => [
     description: t('login-highlight-team-description'),
   },
 ])
-const forgotPasswordRoute = computed(() => ({
-  path: '/forgot_password',
-  query: emailForLogin.value ? { email: emailForLogin.value } : undefined,
-}))
 const authCardShellClass = [
   'rounded-none border-0 bg-transparent p-0 shadow-none backdrop-blur-0',
   'sm:rounded-[1.75rem] sm:border sm:border-slate-200/75 sm:bg-[linear-gradient(180deg,rgba(255,255,255,0.94)_0%,rgba(255,255,255,0.84)_100%)]',
@@ -448,6 +445,17 @@ async function goBackToEmail() {
 
   await nextTick()
   focusLoginEmailInput()
+}
+
+async function goToForgotPassword() {
+  if (typeof sessionStorage !== 'undefined') {
+    if (emailForLogin.value)
+      sessionStorage.setItem(forgotPasswordEmailStorageKey, emailForLogin.value)
+    else
+      sessionStorage.removeItem(forgotPasswordEmailStorageKey)
+  }
+
+  await router.push('/forgot_password')
 }
 
 async function checkAuthUser() {
@@ -998,13 +1006,14 @@ onMounted(checkLogin)
                           >
                             {{ t('create-a-free-account') }}
                           </a>
-                          <router-link
-                            :to="forgotPasswordRoute"
+                          <button
+                            type="button"
                             data-test="forgot-password"
                             :class="authInlineLinkClass"
+                            @click="goToForgotPassword"
                           >
                             {{ t('forgot') }} {{ t('password') }} ?
-                          </router-link>
+                          </button>
                         </div>
                       </div>
                     </FormKit>

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -42,7 +42,6 @@ const isDomainChecking = ref(false)
 const isCheckingSavedSession = ref(true)
 const captchaStatus = ref<'disabled' | 'loading' | 'ready' | 'unavailable'>(captchaKey.value ? 'loading' : 'disabled')
 let captchaInitTimeout: ReturnType<typeof setTimeout> | null = null
-const resetEmailStorageKey = 'capgo:reset-email'
 
 const version = import.meta.env.VITE_APP_VERSION
 const isEmailStepBusy = computed(() => isDomainChecking.value || isCheckingSavedSession.value)
@@ -448,14 +447,10 @@ async function goBackToEmail() {
 }
 
 async function goToForgotPassword() {
-  if (typeof sessionStorage !== 'undefined') {
-    if (emailForLogin.value)
-      sessionStorage.setItem(resetEmailStorageKey, emailForLogin.value)
-    else
-      sessionStorage.removeItem(resetEmailStorageKey)
-  }
-
-  await router.push('/forgot_password')
+  await router.push({
+    path: '/forgot_password',
+    state: emailForLogin.value ? { resetEmail: emailForLogin.value } : undefined,
+  })
 }
 
 async function checkAuthUser() {


### PR DESCRIPTION
## Summary
- Carry the selected login email into `/forgot_password` with router history state, keeping it out of the URL and storage APIs.
- Seed the password reset form from that state, then clear the state value after it is read.
- Update auth Playwright coverage for the preserved email flow.

## Root cause
The forgot-password action on the credential step always navigated to `/forgot_password`, so the reset form lost the email the user had already entered during login.

## Screenshot
![Forgot password form with preserved email](https://raw.githubusercontent.com/Cap-go/capgo/codex/pr-2645-assets/.github/pr-assets/2645/forgot-password-prefill.webp)

## Checks
- `bun lint` (passes with existing unrelated warnings in admin dashboard pages)
- `bun run typecheck:frontend`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`
- `SKIP_STRIPE_EMULATOR_START=1 SKIP_BACKEND_START=1 bunx playwright test playwright/e2e/auth.spec.ts --project=chromium -g "keep email"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-only auth navigation change; password reset and Supabase behavior are unchanged.
> 
> **Overview**
> **Forgot password** now reuses the email entered on the login password step instead of starting with an empty field.
> 
> Login navigates via `goToForgotPassword()`, passing `resetEmail` in **router history state** (not the URL). The forgot-password page reads that state once, seeds the FormKit form with `:value`, then clears `resetEmail` from history so it does not linger on refresh/back.
> 
> The forgot-password link is a **button** with `@click` instead of a plain `router-link`, so navigation can attach state. Playwright asserts the email field still matches after the redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d504a74e70c6231a6451b6515652de446c4b8777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->