### PR TITLE
fix(frontend): clear dashboard lint warnings

### DIFF
--- a/src/pages/admin/dashboard/builder.vue
+++ b/src/pages/admin/dashboard/builder.vue
@@ -672,7 +672,9 @@ displayStore.defaultBack = '/dashboard'
                     <td class="px-4 py-3">
                       <span class="font-medium text-slate-900 dark:text-white">{{ o.org_name }}</span>
                       <span v-if="o.used_ai" class="ml-1.5 text-[10px] text-purple-500">AI</span>
-                      <button v-if="o.org_id && !o.org_id.startsWith('app:')" type="button" class="ml-2 text-[11px] font-medium text-blue-500 hover:underline" @click="spoof(o.org_id)">Spoof</button>
+                      <button v-if="o.org_id && !o.org_id.startsWith('app:')" type="button" class="ml-2 text-[11px] font-medium text-blue-500 hover:underline" @click="spoof(o.org_id)">
+                        Spoof
+                      </button>
                     </td>
                     <td class="px-4 py-3 text-right text-slate-700 dark:text-slate-200">
                       {{ formatNumberValue(o.completed) }}/{{ formatNumberValue(o.attempts) }}
@@ -730,9 +732,15 @@ displayStore.defaultBack = '/dashboard'
                     aria-label="Filter journeys by platform"
                     class="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-900 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
                   >
-                    <option value="">All platforms</option>
-                    <option value="ios">iOS</option>
-                    <option value="android">Android</option>
+                    <option value="">
+                      All platforms
+                    </option>
+                    <option value="ios">
+                      iOS
+                    </option>
+                    <option value="android">
+                      Android
+                    </option>
                   </select>
                   <label class="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
                     <input v-model="journeyQuitOnly" type="checkbox" class="rounded"> Quit only
@@ -744,14 +752,30 @@ displayStore.defaultBack = '/dashboard'
               <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
                 <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:text-slate-400">
                   <tr>
-                    <th class="px-3 py-3">Org</th>
-                    <th class="px-3 py-3">App</th>
-                    <th class="px-3 py-3">Platform</th>
-                    <th class="px-3 py-3">Furthest</th>
-                    <th class="px-3 py-3">Last step (where)</th>
-                    <th class="px-3 py-3">Outcome</th>
-                    <th class="px-3 py-3 text-right">Duration</th>
-                    <th class="px-3 py-3 text-right">Started</th>
+                    <th class="px-3 py-3">
+                      Org
+                    </th>
+                    <th class="px-3 py-3">
+                      App
+                    </th>
+                    <th class="px-3 py-3">
+                      Platform
+                    </th>
+                    <th class="px-3 py-3">
+                      Furthest
+                    </th>
+                    <th class="px-3 py-3">
+                      Last step (where)
+                    </th>
+                    <th class="px-3 py-3">
+                      Outcome
+                    </th>
+                    <th class="px-3 py-3 text-right">
+                      Duration
+                    </th>
+                    <th class="px-3 py-3 text-right">
+                      Started
+                    </th>
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
@@ -759,12 +783,22 @@ displayStore.defaultBack = '/dashboard'
                     <td class="px-3 py-3">
                       <span class="font-medium text-slate-900 dark:text-white">{{ j.org_name }}</span>
                       <span v-if="j.used_ai" class="ml-1.5 text-[10px] text-purple-500">AI</span>
-                      <button v-if="j.org_id && !j.org_id.startsWith('app:')" type="button" class="ml-2 text-[11px] font-medium text-blue-500 hover:underline" @click="spoof(j.org_id)">Spoof</button>
+                      <button v-if="j.org_id && !j.org_id.startsWith('app:')" type="button" class="ml-2 text-[11px] font-medium text-blue-500 hover:underline" @click="spoof(j.org_id)">
+                        Spoof
+                      </button>
                     </td>
-                    <td class="px-3 py-3 text-slate-500 dark:text-slate-400">{{ j.app_id }}</td>
-                    <td class="px-3 py-3 capitalize text-slate-500 dark:text-slate-400">{{ j.platform }}</td>
-                    <td class="px-3 py-3 text-slate-700 dark:text-slate-200">{{ j.milestone_label }}</td>
-                    <td class="px-3 py-3 text-slate-700 dark:text-slate-200">{{ humanStep(j.last_step) }}</td>
+                    <td class="px-3 py-3 text-slate-500 dark:text-slate-400">
+                      {{ j.app_id }}
+                    </td>
+                    <td class="px-3 py-3 capitalize text-slate-500 dark:text-slate-400">
+                      {{ j.platform }}
+                    </td>
+                    <td class="px-3 py-3 text-slate-700 dark:text-slate-200">
+                      {{ j.milestone_label }}
+                    </td>
+                    <td class="px-3 py-3 text-slate-700 dark:text-slate-200">
+                      {{ humanStep(j.last_step) }}
+                    </td>
                     <td class="px-3 py-3">
                       <span
                         class="rounded px-2 py-0.5 text-xs font-medium"
@@ -773,8 +807,12 @@ displayStore.defaultBack = '/dashboard'
                         {{ j.outcome === 'completed' ? 'Completed' : 'Quit' }}
                       </span>
                     </td>
