### PR TITLE
feat(bento): track trial plan tags

### DIFF
--- a/supabase/functions/_backend/triggers/on_organization_create.ts
+++ b/supabase/functions/_backend/triggers/on_organization_create.ts
@@ -1,10 +1,12 @@
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { Hono } from 'hono/tiny'
+import { syncBentoSubscriberTags } from '../utils/bento.ts'
+import { buildBillingPlanBentoTags } from '../utils/billing_bento_tags.ts'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { groupIdentifyPosthog } from '../utils/posthog.ts'
-import { createStripeCustomer, finalizePendingStripeCustomer } from '../utils/supabase.ts'
+import { createStripeCustomer, finalizePendingStripeCustomer, supabaseAdmin } from '../utils/supabase.ts'
 import { buildOnboardingIntentBentoEventData, parseOrgOnboardingIntent, syncOrgOnboardingIntentForOrg } from '../utils/org_onboarding_intent.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
@@ -20,11 +22,28 @@ app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c)
     throw simpleError('no_id', 'No id', { record })
   }
 
+  let trialPlanName: string | null | undefined
   if (!record.customer_id) {
-    await createStripeCustomer(c, record)
+    trialPlanName = await createStripeCustomer(c, record)
   }
   else if (record.customer_id.startsWith('pending_')) {
-    await finalizePendingStripeCustomer(c, record)
+    trialPlanName = await finalizePendingStripeCustomer(c, record)
+  }
+
+  if (trialPlanName) {
+    const { data: creator, error: creatorError } = await supabaseAdmin(c)
+      .from('users')
+      .select('email')
+      .eq('id', record.created_by)
+      .maybeSingle()
+    if (creatorError)
+      cloudlog({ requestId: c.get('requestId'), message: 'trial plan Bento creator lookup failed', userId: record.created_by, error: creatorError })
+    if (creator?.email) {
+      await backgroundTask(c, syncBentoSubscriberTags(c, {
+        email: creator.email.trim().toLowerCase(),
+        ...buildBillingPlanBentoTags(trialPlanName, 'trial'),
+      }))
+    }
   }
 
   await backgroundTask(c, groupIdentifyPosthog(c, {

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -341,7 +341,7 @@ async function getBillingPlans(c: Context): Promise<PlanRow[]> {
 
   if (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'getBillingPlans error', error })
-    return []
+    throw error
   }
 
   return plans ?? []

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -334,6 +334,19 @@ async function getBillingBentoEmails(c: Context, org: Org, customerId: string) {
   return emails
 }
 
+async function getBillingPlans(c: Context): Promise<PlanRow[]> {
+  const { data: plans, error } = await supabaseAdmin(c)
+    .from('plans')
+    .select()
+
+  if (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'getBillingPlans error', error })
+    return []
+  }
+
+  return plans ?? []
+}
+
 async function syncBillingBentoTags(
   c: Context,
   org: Org,
@@ -375,21 +388,10 @@ async function syncBillingBentoTagsFromStoredStripeInfo(c: Context, org: Org, cu
   if (!stripeInfo)
     return
 
-  let plan: PlanRow | null = null
-  if (stripeInfo.product_id) {
-    const { data: planData, error: planError } = await supabaseAdmin(c)
-      .from('plans')
-      .select()
-      .eq('stripe_id', stripeInfo.product_id)
-      .maybeSingle()
-
-    if (planError)
-      cloudlogErr({ requestId: c.get('requestId'), message: 'syncBillingBentoTagsFromStoredStripeInfo plan error', customerId, productId: stripeInfo.product_id, error: planError })
-
-    plan = planData ?? null
-  }
-
-  const segment = await customerToSegmentOrg(c, org.id, stripeInfo.price_id, plan)
+  const plans = await getBillingPlans(c)
+  const plan = plans.find(candidate => candidate.stripe_id === stripeInfo.product_id) ?? null
+  const trialPlanNames = plans.map(candidate => candidate.name)
+  const segment = await customerToSegmentOrg(c, org.id, stripeInfo.price_id, plan, trialPlanNames)
   await syncBillingBentoTags(c, org, customerId, segment)
 }
 
@@ -1030,6 +1032,7 @@ async function createdOrUpdated(
     if (paidAt)
       updateData.paid_at = paidAt
     const revenuePlans = await getRevenuePlans(c)
+    const billingPlans = await getBillingPlans(c)
     const revenueMovement = classifyRevenueMovement(currentStripeInfo, updateData, revenuePlans)
     if (shouldTrackOrganizationUpgrade(stripeData.isUpgrade, revenueMovement))
       updateData.upgraded_at = eventOccurredAtIso
@@ -1102,7 +1105,7 @@ async function createdOrUpdated(
       await writePaidAtAtomically(c, stripeData.data.customer_id, paidAt)
     }
 
-    const segment = await customerToSegmentOrg(c, org.id, stripeData.data.price_id, plan)
+    const segment = await customerToSegmentOrg(c, org.id, stripeData.data.price_id, plan, billingPlans.map(candidate => candidate.name))
     const isMonthly = plan.price_m_id === stripeData.data.price_id
     const eventName = `user:subscribe_${statusName}:${isMonthly ? 'monthly' : 'yearly'}`
     const subscriptionMetadata = buildSubscriptionEventMetadata(stripeData, plan, previousPlan)

--- a/supabase/functions/_backend/utils/billing_bento_tags.ts
+++ b/supabase/functions/_backend/utils/billing_bento_tags.ts
@@ -1,0 +1,26 @@
+export type BillingPlanBentoState = 'none' | 'paying' | 'trial'
+
+export function buildBillingPlanBentoTags(
+  planName: string | null | undefined,
+  state: BillingPlanBentoState,
+  trialPlanNamesToRemove?: readonly string[] | null,
+): { segments: string[], deleteSegments: string[] } {
+  if (!planName || state === 'none')
+    return { segments: [], deleteSegments: [] }
+
+  const paidPlanTag = `plan:${planName}`
+  const trialPlanTag = `trial-plan:${planName}`
+
+  if (state === 'trial') {
+    return {
+      segments: [trialPlanTag],
+      deleteSegments: [],
+    }
+  }
+
+  const trialPlanNames = trialPlanNamesToRemove?.length ? trialPlanNamesToRemove : [planName]
+  return {
+    segments: [paidPlanTag],
+    deleteSegments: Array.from(new Set(trialPlanNames.map(name => `trial-plan:${name}`))),
+  }
+}

--- a/supabase/functions/_backend/utils/billing_bento_tags.ts
+++ b/supabase/functions/_backend/utils/billing_bento_tags.ts
@@ -5,22 +5,22 @@ export function buildBillingPlanBentoTags(
   state: BillingPlanBentoState,
   trialPlanNamesToRemove?: readonly string[] | null,
 ): { segments: string[], deleteSegments: string[] } {
-  if (!planName || state === 'none')
+  if (state === 'none')
     return { segments: [], deleteSegments: [] }
-
-  const paidPlanTag = `plan:${planName}`
-  const trialPlanTag = `trial-plan:${planName}`
 
   if (state === 'trial') {
     return {
-      segments: [trialPlanTag],
+      segments: planName ? [`trial-plan:${planName}`] : [],
       deleteSegments: [],
     }
   }
-
-  const trialPlanNames = trialPlanNamesToRemove?.length ? trialPlanNamesToRemove : [planName]
+  let trialPlanNames: readonly string[] = []
+  if (trialPlanNamesToRemove?.length)
+    trialPlanNames = trialPlanNamesToRemove
+  else if (planName)
+    trialPlanNames = [planName]
   return {
-    segments: [paidPlanTag],
+    segments: planName ? [`plan:${planName}`] : [],
     deleteSegments: Array.from(new Set(trialPlanNames.map(name => `trial-plan:${name}`))),
   }
 }

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -4,6 +4,7 @@ import type { AuthInfo, MiddlewareKeyVariables } from './hono.ts'
 import type { Database } from './supabase.types.ts'
 import type { DeviceWithoutCreatedAt, NativeVersionUsage, Order, ReadDevicesParams, ReadStatsInsightsParams, ReadStatsParams, StatsInsightsResult, StatsMetadata, VersionUsage, VersionUsageChannel } from './types.ts'
 import { createClient } from '@supabase/supabase-js'
+import { buildBillingPlanBentoTags } from './billing_bento_tags.ts'
 import { buildNormalizedDeviceForWrite, hasComparableDeviceChanged, nullableString } from './deviceComparison.ts'
 import { simpleError } from './hono.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
@@ -1047,6 +1048,7 @@ export async function customerToSegmentOrg(
   orgId: string,
   price_id?: string | null,
   plan?: Database['public']['Tables']['plans']['Row'] | null,
+  trialPlanNamesToRemove?: readonly string[] | null,
 ): Promise<{ segments: string[], deleteSegments: string[] }> {
   const segmentsObj = {
     capgo: true,
@@ -1057,7 +1059,6 @@ export async function customerToSegmentOrg(
     trial0: false,
     paying: false,
     payingMonthly: plan?.price_m_id === price_id,
-    plan: plan?.name ?? '',
     overuse: false,
     canceled: await isCanceledOrg(c, orgId),
     issueSegment: false,
@@ -1066,9 +1067,18 @@ export async function customerToSegmentOrg(
   const trialDaysLeft = await isTrialOrg(c, orgId)
   const paying = await isPayingOrg(c, orgId)
   const canUseMore = await isGoodPlanOrg(c, orgId)
+  const planTags = buildBillingPlanBentoTags(
+    plan?.name,
+    paying ? 'paying' : trialDaysLeft > 0 ? 'trial' : 'none',
+    trialPlanNamesToRemove,
+  )
 
   if (!segmentsObj.onboarded) {
-    return processSegments(segmentsObj)
+    const segments = processSegments(segmentsObj)
+    return {
+      segments: [...segments.segments, ...planTags.segments],
+      deleteSegments: [...segments.deleteSegments, ...planTags.deleteSegments],
+    }
   }
 
   if (!paying && trialDaysLeft > 1 && trialDaysLeft <= 7) {
@@ -1094,7 +1104,11 @@ export async function customerToSegmentOrg(
     segmentsObj.issueSegment = true
   }
 
-  return processSegments(segmentsObj)
+  const segments = processSegments(segmentsObj)
+  return {
+    segments: [...segments.segments, ...planTags.segments],
+    deleteSegments: [...segments.deleteSegments, ...planTags.deleteSegments],
+  }
 }
 
 function processSegments(segmentsObj: any): { segments: string[], deleteSegments: string[] } {
@@ -1175,6 +1189,7 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
   if (updateUserError)
     cloudlog({ requestId: c.get('requestId'), message: 'updateUserError', updateUserError })
   cloudlog({ requestId: c.get('requestId'), message: 'stripe_info done' })
+  return selectedPlan.name
 }
 
 export async function finalizePendingStripeCustomer(c: Context, org: Database['public']['Tables']['orgs']['Row']) {
@@ -1184,7 +1199,7 @@ export async function finalizePendingStripeCustomer(c: Context, org: Database['p
     return
   }
 
-  await createStripeCustomer(c, org)
+  const trialPlanName = await createStripeCustomer(c, org)
 
   const { data: updatedOrg } = await supabaseAdmin(c)
     .from('orgs')
@@ -1203,6 +1218,8 @@ export async function finalizePendingStripeCustomer(c: Context, org: Database['p
     .eq('customer_id', pendingCustomerId)
   if (deleteError)
     cloudlogErr({ requestId: c.get('requestId'), message: 'finalizePendingStripeCustomer: orphan pending stripe_info', deleteError })
+
+  return trialPlanName
 }
 
 export function trackBandwidthUsageSB(

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1182,8 +1182,10 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
       customer_id: customer.id,
       trial_at: trial_at.toISOString(),
     })
-  if (createInfoError)
+  if (createInfoError) {
     cloudlog({ requestId: c.get('requestId'), message: 'createInfoError', createInfoError })
+    return null
+  }
 
   const { error: updateUserError } = await supabaseAdmin(c)
     .from('orgs')
@@ -1191,8 +1193,10 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
       customer_id: customer.id,
     })
     .eq('id', org.id)
-  if (updateUserError)
+  if (updateUserError) {
     cloudlog({ requestId: c.get('requestId'), message: 'updateUserError', updateUserError })
+    return null
+  }
   cloudlog({ requestId: c.get('requestId'), message: 'stripe_info done' })
   return selectedPlan.name
 }
@@ -1214,7 +1218,7 @@ export async function finalizePendingStripeCustomer(c: Context, org: Database['p
 
   if (!updatedOrg?.customer_id || updatedOrg.customer_id.startsWith('pending_')) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'finalizePendingStripeCustomer: org still has pending customer_id, skipping delete' })
-    return trialPlanName
+    return
   }
 
   const { error: deleteError } = await supabaseAdmin(c)

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1214,7 +1214,7 @@ export async function finalizePendingStripeCustomer(c: Context, org: Database['p
 
   if (!updatedOrg?.customer_id || updatedOrg.customer_id.startsWith('pending_')) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'finalizePendingStripeCustomer: org still has pending customer_id, skipping delete' })
-    return
+    return trialPlanName
   }
 
   const { error: deleteError } = await supabaseAdmin(c)

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -4,7 +4,7 @@ import type { AuthInfo, MiddlewareKeyVariables } from './hono.ts'
 import type { Database } from './supabase.types.ts'
 import type { DeviceWithoutCreatedAt, NativeVersionUsage, Order, ReadDevicesParams, ReadStatsInsightsParams, ReadStatsParams, StatsInsightsResult, StatsMetadata, VersionUsage, VersionUsageChannel } from './types.ts'
 import { createClient } from '@supabase/supabase-js'
-import { buildBillingPlanBentoTags } from './billing_bento_tags.ts'
+import { type BillingPlanBentoState, buildBillingPlanBentoTags } from './billing_bento_tags.ts'
 import { buildNormalizedDeviceForWrite, hasComparableDeviceChanged, nullableString } from './deviceComparison.ts'
 import { simpleError } from './hono.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
@@ -1067,9 +1067,14 @@ export async function customerToSegmentOrg(
   const trialDaysLeft = await isTrialOrg(c, orgId)
   const paying = await isPayingOrg(c, orgId)
   const canUseMore = await isGoodPlanOrg(c, orgId)
+  let billingPlanState: BillingPlanBentoState = 'none'
+  if (paying)
+    billingPlanState = 'paying'
+  else if (trialDaysLeft > 0)
+    billingPlanState = 'trial'
   const planTags = buildBillingPlanBentoTags(
     plan?.name,
-    paying ? 'paying' : trialDaysLeft > 0 ? 'trial' : 'none',
+    billingPlanState,
     trialPlanNamesToRemove,
   )
 

--- a/tests/billing-bento-tags.unit.test.ts
+++ b/tests/billing-bento-tags.unit.test.ts
@@ -23,6 +23,13 @@ describe('billing plan Bento tags', () => {
     })
   })
 
+  it.concurrent('clears trial tags even when the current paid plan is unavailable', () => {
+    expect(buildBillingPlanBentoTags(null, 'paying', ['Solo', 'Team'])).toEqual({
+      segments: [],
+      deleteSegments: ['trial-plan:Solo', 'trial-plan:Team'],
+    })
+  })
+
   it.concurrent('does not create a plan tag outside a trial or paid subscription', () => {
     expect(buildBillingPlanBentoTags('Solo', 'none')).toEqual({
       segments: [],

--- a/tests/billing-bento-tags.unit.test.ts
+++ b/tests/billing-bento-tags.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildBillingPlanBentoTags } from '../supabase/functions/_backend/utils/billing_bento_tags.ts'
+
+describe('billing plan Bento tags', () => {
+  it.concurrent('uses a distinct tag for the plan being trialed', () => {
+    expect(buildBillingPlanBentoTags('Solo', 'trial')).toEqual({
+      segments: ['trial-plan:Solo'],
+      deleteSegments: [],
+    })
+  })
+
+  it.concurrent('replaces the trial-plan tag when the customer starts paying', () => {
+    expect(buildBillingPlanBentoTags('Solo', 'paying')).toEqual({
+      segments: ['plan:Solo'],
+      deleteSegments: ['trial-plan:Solo'],
+    })
+  })
+
+  it.concurrent('removes every possible trial plan when the customer starts paying', () => {
+    expect(buildBillingPlanBentoTags('Maker', 'paying', ['Solo', 'Maker', 'Team'])).toEqual({
+      segments: ['plan:Maker'],
+      deleteSegments: ['trial-plan:Solo', 'trial-plan:Maker', 'trial-plan:Team'],
+    })
+  })
+
+  it.concurrent('does not create a plan tag outside a trial or paid subscription', () => {
+    expect(buildBillingPlanBentoTags('Solo', 'none')).toEqual({
+      segments: [],
+      deleteSegments: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add `trial-plan:<plan>` to the registering user when an organization trial is created
- keep paid `plan:<plan>` tags distinct from trial tags
- remove all known trial-plan tags when billing becomes paid, including plan changes and stored-state reconciliation

## Verification

- `bun lint:backend`
- `bun typecheck`
- `bun test:unit` (138 files, 944 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches org-create and Stripe webhook Bento segmentation; failures are mostly logged/backgrounded, but mis-tagged subscribers could affect marketing automation.
> 
> **Overview**
> Introduces **separate Bento segments** for trial vs paid plans: `trial-plan:<name>` during trial and `plan:<name>` when paying, with shared logic in `buildBillingPlanBentoTags`.
> 
> On **org create**, after Stripe customer setup, the org creator gets a background Bento sync with the trial plan tag. **`createStripeCustomer`** / **`finalizePendingStripeCustomer`** now return the selected plan name (or `null` on persistence failure) to drive that flow.
> 
> **`customerToSegmentOrg`** merges those plan tags into existing billing segments and, when paying, can **delete every known `trial-plan:*` tag** via an optional list of plan names. Stripe webhook handling loads all plans once and passes those names on subscription updates and stored-state Bento reconciliation so trial tags don’t linger after conversion or plan changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0e6ce5bed3c53298100cb4535edc01de7725e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->