### PR TITLE
fix(ci): deploy ephemeral read replica checker

### DIFF
--- a/cloudflare_workers/read-replica-schema-check/wrangler.jsonc
+++ b/cloudflare_workers/read-replica-schema-check/wrangler.jsonc
@@ -8,15 +8,11 @@
     "nodejs_compat_populate_process_env"
   ],
   "workers_dev": true,
-  "env": {
-    "prod": {
-      // Cloud SQL read Hyperdrives use IP origins; keep the live Hyperdrive sslmode=require, not verify-full.
-      "hyperdrive": [
-        {
-          "binding": "HYPERDRIVE_CAPGO_READ_EU",
-          "id": "d5aae8be75f446868352110502fa9a1e"
-        }
-      ]
+  // Cloud SQL read Hyperdrives use IP origins; keep the live Hyperdrive sslmode=require, not verify-full.
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE_CAPGO_READ_EU",
+      "id": "d5aae8be75f446868352110502fa9a1e"
     }
-  }
+  ]
 }

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -100,7 +100,7 @@ READ_REPLICA_PASSWORD='new-password' bash read_replicate/update_readreplica_pass
   by release CI to sync missing additive schema changes and compare the committed
   schema against the live read replica through Hyperdrive.
 - Production Supabase deploys run `bun run readreplicate:check-hyperdrive-schema`
-  before migrations, functions, or workers publish. The check first applies safe
-  missing columns and indexes on the Google subscriber, reindexes invalid
-  same-name indexes left by interrupted concurrent builds, then fails if any
-  unsupported drift remains.
+  before migrations, functions, or workers publish. Each check deploys a uniquely
+  named, token-protected Worker, applies safe missing columns and indexes on the
+  Google subscriber, verifies the live catalog, and deletes the Worker before
+  exiting. Concurrent CI runs therefore never share or replace a checker Worker.

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -8,8 +8,6 @@ cd "$REPO_ROOT"
 EXPECTED_SCHEMA_CATALOG='read_replicate/schema_replicate.catalog.json'
 ACTUAL_SCHEMA_CATALOG="$(mktemp)"
 SYNC_RESPONSE="$(mktemp)"
-WRANGLER_LOG="$(mktemp)"
-PORT="${READ_REPLICA_SCHEMA_CHECK_PORT:-8799}"
 SYNC_MAX_TIME="${READ_REPLICA_SCHEMA_SYNC_MAX_TIME:-1800}"
 if [[ -n "${READ_REPLICA_WRANGLER_CMD:-}" ]]; then
   read -r -a WRANGLER_CMD <<< "$READ_REPLICA_WRANGLER_CMD"
@@ -21,67 +19,80 @@ if ! [[ "$SYNC_MAX_TIME" =~ ^[0-9]+$ ]] || (( SYNC_MAX_TIME <= 30 )); then
   exit 1
 fi
 SYNC_MAX_DURATION_MS="$(( (SYNC_MAX_TIME - 15) * 1000 ))"
-WORKER_PID=''
-SCHEMA_CHECK_TOKEN="$(bun --silent -e 'const bytes = crypto.getRandomValues(new Uint8Array(32)); console.log(Buffer.from(bytes).toString("hex"))')"
+WORKER_DEPLOYED=0
+WORKER_SUFFIX="$(bun --silent -e 'const bytes = crypto.getRandomValues(new Uint8Array(8)); console.log(Buffer.from(bytes).toString("hex"))')"
+WORKER_RUN_ID="${GITHUB_RUN_ID:-local}"
+WORKER_RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
+WORKER_NAME="$(printf 'capgo-rr-%s-%s-%s' "$WORKER_SUFFIX" "$WORKER_RUN_ID" "$WORKER_RUN_ATTEMPT" | tr '[:upper:]_' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-63)"
+export READ_REPLICA_SCHEMA_CHECK_TOKEN="$(bun --silent -e 'const bytes = crypto.getRandomValues(new Uint8Array(32)); console.log(Buffer.from(bytes).toString("hex"))')"
 
 cleanup() {
-  if [[ -n "$WORKER_PID" ]] && kill -0 "$WORKER_PID" 2>/dev/null; then
-    kill "$WORKER_PID" 2>/dev/null || true
-    wait "$WORKER_PID" 2>/dev/null || true
+  local status=$?
+  trap - EXIT
+
+  if (( WORKER_DEPLOYED == 1 )); then
+    echo "==> Deleting ephemeral Worker ${WORKER_NAME}"
+    if ! "${WRANGLER_CMD[@]}" delete "$WORKER_NAME" \
+      --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc \
+      --force; then
+      echo "::error title=Failed to delete read-replica schema checker::Ephemeral Worker ${WORKER_NAME} could not be deleted."
+      status=1
+    fi
   fi
-  rm -f "$ACTUAL_SCHEMA_CATALOG" "$SYNC_RESPONSE" "$WRANGLER_LOG"
+
+  rm -f "$ACTUAL_SCHEMA_CATALOG" "$SYNC_RESPONSE"
+  exit "$status"
 }
 trap cleanup EXIT
