### PR TITLE
fix(types): restore device country code

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1463,6 +1463,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1482,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1501,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string


### PR DESCRIPTION
## Summary

Restores `devices.country_code` in both generated Supabase type mirrors.

The latest auto-sync removed the field even though `20260709131018_add_device_country_code.sql` and the backend device flow use it. That made backend typecheck reject valid device reads, writes, and the country-code regression fixture.

## Validation

- `bun run lint:backend`
- `bun run typecheck:backend`
- `bunx vitest run tests/device-update-format.unit.test.ts`
- `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated type-only change; no runtime or schema behavior. Low risk aside from keeping the two type mirrors in sync.
> 
> **Overview**
> Re-adds **`devices.country_code`** (`string | null`) to the generated Supabase `devices` **Row**, **Insert**, and **Update** types in both mirrors: `src/types/supabase.types.ts` and `supabase/functions/_backend/utils/supabase.types.ts`.
> 
> A recent type auto-sync had dropped this column from the generated types even though the DB migration and backend device paths still read and write `country_code`. Restoring it aligns TypeScript with the live schema and fixes backend typecheck failures on device operations and the country-code regression test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230f18fdd607e2551951223e1eada06188537d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device records now support an optional country code.
  * Country code information is available when viewing, creating, or updating device data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->