### PR TITLE
fix(ci): filter releases by pushed paths

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -45,6 +45,17 @@ jobs:
             echo "::error::CAPGO_KEYCHAIN_HELPER_PATH leaked into the release bundle — dead-code elimination failed"
             exit 1
           fi
+      - name: Resolve previous successful CLI release
+        id: changelog_base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          previous_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1000 --json tagName,isDraft | jq -r --arg current "$GITHUB_REF_NAME" --arg prefix "cli-" '[.[] | select(.isDraft == false and .tagName != $current and (.tagName | startswith($prefix)))] | first | .tagName // empty')
+          if [ -z "$previous_tag" ]; then
+            echo "::error::No previous successful CLI release found"
+            exit 1
+          fi
+          echo "from_tag=$previous_tag" >> "$GITHUB_OUTPUT"
       - name: Generate AI changelog
         id: changelog
         uses: mistricky/ccc@v0.2.6
@@ -52,6 +63,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           model: claude-sonnet-4-5-20250929
+          from_tag: ${{ steps.changelog_base.outputs.from_tag }}
       - name: Publish CLI to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
         env:

--- a/.github/workflows/publish_notifications.yml
+++ b/.github/workflows/publish_notifications.yml
@@ -37,6 +37,17 @@ jobs:
         run: bun run --cwd packages/capacitor-notifications typecheck
       - name: Build notifications plugin
         run: bun run --cwd packages/capacitor-notifications build
+      - name: Resolve previous successful notifications release
+        id: changelog_base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          previous_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1000 --json tagName,isDraft | jq -r --arg current "$GITHUB_REF_NAME" --arg prefix "notifications-" '[.[] | select(.isDraft == false and .tagName != $current and (.tagName | startswith($prefix)))] | first | .tagName // empty')
+          if [ -z "$previous_tag" ]; then
+            echo "::error::No previous successful notifications release found"
+            exit 1
+          fi
+          echo "from_tag=$previous_tag" >> "$GITHUB_OUTPUT"
       - name: Generate AI changelog
         id: changelog
         uses: mistricky/ccc@v0.2.6
@@ -44,6 +55,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           model: claude-sonnet-4-5-20250929
+          from_tag: ${{ steps.changelog_base.outputs.from_tag }}
       - name: Publish notifications plugin to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
         env:

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -1,6 +1,5 @@
 import { execFileSync } from 'node:child_process'
 import process from 'node:process'
-import { TextDecoder } from 'node:util'
 
 export type Component = 'capgo' | 'cli' | 'notifications'
 export type ReleaseAs = 'patch' | 'minor' | 'major'
@@ -10,7 +9,6 @@ const sharedMatchers = [
   /^\.github\/workflows\/bump_version\.yml$/,
   /^\.github\/workflows\/tests\.yml$/,
   /^\.github\/scripts\//,
-  /^scripts\/release-scope\.ts$/,
   /^scripts\/sync-notifications-package-version\.ts$/,
   /^scripts\/setup-bun\.sh$/,
   /^scripts\/setup-bun\.ps1$/,
@@ -84,60 +82,6 @@ function runGit(args: string[]): string {
   }).trim()
 }
 
