### PR TITLE
fix: broken dev policy

### DIFF
--- a/supabase/migrations/20260308121933_restrict_global_stats_access.sql
+++ b/supabase/migrations/20260308121933_restrict_global_stats_access.sql
@@ -12,7 +12,7 @@ DROP POLICY IF EXISTS "Allow anon to select" ON public.global_stats;
 CREATE POLICY "Allow none to select"
 ON public.global_stats
 FOR SELECT
-TO anon
+TO anon, authenticated
 USING (false);
 
 -- Ensure non-service roles cannot query global_stats directly.

--- a/supabase/migrations/20260308121933_restrict_global_stats_access.sql
+++ b/supabase/migrations/20260308121933_restrict_global_stats_access.sql
@@ -9,6 +9,12 @@
 -- Remove the permissive policy that allowed anonymous reads.
 DROP POLICY IF EXISTS "Allow anon to select" ON public.global_stats;
 
+CREATE POLICY "Allow none to select"
+ON public.global_stats
+FOR SELECT
+TO anon
+USING (false);
+
 -- Ensure non-service roles cannot query global_stats directly.
 REVOKE ALL PRIVILEGES ON TABLE public.global_stats FROM anon,
 authenticated;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -21422,7 +21422,7 @@ ALTER TABLE ONLY "public"."webhooks"
 
 
 
-CREATE POLICY " allow anon to select" ON "public"."global_stats" FOR SELECT TO "anon" USING (true);
+CREATE POLICY "Allow anon to select" ON "public"."global_stats" FOR SELECT TO "anon" USING (true);
 
 
 


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

## Test plan

<!-- Include the steps to test your PR -->
<!-- Any PR that requires a complex setup to test MUST include this -->

## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->
<!-- Please include this if CLI/frontend behaviour has changed, can be skipped for backend changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive RLS and privilege changes on `global_stats`; any client or dashboard path that relied on direct reads with the publishable key will stop working until routed through service-side APIs.
> 
> **Overview**
> Addresses **GHSA-73rv-fpp7-r3r4** by changing how `global_stats` is exposed through PostgREST: the permissive **"Allow anon to select"** policy is dropped, a **"Allow none to select"** policy denies `SELECT` for `anon` and `authenticated` (`USING (false)`), and table privileges are **revoked** from those roles so only service-side access remains.
> 
> Separately, **`supabase/schemas/prod.sql`** fixes the `global_stats` RLS policy identifier from **`" allow anon to select"`** (leading space) to **`"Allow anon to select"`**, matching the name the migration drops so dev/schema snapshots stay consistent with the security migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd758c1c267e23cb9ab82baab44ad1acc8e1e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted direct access to global statistics for anonymous and authenticated access.
  * Removed permissive anonymous read permissions to help protect internal metrics.
* **Maintenance**
  * Updated the database policy definition for global statistics access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->