### PR TITLE
fix(frontend): default missing rollout fields in apps list

### DIFF
--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -41,6 +41,8 @@ function normalizeAppRow(app: AppIconSource): AppRow {
     ...app,
     created_from_onboarding: 'created_from_onboarding' in app ? app.created_from_onboarding : false,
     onboarding_completed_at: 'onboarding_completed_at' in app ? app.onboarding_completed_at : null,
+    rollout_channel_count: 'rollout_channel_count' in app ? app.rollout_channel_count : 0,
+    rollout_paused_version_names: 'rollout_paused_version_names' in app ? app.rollout_paused_version_names : [],
   }
 }
 


### PR DESCRIPTION
## Summary (AI generated)

- Fix frontend typecheck failure in `src/pages/apps.vue` by defaulting `rollout_channel_count` and `rollout_paused_version_names` when normalizing rows from `get_org_apps_with_last_upload`.

## Motivation (AI generated)

`apps.Row` gained rollout columns, but the org apps RPC return type still omits them. `normalizeAppRow` already defaulted onboarding fields the same way; without the rollout defaults, `bun run typecheck` fails.

## Business Impact (AI generated)

Unblocks local/CI typecheck so frontend changes can ship without unrelated type errors on the apps list page.

## Test Plan (AI generated)

- [x] `bun run typecheck:frontend` passes
- [ ] Confirm apps list still loads in local console

Generated with AI

Made with [Cursor](https://cursor.com)