### PR TITLE
fix(replica): verify additive schema sync

### DIFF
--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -201,10 +201,26 @@ export async function applyReadReplicaAdditiveSchemaSync(client: Queryable, expe
     await client.query('RESET statement_timeout')
   }
 
+  assertAppliedStatementsVisible(plan.statements, expected, await readReplicaSchemaCatalog(client))
+
   return {
     applied: plan.statements.map(({ kind, table, name }) => ({ kind, table, name })),
     skipped: plan.skipped,
   }
+}
+
+function assertAppliedStatementsVisible(applied: readonly SyncStatement[], expected: unknown, actual: unknown): void {
+  const remaining = new Set(planReadReplicaAdditiveSchemaSync(expected, actual).statements.map(statementKey))
+  const unavailable = applied.filter(statement => remaining.has(statementKey(statement)))
+  if (!unavailable.length)
+    return
+
+  throw new Error(`Read-replica additive schema sync did not persist ${unavailable.map(statement => `${statement.kind} ${statement.table}.${statement.name}`).join(', ')}`)
+}
+
+function statementKey(statement: Pick<SyncStatement, 'kind' | 'table' | 'name'>): string {
+  const kind = statement.kind === 'invalid_index' ? 'index' : statement.kind
+  return `${kind}:${statement.table}.${statement.name}`
 }
 
 async function setStatementTimeoutForRemainingBudget(client: Queryable, maxStatementTimeoutMs: number, deadline: number, statement: SyncStatement): Promise<void> {

--- a/read_replicate/schema_catalog.ts
+++ b/read_replicate/schema_catalog.ts
@@ -48,6 +48,9 @@ export interface Queryable {
   query: (queryText: string, values?: unknown[]) => Promise<{ rows: Record<string, any>[] }>
 }
 
+// The release checker reads this catalog before and after schema DDL. The explicit
+// CURRENT_TIMESTAMP predicate makes Hyperdrive treat the verification read as
+// non-cacheable, so it observes DDL from the same release run.
 export const READ_REPLICA_SCHEMA_CATALOG_SQL = `
 WITH replica_tables(table_name) AS (
   SELECT unnest($1::text[])
@@ -256,6 +259,8 @@ SELECT jsonb_build_object(
     FROM functions
   ), '[]'::jsonb)
 ) AS catalog
+FROM (SELECT CURRENT_TIMESTAMP AS checked_at) AS fresh_catalog_read
+WHERE fresh_catalog_read.checked_at IS NOT NULL
 `
 
 export function stableStringify(value: unknown): string {

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -319,6 +319,7 @@ export type Database = {
           build_timeout_updated_at: string
           channel_device_count: number
           created_at: string | null
+          created_from_onboarding: boolean
           default_upload_channel: string
           existing_app: boolean
           expose_metadata: boolean
@@ -329,6 +330,7 @@ export type Database = {
           manifest_bundle_count: number
           name: string | null
           need_onboarding: boolean
+          onboarding_completed_at: string | null
           owner_org: string
           retention: number
           rollout_channel_count: number
@@ -349,6 +351,7 @@ export type Database = {
           build_timeout_updated_at?: string
           channel_device_count?: number
           created_at?: string | null
+          created_from_onboarding?: boolean
           default_upload_channel?: string
           existing_app?: boolean
           expose_metadata?: boolean
@@ -359,6 +362,7 @@ export type Database = {
           manifest_bundle_count?: number
           name?: string | null
           need_onboarding?: boolean
+          onboarding_completed_at?: string | null
           owner_org: string
           retention?: number
           rollout_channel_count?: number
@@ -379,6 +383,7 @@ export type Database = {
           build_timeout_updated_at?: string
           channel_device_count?: number
           created_at?: string | null
+          created_from_onboarding?: boolean
           default_upload_channel?: string
           existing_app?: boolean
           expose_metadata?: boolean
@@ -389,6 +394,7 @@ export type Database = {
           manifest_bundle_count?: number
           name?: string | null
           need_onboarding?: boolean
+          onboarding_completed_at?: string | null
           owner_org?: string
           retention?: number
           rollout_channel_count?: number
@@ -1463,6 +1469,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1488,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1507,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string
@@ -1522,6 +1531,9 @@ export type Database = {
           active_canceled_orgs: number
           active_past_due_orgs: number
           apps: number
+          apps_created: number
+          apps_with_cli_onboarding_builds_24h: number
+          apps_with_manual_builds_24h: number
           apps_active: number | null
           average_ltv: number
           build_avg_seconds_day_android: number
@@ -1614,6 +1626,9 @@ export type Database = {
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps: number
+          apps_created?: number
+          apps_with_cli_onboarding_builds_24h?: number
+          apps_with_manual_builds_24h?: number
           apps_active?: number | null
           average_ltv?: number
           build_avg_seconds_day_android?: number
@@ -1706,6 +1721,9 @@ export type Database = {
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps?: number
+          apps_created?: number
+          apps_with_cli_onboarding_builds_24h?: number
+          apps_with_manual_builds_24h?: number
           apps_active?: number | null
           average_ltv?: number
           build_avg_seconds_day_android?: number
@@ -3870,6 +3888,7 @@ export type Database = {
           build_timeout_updated_at: string
           channel_device_count: number
           created_at: string | null
+          created_from_onboarding: boolean
           default_upload_channel: string
           existing_app: boolean
           expose_metadata: boolean
@@ -3880,6 +3899,7 @@ export type Database = {
           manifest_bundle_count: number
           name: string | null
           need_onboarding: boolean
+          onboarding_completed_at: string | null
           owner_org: string
           retention: number
           rollout_channel_count: number

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -319,6 +319,7 @@ export type Database = {
           build_timeout_updated_at: string
           channel_device_count: number
           created_at: string | null
+          created_from_onboarding: boolean
           default_upload_channel: string
           existing_app: boolean
           expose_metadata: boolean
@@ -329,6 +330,7 @@ export type Database = {
           manifest_bundle_count: number
           name: string | null
           need_onboarding: boolean
+          onboarding_completed_at: string | null
           owner_org: string
           retention: number
           rollout_channel_count: number
@@ -349,6 +351,7 @@ export type Database = {
           build_timeout_updated_at?: string
           channel_device_count?: number
           created_at?: string | null
+          created_from_onboarding?: boolean
           default_upload_channel?: string
           existing_app?: boolean
           expose_metadata?: boolean
@@ -359,6 +362,7 @@ export type Database = {
           manifest_bundle_count?: number
           name?: string | null
           need_onboarding?: boolean
+          onboarding_completed_at?: string | null
           owner_org: string
           retention?: number
           rollout_channel_count?: number
@@ -379,6 +383,7 @@ export type Database = {
           build_timeout_updated_at?: string
           channel_device_count?: number
           created_at?: string | null
+          created_from_onboarding?: boolean
           default_upload_channel?: string
           existing_app?: boolean
           expose_metadata?: boolean
@@ -389,6 +394,7 @@ export type Database = {
           manifest_bundle_count?: number
           name?: string | null
           need_onboarding?: boolean
+          onboarding_completed_at?: string | null
           owner_org?: string
           retention?: number
           rollout_channel_count?: number
@@ -1463,6 +1469,7 @@ export type Database = {
       devices: {
         Row: {
           app_id: string
+          country_code: string | null
           custom_id: string
           default_channel: string | null
           device_id: string
@@ -1481,6 +1488,7 @@ export type Database = {
         }
         Insert: {
           app_id: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id: string
@@ -1499,6 +1507,7 @@ export type Database = {
         }
         Update: {
           app_id?: string
+          country_code?: string | null
           custom_id?: string
           default_channel?: string | null
           device_id?: string
@@ -1522,6 +1531,9 @@ export type Database = {
           active_canceled_orgs: number
           active_past_due_orgs: number
           apps: number
+          apps_created: number
+          apps_with_cli_onboarding_builds_24h: number
+          apps_with_manual_builds_24h: number
           apps_active: number | null
           average_ltv: number
           build_avg_seconds_day_android: number
@@ -1614,6 +1626,9 @@ export type Database = {
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps: number
+          apps_created?: number
+          apps_with_cli_onboarding_builds_24h?: number
+          apps_with_manual_builds_24h?: number
           apps_active?: number | null
           average_ltv?: number
           build_avg_seconds_day_android?: number
@@ -1706,6 +1721,9 @@ export type Database = {
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps?: number
+          apps_created?: number
+          apps_with_cli_onboarding_builds_24h?: number
+          apps_with_manual_builds_24h?: number
           apps_active?: number | null
           average_ltv?: number
           build_avg_seconds_day_android?: number
@@ -3870,6 +3888,7 @@ export type Database = {
           build_timeout_updated_at: string
           channel_device_count: number
           created_at: string | null
+          created_from_onboarding: boolean
           default_upload_channel: string
           existing_app: boolean
           expose_metadata: boolean
@@ -3880,6 +3899,7 @@ export type Database = {
           manifest_bundle_count: number
           name: string | null
           need_onboarding: boolean
+          onboarding_completed_at: string | null
           owner_org: string
           retention: number
           rollout_channel_count: number

--- a/tests/read-replica-schema-additive-sync.unit.test.ts
+++ b/tests/read-replica-schema-additive-sync.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { applyReadReplicaAdditiveSchemaSync } from '../read_replicate/schema_additive_sync.ts'
+import { READ_REPLICA_SCHEMA_CATALOG_SQL } from '../read_replicate/schema_catalog.ts'
+
+function catalogs() {
+  const expected = {
+    tables: [{ name: 'apps' }],
+    columns: [
+      { table: 'apps', name: 'id', type: 'uuid', notNull: true, default: null, identity: '', generated: '' },
+      { table: 'apps', name: 'created_from_onboarding', type: 'boolean', notNull: true, default: 'false', identity: '', generated: '' },
+    ],
+    constraints: [],
+    indexes: [{ table: 'apps', name: 'idx_apps_id', definition: 'CREATE INDEX idx_apps_id ON public.apps USING btree (id)', valid: true }],
+  }
+  const initial = {
+    ...expected,
+    columns: [expected.columns[0]],
+    indexes: [] as typeof expected.indexes,
+  }
+
+  return { expected, initial }
+}
+
+describe('read-replica additive schema sync', () => {
+  it.concurrent('fails instead of reporting applied objects when the post-DDL catalog is stale', async () => {
+    const { expected, initial } = catalogs()
+    const statements: string[] = []
+    let catalogReads = 0
+    const client = {
+      query: async (text: string) => {
+        if (text === READ_REPLICA_SCHEMA_CATALOG_SQL) {
+          catalogReads += 1
+          return { rows: [{ catalog: initial }] }
+        }
+
+        statements.push(text)
+        return { rows: [] }
+      },
+    }
+
+    await expect(applyReadReplicaAdditiveSchemaSync(client, expected)).rejects.toThrow('did not persist column apps.created_from_onboarding, index apps.idx_apps_id')
+    expect(catalogReads).toBe(2)
+    expect(statements).toEqual(expect.arrayContaining([
+      'ALTER TABLE public."apps" ADD COLUMN IF NOT EXISTS "created_from_onboarding" boolean DEFAULT false NOT NULL',
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_apps_id" ON public."apps" USING btree (id)',
+    ]))
+  })
+
+  it.concurrent('fails when a created index remains invalid after the catalog refresh', async () => {
+    const { expected } = catalogs()
+    const current = {
+      ...expected,
+      indexes: [] as typeof expected.indexes,
+    }
+    const client = {
+      query: async (text: string) => {
+        if (text === READ_REPLICA_SCHEMA_CATALOG_SQL)
+          return { rows: [{ catalog: current }] }
+
+        if (text.startsWith('CREATE INDEX'))
+          current.indexes.push({ ...expected.indexes[0], valid: false })
+        return { rows: [] }
+      },
+    }
+
+    await expect(applyReadReplicaAdditiveSchemaSync(client, expected)).rejects.toThrow('did not persist index apps.idx_apps_id')
+  })
+
+  it.concurrent('returns applied only after the post-DDL catalog contains every statement', async () => {
+    const { expected, initial } = catalogs()
+    const current = structuredClone(initial)
+    let catalogReads = 0
+    const client = {
+      query: async (text: string) => {
+        if (text === READ_REPLICA_SCHEMA_CATALOG_SQL) {
+          catalogReads += 1
+          return { rows: [{ catalog: current }] }
+        }
+
+        if (text.startsWith('ALTER TABLE'))
+          current.columns.push(expected.columns[1])
+        if (text.startsWith('CREATE INDEX'))
+          current.indexes.push(expected.indexes[0])
+        return { rows: [] }
+      },
+    }
+
+    await expect(applyReadReplicaAdditiveSchemaSync(client, expected)).resolves.toEqual({
+      applied: [
+        { kind: 'column', table: 'apps', name: 'created_from_onboarding' },
+        { kind: 'index', table: 'apps', name: 'idx_apps_id' },
+      ],
+      skipped: [],
+    })
+    expect(catalogReads).toBe(2)
+  })
+})

--- a/tests/read-replica-schema-catalog.unit.test.ts
+++ b/tests/read-replica-schema-catalog.unit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readReplicaSchemaCatalog } from '../read_replicate/schema_catalog.ts'
+
+describe('read-replica schema catalog', () => {
+  it.concurrent('makes the post-DDL catalog read uncacheable in Hyperdrive', async () => {
+    const queries: Array<{ text: string, values?: unknown[] }> = []
+    const catalog = await readReplicaSchemaCatalog({
+      query: async (text, values) => {
+        queries.push({ text, values })
+        return { rows: [{ catalog: { version: 1 } }] }
+      },
+    })
+
+    expect(catalog).toEqual({ version: 1 })
+    expect(queries).toHaveLength(1)
+    expect(queries[0]?.text).toContain('CURRENT_TIMESTAMP')
+    expect(queries[0]?.text).toContain('fresh_catalog_read.checked_at IS NOT NULL')
+  })
+})


### PR DESCRIPTION
## Summary

- make the read-replica catalog verification query fresh through Hyperdrive
- re-read the catalog after additive DDL before reporting statements as applied
- cover stale and fresh post-DDL catalog responses with unit tests
- restore generated database types for migrations that have not reached the remote schema yet

## Root cause

The release checker returned its planned DDL as `applied` without first proving that a subsequent catalog read could see it. The following Hyperdrive catalog request could therefore report an older schema view and falsely block the deployment even though the columns and index had been created.

The release workflow stops before applying these migrations, while the automatic remote-type sync removed their generated fields. That made the baseline backend typecheck fail even though the migrations and callers were already committed.

## Impact

The checker now fails the sync endpoint when an applied column or index is still absent or invalid after the post-DDL catalog read. It also keeps the generated type mirrors aligned with the pending migrations, so compiler checks stay truthful until the release applies them.

The pre-existing unexpected replica indexes remain a separate, intentional guard failure and require a maintenance operation; this PR does not hide or remove them.

## Validation

- `bun lint`
- `bun typecheck`
- `bun test:unit` (143 files, 960 tests; also passed from a clean worktree)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release-time read-replica schema DDL and deployment gating; failures are explicit but incorrect behavior could still block or delay releases.
> 
> **Overview**
> Fixes false release failures where additive DDL was reported as **applied** before a follow-up catalog read could see it (often due to **Hyperdrive** caching).
> 
> **Read-replica additive sync** now re-reads the schema catalog after DDL and only returns `applied` when every executed statement shows up in that fresh catalog; otherwise it throws with the missing column/index names. Invalid indexes still count as not persisted.
> 
> The catalog SQL is wrapped with a **`CURRENT_TIMESTAMP`** predicate so post-DDL verification reads are treated as non-cacheable and reflect the same release run.
> 
> Generated **Supabase types** are restored for columns/stats fields tied to migrations not yet on remote, keeping typecheck aligned with committed callers.
> 
> Unit tests cover stale vs fresh post-DDL catalogs and the Hyperdrive-oriented catalog query shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcc1cce17f9f995acad8c64efb259586d338597f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->