### PR TITLE
fix(api): suppress retrying cron stat alerts

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -913,6 +913,7 @@ export async function http_post_helper(
     headers['x-capgo-queue-name'] = metadata.queueName
     headers['x-capgo-queue-msg-id'] = String(metadata.msgId)
     headers['x-capgo-queue-read-count'] = String(metadata.readCount)
+    headers['x-capgo-queue-max-reads'] = String(MAX_QUEUE_READS)
   }
 
   const controller = new AbortController()

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -389,9 +389,17 @@ export async function runQueryToCFA<T>(c: Context, query: string) {
     })
 
     if (!response.ok) {
-      const errorJson = await response.json()
-      cloudlogErr({ requestId: c.get('requestId'), message: 'runQueryToCFA HTTPError', status: response.status, error: errorJson })
-      throw new Error('runQueryToCFA encountered an error')
+      const errorText = await response.text()
+      let errorForLog: unknown = errorText
+      try {
+        errorForLog = JSON.parse(errorText)
+      }
+      catch {
+        // Keep the raw text body when Cloudflare returns HTML or plain text.
+      }
+      const errorPreview = (errorText || response.statusText).replace(/\s+/g, ' ').trim().slice(0, 500)
+      cloudlogErr({ requestId: c.get('requestId'), message: 'runQueryToCFA HTTPError', status: response.status, error: errorForLog })
+      throw new Error(`runQueryToCFA HTTP ${response.status}: ${errorPreview}`)
     }
 
     const res = await response.json() as AnalyticsApiResponse & { data: T[] }
@@ -399,7 +407,10 @@ export async function runQueryToCFA<T>(c: Context, query: string) {
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'runQueryToCFA error', error: serializeError(e) })
-    throw new Error('runQueryToCFA encountered an error')
+    if (e instanceof Error && e.message.startsWith('runQueryToCFA HTTP '))
+      throw e
+    const errorMessage = e instanceof Error ? e.message : String(e)
+    throw new Error(`runQueryToCFA encountered an error: ${errorMessage}`, { cause: e })
   }
 }
 

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -8,6 +8,11 @@ import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
 const filesUploadFunctionNames = new Set(['files', 'TUS handler'])
