### PR TITLE
fix(read-replica): check replication compatibility

### DIFF
--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -50,7 +50,7 @@ bun run readreplicate:check-schema
 ```
 
 Sync safe additive changes through Hyperdrive, then check that the live read
-replica matches the committed replica schema catalog:
+replica is operationally compatible with the committed replica schema catalog:
 
 ```bash
 bun run readreplicate:check-hyperdrive-schema
@@ -97,8 +97,11 @@ READ_REPLICA_PASSWORD='new-password' bash read_replicate/update_readreplica_pass
 - `schema_replicate.sql` is intentionally limited to tables replicated into the
   Google subscriber. It excludes foreign keys, triggers, and RLS policies.
 - `schema_replicate.catalog.json` is the machine-readable catalog snapshot used
-  by release CI to sync missing additive schema changes and compare the committed
-  schema against the live read replica through Hyperdrive.
+  by release CI to sync missing additive schema changes and verify compatible
+  tables, columns, types, and exact index parity through Hyperdrive. The check
+  ignores column order, defaults, constraints, sequences, and functions because
+  they do not prevent logical replication. Unexpected indexes still fail the
+  check because they add storage and write-maintenance cost.
 - Production Supabase deploys run `bun run readreplicate:check-hyperdrive-schema`
   before migrations, functions, or workers publish. Each check deploys a uniquely
   named, token-protected Worker, applies safe missing columns and indexes on the