-function stringifyGitErrorOutput(value: unknown): string {
-  if (typeof value === 'string') {
-    return value
-  }
-
-  if (value instanceof Uint8Array) {
-    return new TextDecoder().decode(value)
-  }
-
-  return ''
-}
-
-function getGitErrorText(error: unknown): string {
-  const parts = []
-
-  if (error instanceof Error) {
-    parts.push(error.message)
-  }
-
-  if (typeof error === 'object' && error !== null) {
-    const outputs = error as { stdout?: unknown, stderr?: unknown }
-    parts.push(stringifyGitErrorOutput(outputs.stdout))
-    parts.push(stringifyGitErrorOutput(outputs.stderr))
-  }
-
-  return parts.filter(Boolean).join('\n')
-}
-
-function isNoMatchingTagError(error: unknown): boolean {
-  return /no matching tag|no names found|no tags can describe|fatal: no tag/i.test(getGitErrorText(error))
-}
-
-export function getComponentTagPattern(component: Component): string {
-  return `${component}-[0-9]*`
-}
-
-export function getLatestComponentTag(component: Component, after: string, run: GitRunner = runGit): string | null {
-  try {
-    const tag = run(['describe', '--tags', '--match', getComponentTagPattern(component), '--abbrev=0', after])
-    return tag || null
-  }
-  catch (error) {
-    if (!isNoMatchingTagError(error)) {
-      throw error
-    }
-
-    return null
-  }
-}
-
-export function getReleaseRangeBase(component: Component, before: string, after: string, run: GitRunner = runGit): string {
-  return getLatestComponentTag(component, after, run) ?? before
-}
-
 function getCommitShas(before: string, after: string, run: GitRunner = runGit): string[] {
   const isZero = before === '' || /^0+$/.test(before)
 
@@ -197,10 +141,8 @@ export function toReleaseAs(severity: number): ReleaseAs {
 
   return 'patch'
 }
-
 export function resolveReleaseScope(component: Component, before: string, after: string, run: GitRunner = runGit) {
-  const releaseBase = getReleaseRangeBase(component, before, after, run)
-  const commits = getCommitShas(releaseBase, after, run)
+  const commits = getCommitShas(before, after, run)
 
   let shouldRelease = false
   let highestSeverity = 0

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { getReleaseRangeBase, matchesComponent, resolveReleaseScope } from '../scripts/release-scope.ts'
+import { matchesComponent, resolveReleaseScope } from '../scripts/release-scope.ts'
 
 describe('release scope matching', () => {
   it.concurrent('treats shared release infrastructure as affecting all components', () => {
@@ -9,7 +9,6 @@ describe('release scope matching', () => {
       '.github/workflows/bump_version.yml',
       '.github/scripts/start-background-service.sh',
       'scripts/setup-bun.sh',
-      'scripts/release-scope.ts',
       'scripts/sync-notifications-package-version.ts',
     ]
 
@@ -18,6 +17,16 @@ describe('release scope matching', () => {
     expect(matchesComponent('notifications', files)).toBe(true)
   })
 
+  it.concurrent('does not publish packages for release scope logic changes', () => {
+    const files = [
+      'scripts/release-scope.ts',
+      'tests/release-scope.test.ts',
+    ]
+
+    expect(matchesComponent('capgo', files)).toBe(false)
+    expect(matchesComponent('cli', files)).toBe(false)
+    expect(matchesComponent('notifications', files)).toBe(false)
+  })
   it.concurrent('treats capgo deploy workflow changes as capgo-only releases', () => {
     const files = ['.github/workflows/build_and_deploy.yml', 'scripts/deploy-scope.ts']
 
@@ -55,6 +64,19 @@ describe('release scope matching', () => {
     expect(workflow).not.toContain('--access restricted')
   })
 
+  it.concurrent('builds package changelogs from the last successful component release', () => {
+    for (const [workflowPath, prefix] of [
+      ['.github/workflows/publish_cli.yml', 'cli-'],
+      ['.github/workflows/publish_notifications.yml', 'notifications-'],
+    ] as const) {
+      const workflow = readFileSync(workflowPath, 'utf8')
+
+      expect(workflow).toContain('gh release list')
+      expect(workflow).toContain(`--arg prefix "${prefix}"`)
+      expect(workflow).toContain('from_tag: $' + '{{ steps.changelog_base.outputs.from_tag }}')
+    }
+  })
+
   it.concurrent('uses the released package in Discord release footers', () => {
     const workflow = readFileSync('.github/workflows/github-releases-to-discord.yml', 'utf8')
     const cliPackage = JSON.parse(readFileSync('cli/package.json', 'utf8')) as { name: string }
@@ -90,67 +112,34 @@ describe('release scope matching', () => {
     expect(matchesComponent('notifications', files)).toBe(false)
   })
 
-  it.concurrent('uses the latest component tag instead of only the pushed range', () => {
-    const run = (args: string[]) => {
-      if (args[0] === 'describe') {
-        expect(args).toEqual(['describe', '--tags', '--match', 'cli-[0-9]*', '--abbrev=0', 'HEAD'])
-        return 'cli-7.95.15'
+  it.concurrent('only evaluates component paths from the current push', () => {
+    for (const [component, previousTag, componentFile] of [
+      ['cli', 'cli-8.25.11', 'cli/src/posthog.ts'],
+      ['notifications', 'notifications-0.1.10', 'packages/capacitor-notifications/src/index.ts'],
+    ] as const) {
+      const run = (args: string[]) => {
+        const key = args.join(' ')
+        const responses: Record<string, string> = {
+          [`describe --tags --match ${component}-[0-9]* --abbrev=0 head-capgo-only`]: previousTag,
+          [`rev-list --reverse ${previousTag}..head-capgo-only`]: `${component}-change\ncapgo-change`,
+          'rev-list --reverse current-push-parent..head-capgo-only': 'capgo-change',
+          [`show --format= --name-only ${component}-change`]: componentFile,
+          'show --format= --name-only capgo-change': 'src/pages/index.vue',
+          [`log -1 --format=%s ${component}-change`]: `feat(${component}): previous change`,
+          [`log -1 --format=%b ${component}-change`]: '',
+        }
+
+        if (key in responses) {
+          return responses[key]
+        }
+
+        throw new Error(`Unexpected git call: ${key}`)
       }
 
-      throw new Error(`Unexpected git call: ${args.join(' ')}`)
+      expect(resolveReleaseScope(component, 'current-push-parent', 'head-capgo-only', run)).toEqual({
+        shouldRelease: false,
+        releaseAs: 'patch',
+      })
     }
-
-    expect(getReleaseRangeBase('cli', 'previous-push-sha', 'HEAD', run)).toBe('cli-7.95.15')
-  })
-
-  it.concurrent('falls back to the pushed range when no component tag exists', () => {
-    const run = (args: string[]) => {
-      if (args[0] === 'describe') {
-        throw Object.assign(new Error('git describe failed'), {
-          stderr: 'fatal: No names found, cannot describe anything.',
-        })
-      }
-
-      throw new Error(`Unexpected git call: ${args.join(' ')}`)
-    }
-
-    expect(getReleaseRangeBase('capgo', 'previous-push-sha', 'HEAD', run)).toBe('previous-push-sha')
-  })
-
-  it.concurrent('rethrows unexpected git describe failures', () => {
-    const run = (args: string[]) => {
-      if (args[0] === 'describe') {
-        throw new Error('fatal: bad revision HEAD')
-      }
-
-      throw new Error(`Unexpected git call: ${args.join(' ')}`)
-    }
-
-    expect(() => getReleaseRangeBase('cli', 'previous-push-sha', 'HEAD', run)).toThrow('fatal: bad revision HEAD')
-  })
-
-  it.concurrent('keeps missed CLI changes releasable after a later Capgo-only push', () => {
-    const run = (args: string[]) => {
-      const key = args.join(' ')
-      const responses: Record<string, string> = {
-        'describe --tags --match cli-[0-9]* --abbrev=0 head-capgo-only': 'cli-7.95.15',
-        'rev-list --reverse cli-7.95.15..head-capgo-only': 'cli-change\ncapgo-change',
-        'show --format= --name-only cli-change': 'cli/src/posthog.ts',
-        'show --format= --name-only capgo-change': 'src/pages/index.vue',
-        'log -1 --format=%s cli-change': 'feat(cli): capture exceptions',
-        'log -1 --format=%b cli-change': '',
-      }
-
-      if (key in responses) {
-        return responses[key]
-      }
-
-      throw new Error(`Unexpected git call: ${key}`)
-    }
-
-    expect(resolveReleaseScope('cli', 'capgo-change-parent', 'head-capgo-only', run)).toEqual({
-      shouldRelease: true,
-      releaseAs: 'minor',
-    })
   })
 })


### PR DESCRIPTION
## Summary

- restore release detection to the current GitHub push range (`github.event.before..github.sha`)
- keep existing component path matchers as the release authority
- remove tag-based missed-release recovery that published old components on unrelated pushes
- build CLI and notifications changelogs from each component's last successful GitHub release
- prevent release-scope logic/tests from being treated as package content

## Behavior

- unrelated later push: does not publish the failed component
- next same-component change: publishes cumulative code, including the previously failed change
- release text: spans from the last successful release for that component, so it includes both the previously failed and new changes
- rerunning the original failed workflow remains the immediate recovery path when no new component change exists

## Root cause

PR #2095 changed release detection from the current push range to each component's latest tag. The path matcher worked, but it received an oversized commit range. Separately, `mistricky/ccc` defaults to the immediately previous repository tag, mixing Capgo, CLI, and notifications changelog ranges.

## Validation

- release-scope regression failed before the fix with a false component release
- `bunx vitest run tests/release-scope.test.ts` (11 tests)
- `bun test:unit` (139 files, 946 tests)
- `bun lint`
- Prettier workflow validation
- historical Capgo-only commit `a23e043a`: CLI and notifications both return `should_release=false`
- real CLI and notifications feature commits still return `should_release=true`
- live release lookup resolves `cli-8.25.12` and `notifications-0.1.11` as the current last successful component releases

## Existing main blocker

Current `main` has unrelated generated Supabase type drift: `country_code` was removed from both generated type files while device code still uses it. That currently fails repository typecheck before this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when CLI/notifications publish and what commits appear in release notes; incorrect `from_tag` resolution would fail the workflow or produce wrong changelogs, but runtime app code is untouched.
> 
> **Overview**
> **Release detection** no longer walks from each component’s latest tag back to `HEAD`. `resolveReleaseScope` again only inspects commits in the **current push** (`before..after`), so a Capgo-only push won’t trigger CLI or notifications publishes for older component commits that were never released.
> 
> **Changelog generation** for CLI and notifications now sets `from_tag` on `mistricky/ccc` by resolving the **previous non-draft GitHub release** with the matching tag prefix (`cli-` / `notifications-`), instead of defaulting to the repo’s immediately previous tag (which mixed Capgo, CLI, and notifications).
> 
> **Release-scope maintenance** is decoupled from package releases: `scripts/release-scope.ts` is removed from shared path matchers, and tests assert that edits to release-scope logic/tests don’t match any component for publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f151ebdd6ec57c9e5148d1979e7d72075efb6677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->