+trap 'exit 130' INT TERM
 
 if [[ ! -f "$EXPECTED_SCHEMA_CATALOG" ]]; then
   echo "::error title=Missing read-replica schema catalog::${EXPECTED_SCHEMA_CATALOG} does not exist."
   exit 1
 fi
 
-"${WRANGLER_CMD[@]}" dev \
-  --remote \
+echo "==> Deploying ephemeral Worker ${WORKER_NAME}"
+WORKER_DEPLOYED=1
+DEPLOY_OUTPUT="$("${WRANGLER_CMD[@]}" deploy \
   --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc \
-  --env=prod \
-  --ip 127.0.0.1 \
-  --port "$PORT" \
-  --log-level warn \
-  --show-interactive-dev-session=false \
-  --var "READ_REPLICA_SCHEMA_CHECK_TOKEN:${SCHEMA_CHECK_TOKEN}" \
-  > "$WRANGLER_LOG" 2>&1 &
-WORKER_PID=$!
+  --name "$WORKER_NAME" \
+  --minify)"
+printf '%s\n' "$DEPLOY_OUTPUT"
+
+bun --silent -e 'process.stdout.write(process.env.READ_REPLICA_SCHEMA_CHECK_TOKEN)' \
+  | "${WRANGLER_CMD[@]}" secret put READ_REPLICA_SCHEMA_CHECK_TOKEN \
+    --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc \
+    --name "$WORKER_NAME"
+
+WORKER_URL="$(bun --silent -e 'const output = await Bun.stdin.text(); console.log(output.match(/https:\/\/[a-z0-9.-]+\.workers\.dev/i)?.[0] ?? "")' <<< "$DEPLOY_OUTPUT")"
+if [[ -z "$WORKER_URL" ]]; then
+  echo '::error title=Missing read-replica schema checker URL::Wrangler deployed the ephemeral Worker but did not return a workers.dev URL.'
+  exit 1
+fi
 
 for _ in $(seq 1 60); do
-  if curl -fsS --connect-timeout 5 --max-time 5 "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
+  if curl -fsS --connect-timeout 5 --max-time 5 "${WORKER_URL}/ok" >/dev/null 2>&1; then
     break
   fi
-
-  if ! kill -0 "$WORKER_PID" 2>/dev/null; then
-    echo "::error title=Read-replica schema checker failed to start::wrangler dev exited before the health check passed."
-    cat "$WRANGLER_LOG"
-    exit 1
-  fi
-
   sleep 2
 done
 
-if ! curl -fsS --connect-timeout 5 --max-time 5 "http://127.0.0.1:${PORT}/ok" >/dev/null 2>&1; then
-  echo "::error title=Read-replica schema checker did not become ready::Timed out waiting for the Hyperdrive checker worker."
-  cat "$WRANGLER_LOG"
+if ! curl -fsS --connect-timeout 5 --max-time 5 "${WORKER_URL}/ok" >/dev/null 2>&1; then
+  echo "::error title=Read-replica schema checker did not become ready::Timed out waiting for ephemeral Worker ${WORKER_NAME}."
   exit 1
 fi
 
 SYNC_STATUS="$(curl -sS --connect-timeout 10 --max-time "$SYNC_MAX_TIME" \
-  --header "authorization: Bearer ${SCHEMA_CHECK_TOKEN}" \
+  --header "authorization: Bearer ${READ_REPLICA_SCHEMA_CHECK_TOKEN}" \
   --header 'content-type: application/json' \
   --header "x-schema-sync-max-duration-ms: ${SYNC_MAX_DURATION_MS}" \
   --data-binary "@${EXPECTED_SCHEMA_CATALOG}" \
   -w '%{http_code}' \
   -o "$SYNC_RESPONSE" \
-  "http://127.0.0.1:${PORT}/sync-additive" || true)"
+  "${WORKER_URL}/sync-additive" || true)"
 if [[ "$SYNC_STATUS" != "200" ]]; then
   echo "::error title=Failed to sync additive read-replica schema::Worker /sync-additive returned HTTP ${SYNC_STATUS}."
   cat "$SYNC_RESPONSE"
