### PR TITLE
fix(ci): prevent unrelated package releases

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -85,7 +85,7 @@ jobs:
 
             ---
 
-            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag || github.ref_name }}...${{ steps.changelog.outputs.to_tag || github.ref_name }}
+            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog_base.outputs.from_tag }}...${{ github.ref_name }}
           make_latest: false
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/publish_notifications.yml
+++ b/.github/workflows/publish_notifications.yml
@@ -77,7 +77,7 @@ jobs:
 
             ---
 
-            Full changelog: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag || github.ref_name }}...${{ steps.changelog.outputs.to_tag || github.ref_name }}
+            Full changelog: https://github.com/${{ github.repository }}/compare/${{ steps.changelog_base.outputs.from_tag }}...${{ github.ref_name }}
           make_latest: false
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -5,7 +5,7 @@ export type Component = 'capgo' | 'cli' | 'notifications'
 export type ReleaseAs = 'patch' | 'minor' | 'major'
 type GitRunner = (args: string[]) => string
 
-const sharedMatchers = [
+const capgoRootMatchers = [
   /^package\.json$/,
   /^bun\.lock$/,
   /^\.npmrc$/,
@@ -19,7 +19,7 @@ const sharedMatchers = [
 
 export const componentMatchers: Record<Component, RegExp[]> = {
   capgo: [
-    ...sharedMatchers,
+    ...capgoRootMatchers,
     /^\.github\/workflows\/build_and_deploy\.yml$/,
     /^\.github\/workflows\/build_mobile_ios\.yml$/,
     /^scripts\/deploy-scope\.ts$/,
@@ -52,7 +52,6 @@ export const componentMatchers: Record<Component, RegExp[]> = {
     /^wrangler\.jsonc$/,
   ],
   cli: [
-    ...sharedMatchers,
     /^cli\/src\//,
     /^cli\/skills\/[^/]+\/SKILL\.md$/,
     /^cli\/skills\/(?!.*\.(md|mdx)$)/,
@@ -62,7 +61,6 @@ export const componentMatchers: Record<Component, RegExp[]> = {
     /^cli\/\.npmrc$/,
   ],
   notifications: [
-    ...sharedMatchers,
     /^packages\/capacitor-notifications\//,
   ],
 }

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -52,12 +52,12 @@ describe('release scope matching', () => {
     }
   })
 
-  it.concurrent('treats shared package inputs as affecting all components', () => {
-    const files = ['package.json', 'bun.lock', 'tsconfig.json']
+  it.concurrent('treats root package and test inputs as Capgo-only', () => {
+    const files = ['package.json', 'bun.lock', 'tsconfig.json', 'vitest.config.ts']
 
     expect(matchesComponent('capgo', files)).toBe(true)
-    expect(matchesComponent('cli', files)).toBe(true)
-    expect(matchesComponent('notifications', files)).toBe(true)
+    expect(matchesComponent('cli', files)).toBe(false)
+    expect(matchesComponent('notifications', files)).toBe(false)
   })
 
   it.concurrent('treats capgo deploy workflow changes as capgo-only releases', () => {
@@ -93,10 +93,14 @@ describe('release scope matching', () => {
       ['.github/workflows/publish_notifications.yml', 'notifications-'],
     ] as const) {
       const workflow = readFileSync(workflowPath, 'utf8')
+      const changelogUrl = 'compare/$' + '{{ steps.changelog_base.outputs.from_tag }}...$' + '{{ github.ref_name }}'
+      const legacyChangelogUrl = 'compare/$' + '{{ steps.changelog.outputs.from_tag }}...$' + '{{ steps.changelog.outputs.to_tag }}'
 
       expect(workflow).toContain('gh release list')
       expect(workflow).toContain(`--arg prefix "${prefix}"`)
-      expect(workflow).toContain('from_tag: $' + '{{ steps.changelog_base.outputs.from_tag }}')
+      expect(workflow).toContain('FROM_TAG: $' + '{{ steps.changelog_base.outputs.from_tag }}')
+      expect(workflow).toContain(changelogUrl)
+      expect(workflow).not.toContain(legacyChangelogUrl)
     }
   })
 


### PR DESCRIPTION
## Summary

- Scope root package and test configuration changes to the Capgo release only.
- Require CLI and notifications changes to originate in their own package paths.
- Build comparison links from the component-resolved prior release and the pushed tag.
- Add regressions for both release-scope and changelog-link failures.

## Root cause

A backend-only audit change adjusted root test configuration. Those root paths were treated as shared by all release components, so the bump workflow created and published CLI and notifications tags. The changelog action also exposed its nearest global tag instead of the resolved component tag in public comparison links.

## Validation

- bun install --frozen-lockfile
- bun lint and bun lint:backend
- bun typecheck
- bunx vitest run tests/release-scope.test.ts
- YAML parsing for both publish workflows
- Replay of the original push range: Capgo releases; CLI and notifications do not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release gating for all three components; mis-scoped matchers could skip needed releases or still over-publish, though regressions are covered by release-scope tests.
> 
> **Overview**
> Stops root monorepo files (e.g. `package.json`, `bun.lock`, `vitest.config.ts`) from counting as changes for **CLI** and **notifications** bumps. Those paths are now **Capgo-only** via `capgoRootMatchers`; CLI and notifications matchers are limited to their package directories.
> 
> GitHub release bodies for CLI and notifications now link **Full Changelog** compares from `changelog_base`’s prior component tag to the pushed tag (`github.ref_name`), instead of the AI changelog step’s `from_tag`/`to_tag` fallbacks.
> 
> `tests/release-scope.test.ts` is updated to lock in Capgo-only root matching and the new compare URL shape in both publish workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10f3825a3303f87ba2a4cadf2d17f46ce387746e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->