+const queueRetryHeaderNames = {
+  maxReads: 'x-capgo-queue-max-reads',
+  name: 'x-capgo-queue-name',
+  readCount: 'x-capgo-queue-read-count',
+}
 const sensitiveRequestBodyKeys = new Set([
   'captchaToken',
   'captcha_token',
@@ -40,6 +45,29 @@ function isFilesDurableObjectStorageTimeout(functionName: string, error: unknown
   const normalizedMessage = message.toLowerCase()
   return normalizedMessage.includes('storage operation exceeded timeout')
     && normalizedMessage.includes('object to be reset')
+}
+
+function readRequestHeader(c: Context, name: string): string | undefined {
+  const fromHono = c.req.header?.(name)
+  if (fromHono)
+    return fromHono
+  return c.req.raw.headers.get(name) ?? undefined
+}
+
+function parsePositiveInteger(value: string | undefined): number | null {
+  if (!value)
+    return null
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    return null
+  return parsed
+}
+
+function shouldSuppressQueueRetryAlert(c: Context): boolean {
+  const queueName = readRequestHeader(c, queueRetryHeaderNames.name)
+  const readCount = parsePositiveInteger(readRequestHeader(c, queueRetryHeaderNames.readCount))
+  const maxReads = parsePositiveInteger(readRequestHeader(c, queueRetryHeaderNames.maxReads))
+  return Boolean(queueName) && readCount !== null && maxReads !== null && readCount < maxReads
 }
 
 export function onError(functionName: string) {
@@ -138,6 +166,7 @@ export function onError(functionName: string) {
       const suppressDiscordAlert = e.cause
         && typeof e.cause === 'object'
         && (e.cause as { suppressDiscordAlert?: unknown }).suppressDiscordAlert === true
+      const suppressBackendAlert = suppressDiscordAlert || shouldSuppressQueueRetryAlert(c)
       if (e.status === 429) {
         // Set rate-limit headers from moreInfo when available, but DO NOT
         // overwrite the response body. Several distinct conditions reach this
@@ -161,7 +190,7 @@ export function onError(functionName: string) {
           c.header('Retry-After', String(Math.max(0, Math.floor(retryAfterSeconds))))
         }
       }
-      if (e.status >= 500 && !suppressDiscordAlert) {
+      if (e.status >= 500 && !suppressBackendAlert) {
         await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
         void backgroundTask(c, capturePosthogException(c, {
           error: e,
@@ -196,7 +225,8 @@ export function onError(functionName: string) {
       return c.json(defaultResponse, 500)
     }
     // Non-HTTP errors: log with stack and return 500
-    const suppressDiscordAlert = isFilesDurableObjectStorageTimeout(functionName, e)
+    const suppressQueueRetryAlert = shouldSuppressQueueRetryAlert(c)
+    const suppressDiscordAlert = suppressQueueRetryAlert || isFilesDurableObjectStorageTimeout(functionName, e)
     cloudlogErr({
       requestId: c.get('requestId'),
       functionName,
@@ -209,12 +239,14 @@ export function onError(functionName: string) {
     if (!suppressDiscordAlert)
       await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
 
-    void backgroundTask(c, capturePosthogException(c, {
-      error: e,
-      functionName,
-      kind: 'unhandled_error',
-      status: 500,
-    }))
+    if (!suppressQueueRetryAlert) {
+      void backgroundTask(c, capturePosthogException(c, {
+        error: e,
+        functionName,
+        kind: 'unhandled_error',
+        status: 500,
+      }))
+    }
     return c.json(defaultResponse, 500)
   }
 }

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/tests/backend-alert-resilience.unit.test.ts
+++ b/tests/backend-alert-resilience.unit.test.ts
@@ -477,4 +477,37 @@ describe('backend alert resilience helpers', () => {
       status: 'skipped',
     })
   })
+
+  it('passes the queue retry budget to dispatched trigger requests', async () => {
+    const { http_post_helper, MAX_QUEUE_READS } = await import('../supabase/functions/_backend/triggers/queue_consumer.ts')
+    const originalFetch = globalThis.fetch
+    let dispatchedHeaders: Record<string, string> = {}
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      dispatchedHeaders = init?.headers as Record<string, string>
+      return new Response(JSON.stringify({ status: 'ok' }), { status: 200 })
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      await http_post_helper({
+        env: { API_SECRET: 'testsecret' },
+        get: (key: string) => key === 'requestId' ? 'request-id' : undefined,
+      } as any, 'cron_stat_app', 'cloudflare', {
+        appId: 'com.example.app',
+        orgId: 'org-id',
+      }, 'cf-id', {
+        msgId: 1271329,
+        queueName: 'cron_stat_app',
+        readCount: 1,
+      }, 'https://api.capgo.app/triggers/cron_stat_app')
+    }
+    finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(dispatchedHeaders['x-capgo-queue-name']).toBe('cron_stat_app')
+    expect(dispatchedHeaders['x-capgo-queue-read-count']).toBe('1')
+    expect(dispatchedHeaders['x-capgo-queue-max-reads']).toBe(String(MAX_QUEUE_READS))
+  })
 })

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -179,6 +179,24 @@ describe('readBandwidthUsageCF', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('includes Cloudflare Analytics HTTP error details in strict bandwidth failures', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      errors: [{ message: 'bad Analytics Engine query' }],
+    }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(readBandwidthUsageCF(
+      createContextMock() as unknown as Context,
+      'com.example.app',
+      '2026-06-01',
+      '2026-07-01',
+      { throwOnError: true },
+    )).rejects.toThrow('runQueryToCFA HTTP 400: {"errors":[{"message":"bad Analytics Engine query"}]}')
+  })
 })
 
 describe('countInstallSourcesCF', () => {

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -166,6 +166,62 @@ describe('onError PostHog capture', () => {
     })
   })
 
+  it('suppresses backend alerts for queue retries before the retry budget is exhausted', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const response = await onError('api')(new HTTPException(500, {
+      cause: {
+        error: 'analytics_engine_failed',
+        message: 'Analytics Engine temporarily failed',
+        moreInfo: {},
+      },
+    }), createContext(new Request('https://api.capgo.app/triggers/cron_stat_app', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-capgo-queue-max-reads': '5',
+        'x-capgo-queue-name': 'cron_stat_app',
+        'x-capgo-queue-read-count': '1',
+      },
+      body: JSON.stringify({ appId: 'com.example.app', orgId: 'org-id' }),
+    })))
+
+    expect(backgroundTaskMock).not.toHaveBeenCalled()
+    expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
+    expect(capturePosthogExceptionMock).not.toHaveBeenCalled()
+    expect(response.status).toBe(500)
+  })
+
+  it('keeps backend alerts for queue retries that exhausted the retry budget', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const response = await onError('api')(new HTTPException(500, {
+      cause: {
+        error: 'analytics_engine_failed',
+        message: 'Analytics Engine still failed',
+        moreInfo: {},
+      },
+    }), createContext(new Request('https://api.capgo.app/triggers/cron_stat_app', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-capgo-queue-max-reads': '5',
+        'x-capgo-queue-name': 'cron_stat_app',
+        'x-capgo-queue-read-count': '5',
+      },
+      body: JSON.stringify({ appId: 'com.example.app', orgId: 'org-id' }),
+    })))
+
+    expect(backgroundTaskMock).toHaveBeenCalledTimes(2)
+    expect(sendDiscordAlert500Mock).toHaveBeenCalledOnce()
+    expect(capturePosthogExceptionMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      functionName: 'api',
+      kind: 'http_exception',
+      status: 500,
+    }))
+    expect(response.status).toBe(500)
+  })
+
   it('skips PostHog capture for client HTTP exceptions', async () => {
     const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
 


### PR DESCRIPTION
## Summary

- suppress backend Discord/PostHog alerts for internal queue-triggered failures while the PGMQ retry budget is still available
- pass the queue max-read budget through queue dispatch headers so nested trigger handlers can make that decision without duplicating retry constants
- preserve Cloudflare Analytics Engine HTTP status/body details in `runQueryToCFA` errors instead of collapsing them to a generic message

## Root Cause

`cron_stat_app` is dispatched through `queue_consumer`, which already suppresses queue-level Discord alerts until the retry budget is exhausted. The nested `/triggers/cron_stat_app` request still ran the normal backend `onError` path, so a first-delivery Analytics Engine failure produced an immediate 500 alert before PGMQ could retry. The alert also lost the real Cloudflare SQL status/body because `runQueryToCFA` rethrew every failure as the same generic error.

## Validation

- `bun lint:backend`
- `bunx vitest run tests/on-error-posthog.unit.test.ts tests/backend-alert-resilience.unit.test.ts tests/cloudflare-device-pagination.unit.test.ts`
- `bun run typecheck:backend`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-message changes on internal queue/cron paths; no auth or customer-facing API behavior change beyond quieter alerts during retries.
> 
> **Overview**
> Stops **false-positive backend alerts** when queue-dispatched triggers (e.g. `cron_stat_app`) fail on an attempt that PGMQ will still retry. The queue consumer now forwards **`x-capgo-queue-max-reads`** with the existing queue name/read-count headers so nested handlers can tell whether the retry budget is exhausted.
> 
> **`onError`** skips Discord 500 alerts and PostHog capture when queue headers show `read_count < max_reads`; alerts still fire on the final attempt.
> 
> **`runQueryToCFA`** no longer collapses Cloudflare Analytics Engine failures to a generic message—it surfaces HTTP status and a short body preview (and preserves the HTTP error when rethrowing).
> 
> Generated **`devices.country_code`** appears in Supabase types (schema sync). Unit tests cover header propagation, alert suppression vs exhaustion, and stricter CFA errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d907e8468395bbd208864ff69c3b5081934d0828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->