-  cat "$WRANGLER_LOG"
   exit 1
 fi
 
@@ -89,11 +100,10 @@ echo 'Read-replica additive schema sync result:'
 cat "$SYNC_RESPONSE"
 echo
 
-HTTP_STATUS="$(curl -sS --connect-timeout 5 --max-time 30 --header "authorization: Bearer ${SCHEMA_CHECK_TOKEN}" -w '%{http_code}' -o "$ACTUAL_SCHEMA_CATALOG" "http://127.0.0.1:${PORT}/catalog" || true)"
+HTTP_STATUS="$(curl -sS --connect-timeout 5 --max-time 30 --header "authorization: Bearer ${READ_REPLICA_SCHEMA_CHECK_TOKEN}" -w '%{http_code}' -o "$ACTUAL_SCHEMA_CATALOG" "${WORKER_URL}/catalog" || true)"
 if [[ "$HTTP_STATUS" != "200" ]]; then
   echo "::error title=Failed to fetch read-replica schema catalog::Worker /catalog returned HTTP ${HTTP_STATUS}."
   cat "$ACTUAL_SCHEMA_CATALOG"
-  cat "$WRANGLER_LOG"
   exit 1
 fi
 

--- a/tests/read-replica-ephemeral-worker.unit.test.ts
+++ b/tests/read-replica-ephemeral-worker.unit.test.ts
@@ -1,0 +1,114 @@
+import { execFile } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(import.meta.dirname, '..')
+const checkerScript = join(repoRoot, 'scripts/check-read-replica-hyperdrive-schema.sh')
+const expectedCatalog = join(repoRoot, 'read_replicate/schema_replicate.catalog.json')
+const execFileAsync = promisify(execFile)
+
+describe('read-replica ephemeral schema checker', () => {
+  it.concurrent('uses a unique deployed Worker per run and always deletes it', async () => {
+    const testDir = await mkdtemp(join(tmpdir(), 'capgo-read-replica-worker-'))
+    const binDir = join(testDir, 'bin')
+    const wranglerLog = join(testDir, 'wrangler.log')
+    const mockWrangler = join(binDir, 'wrangler')
+    const mockCurl = join(binDir, 'curl')
+
+    await mkdir(binDir)
+    await writeFile(mockWrangler, `#!/usr/bin/env bash
+set -euo pipefail
+command="$1"
+shift
+name=''
+if [[ "$command" == 'delete' ]]; then
+  name="$1"
+fi
+previous=''
+for argument in "$@"; do
+  if [[ "$previous" == '--name' ]]; then
+    name="$argument"
+  fi
+  previous="$argument"
+done
+if [[ "$command" == 'secret' ]]; then
+  IFS= read -r token || true
+  [[ "$(printf %s "$token" | wc -c)" -eq 64 ]]
+fi
+printf '%s\\t%s\\n' "$command" "$name" >> "$MOCK_WRANGLER_LOG"
+if [[ "$command" == 'deploy' ]]; then
+  printf 'Uploaded %s\\nhttps://%s.example.workers.dev\\n' "$name" "$name"
+fi
+`)
+    await writeFile(mockCurl, `#!/usr/bin/env bash
+set -euo pipefail
+output=''
+previous=''
+url=''
+for argument in "$@"; do
+  if [[ "$previous" == '-o' ]]; then
+    output="$argument"
+  fi
+  previous="$argument"
+  url="$argument"
+done
+case "$url" in
+  */ok)
+    exit 0
+    ;;
+  */sync-additive)
+    printf '{"applied":[]}' > "$output"
+    printf '200'
+    ;;
+  */catalog)
+    cp "$EXPECTED_SCHEMA_CATALOG" "$output"
+    printf '200'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+    await Promise.all([chmod(mockWrangler, 0o755), chmod(mockCurl, 0o755)])
+
+    const runChecker = async () => {
+      const { stderr, stdout } = await execFileAsync('bash', [checkerScript], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          EXPECTED_SCHEMA_CATALOG: expectedCatalog,
+          GITHUB_RUN_ATTEMPT: '2',
+          GITHUB_RUN_ID: '12345',
+          MOCK_WRANGLER_LOG: wranglerLog,
+          PATH: `${binDir}:${process.env.PATH}`,
+          READ_REPLICA_SCHEMA_SYNC_MAX_TIME: '31',
+          READ_REPLICA_WRANGLER_CMD: mockWrangler,
+        },
+      })
+      expect(stderr).toBe('')
+      expect(stdout).toContain('Read-replica schema catalog matches the committed snapshot.')
+    }
+
+    await Promise.all([runChecker(), runChecker()])
+
+    const invocations = (await readFile(wranglerLog, 'utf8')).trim().split('\n')
+    const deployedNames = invocations
+      .filter(line => line.startsWith('deploy\t'))
+      .map(line => line.split('\t')[1])
+    const deletedNames = invocations
+      .filter(line => line.startsWith('delete\t'))
+      .map(line => line.split('\t')[1])
+
+    expect(deployedNames).toHaveLength(2)
+    expect(new Set(deployedNames).size).toBe(2)
+    expect(deployedNames).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^capgo-rr-[0-9a-f]{16}-12345-2$/),
+      expect.stringMatching(/^capgo-rr-[0-9a-f]{16}-12345-2$/),
+    ]))
+    expect(deletedNames.sort()).toEqual(deployedNames.sort())
+    expect(invocations.some(line => line.startsWith('dev\t'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- replace the legacy `wrangler dev --remote` schema check with a short-lived deployed Worker
- give every invocation a collision-safe name using a cryptographic suffix plus the GitHub run ID and attempt
- upload the bearer token as a Worker secret, call the sync and catalog routes, and delete the Worker from the exit trap
- add a concurrency regression test proving parallel runs deploy and delete distinct Workers

## Root cause

The release guard timed out on the unauthenticated `/ok` route before it accessed Hyperdrive. The TLS hostname mismatch came from Wrangler's legacy remote-preview tunnel, while deployed plugin Workers using the same Hyperdrive binding remained healthy.

## Validation

- `bun lint`
- `bun test:unit` — 138 files, 937 tests
- `bun typecheck`
- `bunx vitest run tests/read-replica-ephemeral-worker.unit.test.ts`
- `bunx wrangler@4.107.0 deploy --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc --name capgo-rr-dry-run --dry-run --outdir /tmp/capgo-rr-schema-check-dry-run`
- `bash -n scripts/check-read-replica-hyperdrive-schema.sh`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy gating and live Hyperdrive/DDL sync behavior; mis-deploy or failed cleanup could block releases or leave stray Workers, though scope is limited to the schema-check script and wrangler config.
> 
> **Overview**
> Replaces the release **read-replica Hyperdrive schema check** that ran via local `wrangler dev --remote` with a **short-lived deployed Worker** on `workers.dev`, avoiding remote-preview TLS/timeouts while keeping the same `/ok`, `/sync-additive`, and `/catalog` flow.
> 
> Each CI run gets a **unique Worker name** (`capgo-rr-<suffix>-<run>-<attempt>`), deploys with top-level **Hyperdrive** config (no `env.prod`), sets the bearer token via **`wrangler secret put`**, hits the deployed URL, and **deletes the Worker in an EXIT trap** (including on failure). Docs in `read_replicate/README.md` describe this concurrency-safe behavior.
> 
> A **Vitest unit test** runs two checker invocations in parallel with mocked `wrangler`/`curl` and asserts two distinct deploy/delete pairs and no `dev` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d3fecc8ca1e688765778caabb9d3f2debd30bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->