### PR TITLE
feat(bento): tag users by email type

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/supabase/functions/_backend/utils/user_preferences.ts
+++ b/supabase/functions/_backend/utils/user_preferences.ts
@@ -1,8 +1,9 @@
 import type { Context } from 'hono'
+import type { EmailType } from './emailClassification.ts'
 import type { EmailPreferenceKey, EmailPreferences } from './org_email_notifications.ts'
 import type { Database } from './supabase.types.ts'
 import { syncBentoSubscriberTags } from './bento.ts'
-import { classifyEmailAddress, type EmailType } from './emailClassification.ts'
+import { classifyEmailAddress } from './emailClassification.ts'
 import { cloudlog } from './logging.ts'
 
 // Legacy tags for general notifications and newsletters
@@ -96,6 +97,14 @@ export async function syncUserPreferenceTags(
     const currentTags = buildDesiredTags(email, record)
     const previousTags = previousEmail === email && previousRecord ? buildDesiredTags(email, previousRecord) : undefined
     const segments = buildTagDelta(currentTags, previousTags)
+    if (previousTags) {
+      const emailTypeTag = EMAIL_TYPE_TAGS[classifyEmailAddress(email)]
+      segments.segments = [...new Set([...segments.segments, emailTypeTag])]
+      segments.deleteSegments = [...new Set([
+        ...segments.deleteSegments,
+        ...ALL_EMAIL_TYPE_TAGS.filter(tag => tag !== emailTypeTag),
+      ])]
+    }
     if (segments.segments.length === 0 && segments.deleteSegments.length === 0)
       return
     await syncBentoSubscriberTags(c, { email, ...segments })

--- a/supabase/functions/_backend/utils/user_preferences.ts
+++ b/supabase/functions/_backend/utils/user_preferences.ts
@@ -2,11 +2,18 @@ import type { Context } from 'hono'
 import type { EmailPreferenceKey, EmailPreferences } from './org_email_notifications.ts'
 import type { Database } from './supabase.types.ts'
 import { syncBentoSubscriberTags } from './bento.ts'
+import { classifyEmailAddress, type EmailType } from './emailClassification.ts'
 import { cloudlog } from './logging.ts'
 
 // Legacy tags for general notifications and newsletters
 const NOTIFICATION_TAG = 'notifications_opt_in'
 const NEWSLETTER_TAG = 'newsletter_opt_in'
+
+const EMAIL_TYPE_TAGS: Record<EmailType, string> = {
+  professional: 'email_type:professional',
+  personal: 'email_type:personal',
+  disposable: 'email_type:disposable',
+}
 
 // Email preference disabled tags - when a user opts OUT, we add these tags
 // Bento automations should exclude users with these tags
@@ -30,14 +37,15 @@ const EMAIL_PREF_DISABLED_TAGS: Record<EmailPreferenceKey, string> = {
 
 const ALL_LEGACY_TAGS = [NOTIFICATION_TAG, NEWSLETTER_TAG]
 const ALL_EMAIL_PREF_DISABLED_TAGS = Object.values(EMAIL_PREF_DISABLED_TAGS)
-const ALL_TAGS = [...ALL_LEGACY_TAGS, ...ALL_EMAIL_PREF_DISABLED_TAGS]
+const ALL_EMAIL_TYPE_TAGS = Object.values(EMAIL_TYPE_TAGS)
+const ALL_TAGS = [...ALL_LEGACY_TAGS, ...ALL_EMAIL_PREF_DISABLED_TAGS, ...ALL_EMAIL_TYPE_TAGS]
 
 type UserPreferenceRecord = Database['public']['Tables']['users']['Row'] & {
   email_preferences?: EmailPreferences | null
 }
 
-function buildDesiredTags(record: UserPreferenceRecord | null | undefined) {
-  const tags = new Set<string>()
+function buildDesiredTags(email: string, record: UserPreferenceRecord | null | undefined) {
+  const tags = new Set<string>([EMAIL_TYPE_TAGS[classifyEmailAddress(email)]])
 
   if (record?.enable_notifications)
     tags.add(NOTIFICATION_TAG)
@@ -85,8 +93,8 @@ export async function syncUserPreferenceTags(
     if (!email)
       return
 
-    const currentTags = buildDesiredTags(record)
-    const previousTags = previousEmail === email && previousRecord ? buildDesiredTags(previousRecord) : undefined
+    const currentTags = buildDesiredTags(email, record)
+    const previousTags = previousEmail === email && previousRecord ? buildDesiredTags(email, previousRecord) : undefined
     const segments = buildTagDelta(currentTags, previousTags)
     if (segments.segments.length === 0 && segments.deleteSegments.length === 0)
       return

--- a/tests/user-preference-bento-tags.unit.test.ts
+++ b/tests/user-preference-bento-tags.unit.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { syncUserPreferenceTags } from '../supabase/functions/_backend/utils/user_preferences.ts'
+
 const syncBentoSubscriberTagsMock = vi.hoisted(() => vi.fn(async () => true))
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
   syncBentoSubscriberTags: syncBentoSubscriberTagsMock,
 }))
-
-import { syncUserPreferenceTags } from '../supabase/functions/_backend/utils/user_preferences.ts'
 
 function createContext() {
   return {
@@ -59,6 +59,22 @@ describe('syncUserPreferenceTags email type', () => {
       email: 'developer@company.com',
       segments: ['email_type:professional'],
       deleteSegments: expect.arrayContaining(['email_type:personal', 'email_type:disposable']),
+    }))
+  })
+
+  it('backfills the email type tag for a same-address preference update', async () => {
+    const context = createContext()
+
+    await syncUserPreferenceTags(context, 'developer@gmail.com', {
+      email_preferences: {},
+      enable_notifications: true,
+      opt_for_newsletters: false,
+    } as never, record, 'developer@gmail.com')
+
+    expect(syncBentoSubscriberTagsMock).toHaveBeenCalledWith(context, expect.objectContaining({
+      email: 'developer@gmail.com',
+      segments: expect.arrayContaining(['email_type:personal', 'notifications_opt_in']),
+      deleteSegments: expect.arrayContaining(['email_type:professional', 'email_type:disposable']),
     }))
   })
 })

