### PR TITLE
fix(ci): scope Discord release footers

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -19,10 +19,20 @@ jobs:
           node-version: 24.x
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Resolve release metadata
+        id: release_metadata
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          case "$tag" in
+            cli-[0-9]*) footer_title="Release $(node -p 'require("./cli/package.json").name')" ;;
+            notifications-[0-9]*) footer_title="Release $(node -p 'require("./packages/capacitor-notifications/package.json").name')" ;;
+            *) footer_title="Release @${{ github.repository }}" ;;
+          esac
+          printf 'footer_title=%s\n' "$footer_title" >> "$GITHUB_OUTPUT"
       - name: GitHub Releases to Discord
         uses: SethCohen/github-releases-to-discord@v1
         with:
           webhook_url: ${{ secrets.WEBHOOK_DISCORD_RELEASE_URL }}
           color: "2105893"
-          footer_title: "Release @${{ github.repository }}"
+          footer_title: ${{ steps.release_metadata.outputs.footer_title }}
           reduce_headings: true

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -55,6 +55,24 @@ describe('release scope matching', () => {
     expect(workflow).not.toContain('--access restricted')
   })
 
+  it.concurrent('uses the released package in Discord release footers', () => {
+    const workflow = readFileSync('.github/workflows/github-releases-to-discord.yml', 'utf8')
+    const cliPackage = JSON.parse(readFileSync('cli/package.json', 'utf8')) as { name: string }
+    const notificationsPackage = JSON.parse(
+      readFileSync('packages/capacitor-notifications/package.json', 'utf8'),
+    ) as { name: string }
+
+    expect(workflow).toContain('id: release_metadata')
+    expect(workflow).toContain(`cli-[0-9]*) footer_title="Release $(node -p 'require("./cli/package.json").name')"`)
+    expect(workflow).toContain(
+      `notifications-[0-9]*) footer_title="Release $(node -p 'require("./packages/capacitor-notifications/package.json").name')"`,
+    )
+    expect(workflow).not.toContain('cli-*) footer_title=')
+    expect(workflow).toContain('footer_title: $' + '{{ steps.release_metadata.outputs.footer_title }}')
+    expect(cliPackage.name).toBe('@capgo/cli')
+    expect(notificationsPackage.name).toBe('@capgo/capacitor-notifications')
+  })
+
   it.concurrent('keeps runtime code scoped to the matching component', () => {
     expect(matchesComponent('capgo', ['src/pages/index.vue'])).toBe(true)
     expect(matchesComponent('cli', ['src/pages/index.vue'])).toBe(false)


### PR DESCRIPTION
## Summary
- derive Discord release footer text from the published release tag prefix
- show @capgo/cli for CLI releases and @capgo/capacitor-notifications for notifications releases
- keep the repository footer for the main Capgo release path

## Tests
- bunx vitest run tests/release-scope.test.ts
- bun lint
- bunx eslint tests/release-scope.test.ts
- git diff --check -- .github/workflows/github-releases-to-discord.yml tests/release-scope.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Discord notification text; no runtime, auth, or publish logic changes.
> 
> **Overview**
> Discord release announcements no longer always show the monorepo name in the footer. A new workflow step maps **`github.event.release.tag_name`** to footer text: **`cli-[0-9]*`** and **`notifications-[0-9]*`** tags resolve to the npm **`name`** from the matching **`package.json`**; everything else keeps **`Release @<repository>`**.
> 
> The Discord action’s **`footer_title`** now uses that step’s output instead of a fixed repo string. **`tests/release-scope.test.ts`** adds coverage so the workflow wiring, tag patterns, and expected package names stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5c8787b50f2180b9adf1f0fef6d839dd43bec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->