--- a/read_replicate/schema_compatibility.ts
+++ b/read_replicate/schema_compatibility.ts
@@ -1,0 +1,214 @@
+interface SchemaColumn {
+  table: string
+  name: string
+  type: string
+  notNull: boolean
+  default: string | null
+  generated: string
+}
+
+interface SchemaIndex {
+  table: string
+  name: string
+  definition: string
+  valid: boolean
+}
+interface SchemaTable {
+  name: string
+  kind: string
+  reloptions: unknown
+}
+
+interface SchemaType {
+  name: string
+  kind: string
+  definition: unknown
+}
+
+interface SchemaCatalog {
+  version?: number
+  columns?: SchemaColumn[]
+  indexes?: SchemaIndex[]
+  tables?: SchemaTable[]
+  types?: SchemaType[]
+}
+
+export interface SchemaCompatibilityIssue {
+  kind: 'catalog_version' | 'column' | 'index' | 'table' | 'type'
+  object: string
+  reason: string
+}
+
+export function readReplicaSchemaCompatibilityIssues(expected: unknown, actual: unknown): SchemaCompatibilityIssue[] {
+  const expectedCatalog = assertSchemaCatalog(expected, 'expected')
+  const actualCatalog = assertSchemaCatalog(actual, 'actual')
+  const issues: SchemaCompatibilityIssue[] = []
+
+  if (expectedCatalog.version !== actualCatalog.version) {
+    issues.push({
+      kind: 'catalog_version',
+      object: 'catalog',
+      reason: `expected version ${expectedCatalog.version ?? 'missing'}, found ${actualCatalog.version ?? 'missing'}`,
+    })
+  }
+
+  compareTables(expectedCatalog, actualCatalog, issues)
+  compareColumns(expectedCatalog, actualCatalog, issues)
+  compareTypes(expectedCatalog, actualCatalog, issues)
+  compareIndexes(expectedCatalog, actualCatalog, issues)
+
+  return issues
+}
+
+function compareTables(expected: SchemaCatalog, actual: SchemaCatalog, issues: SchemaCompatibilityIssue[]): void {
+  const actualTables = new Map((actual.tables ?? []).map(table => [table.name, table]))
+  for (const expectedTable of expected.tables ?? []) {
+    const actualTable = actualTables.get(expectedTable.name)
+    if (!actualTable) {
+      issues.push({ kind: 'table', object: expectedTable.name, reason: 'missing required table' })
+      continue
+    }
+    if (actualTable.kind !== expectedTable.kind)
+      issues.push({ kind: 'table', object: expectedTable.name, reason: `expected kind ${expectedTable.kind}, found ${actualTable.kind}` })
+    if (stableJson(actualTable.reloptions) !== stableJson(expectedTable.reloptions))
+      issues.push({ kind: 'table', object: expectedTable.name, reason: 'table options differ' })
+  }
+}
+
+function compareColumns(expected: SchemaCatalog, actual: SchemaCatalog, issues: SchemaCompatibilityIssue[]): void {
+  const expectedColumns = new Set((expected.columns ?? []).map(column => columnKey(column)))
+  const actualColumns = new Map((actual.columns ?? []).map(column => [columnKey(column), column]))
+
+  for (const expectedColumn of expected.columns ?? []) {
+    const key = columnKey(expectedColumn)
+    const actualColumn = actualColumns.get(key)
+    if (!actualColumn) {
+      issues.push({ kind: 'column', object: key, reason: 'missing required column' })
+      continue
+    }
+    if (actualColumn.type !== expectedColumn.type) {
+      issues.push({
+        kind: 'column',
+        object: key,
+        reason: `expected type ${expectedColumn.type}, found ${actualColumn.type}`,
+      })
+    }
+    if (!expectedColumn.notNull && actualColumn.notNull) {
+      issues.push({
+        kind: 'column',
+        object: key,
+        reason: 'subscriber is NOT NULL while publisher accepts NULL',
+      })
+    }
+    if (actualColumn.generated !== expectedColumn.generated) {
+      issues.push({
+        kind: 'column',
+        object: key,
+        reason: `expected generated kind ${displayValue(expectedColumn.generated)}, found ${displayValue(actualColumn.generated)}`,
+      })
+    }
+  }
+
+  for (const actualColumn of actual.columns ?? []) {
+    const key = columnKey(actualColumn)
+    if (!expectedColumns.has(key) && actualColumn.notNull && actualColumn.default === null && !actualColumn.generated) {
+      issues.push({
+        kind: 'column',
+        object: key,
+        reason: 'subscriber-only NOT NULL column has no default',
+      })
+    }
+  }
+}
+
+function compareTypes(expected: SchemaCatalog, actual: SchemaCatalog, issues: SchemaCompatibilityIssue[]): void {
+  const actualTypes = new Map((actual.types ?? []).map(type => [type.name, type]))
+
+  for (const expectedType of expected.types ?? []) {
+    const actualType = actualTypes.get(expectedType.name)
+    if (!actualType) {
+      issues.push({ kind: 'type', object: expectedType.name, reason: 'missing required type' })
+      continue
+    }
+    if (actualType.kind !== expectedType.kind) {
+      issues.push({
+        kind: 'type',
+        object: expectedType.name,
+        reason: `expected kind ${expectedType.kind}, found ${actualType.kind}`,
+      })
+      continue
+    }
+
+    const compatible = expectedType.kind === 'e'
+      ? enumContainsExpectedValues(expectedType.definition, actualType.definition)
+      : stableJson(expectedType.definition) === stableJson(actualType.definition)
+    if (!compatible) {
+      issues.push({
+        kind: 'type',
+        object: expectedType.name,
+        reason: expectedType.kind === 'e' ? 'subscriber enum is missing publisher values' : 'type definition differs',
+      })
+    }
+  }
+}
+
+function compareIndexes(expected: SchemaCatalog, actual: SchemaCatalog, issues: SchemaCompatibilityIssue[]): void {
+  const expectedIndexes = new Map((expected.indexes ?? []).map(index => [index.name, index]))
+  const actualIndexes = new Map((actual.indexes ?? []).map(index => [index.name, index]))
+
+  for (const expectedIndex of expected.indexes ?? []) {
+    const actualIndex = actualIndexes.get(expectedIndex.name)
+    if (!actualIndex) {
+      issues.push({ kind: 'index', object: expectedIndex.name, reason: 'missing required index' })
+      continue
+    }
+    if (actualIndex.table !== expectedIndex.table) {
+      issues.push({
+        kind: 'index',
+        object: expectedIndex.name,
+        reason: `expected table ${expectedIndex.table}, found ${actualIndex.table}`,
+      })
+    }
+    if (!actualIndex.valid)
+      issues.push({ kind: 'index', object: expectedIndex.name, reason: 'index is invalid' })
+    if (actualIndex.definition !== expectedIndex.definition)
+      issues.push({ kind: 'index', object: expectedIndex.name, reason: 'index definition differs' })
+  }
+
+  for (const actualIndex of actual.indexes ?? []) {
+    if (!expectedIndexes.has(actualIndex.name))
+      issues.push({ kind: 'index', object: actualIndex.name, reason: 'unexpected index adds storage and write cost' })
+  }
+}
+
+function assertSchemaCatalog(value: unknown, label: string): SchemaCatalog {
+  if (!value || typeof value !== 'object')
+    throw new Error(`Expected ${label} read-replica schema catalog JSON object`)
+
+  const catalog = value as SchemaCatalog
+  for (const collection of ['columns', 'indexes', 'tables', 'types'] as const) {
+    if (catalog[collection] !== undefined && !Array.isArray(catalog[collection]))
+      throw new Error(`Read-replica schema catalog ${collection} must be an array`)
+  }
+  return catalog
+}
+
+function enumContainsExpectedValues(expected: unknown, actual: unknown): boolean {
+  if (!Array.isArray(expected) || !Array.isArray(actual))
+    return stableJson(expected) === stableJson(actual)
+
+  const actualValues = new Set(actual.map(value => stableJson(value)))
+  return expected.every(value => actualValues.has(stableJson(value)))
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function columnKey(column: Pick<SchemaColumn, 'table' | 'name'>): string {
+  return `${column.table}.${column.name}`
+}
+
+function displayValue(value: string): string {
+  return value || 'none'
+}

--- a/scripts/compare-read-replica-schema-catalog.ts
+++ b/scripts/compare-read-replica-schema-catalog.ts
@@ -1,8 +1,6 @@
-import { spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { stableStringify } from '../read_replicate/schema_catalog.ts'
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+import { readReplicaSchemaCompatibilityIssues } from '../read_replicate/schema_compatibility.ts'
 
 const [expectedPath, actualPath] = process.argv.slice(2)
 
@@ -13,44 +11,24 @@ async function main() {
     return
   }
 
-  const tempDir = await mkdtemp(join(tmpdir(), 'read-replica-schema-'))
+  const expected = JSON.parse(await readFile(expectedPath, 'utf8'))
+  const actual = JSON.parse(await readFile(actualPath, 'utf8'))
+  const issues = readReplicaSchemaCompatibilityIssues(expected, actual)
 
-  try {
-    const expected = JSON.parse(await readFile(expectedPath, 'utf8'))
-    const actual = JSON.parse(await readFile(actualPath, 'utf8'))
-    const expectedText = `${stableStringify(expected)}\n`
-    const actualText = `${stableStringify(actual)}\n`
-
-    if (expectedText === actualText) {
-      console.log('Read-replica schema catalog matches the committed snapshot.')
-      return
-    }
-
-    const normalizedExpectedPath = join(tempDir, 'expected.json')
-    const normalizedActualPath = join(tempDir, 'actual.json')
-    await writeFile(normalizedExpectedPath, expectedText)
-    await writeFile(normalizedActualPath, actualText)
-
-    console.error('::error title=Read-replica schema is out of date::Hyperdrive read replica does not match read_replicate/schema_replicate.catalog.json after additive sync.')
-    console.error('')
-    console.error('The production source schema was updated, but the read replica visible through Hyperdrive still differs from the committed replica schema catalog.')
-    console.error('Automatic sync only applies safe missing columns and indexes. Apply any remaining non-additive DDL or maintenance flow, then retry the release.')
-    console.error('')
-    console.error('Diff:')
-
-    const diff = spawnSync('diff', ['-u', normalizedExpectedPath, normalizedActualPath], {
-      encoding: 'utf8',
-    })
-    if (diff.stdout)
-      console.error(diff.stdout)
-    if (diff.stderr)
-      console.error(diff.stderr)
-
-    process.exitCode = 1
+  if (!issues.length) {
+    console.log('Read-replica schema is compatible with the committed snapshot.')
+    return
   }
-  finally {
-    await rm(tempDir, { recursive: true, force: true })
-  }
+
+  console.error('::error title=Read-replica schema is incompatible::Hyperdrive read replica is not compatible with read_replicate/schema_replicate.catalog.json after additive sync.')
+  console.error('')
+  console.error('The check ignores column order, defaults, constraints, sequences, and functions because they do not prevent logical replication.')
+  console.error('Indexes still require exact parity because unexpected indexes add storage and write-maintenance cost.')
+  console.error('')
+  console.error('Incompatible objects:')
+  for (const issue of issues)
+    console.error(`- ${issue.kind} ${issue.object}: ${issue.reason}`)
+  process.exitCode = 1
 }
 
 await main()

--- a/tests/read-replica-ephemeral-worker.unit.test.ts
+++ b/tests/read-replica-ephemeral-worker.unit.test.ts
@@ -89,7 +89,7 @@ esac
         },
       })
       expect(stderr).toBe('')
