### PR TITLE
perf(ci): speed up migration order check

### DIFF
--- a/scripts/check-supabase-migration-order.sh
+++ b/scripts/check-supabase-migration-order.sh
@@ -4,14 +4,37 @@ set -euo pipefail
 
 extract_timestamp() {
   local file_name="$1"
+  local out_var="${2:-}"
   local base_name
-  base_name="$(basename "$file_name")"
+  base_name="${file_name##*/}"
 
   if [[ "$base_name" =~ ^([0-9]{14})_.+\.sql$ ]]; then
-    echo "${BASH_REMATCH[1]}"
+    if [[ -n "$out_var" ]]; then
+      printf -v "$out_var" '%s' "${BASH_REMATCH[1]}"
+    else
+      printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
   else
+    if [[ -n "$out_var" ]]; then
+      printf -v "$out_var" ''
+    fi
     return 1
   fi
+}
+
+resolve_github_merge_base_ref() {
+  case "${GITHUB_EVENT_NAME:-}" in
+    pull_request | merge_group) ;;
+    *) return 1 ;;
+  esac
+
+  if git rev-parse --verify --quiet "HEAD^1^{commit}" >/dev/null \
+    && git rev-parse --verify --quiet "HEAD^2^{commit}" >/dev/null; then
+    echo 'HEAD^1'
+    return
+  fi
+
+  return 1
 }
 
 resolve_target_branch() {
@@ -48,42 +71,59 @@ resolve_target_branch() {
 
 target_branch="$(resolve_target_branch)"
 base_ref="origin/${target_branch}"
+base_label="${base_ref}"
 tmp_dir="$(mktemp -d)"
 base_timestamps_file="${tmp_dir}/base_timestamps.tsv"
 added_timestamps_file="${tmp_dir}/added_timestamps.tsv"
 
 trap 'rm -rf "${tmp_dir}"' EXIT
 
-echo "Checking Supabase migrations against ${base_ref}"
-if ! git fetch --no-tags origin "${target_branch}"; then
-  if git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-    echo "⚠️  Could not fetch ${base_ref}; using existing local ref."
-  elif git rev-parse --verify --quiet "HEAD^1^{commit}" >/dev/null \
+local_base_ref=''
+if local_base_ref="$(resolve_github_merge_base_ref)"; then
+  base_ref="${local_base_ref}"
+  base_label="local merge base parent (${target_branch})"
+  echo "Checking Supabase migrations against ${base_label}"
+else
+  echo "Checking Supabase migrations against ${base_ref}"
+  if ! git fetch --no-tags origin "+refs/heads/${target_branch}:refs/remotes/origin/${target_branch}"; then
+    if git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+      echo "⚠️  Could not fetch ${base_ref}; using existing local ref."
+    elif git rev-parse --verify --quiet "HEAD^1^{commit}" >/dev/null \
+      && git rev-parse --verify --quiet "HEAD^2^{commit}" >/dev/null; then
+      base_ref='HEAD^1'
+      base_label="local merge base parent (${target_branch})"
+      echo "⚠️  Could not fetch origin/${target_branch}; using PR merge base parent."
+    else
+      echo "❌ Could not fetch ${base_ref} and no local fallback was available."
+      exit 1
+    fi
+  fi
+fi
+
+if ! git merge-base "${base_ref}" HEAD >/dev/null; then
+  if git rev-parse --verify --quiet "HEAD^1^{commit}" >/dev/null \
     && git rev-parse --verify --quiet "HEAD^2^{commit}" >/dev/null; then
     base_ref='HEAD^1'
-    echo "⚠️  Could not fetch origin/${target_branch}; using PR merge base parent."
+    base_label="local merge base parent (${target_branch})"
+    echo "⚠️  Could not find a merge base for ${target_branch}; using PR merge base parent."
   else
-    echo "❌ Could not fetch ${base_ref} and no local fallback was available."
+    echo "❌ Could not find a merge base between ${base_ref} and HEAD."
     exit 1
   fi
 fi
 
 : > "${base_timestamps_file}"
+latest_base_timestamp='00000000000000'
 while IFS= read -r file; do
   [[ "$file" != supabase/migrations/*.sql ]] && continue
-  ts="$(extract_timestamp "$file" || true)"
-  [[ -z "$ts" ]] && continue
+  if ! extract_timestamp "$file" ts; then
+    continue
+  fi
   printf '%s\t%s\n' "$ts" "$file" >> "${base_timestamps_file}"
+  if [[ "$ts" > "$latest_base_timestamp" ]]; then
+    latest_base_timestamp="$ts"
+  fi
 done < <(git ls-tree -r --name-only "${base_ref}" -- supabase/migrations)
-
-latest_base_timestamp='00000000000000'
-if [[ -s "${base_timestamps_file}" ]]; then
-  latest_base_timestamp="$(awk -F '\t' '
-    BEGIN { max = "00000000000000" }
-    $1 > max { max = $1 }
-    END { print max }
-  ' "${base_timestamps_file}")"
-fi
 
 status=0
 
@@ -96,8 +136,9 @@ restamped_files=''
 while IFS=$'\t' read -r similarity _old_path new_path; do
   [[ -z "${new_path:-}" ]] && continue
   [[ "$similarity" != "R100" ]] && continue
-  new_ts="$(extract_timestamp "$new_path" || true)"
-  [[ -z "$new_ts" ]] && continue
+  if ! extract_timestamp "$new_path" new_ts; then
+    continue
+  fi
   if (( 10#$new_ts > 10#$latest_base_timestamp )); then
     restamped_files+="${new_path}"$'\n'
   fi
@@ -110,7 +151,8 @@ if [[ -n "$modified_files" ]]; then
   while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
-    ts="$(extract_timestamp "$file" || true)"
+    ts=''
+    extract_timestamp "$file" ts || true
     if [[ -n "$ts" && "$ts" == "$latest_base_timestamp" ]]; then
       echo "⚠️  Allowing fix to latest Supabase migration: $file"
       continue
@@ -153,8 +195,7 @@ if [[ -n "$added_files" ]]; then
   while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
-    ts="$(extract_timestamp "$file" || true)"
-    if [[ -z "$ts" ]]; then
+    if ! extract_timestamp "$file" ts; then
       echo "❌ Invalid Supabase migration filename: $file"
       echo '  Expected format: YYYYMMDDHHMMSS_description.sql'
       status=1

--- a/tests/check-supabase-migration-order.unit.test.ts
+++ b/tests/check-supabase-migration-order.unit.test.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function run(command: string, args: string[], cwd: string, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env,
+  })
+
+  if (result.status !== 0) {
+    throw new Error([
+      `${command} ${args.join(' ')} failed with ${result.status}`,
+      result.stdout,
+      result.stderr,
+    ].join('\n'))
+  }
+
+  return result
+}
+
+function resolveGitPath(): string {
+  return run('bash', ['-lc', 'command -v git'], process.cwd()).stdout.trim()
+}
+
+describe('supabase migration order check', () => {
+  it('uses the local PR merge parent instead of fetching in GitHub pull request runs', () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'capgo-migration-order-'))
+    const fakeBinDir = join(repoDir, 'fake-bin')
+    const migrationsDir = join(repoDir, 'supabase', 'migrations')
+    const scriptPath = join(process.cwd(), 'scripts', 'check-supabase-migration-order.sh')
+    const realGit = resolveGitPath()
+
+    try {
+      mkdirSync(migrationsDir, { recursive: true })
+      run('git', ['init', '-b', 'main'], repoDir)
+      run('git', ['config', 'user.email', 'test@example.com'], repoDir)
+      run('git', ['config', 'user.name', 'Capgo Test'], repoDir)
+      run('git', ['config', 'commit.gpgsign', 'false'], repoDir)
+
+      writeFileSync(join(migrationsDir, '20260101000000_base.sql'), 'select 1;\n')
+      run('git', ['add', '.'], repoDir)
+      run('git', ['commit', '-m', 'base migration'], repoDir)
+
+      run('git', ['checkout', '-b', 'feature'], repoDir)
+      writeFileSync(join(migrationsDir, '20260102000000_feature.sql'), 'select 2;\n')
+      run('git', ['add', '.'], repoDir)
+      run('git', ['commit', '-m', 'feature migration'], repoDir)
+
+      run('git', ['checkout', 'main'], repoDir)
+      run('git', ['merge', '--no-ff', 'feature', '-m', 'merge feature'], repoDir)
+
+      mkdirSync(fakeBinDir)
+      writeFileSync(join(fakeBinDir, 'git'), `#!/usr/bin/env bash
+if [[ "$1" == "fetch" ]]; then
+  echo "unexpected git fetch" >&2
+  exit 88
+fi
+exec "$REAL_GIT" "$@"
+`)
+      chmodSync(join(fakeBinDir, 'git'), 0o755)
+
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GITHUB_BASE_REF: 'main',
+          GITHUB_EVENT_NAME: 'pull_request',
+          PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ''}`,
+          REAL_GIT: realGit,
+        },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).not.toContain('unexpected git fetch')
+      expect(result.stdout).toContain('Checking Supabase migrations against local merge base parent (main)')
+      expect(result.stdout).toContain('Supabase migration filenames are unique')
+    }
+    finally {
+      rmSync(repoDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- skip the network fetch in GitHub pull request and merge-group runs when the checkout already has the synthetic merge commit
- update the migration timestamp parser to avoid per-file `basename` subprocesses and compute the latest base timestamp during the base scan
- add a unit test that fails if the PR merge-commit path tries to run `git fetch`

## Root cause
The migration-order check looked text-only, but it always fetched the target branch and spawned extra shell work while scanning every base migration. In GitHub PR checkouts the base tree is already available as `HEAD^1`, so the fetch is avoidable.

## Validation
- `bash -n scripts/check-supabase-migration-order.sh`
- `/usr/bin/time -p bash scripts/check-supabase-migration-order.sh`
- `bunx vitest run tests/check-supabase-migration-order.unit.test.ts`
- `bun lint`
- `bun test:unit`
- `bun typecheck`
- `bunx eslint tests/check-supabase-migration-order.unit.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the migration filename/order guard script and its tests; no runtime app or database behavior.
> 
> **Overview**
> **Speeds up the Supabase migration order CI check** by avoiding unnecessary network and shell work while keeping the same validation rules.
> 
> On **GitHub `pull_request` and `merge_group` runs**, the script now prefers **`HEAD^1`** as the comparison ref when the synthetic merge commit is present, so it **skips `git fetch`** when the base tree is already local. Fetch fallbacks and a **`git merge-base`** check still apply when fetch fails or no merge base exists.
> 
> **`extract_timestamp`** no longer shells out to `basename`; it uses Bash path expansion and can write into a variable. The **latest base migration timestamp** is tracked in the same loop that builds the base file list instead of a separate `awk` pass.
> 
> A new **Vitest unit test** builds a mini repo with a merge commit, stubs `git fetch` to fail if called, and asserts the script uses the local merge parent and passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbfe9cef6de051ecad1b25e00ea63d8288ddfd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->