### PR TITLE
fix(db): remove redundant RLS policies and indexes

### DIFF
--- a/supabase/migrations/20260713203749_fix_rls_policy_index_lints.sql
+++ b/supabase/migrations/20260713203749_fix_rls_policy_index_lints.sql
@@ -1,0 +1,14 @@
+-- Keep the optimized policies introduced by the unfiltered-read timeout fix.
+-- These legacy policies cover the same SELECT roles and force PostgreSQL to
+-- evaluate a second permissive expression for every read.
+DROP POLICY IF EXISTS "Allow read for auth (read+)"
+ON "public"."channel_devices";
+
+DROP POLICY IF EXISTS "Allow org admins to select sso_providers"
+ON "public"."sso_providers";
+
+-- The idx_manifest_* versions were added later for the same one-column
+-- lookups. The older manifest_* indexes are fully redundant.
+-- Supabase migrations run in a transaction, so this cannot use DROP INDEX CONCURRENTLY.
+DROP INDEX IF EXISTS "public"."manifest_file_hash_idx";
+DROP INDEX IF EXISTS "public"."manifest_file_name_idx";

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -1,9 +1,7 @@
 -- Test RLS Policies
 -- This file tests all Row Level Security policies in the database
 BEGIN;
-SELECT plan(66);
-
--- Test app_versions policies
+SELECT plan(70);
 SELECT
     policies_are(
         'public',
@@ -146,6 +144,74 @@ SELECT
         ),
         0::bigint,
         'public RLS should not have duplicate permissive policies for the same table operation'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM (
+                SELECT role_name
+                FROM pg_policies
+                CROSS JOIN LATERAL unnest(roles) AS role_name
+                WHERE schemaname = 'public'
+                  AND tablename = 'channel_devices'
+                  AND permissive = 'PERMISSIVE'
+                  AND cmd = 'SELECT'
+                  AND role_name IN ('anon', 'authenticated')
+                GROUP BY role_name
+                HAVING count(*) > 1
+            ) duplicate_channel_devices_select_roles
+        ),
+        0::bigint,
+        'channel_devices should have one permissive SELECT policy per API role'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM (
+                SELECT role_name
+                FROM pg_policies
+                CROSS JOIN LATERAL unnest(roles) AS role_name
+                WHERE schemaname = 'public'
+                  AND tablename = 'sso_providers'
+                  AND permissive = 'PERMISSIVE'
+                  AND cmd = 'SELECT'
+                  AND role_name IN ('anon', 'authenticated')
+                GROUP BY role_name
+                HAVING count(*) > 1
+            ) duplicate_sso_provider_select_roles
+        ),
+        0::bigint,
+        'sso_providers should have one permissive SELECT policy per API role'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'manifest'
+              AND indexname IN ('manifest_file_hash_idx', 'manifest_file_name_idx')
+        ),
+        0::bigint,
+        'manifest should not retain redundant single-column indexes'
+    );
+
+SELECT
+    is(
+        (
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'manifest'
+              AND indexname IN ('idx_manifest_file_hash', 'idx_manifest_file_name')
+        ),
+        2::bigint,
+        'manifest should retain the supported single-column indexes'
     );
 
 -- Test orgs policies


### PR DESCRIPTION
## Summary
- remove legacy permissive SELECT policies superseded by the optimized policies
- drop redundant manifest single-column indexes
- add pgTAP coverage for role-specific permissive policy duplication and manifest index retention

## Validation
- `bun lint:backend`
- commit hook: CLI, backend, and frontend typechecks
- local pgTAP unavailable: Docker daemon is not running (`supabase test db --local`)

Closes the Supabase database-linter warnings for `channel_devices`, `sso_providers`, and `manifest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RLS on `channel_devices` and `sso_providers` and manifest indexing; behavior should be unchanged if only superseded policies/indexes were removed, but mis-drops could affect read access or query plans.
> 
> **Overview**
> Addresses Supabase database-linter warnings by cleaning up **duplicate permissive SELECT RLS** and **redundant `manifest` indexes**, with pgTAP guards so the state does not regress.
> 
> A new migration drops legacy policies on **`channel_devices`** (`Allow read for auth (read+)`) and **`sso_providers`** (`Allow org admins to select sso_providers`) that overlapped newer optimized read policies and forced PostgreSQL to evaluate an extra permissive expression on every SELECT. It also drops **`manifest_file_hash_idx`** and **`manifest_file_name_idx`**, leaving the later **`idx_manifest_*`** single-column indexes for the same lookups (non-concurrent drops because migrations run in a transaction).
> 
> **`26_test_rls_policies.sql`** raises the plan count to 70 and adds assertions: at most one permissive SELECT policy per `anon`/`authenticated` role on `channel_devices` and `sso_providers`, no legacy manifest index names, and both supported `idx_manifest_*` indexes present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222d99fbe86e9a38f2388e9b74dd8e2edaa3adcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->