--- a/tests/user-preference-bento-tags.unit.test.ts
+++ b/tests/user-preference-bento-tags.unit.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const syncBentoSubscriberTagsMock = vi.hoisted(() => vi.fn(async () => true))
+
+vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
+  syncBentoSubscriberTags: syncBentoSubscriberTagsMock,
+}))
+
+import { syncUserPreferenceTags } from '../supabase/functions/_backend/utils/user_preferences.ts'
+
+function createContext() {
+  return {
+    get: vi.fn(() => 'test-request-id'),
+  } as never
+}
+
+const record = {
+  email_preferences: {},
+  enable_notifications: false,
+  opt_for_newsletters: false,
+} as never
+
+describe('syncUserPreferenceTags email type', () => {
+  beforeEach(() => {
+    syncBentoSubscriberTagsMock.mockClear()
+  })
+
+  it.each([
+    ['developer@company.com', 'email_type:professional', ['email_type:personal', 'email_type:disposable']],
+    ['developer@gmail.com', 'email_type:personal', ['email_type:professional', 'email_type:disposable']],
+    ['developer@mailinator.com', 'email_type:disposable', ['email_type:professional', 'email_type:personal']],
+  ])('tags %s as %s', async (email, expectedTag, removedTags) => {
+    const context = createContext()
+
+    await syncUserPreferenceTags(context, email, record)
+
+    expect(syncBentoSubscriberTagsMock).toHaveBeenCalledWith(context, expect.objectContaining({
+      email,
+      segments: [expectedTag],
+      deleteSegments: expect.arrayContaining(removedTags),
+    }))
+  })
+
+  it('moves all managed tags when an email address changes', async () => {
+    const context = createContext()
+
+    await syncUserPreferenceTags(context, 'developer@company.com', record, record, 'developer@gmail.com')
+
+    expect(syncBentoSubscriberTagsMock).toHaveBeenNthCalledWith(1, context, expect.objectContaining({
+      email: 'developer@gmail.com',
+      segments: [],
+      deleteSegments: expect.arrayContaining([
+        'email_type:professional',
+        'email_type:personal',
+        'email_type:disposable',
+      ]),
+    }))
+    expect(syncBentoSubscriberTagsMock).toHaveBeenNthCalledWith(2, context, expect.objectContaining({
+      email: 'developer@company.com',
+      segments: ['email_type:professional'],
+      deleteSegments: expect.arrayContaining(['email_type:personal', 'email_type:disposable']),
+    }))
+  })
+})


### PR DESCRIPTION
## Summary

- classify Bento subscribers with the same email-domain logic used by the admin dashboard
- add one mutually exclusive `email_type:professional`, `email_type:personal`, or `email_type:disposable` tag in the existing subscriber sync
- refresh the tag when a user changes email address
- restore the generated `devices.country_code` declaration required by the existing migration

## Test plan

- `bun lint && bun lint:backend`
- `bun typecheck`
- `bun run test:unit`

## Screenshots

Not applicable; backend and generated-type changes only.

## Checklist

- [x] Code follows the project style and passes linting.
- [x] The typecheck succeeds.
- [x] The email-type flow has unit coverage for professional, personal, disposable, and changed-email cases.
- [x] No documentation change is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Bento marketing tags and generated types; no auth or billing paths, with dedicated unit coverage for tag transitions.
> 
> **Overview**
> Bento subscriber sync now assigns a single **email-type** segment (`email_type:professional`, `email_type:personal`, or `email_type:disposable`) using the same `classifyEmailAddress` domain logic as the admin dashboard, alongside existing notification and preference tags.
> 
> `syncUserPreferenceTags` always includes the current type in desired tags, strips the other two type tags on same-address updates (backfill), and clears all managed tags on the old address when the user changes email. Generated Supabase types restore optional `devices.country_code` on Row/Insert/Update.
> 
> Unit tests cover classification for each type, email-change handoff, and backfill on preference-only updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb83f8c38c8bca881cb741951a1a325112a4eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added country code support for device records.
  * Added email-type tags to subscriber preference data, including professional, personal, and disposable categories.
  * Subscriber tags now update correctly when an email address changes.

* **Tests**
  * Added coverage for email-type classification and tag transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->