-      expect(stdout).toContain('Read-replica schema catalog matches the committed snapshot.')
+      expect(stdout).toContain('Read-replica schema is compatible with the committed snapshot.')
     }
 
     await Promise.all([runChecker(), runChecker()])

--- a/tests/read-replica-schema-compatibility.unit.test.ts
+++ b/tests/read-replica-schema-compatibility.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { readReplicaSchemaCompatibilityIssues } from '../read_replicate/schema_compatibility.ts'
+
+function catalog() {
+  return {
+    version: 1,
+    tables: [{ name: 'apps', kind: 'r', reloptions: [] }],
+    columns: [
+      { table: 'apps', name: 'id', type: 'uuid', notNull: true, default: 'gen_random_uuid()', identity: '', generated: '', position: 1 },
+      { table: 'apps', name: 'name', type: 'text', notNull: false, default: null, identity: '', generated: '', position: 2 },
+    ],
+    constraints: [{ table: 'apps', name: 'apps_name_check', type: 'c', definition: 'CHECK (name <> \'\')' }],
+    indexes: [{ table: 'apps', name: 'apps_pkey', definition: 'CREATE UNIQUE INDEX apps_pkey ON public.apps USING btree (id)', valid: true }],
+    types: [{ name: 'status', kind: 'e', definition: ['active', 'disabled'] }],
+    sequences: [{ name: 'apps_id_seq', start: '1' }],
+    functions: [{ name: 'helper', arguments: '', definition: 'old' }],
+  }
+}
+
+describe('read-replica schema compatibility', () => {
+  it.concurrent('accepts metadata drift that does not prevent logical replication', () => {
+    const expected = catalog()
+    const actual = catalog()
+    actual.columns = [
+      { ...actual.columns[1], position: 1, default: '\'replica\'' },
+      { ...actual.columns[0], position: 2, default: 'different_default()' },
+    ]
+    actual.constraints = []
+    actual.sequences = []
+    actual.functions = []
+    actual.types[0].definition.push('replica_only')
+
+    expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual([])
+  })
+
+  it.concurrent('rejects missing or incompatible replication objects', () => {
+    const expected = catalog()
+    const actual = catalog()
+    actual.columns = [
+      { ...actual.columns[1], type: 'integer', notNull: true },
+      { ...actual.columns[1], name: 'replica_only', notNull: true, default: null },
+    ]
+    actual.indexes[0].valid = false
+    actual.types[0].definition = ['active']
+
+    expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'column', object: 'apps.id', reason: 'missing required column' }),
+      expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'expected type text, found integer' }),
+      expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'subscriber is NOT NULL while publisher accepts NULL' }),
+      expect.objectContaining({ kind: 'column', object: 'apps.replica_only', reason: 'subscriber-only NOT NULL column has no default' }),
+      expect.objectContaining({ kind: 'index', object: 'apps_pkey', reason: 'index is invalid' }),
+      expect.objectContaining({ kind: 'type', object: 'status', reason: 'subscriber enum is missing publisher values' }),
+    ]))
+  })
+
+  it.concurrent('rejects unexpected indexes because they add storage and write cost', () => {
+    const expected = catalog()
+    const actual = catalog()
+    actual.indexes.push({
+      table: 'apps',
+      name: 'replica_only_idx',
+      definition: 'CREATE INDEX replica_only_idx ON public.apps USING btree (name)',
+      valid: true,
+    })
+
+    expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toContainEqual({
+      kind: 'index',
+      object: 'replica_only_idx',
+      reason: 'unexpected index adds storage and write cost',
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- replace byte-for-byte read-replica catalog comparison with logical-replication compatibility checks
- ignore column position, defaults, CHECK constraints, sequences, and functions
- keep table options and exact index parity strict, including rejecting replica-only indexes because they add storage and write-maintenance cost
- report incompatible objects directly instead of emitting a full catalog diff
- add regression coverage for harmless metadata drift and blocking schema/index drift

## Why

The additive Hyperdrive sync successfully created missing indexes, but the release still failed because the final guard compared metadata that PostgreSQL logical replication does not require to match. In particular, columns are matched by name rather than physical position, and publisher defaults are materialized before row values are replicated.

## Impact

Production releases remain fail-closed for schema differences that can break replication or create unwanted index cost, without being blocked by harmless physical ordering, default, or CHECK-constraint drift.

## Validation

- `bun run lint`
- `bun test:unit` — 140 files, 949 tests passed
- focused ESLint and TypeScript compilation for the new compatibility checker
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release gate for Hyperdrive schema verification—stricter on unexpected indexes but looser on defaults/constraints—so incorrect rules could either block releases or miss real replication issues.
> 
> **Overview**
> Replaces **byte-for-byte** comparison of the committed read-replica schema catalog with **logical-replication compatibility** checks, so release CI no longer fails on metadata PostgreSQL does not require to match.
> 
> The new `readReplicaSchemaCompatibilityIssues` in `read_replicate/schema_compatibility.ts` enforces tables (kind/options), column names/types/nullability/generated columns, types (including enum value superset on the subscriber), and **exact index parity** (missing, invalid, or differing definitions fail; **extra** replica-only indexes fail for cost). It **does not** compare column order, defaults, constraints, sequences, or functions.
> 
> `scripts/compare-read-replica-schema-catalog.ts` now loads two JSON catalogs, runs the compatibility checker, and prints a list of incompatible objects instead of a full `diff` of normalized JSON. Success messaging is updated to “compatible with the committed snapshot.”
> 
> Docs in `read_replicate/README.md` describe the new semantics. Unit tests cover harmless drift vs blocking drift and unexpected indexes; the ephemeral Hyperdrive checker test expects the new success string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7099f5f56e3d02c000661f3ae21fdaae59f8c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->