### PR TITLE
fix(replica): harden schema reconciliation

### DIFF
--- a/cloudflare_workers/read-replica-schema-check/index.ts
+++ b/cloudflare_workers/read-replica-schema-check/index.ts
@@ -107,6 +107,9 @@ function schemaCheckSetup(
   return { masterConnectionString, replicaConnectionString }
 }
 
+// These catalogs use independent connections, not one cross-database snapshot.
+// Concurrent DDL can transiently report drift. The release workflow serializes
+// schema writers before this check.
 async function verifyMasterSchema(setup: SchemaCheckSetup): Promise<Response> {
   const [expected, actual] = await Promise.all([
     withPgClient(setup.masterConnectionString, readReplicaSchemaCatalog),

--- a/read_replicate/schema_catalog.ts
+++ b/read_replicate/schema_catalog.ts
@@ -1,3 +1,5 @@
+import { sortJson } from './schema_json.ts'
+
 export const REPLICA_TABLES = [
   'orgs',
   'stripe_info',
@@ -53,7 +55,7 @@ export interface Queryable {
 // CURRENT_TIMESTAMP predicate makes Hyperdrive treat the verification read as
 // non-cacheable, so it observes DDL from the same release run.
 export const READ_REPLICA_SCHEMA_CATALOG_SQL = `
-WITH replica_tables(table_name) AS (
+WITH RECURSIVE replica_tables(table_name) AS (
   SELECT unnest($1::text[])
 ),
 replica_sequences(sequence_name) AS (
@@ -80,26 +82,35 @@ tables AS (
   WHERE n.nspname = 'public'
     AND c.relkind IN ('r', 'p')
 ),
+selected_column_types(type_oid) AS (
+  SELECT DISTINCT a.atttypid
+  FROM tables t
+  JOIN pg_attribute a ON a.attrelid = t.table_oid
+  WHERE a.attnum > 0
+    AND NOT a.attisdropped
+),
+referenced_types(type_oid) AS (
+  SELECT type_oid
+  FROM selected_column_types
+  UNION
+  SELECT CASE
+    WHEN typ.typbasetype <> 0 THEN typ.typbasetype
+    ELSE typ.typelem
+  END
+  FROM referenced_types referenced
+  JOIN pg_type typ ON typ.oid = referenced.type_oid
+  WHERE typ.typbasetype <> 0
+     OR typ.typelem <> 0
+),
 selected_type_names(type_name) AS (
   SELECT unnest($2::text[])
   UNION
-  SELECT DISTINCT base_type.typname
-  FROM tables t
-  JOIN pg_attribute a ON a.attrelid = t.table_oid
-  JOIN pg_type declared_type ON declared_type.oid = a.atttypid
-  JOIN pg_type element_type ON element_type.oid = CASE
-    WHEN declared_type.typelem <> 0 THEN declared_type.typelem
-    ELSE declared_type.oid
-  END
-  JOIN pg_type base_type ON base_type.oid = CASE
-    WHEN element_type.typbasetype <> 0 THEN element_type.typbasetype
-    ELSE element_type.oid
-  END
-  JOIN pg_namespace type_namespace ON type_namespace.oid = base_type.typnamespace
-  WHERE a.attnum > 0
-    AND NOT a.attisdropped
-    AND type_namespace.nspname = 'public'
-    AND base_type.typtype IN ('e', 'c')
+  SELECT DISTINCT typ.typname
+  FROM referenced_types referenced
+  JOIN pg_type typ ON typ.oid = referenced.type_oid
+  JOIN pg_namespace type_namespace ON type_namespace.oid = typ.typnamespace
+  WHERE type_namespace.nspname = 'public'
+    AND typ.typtype IN ('e', 'c')
 ),
 columns AS (
   SELECT
@@ -178,6 +189,23 @@ types AS (
   JOIN selected_type_names rt ON rt.type_name = typ.typname
   WHERE n.nspname = 'public'
 ),
+selected_sequence_oids(sequence_oid) AS (
+  SELECT seq.oid
+  FROM pg_class seq
+  JOIN pg_namespace n ON n.oid = seq.relnamespace
+  JOIN replica_sequences rs ON rs.sequence_name = seq.relname
+  WHERE n.nspname = 'public'
+    AND seq.relkind = 'S'
+  UNION
+  SELECT dep.objid
+  FROM pg_depend dep
+  JOIN tables t ON t.table_oid = dep.refobjid
+  JOIN pg_class seq ON seq.oid = dep.objid
+  JOIN pg_namespace n ON n.oid = seq.relnamespace
+  WHERE dep.deptype IN ('a', 'i')
+    AND n.nspname = 'public'
+    AND seq.relkind = 'S'
+),
 sequences AS (
   SELECT
     seq.relname AS sequence_name,
@@ -193,7 +221,7 @@ sequences AS (
   FROM pg_class seq
   JOIN pg_namespace n ON n.oid = seq.relnamespace
   JOIN pg_sequence s ON s.seqrelid = seq.oid
-  JOIN replica_sequences rs ON rs.sequence_name = seq.relname
+  JOIN selected_sequence_oids selected_sequence ON selected_sequence.sequence_oid = seq.oid
   LEFT JOIN pg_depend dep ON dep.objid = seq.oid AND dep.deptype IN ('a', 'i')
   LEFT JOIN pg_class owned_table ON owned_table.oid = dep.refobjid
   LEFT JOIN pg_attribute owned_attr ON owned_attr.attrelid = dep.refobjid AND owned_attr.attnum = dep.refobjsubid
@@ -308,18 +336,4 @@ export async function readReplicaSchemaCatalog(
     throw new Error('Read-replica schema catalog query returned no rows')
 
   return sortJson(catalog)
-}
-
-function sortJson(value: unknown): unknown {
-  if (Array.isArray(value))
-    return value.map(sortJson)
-
-  if (!value || typeof value !== 'object')
-    return value
-
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, child]) => [key, sortJson(child)]),
-  )
 }

--- a/read_replicate/schema_compatibility.ts
+++ b/read_replicate/schema_compatibility.ts
@@ -1,3 +1,5 @@
+import { stableJson } from './schema_json.ts'
+
 interface SchemaColumn {
   table: string
   name: string
@@ -244,12 +246,14 @@ function compareIndexes(expected: SchemaCatalog, actual: SchemaCatalog, issues: 
           : `expected valid ${displayValue(expectedIndex.valid)}, found ${displayValue(actualIndex.valid)}`,
       })
     }
-    if (actualIndex.constraintOwned !== expectedIndex.constraintOwned) {
-      issues.push({
-        kind: 'index',
-        object: expectedIndex.name,
-        reason: `expected constraintOwned ${displayValue(expectedIndex.constraintOwned)}, found ${displayValue(actualIndex.constraintOwned)}`,
-      })
+    if (expectedIndex.constraintOwned !== undefined && actualIndex.constraintOwned !== undefined) {
+      if (actualIndex.constraintOwned !== expectedIndex.constraintOwned) {
+        issues.push({
+          kind: 'index',
+          object: expectedIndex.name,
+          reason: `expected constraintOwned ${displayValue(expectedIndex.constraintOwned)}, found ${displayValue(actualIndex.constraintOwned)}`,
+        })
+      }
     }
   }
 
@@ -362,24 +366,6 @@ function assertSchemaCatalog(value: unknown, label: string): SchemaCatalog {
 
 function sameValue(left: unknown, right: unknown): boolean {
   return stableJson(left) === stableJson(right)
-}
-
-function stableJson(value: unknown): string {
-  return JSON.stringify(sortJson(value)) ?? 'undefined'
-}
-
-function sortJson(value: unknown): unknown {
-  if (Array.isArray(value))
-    return value.map(sortJson)
-
-  if (!value || typeof value !== 'object')
-    return value
-
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, child]) => [key, sortJson(child)]),
-  )
 }
 
 function columnKey(column: Pick<SchemaColumn, 'table' | 'name'>): string {

--- a/read_replicate/schema_json.ts
+++ b/read_replicate/schema_json.ts
@@ -1,0 +1,17 @@
+export function sortJson(value: unknown): unknown {
+  if (Array.isArray(value))
+    return value.map(sortJson)
+
+  if (!value || typeof value !== 'object')
+    return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, sortJson(child)]),
+  )
+}
+
+export function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value)) ?? 'undefined'
+}

--- a/scripts/check-read-replica-hyperdrive-schema.sh
+++ b/scripts/check-read-replica-hyperdrive-schema.sh
@@ -117,7 +117,6 @@ READY=0
 LAST_READY_STATUS=''
 READY_ATTEMPTS_USED=0
 for attempt in $(seq 1 "$READY_ATTEMPTS"); do
-  READY_ATTEMPTS_USED="$attempt"
   REMAINING_TIME="$(remaining_check_time)"
   if (( REMAINING_TIME <= CHECK_CLEANUP_RESERVE_SECONDS )); then
     break
@@ -129,6 +128,7 @@ for attempt in $(seq 1 "$READY_ATTEMPTS"); do
   fi
   : > "$READY_ATTEMPT_RESPONSE"
   : > "$READY_ATTEMPT_ERROR"
+  READY_ATTEMPTS_USED="$attempt"
   LAST_READY_STATUS="$(curl -sS --connect-timeout 10 --max-time "$ATTEMPT_MAX_TIME" \
     --header "authorization: Bearer ${READ_REPLICA_SCHEMA_CHECK_TOKEN}" \
     -w '%{http_code}' \
@@ -159,7 +159,6 @@ VERIFIED=0
 LAST_VERIFY_STATUS=''
 VERIFY_ATTEMPTS_USED=0
 for attempt in $(seq 1 "$VERIFY_ATTEMPTS"); do
-  VERIFY_ATTEMPTS_USED="$attempt"
   REMAINING_TIME="$(remaining_check_time)"
   if (( REMAINING_TIME <= CHECK_CLEANUP_RESERVE_SECONDS )); then
     break
@@ -171,6 +170,7 @@ for attempt in $(seq 1 "$VERIFY_ATTEMPTS"); do
   fi
   : > "$VERIFY_ATTEMPT_RESPONSE"
   : > "$VERIFY_ATTEMPT_ERROR"
+  VERIFY_ATTEMPTS_USED="$attempt"
   LAST_VERIFY_STATUS="$(curl -sS --connect-timeout 10 --max-time "$ATTEMPT_MAX_TIME" \
     --header "authorization: Bearer ${READ_REPLICA_SCHEMA_CHECK_TOKEN}" \
     -w '%{http_code}' \

--- a/supabase/migrations/20260711094204_align_replica_source_schema.sql
+++ b/supabase/migrations/20260711094204_align_replica_source_schema.sql
@@ -1,4 +1,5 @@
--- Keep local migrations aligned with the primary schema used by the read replica.
+-- Keep local migrations aligned with the primary schema
+-- replicated to the read replica.
 DO $$
 DECLARE
   existing_name "text";

--- a/tests/read-replica-schema-catalog.test.ts
+++ b/tests/read-replica-schema-catalog.test.ts
@@ -1,12 +1,30 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, it } from 'vitest'
-import { readReplicaSchemaCatalog } from '../read_replicate/schema_catalog.ts'
+import { READ_REPLICA_SCHEMA_CATALOG_SQL, readReplicaSchemaCatalog } from '../read_replicate/schema_catalog.ts'
 import { cleanupPostgresClient, getPostgresClient } from './test-utils.ts'
 
 interface CatalogIndex {
   table: string
   name: string
   constraintOwned: boolean
+}
+
+interface CatalogType {
+  name: string
+  kind: string
+  definition: unknown
+}
+
+interface CatalogSequence {
+  name: string
+  ownedTable: string | null
+  ownedColumn: string | null
+}
+
+interface SchemaCatalog {
+  indexes: CatalogIndex[]
+  types: CatalogType[]
+  sequences: CatalogSequence[]
 }
 
 afterAll(async () => {
@@ -37,6 +55,60 @@ describe('read-replica schema catalog', () => {
     }
     finally {
       await pool.query(`DROP TABLE IF EXISTS public.${tableName}`)
+    }
+  })
+
+  it('follows nested selected column types and identity-owned sequences', async () => {
+    const suffix = randomUUID().replaceAll('-', '').slice(0, 8)
+    const tableName = `rrcat_${suffix}_table`
+    const enumName = `rrcat_${suffix}_enum`
+    const domainName = `rrcat_${suffix}_domain`
+    const arrayDomainName = `rrcat_${suffix}_array_domain`
+    const domainColumn = `rrcat_${suffix}_value`
+    const domainArrayColumn = `rrcat_${suffix}_value_array`
+    const arrayDomainColumn = `rrcat_${suffix}_array_domain`
+    const identityColumn = `rrcat_${suffix}_identity`
+    const pool = await getPostgresClient()
+
+    try {
+      await pool.query(`
+        CREATE TYPE public.${enumName} AS ENUM ('ready', 'paused');
+        CREATE DOMAIN public.${domainName} AS public.${enumName};
+        CREATE DOMAIN public.${arrayDomainName} AS public.${enumName}[];
+        CREATE TABLE public.${tableName} (
+          ${domainColumn} public.${domainName},
+          ${domainArrayColumn} public.${domainName}[],
+          ${arrayDomainColumn} public.${arrayDomainName},
+          ${identityColumn} bigint GENERATED ALWAYS AS IDENTITY
+        );
+      `)
+
+      const result = await pool.query(READ_REPLICA_SCHEMA_CATALOG_SQL, [[tableName], [], [], [], []])
+      const catalog = result.rows[0].catalog as SchemaCatalog
+      const enumType = catalog.types.find(type => type.name === enumName)
+      const identitySequence = catalog.sequences.find(sequence => (
+        sequence.ownedTable === tableName
+        && sequence.ownedColumn === identityColumn
+      ))
+
+      expect(enumType).toMatchObject({
+        name: enumName,
+        kind: 'e',
+        definition: ['ready', 'paused'],
+      })
+      expect(identitySequence).toMatchObject({
+        ownedTable: tableName,
+        ownedColumn: identityColumn,
+      })
+      expect(identitySequence?.name).toBe(`${tableName}_${identityColumn}_seq`)
+    }
+    finally {
+      await pool.query(`
+        DROP TABLE IF EXISTS public.${tableName};
+        DROP DOMAIN IF EXISTS public.${arrayDomainName};
+        DROP DOMAIN IF EXISTS public.${domainName};
+        DROP TYPE IF EXISTS public.${enumName};
+      `)
     }
   })
 })

--- a/tests/read-replica-schema-catalog.unit.test.ts
+++ b/tests/read-replica-schema-catalog.unit.test.ts
@@ -29,8 +29,11 @@ describe('read-replica schema catalog', () => {
       expect(queries[0]?.text).toContain('dep.deptype IN (\'a\', \'i\')')
       expect(queries[0]?.text).toContain("'valid', is_valid")
       expect(queries[0]?.text).toContain("'constraintOwned', constraint_owned")
-      expect(queries[0]?.text).toContain('selected_type_names(type_name)')
-      expect(queries[0]?.text).toContain('JOIN pg_type element_type')
+      expect(queries[0]?.text).toContain('WITH RECURSIVE')
+      expect(queries[0]?.text).toContain('referenced_types(type_oid)')
+      expect(queries[0]?.text).toContain('JOIN pg_type typ ON typ.oid = referenced.type_oid')
+      expect(queries[0]?.text).toContain('selected_sequence_oids(sequence_oid)')
+      expect(queries[0]?.text).toContain('JOIN selected_sequence_oids selected_sequence')
       expect(queries[0]?.text).toContain('JOIN selected_type_names rt')
     },
   )

--- a/tests/read-replica-schema-compatibility.unit.test.ts
+++ b/tests/read-replica-schema-compatibility.unit.test.ts
@@ -65,6 +65,17 @@ describe('read-replica schema compatibility', () => {
     expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual([])
   })
 
+  it.concurrent('accepts legacy catalogs without constraint-owned index metadata', () => {
+    const expected = catalog() as Record<string, unknown>
+    const actual = catalog()
+    const indexes = expected.indexes as Array<Record<string, unknown>>
+
+    for (const index of indexes)
+      delete index.constraintOwned
+
+    expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual([])
+  })
+
   it.concurrent('rejects structural drift across selected schema objects', () => {
     const expected = catalog()
     const actual = catalog()


### PR DESCRIPTION
## Summary

- discover selected-table enum/composite dependencies through nested domain and array layers, plus identity-owned sequences
- keep catalog canonicalization shared and accept legacy catalogs without optional index ownership metadata
- make checker deadline diagnostics report zero attempts until a request is actually sent
- document the intentionally non-atomic cross-database verification read

## Validation

- `bun typecheck`
- `bun lint:backend && bun lint`
- `bun test:unit` (146 files, 988 tests)
- `bun test:db` (18 files, 252 tests)
- `bun run readreplicate:check-schema` against local Supabase
- `bunx wrangler deploy --dry-run --config cloudflare_workers/read-replica-schema-check/wrangler.jsonc --name capgo-rr-schema-check-dry-run --minify`
- focused catalog and compatibility tests

## Deployment evidence

The reported failed release run `29147151922` used `e2a5895` at 09:05 UTC, before #2668 merged at 13:11 UTC. It cannot exercise the merged direct reconciliation and diagnostic path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release-gating schema SQL and compatibility rules for production read-replica verification; behavior is broader (more types/sequences) and slightly looser for optional index metadata, with mitigating tests and workflow serialization.
> 
> **Overview**
> **Hardens read-replica schema cataloging and compatibility** so master/replica checks catch nested type dependencies and identity sequences, while staying tolerant of older catalog snapshots.
> 
> The catalog SQL now **recursively resolves** public enum/composite types referenced from selected-table columns (domains, arrays, nested layers) instead of only walking one hop. **Sequences** are gathered from the fixed replica list **plus** sequences owned by selected tables (e.g. `GENERATED ALWAYS AS IDENTITY`), via `pg_depend`.
> 
> **Canonical JSON** (`sortJson` / `stableJson`) lives in `read_replicate/schema_json.ts` and is shared by the catalog and compatibility comparer. Index **`constraintOwned`** drift is reported only when **both** catalogs define that field, so legacy snapshots without it still compare clean.
> 
> The Hyperdrive checker script only bumps **ready/verify attempt counters after a curl is actually issued**, so timeout exits no longer look like “N attempts” when nothing was sent. The schema-check Worker documents that master and replica catalogs are read on **separate connections** (possible transient drift under concurrent DDL; release workflow serializes writers).
> 
> Tests cover nested column types, identity-owned sequences, recursive SQL shape, and legacy index metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0680b26b82b5a7746a2f5b31c6712180bc05d6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->