### PR TITLE
ci(notifications): publish plugin publicly

### DIFF
--- a/.github/workflows/publish_notifications.yml
+++ b/.github/workflows/publish_notifications.yml
@@ -44,16 +44,16 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           model: claude-sonnet-4-5-20250929
-      - name: Publish notifications plugin privately
+      - name: Publish notifications plugin to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --cwd packages/capacitor-notifications --access restricted
-      - name: Publish notifications plugin privately with next tag
+        run: bun publish --cwd packages/capacitor-notifications --access public
+      - name: Publish notifications plugin to npm with next tag
         if: ${{ contains(github.ref, '-alpha.') }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --cwd packages/capacitor-notifications --tag next --access restricted
+        run: bun publish --cwd packages/capacitor-notifications --tag next --access public
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,6 +202,8 @@ jobs:
         run: bun run --cwd packages/capacitor-notifications typecheck
       - name: Build notifications plugin
         run: bun run --cwd packages/capacitor-notifications build
+      - name: Verify notifications publish access
+        run: bunx vitest run tests/release-scope.test.ts
 
   lint_typecheck:
     needs: changes

--- a/packages/capacitor-notifications/README.md
+++ b/packages/capacitor-notifications/README.md
@@ -13,7 +13,7 @@ It handles:
 
 ## Setup
 
-This package is in private Capgo preview. Until the private package is enabled for your npm account, use this only from Capgo-managed workspaces or an internal registry token.
+Install the plugin from npm with the Capgo updater peer dependency when you want silent live-update checks from push notifications.
 
 ```bash
 npm install @capgo/capacitor-notifications @capgo/capacitor-updater

--- a/packages/capacitor-notifications/package.json
+++ b/packages/capacitor-notifications/package.json
@@ -52,7 +52,7 @@
     }
   },
   "publishConfig": {
-    "access": "restricted",
+    "access": "public",
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { getReleaseRangeBase, matchesComponent, resolveReleaseScope } from '../scripts/release-scope.ts'
 
@@ -41,6 +42,17 @@ describe('release scope matching', () => {
     expect(matchesComponent('capgo', files)).toBe(false)
     expect(matchesComponent('cli', files)).toBe(false)
     expect(matchesComponent('notifications', files)).toBe(true)
+  })
+
+  it.concurrent('publishes notifications as a public npm package', () => {
+    const packageJson = JSON.parse(
+      readFileSync('packages/capacitor-notifications/package.json', 'utf8'),
+    ) as { publishConfig?: { access?: string } }
+    const workflow = readFileSync('.github/workflows/publish_notifications.yml', 'utf8')
+
+    expect(packageJson.publishConfig?.access).toBe('public')
+    expect(workflow).toContain('--access public')
+    expect(workflow).not.toContain('--access restricted')
   })
 
   it.concurrent('keeps runtime code scoped to the matching component', () => {


### PR DESCRIPTION
## Summary

- Publish `@capgo/capacitor-notifications` with npm public access instead of restricted access.
- Align the package `publishConfig` and README install wording with a public package.
- Add a regression test that keeps the notifications publish workflow and package metadata on public npm access.

## Root Cause

The notification release tags are being created, but the publish workflow failed on every `notifications-*` tag because it ran `bun publish --access restricted`. npm rejected the scoped package publish with `402 Payment Required` because private packages are not enabled, and `@capgo/capacitor-notifications` is still missing from the public registry.

## Validation

- `bun run --cwd packages/capacitor-notifications typecheck`
- `bun run --cwd packages/capacitor-notifications build`
- `bunx vitest run tests/release-scope.test.ts`
- `bun run lint:deadcode`
- `bun publish --cwd packages/capacitor-notifications --access public --dry-run`
- Commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and documentation changes for npm access plus a typegen sync; no runtime auth or payment logic changes.
> 
> **Overview**
> Fixes failed `notifications-*` tag publishes by switching `@capgo/capacitor-notifications` from **restricted** to **public** npm access everywhere that matters: `publishConfig.access`, both `bun publish` steps in `publish_notifications.yml`, and README install guidance (no more private-preview wording).
> 
> CI now runs `tests/release-scope.test.ts` in the notifications package job, including a new assertion that package metadata and the publish workflow stay on `--access public` and never regress to `restricted`.
> 
> The diff also refreshes generated Supabase types so `devices.country_code` appears on Row/Insert/Update (aligned with existing backend/device usage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19efe2b071bde31a27966c0fa49060ba6e67429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->