-                    <td class="px-3 py-3 text-right text-slate-500 dark:text-slate-400">{{ fmtDuration(j.duration_ms) }}</td>
-                    <td class="px-3 py-3 text-right text-slate-500 dark:text-slate-400">{{ ago(j.started_at) }}</td>
+                    <td class="px-3 py-3 text-right text-slate-500 dark:text-slate-400">
+                      {{ fmtDuration(j.duration_ms) }}
+                    </td>
+                    <td class="px-3 py-3 text-right text-slate-500 dark:text-slate-400">
+                      {{ ago(j.started_at) }}
+                    </td>
                   </tr>
                 </tbody>
               </table>

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -657,26 +657,50 @@ displayStore.defaultBack = '/dashboard'
           <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">Total Paid Organizations</p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-success">{{ formatNumberValue(latestGlobalStats.paying_orgs_total || latestGlobalStats.paying || 0) }}</p>
-                <p v-else class="mt-2 text-3xl font-bold text-success">0</p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Subscription and/or available credits</p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Total Paid Organizations
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-success">
+                  {{ formatNumberValue(latestGlobalStats.paying_orgs_total || latestGlobalStats.paying || 0) }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-success">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Subscription and/or available credits
+                </p>
               </div>
             </div>
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Subscription</p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-primary">{{ formatNumberValue(latestGlobalStats.paying_orgs_subscription || latestGlobalStats.paying || 0) }}</p>
-                <p v-else class="mt-2 text-3xl font-bold text-primary">0</p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Active subscription organizations</p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Paid via Subscription
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-primary">
+                  {{ formatNumberValue(latestGlobalStats.paying_orgs_subscription || latestGlobalStats.paying || 0) }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-primary">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Active subscription organizations
+                </p>
               </div>
             </div>
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Credits</p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-accent">{{ formatNumberValue(latestGlobalStats.paying_orgs_credits || 0) }}</p>
-                <p v-else class="mt-2 text-3xl font-bold text-accent">0</p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Organizations with available credits</p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Paid via Credits
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-accent">
+                  {{ formatNumberValue(latestGlobalStats.paying_orgs_credits || 0) }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-accent">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Organizations with available credits
+                </p>
               </div>
             </div>
           </div>

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -992,26 +992,50 @@ displayStore.defaultBack = '/dashboard'
           <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">Total Paid Organizations</p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-emerald-500">{{ formatNumberValue(latestGlobalStats.paying_orgs_total || latestGlobalStats.paying || 0) }}</p>
-                <p v-else class="mt-2 text-3xl font-bold text-emerald-500">0</p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Subscription and/or available credits</p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Total Paid Organizations
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-emerald-500">
+                  {{ formatNumberValue(latestGlobalStats.paying_orgs_total || latestGlobalStats.paying || 0) }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-emerald-500">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Subscription and/or available credits
+                </p>
               </div>
             </div>
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Subscription</p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-primary">{{ formatNumberValue(latestGlobalStats.paying_orgs_subscription || latestGlobalStats.paying || 0) }}</p>
-                <p v-else class="mt-2 text-3xl font-bold text-primary">0</p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Active subscription organizations</p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Paid via Subscription
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-primary">
+                  {{ formatNumberValue(latestGlobalStats.paying_orgs_subscription || latestGlobalStats.paying || 0) }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-primary">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Active subscription organizations
+                </p>
               </div>
             </div>
             <div class="flex flex-col justify-between p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
               <div>
-                <p class="text-sm text-slate-600 dark:text-slate-400">Paid via Credits</p>
-                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-accent">{{ formatNumberValue(latestGlobalStats.paying_orgs_credits || 0) }}</p>
-                <p v-else class="mt-2 text-3xl font-bold text-accent">0</p>
-                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Organizations with available credits</p>
+                <p class="text-sm text-slate-600 dark:text-slate-400">
+                  Paid via Credits
+                </p>
+                <p v-if="latestGlobalStats" class="mt-2 text-3xl font-bold text-accent">
+                  {{ formatNumberValue(latestGlobalStats.paying_orgs_credits || 0) }}
+                </p>
+                <p v-else class="mt-2 text-3xl font-bold text-accent">
+                  0
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Organizations with available credits
+                </p>
               </div>
             </div>
 


### PR DESCRIPTION
## What changed

- Reflowed the affected admin dashboard Vue templates so eslint no longer reports `vue/singleline-html-element-content-newline` warnings.
- Kept the change formatting-only in `builder.vue`, `revenue.vue`, and `users.vue`.

## Root cause

The dashboard templates had inline text inside Vue elements that violates the configured single-line element newline rule. The default `bun lint` command exits successfully with warnings, but stricter zero-warning lint gates fail on these warnings.

## Validation

- `bun lint`
- `bun typecheck`
- `bunx eslint src/pages/admin/dashboard/builder.vue src/pages/admin/dashboard/revenue.vue src/pages/admin/dashboard/users.vue --max-warnings=0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only whitespace/formatting in admin UI pages; no logic, API, or security impact.
> 
> **Overview**
> **Formatting-only** updates to admin dashboard Vue templates so they satisfy `vue/singleline-html-element-content-newline` and pass stricter lint gates (`--max-warnings=0`).
> 
> In **`builder.vue`**, inline element content is split onto new lines for Spoof buttons, platform `<option>` labels, journey table headers, and table cells (interpolations unchanged). **`revenue.vue`** and **`users.vue`** get the same treatment for the paid-organization metric cards (labels, values, and helper text).
> 
> No script, data binding, or behavior changes—only markup layout for ESLint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee18c517f903ebd29ed797a77a6c29c028fd90c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->