### PR TITLE
fix(ci): ignore release-only package paths

### DIFF
--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -6,12 +6,6 @@ export type ReleaseAs = 'patch' | 'minor' | 'major'
 type GitRunner = (args: string[]) => string
 
 const sharedMatchers = [
-  /^\.github\/workflows\/bump_version\.yml$/,
-  /^\.github\/workflows\/tests\.yml$/,
-  /^\.github\/scripts\//,
-  /^scripts\/sync-notifications-package-version\.ts$/,
-  /^scripts\/setup-bun\.sh$/,
-  /^scripts\/setup-bun\.ps1$/,
   /^package\.json$/,
   /^bun\.lock$/,
   /^\.npmrc$/,
@@ -59,7 +53,6 @@ export const componentMatchers: Record<Component, RegExp[]> = {
   ],
   cli: [
     ...sharedMatchers,
-    /^\.github\/workflows\/publish_cli\.yml$/,
     /^cli\/src\//,
     /^cli\/skills\/[^/]+\/SKILL\.md$/,
     /^cli\/skills\/(?!.*\.(md|mdx)$)/,
@@ -70,7 +63,6 @@ export const componentMatchers: Record<Component, RegExp[]> = {
   ],
   notifications: [
     ...sharedMatchers,
-    /^\.github\/workflows\/publish_notifications\.yml$/,
     /^packages\/capacitor-notifications\//,
   ],
 }

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -3,22 +3,16 @@ import { describe, expect, it } from 'vitest'
 import { matchesComponent, resolveReleaseScope } from '../scripts/release-scope.ts'
 
 describe('release scope matching', () => {
-  it.concurrent('treats shared release infrastructure as affecting all components', () => {
+  it.concurrent('does not publish packages for release infrastructure changes', () => {
     const files = [
       '.github/workflows/tests.yml',
       '.github/workflows/bump_version.yml',
+      '.github/workflows/publish_cli.yml',
+      '.github/workflows/publish_notifications.yml',
       '.github/scripts/start-background-service.sh',
       'scripts/setup-bun.sh',
+      'scripts/setup-bun.ps1',
       'scripts/sync-notifications-package-version.ts',
-    ]
-
-    expect(matchesComponent('capgo', files)).toBe(true)
-    expect(matchesComponent('cli', files)).toBe(true)
-    expect(matchesComponent('notifications', files)).toBe(true)
-  })
-
-  it.concurrent('does not publish packages for release scope logic changes', () => {
-    const files = [
       'scripts/release-scope.ts',
       'tests/release-scope.test.ts',
     ]
@@ -27,26 +21,55 @@ describe('release scope matching', () => {
     expect(matchesComponent('cli', files)).toBe(false)
     expect(matchesComponent('notifications', files)).toBe(false)
   })
+
+  it.concurrent('does not release the packages changed only by the release-scope fix', () => {
+    const files = [
+      '.github/workflows/publish_cli.yml',
+      '.github/workflows/publish_notifications.yml',
+      'scripts/release-scope.ts',
+      'tests/release-scope.test.ts',
+    ]
+
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'rev-list --reverse release-parent..release-fix': 'release-fix',
+        'show --format= --name-only release-fix': files.join('\n'),
+      }
+
+      if (key in responses) {
+        return responses[key]
+      }
+
+      throw new Error(`Unexpected git call: ${key}`)
+    }
+
+    for (const component of ['capgo', 'cli', 'notifications'] as const) {
+      expect(resolveReleaseScope(component, 'release-parent', 'release-fix', run)).toEqual({
+        shouldRelease: false,
+        releaseAs: 'patch',
+      })
+    }
+  })
+
+  it.concurrent('treats shared package inputs as affecting all components', () => {
+    const files = ['package.json', 'bun.lock', 'tsconfig.json']
+
+    expect(matchesComponent('capgo', files)).toBe(true)
+    expect(matchesComponent('cli', files)).toBe(true)
+    expect(matchesComponent('notifications', files)).toBe(true)
+  })
+
   it.concurrent('treats capgo deploy workflow changes as capgo-only releases', () => {
     const files = ['.github/workflows/build_and_deploy.yml', 'scripts/deploy-scope.ts']
 
     expect(matchesComponent('capgo', files)).toBe(true)
     expect(matchesComponent('cli', files)).toBe(false)
-  })
-
-  it.concurrent('treats cli publish workflow changes as cli-only releases', () => {
-    const files = ['.github/workflows/publish_cli.yml']
-
-    expect(matchesComponent('capgo', files)).toBe(false)
-    expect(matchesComponent('cli', files)).toBe(true)
     expect(matchesComponent('notifications', files)).toBe(false)
   })
 
   it.concurrent('treats notifications package changes as notifications-only releases', () => {
-    const files = [
-      'packages/capacitor-notifications/src/index.ts',
-      '.github/workflows/publish_notifications.yml',
-    ]
+    const files = ['packages/capacitor-notifications/src/index.ts']
 
     expect(matchesComponent('capgo', files)).toBe(false)
     expect(matchesComponent('cli', files)).toBe(false)


### PR DESCRIPTION
## Summary

- exclude release/test workflows and their helper scripts from package release scope
- keep real shared package inputs and component source/build paths releasable
- cover the exact release-scope-only merge shape with a regression test

## Why

The current-push range fix in #2656 was correct, but its own publish workflow changes still matched the CLI and notifications components. That could create another empty release for changes that only adjust release automation.

The resulting [Bump version run](https://github.com/Cap-go/capgo/actions/runs/29104415867) was cancelled before its tag job completed. No `cli-8.25.14`, `notifications-0.1.13`, or `capgo-12.194.2` tags were created.

## Validation

- `bunx vitest run tests/release-scope.test.ts` (11 passed)
- `bun test:unit` (951 passed)
- `bun typecheck`
- `bun lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only release automation path matching and tests; no runtime or publish pipeline logic beyond when tags are created.
> 
> **Overview**
> **Release scope** no longer treats CI/release automation paths as reasons to bump **capgo**, **cli**, or **notifications**. Removed from `componentMatchers` / `sharedMatchers`: bump/tests/publish workflows, `.github/scripts`, bun setup scripts, and `sync-notifications-package-version.ts`. **CLI** and **notifications** no longer match edits to their own `publish_*.yml` workflows.
> 
> **Shared package inputs** (`package.json`, `bun.lock`, `tsconfig.json`, etc.) still match all three components. Capgo-only deploy paths and real component source paths are unchanged.
> 
> **Tests** now assert release infra changes do not match any component, add a `resolveReleaseScope` regression for merges that only touch publish workflows + `release-scope` files, and drop workflow paths from notifications-only examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc9a44c539595f9acf809b882241143f21a93bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->