### PR TITLE
fix(read-replica): stabilize Hyperdrive schema check

### DIFF
--- a/cloudflare_workers/read-replica-schema-check/wrangler.jsonc
+++ b/cloudflare_workers/read-replica-schema-check/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "name": "capgo_read_replica_schema_check",
+  "account_id": "9ee3d7479a3c359681e3fab2c8cb22c0",
   "main": "./index.ts",
   "compatibility_date": "2026-04-21",
   "compatibility_flags": [
@@ -9,6 +10,7 @@
   "workers_dev": true,
   "env": {
     "prod": {
+      // Cloud SQL read Hyperdrives use IP origins; keep the live Hyperdrive sslmode=require, not verify-full.
       "hyperdrive": [
         {
           "binding": "HYPERDRIVE_CAPGO_READ_EU",

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -11,6 +11,11 @@ SYNC_RESPONSE="$(mktemp)"
 WRANGLER_LOG="$(mktemp)"
 PORT="${READ_REPLICA_SCHEMA_CHECK_PORT:-8799}"
 SYNC_MAX_TIME="${READ_REPLICA_SCHEMA_SYNC_MAX_TIME:-1800}"
+if [[ -n "${READ_REPLICA_WRANGLER_CMD:-}" ]]; then
+  read -r -a WRANGLER_CMD <<< "$READ_REPLICA_WRANGLER_CMD"
+else
+  WRANGLER_CMD=(bunx wrangler@4.107.0)
+fi
 if ! [[ "$SYNC_MAX_TIME" =~ ^[0-9]+$ ]] || (( SYNC_MAX_TIME <= 30 )); then
   echo '::error title=Invalid read-replica schema sync timeout::READ_REPLICA_SCHEMA_SYNC_MAX_TIME must be an integer greater than 30 seconds.'
   exit 1
@@ -33,7 +38,7 @@ if [[ ! -f "$EXPECTED_SCHEMA_CATALOG" ]]; then
   exit 1
 fi
 
-bunx wrangler dev \
+"${WRANGLER_CMD[@]}" dev \
   --remote \
   --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc \
   --env=prod \


### PR DESCRIPTION
## Summary
- pin the read-replica schema check to Wrangler 4.107.0 by default while keeping an override via `READ_REPLICA_WRANGLER_CMD`
- add the Capgo Cloudflare account id to the schema-check worker config for non-interactive `wrangler dev --remote`
- document that the live Cloud SQL read Hyperdrive must stay on `sslmode=require` because the origins are IP addresses

## Production config note
The live read Hyperdrive configs were updated before this PR so all regional read replicas now report `mtls.sslmode = "require"`. The failing EU binding is `d5aae8be75f446868352110502fa9a1e`.

## Validation
- `bash -n scripts/check-read-replica-hyperdrive-schema.sh`
- `git diff --check -- cloudflare_workers/read-replica-schema-check/wrangler.jsonc scripts/check-read-replica-hyperdrive-schema.sh`
- `CLOUDFLARE_ACCOUNT_ID=9ee3d7479a3c359681e3fab2c8cb22c0 bunx wrangler@4.107.0 deploy --dry-run --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc --env=prod --outdir /tmp/capgo-read-replica-check-dry-run`
- commit hook: `bun run cli:typecheck && bun run typecheck:backend && bun run typecheck:frontend`

## Caveat
A local full `wrangler dev --remote` run hung before `/ok` returned on this machine, after bundling and preview upload. The dry-run bundle and live Hyperdrive metadata checks passed; CI should exercise the release command path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/script and worker config only; no runtime app logic or auth changes, though the check exercises live read Hyperdrive in prod env.
> 
> **Overview**
> Stabilizes the read-replica Hyperdrive schema check so CI and non-interactive runs can start `wrangler dev --remote` reliably.
> 
> The schema-check worker config now includes the Capgo **Cloudflare `account_id`**, with a comment that live read Hyperdrive bindings must use **`sslmode=require`** (not `verify-full`) because Cloud SQL origins are IP addresses.
> 
> The **`check-read-replica-hyperdrive-schema.sh`** script defaults to **`bunx wrangler@4.107.0`** instead of unpinned `bunx wrangler`, and allows overriding via **`READ_REPLICA_WRANGLER_CMD`** before invoking `wrangler dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f1e094a4f58fcb156dd59fa073e91f8a0eb52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->