### PR TITLE
fix(replica): enforce logical subscriber schema contract

### DIFF
--- a/read_replicate/cloud_sql_data_api_response.ts
+++ b/read_replicate/cloud_sql_data_api_response.ts
@@ -1,0 +1,18 @@
+export interface CloudSqlDataApiResponse {
+  status?: {
+    code?: number
+    message?: string
+  }
+}
+
+export function assertCloudSqlDataApiResponseSucceeded(
+  response: CloudSqlDataApiResponse,
+  errorFromMessage: (message: string) => Error,
+): void {
+  const status = response.status
+  if (status?.code !== undefined && status.code !== 0) {
+    throw errorFromMessage(
+      status.message ?? `status code ${status.code}`,
+    )
+  }
+}

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -85,7 +85,6 @@ interface SchemaCatalog {
 
 type SyncStatementKind
   = | 'column'
-    | 'column_default'
     | 'column_not_null'
     | 'constraint'
     | 'function'
@@ -285,29 +284,6 @@ export function planReadReplicaSchemaSync(
       continue
     }
 
-    if (actualColumn.default !== column.default) {
-      const defaultSql = buildAlterColumnDefaultStatement(
-        column,
-        actualTables,
-      )
-      if (!defaultSql) {
-        skipped.push({
-          kind: 'column',
-          table: column.table,
-          name: column.name,
-          reason: 'unsupported_column_default',
-        })
-      }
-      else {
-        statements.push({
-          kind: 'column_default',
-          table: column.table,
-          name: column.name,
-          sql: defaultSql,
-        })
-      }
-    }
-
     if (actualColumn.notNull !== column.notNull) {
       const notNullSql = buildAlterColumnNotNullStatement(
         column,
@@ -435,29 +411,16 @@ export function planReadReplicaSchemaSync(
   }
 
   for (const constraint of expectedCatalog.constraints ?? []) {
+    // Publisher CHECK constraints do not need to exist on a read-only logical
+    // subscriber. Creating them here can only add avoidable replica writes.
+    if (constraint.type === 'c')
+      continue
+
     const actualConstraint = actualConstraintsByKey.get(
       constraintKey(constraint),
     )
     if (constraintMatches(constraint, actualConstraint))
       continue
-
-    if (
-      actualConstraint
-      && constraintShapeMatches(constraint, actualConstraint)
-      && constraint.valid === true
-      && actualConstraint.valid === false
-    ) {
-      const sql = buildValidateConstraintStatement(constraint, actualTables)
-      if (sql) {
-        statements.push({
-          kind: 'constraint',
-          table: constraint.table,
-          name: constraint.name,
-          sql,
-        })
-        continue
-      }
-    }
 
     if (actualConstraint) {
       skipped.push({
@@ -465,27 +428,6 @@ export function planReadReplicaSchemaSync(
         table: constraint.table,
         name: constraint.name,
         reason: 'constraint_conflict',
-      })
-      continue
-    }
-
-    if (constraint.type === 'c') {
-      const sql = buildAddCheckConstraintStatement(constraint, actualTables)
-      if (!sql) {
-        skipped.push({
-          kind: 'constraint',
-          table: constraint.table,
-          name: constraint.name,
-          reason: 'unsupported_check_constraint',
-        })
-        continue
-      }
-
-      statements.push({
-        kind: 'constraint',
-        table: constraint.table,
-        name: constraint.name,
-        sql,
       })
       continue
     }
@@ -1161,7 +1103,7 @@ function quoteEnumValues(values: readonly string[]): string[] | null {
       return null
 
     quotedValues.push(
-      `E'${value.replaceAll('\\', '\\\\').replaceAll("'", "''")}'`,
+      `E'${value.replaceAll('\\', '\\\\').replaceAll('\'', '\'\'')}'`,
     )
   }
 
@@ -1200,25 +1142,6 @@ function buildAddColumnStatement(
   return `ALTER TABLE ${quoteQualifiedTable(column.table)} ADD COLUMN IF NOT EXISTS ${quoteIdent(column.name)} ${column.type}${defaultSql}${notNullSql}`
 }
 
-function buildAlterColumnDefaultStatement(
-  column: SchemaColumn,
-  actualTables: Set<string>,
-): string | null {
-  if (
-    !isSafeReplicaTable(column.table, actualTables)
-    || !isSafeIdentifier(column.name)
-  ) {
-    return null
-  }
-  if (column.default === null) {
-    return `ALTER TABLE ${quoteQualifiedTable(column.table)} ALTER COLUMN ${quoteIdent(column.name)} DROP DEFAULT`
-  }
-  if (!isSafeSqlFragment(column.default))
-    return null
-
-  return `ALTER TABLE ${quoteQualifiedTable(column.table)} ALTER COLUMN ${quoteIdent(column.name)} SET DEFAULT ${column.default}`
-}
-
 function buildAlterColumnNotNullStatement(
   column: SchemaColumn,
   actualTables: Set<string>,
@@ -1254,42 +1177,6 @@ function buildCreateIndexStatement(
     return null
 
   return `CREATE ${unique}INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteQualifiedTable(index.table)} ${indexTail}`
-}
-
-function buildAddCheckConstraintStatement(
-  constraint: SchemaConstraint,
-  actualTables: Set<string>,
-): string | null {
-  if (
-    constraint.type !== 'c'
-    || !isSafeReplicaTable(constraint.table, actualTables)
-    || !isSafeQuotedIdentifier(constraint.name)
-    || !constraint.definition.startsWith('CHECK ')
-    || !isSafeSchemaDefinition(constraint.definition)
-  ) {
-    return null
-  }
-
-  const notValid = constraint.valid === false
-    && !/\bNOT VALID\s*$/i.test(constraint.definition)
-    ? ' NOT VALID'
-    : ''
-  return `ALTER TABLE ${quoteQualifiedTable(constraint.table)} ADD CONSTRAINT ${quoteIdent(constraint.name)} ${constraint.definition}${notValid}`
-}
-
-function buildValidateConstraintStatement(
-  constraint: SchemaConstraint,
-  actualTables: Set<string>,
-): string | null {
-  if (
-    constraint.type !== 'c'
-    || !isSafeReplicaTable(constraint.table, actualTables)
-    || !isSafeQuotedIdentifier(constraint.name)
-  ) {
-    return null
-  }
-
-  return `ALTER TABLE ${quoteQualifiedTable(constraint.table)} VALIDATE CONSTRAINT ${quoteIdent(constraint.name)}`
 }
 
 function buildAttachConstraintStatement(

--- a/read_replicate/schema_compatibility.ts
+++ b/read_replicate/schema_compatibility.ts
@@ -75,8 +75,9 @@ export interface SchemaCompatibilityIssue {
   reason: string
 }
 
-// The catalog intentionally excludes foreign keys, triggers, and RLS. Those
-// objects remain outside the selected read-replica schema contract.
+// The compatibility check intentionally ignores existing column defaults and
+// missing publisher CHECK constraints. A read-only logical subscriber does not
+// use defaults and does not need source CHECK constraints.
 export function readReplicaSchemaCompatibilityIssues(expected: unknown, actual: unknown): SchemaCompatibilityIssue[] {
   const expectedCatalog = assertSchemaCatalog(expected, 'expected')
   const actualCatalog = assertSchemaCatalog(actual, 'actual')
@@ -149,13 +150,6 @@ function compareColumns(expected: SchemaCatalog, actual: SchemaCatalog, issues: 
           : 'subscriber is NOT NULL while publisher accepts NULL',
       })
     }
-    if (!sameValue(actualColumn.default, expectedColumn.default)) {
-      issues.push({
-        kind: 'column',
-        object: key,
-        reason: `expected default ${displayValue(expectedColumn.default)}, found ${displayValue(actualColumn.default)}`,
-      })
-    }
     if (actualColumn.identity !== expectedColumn.identity) {
       issues.push({
         kind: 'column',
@@ -186,6 +180,19 @@ function compareConstraints(expected: SchemaCatalog, actual: SchemaCatalog, issu
   for (const expectedConstraint of expected.constraints ?? []) {
     const key = constraintKey(expectedConstraint)
     const actualConstraint = actualConstraints.get(key)
+    if (expectedConstraint.type === 'c') {
+      if (
+        actualConstraint
+        && (
+          actualConstraint.type !== 'c'
+          || actualConstraint.definition !== expectedConstraint.definition
+        )
+      ) {
+        issues.push({ kind: 'constraint', object: key, reason: 'subscriber CHECK constraint differs' })
+      }
+      continue
+    }
+
     if (!actualConstraint) {
       issues.push({ kind: 'constraint', object: key, reason: 'missing required constraint' })
       continue

--- a/scripts/sync-read-replica-schema.ts
+++ b/scripts/sync-read-replica-schema.ts
@@ -1,5 +1,7 @@
+import type { CloudSqlDataApiResponse } from '../read_replicate/cloud_sql_data_api_response.ts'
 import type { Queryable } from '../read_replicate/schema_catalog.ts'
 import process from 'node:process'
+import { assertCloudSqlDataApiResponseSucceeded } from '../read_replicate/cloud_sql_data_api_response.ts'
 import { applyReadReplicaSchemaSync } from '../read_replicate/schema_additive_sync.ts'
 import {
   READ_REPLICA_SCHEMA_CATALOG_SQL,
@@ -17,7 +19,7 @@ const GOOGLE_DATA_API_REQUEST_LIMIT_BYTES = 500_000
 const GOOGLE_DATA_API_REQUEST_METADATA_BUFFER_BYTES = 1_024
 const GOOGLE_DATA_API_RESPONSE_LIMIT_BYTES = 10_000_000
 
-interface DataApiResponse {
+interface DataApiResponse extends CloudSqlDataApiResponse {
   results?: Array<{
     columns?: Array<{ name?: string }>
     partialResult?: boolean
@@ -155,6 +157,10 @@ async function executeGoogleSql(
     if (exitCode !== 0)
       throw dataApiCommandError(stderr || stdout)
     const response = JSON.parse(stdout) as DataApiResponse
+    assertCloudSqlDataApiResponseSucceeded(
+      response,
+      dataApiCommandError,
+    )
     assertCompleteDataApiResponse(response)
     return response
   }
@@ -297,11 +303,13 @@ function commandOutput(value: string): string {
   return message ? message.slice(0, 4096) : 'no diagnostic output'
 }
 
-try {
-  await main()
-}
-catch (error) {
-  const message = error instanceof Error ? error.message : String(error)
-  console.error(`::error title=Read-replica Data API sync failed::${message}`)
-  process.exitCode = 1
+if (import.meta.main) {
+  try {
+    await main()
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`::error title=Read-replica Data API sync failed::${message}`)
+    process.exitCode = 1
+  }
 }

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1528,8 +1528,6 @@ export type Database = {
       }
       global_stats: {
         Row: {
-          above_plan_with_credits: number | null
-          above_plan_without_credits: number | null
           active_canceled_orgs: number
           active_past_due_orgs: number
           apps: number
@@ -1574,6 +1572,8 @@ export type Database = {
           longest_ltv: number
           mrr: number
           need_upgrade: number | null
+          above_plan_with_credits: number | null
+          above_plan_without_credits: number | null
           new_paying_orgs: number
           not_paying: number | null
           nrr: number
@@ -1625,8 +1625,6 @@ export type Database = {
           users_active: number | null
         }
         Insert: {
-          above_plan_with_credits?: number | null
-          above_plan_without_credits?: number | null
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps: number
@@ -1671,6 +1669,8 @@ export type Database = {
           longest_ltv?: number
           mrr?: number
           need_upgrade?: number | null
+          above_plan_with_credits?: number | null
+          above_plan_without_credits?: number | null
           new_paying_orgs?: number
           not_paying?: number | null
           nrr?: number
@@ -1722,8 +1722,6 @@ export type Database = {
           users_active?: number | null
         }
         Update: {
-          above_plan_with_credits?: number | null
-          above_plan_without_credits?: number | null
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps?: number
@@ -1768,6 +1766,8 @@ export type Database = {
           longest_ltv?: number
           mrr?: number
           need_upgrade?: number | null
+          above_plan_with_credits?: number | null
+          above_plan_without_credits?: number | null
           new_paying_orgs?: number
           not_paying?: number | null
           nrr?: number
@@ -2281,33 +2281,33 @@ export type Database = {
           channel_id: number | null
           created_at: string | null
           id: number
+          is_invite: boolean
           org_id: string
           rbac_role_name: string | null
           updated_at: string | null
           user_id: string
-          user_right: Database["public"]["Enums"]["user_min_right"] | null
         }
         Insert: {
           app_id?: string | null
           channel_id?: number | null
           created_at?: string | null
           id?: number
+          is_invite?: boolean
           org_id: string
           rbac_role_name?: string | null
           updated_at?: string | null
           user_id: string
-          user_right?: Database["public"]["Enums"]["user_min_right"] | null
         }
         Update: {
           app_id?: string | null
           channel_id?: number | null
           created_at?: string | null
           id?: number
+          is_invite?: boolean
           org_id?: string
           rbac_role_name?: string | null
           updated_at?: string | null
           user_id?: string
-          user_right?: Database["public"]["Enums"]["user_min_right"] | null
         }
         Relationships: [
           {
@@ -2363,7 +2363,6 @@ export type Database = {
           stats_refresh_requested_at: string | null
           stats_updated_at: string | null
           updated_at: string | null
-          use_new_rbac: boolean
           website: string | null
         }
         Insert: {
@@ -2388,7 +2387,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Update: {
@@ -2413,7 +2411,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Relationships: [
@@ -2942,8 +2939,7 @@ export type Database = {
           invite_magic_string: string
           last_name: string
           org_id: string
-          rbac_role_name: string | null
-          role: Database["public"]["Enums"]["user_min_right"]
+          rbac_role_name: string
           updated_at: string
         }
         Insert: {
@@ -2956,8 +2952,7 @@ export type Database = {
           invite_magic_string?: string
           last_name: string
           org_id: string
-          rbac_role_name?: string | null
-          role: Database["public"]["Enums"]["user_min_right"]
+          rbac_role_name?: string
           updated_at?: string
         }
         Update: {
@@ -2970,8 +2965,7 @@ export type Database = {
           invite_magic_string?: string
           last_name?: string
           org_id?: string
-          rbac_role_name?: string | null
-          role?: Database["public"]["Enums"]["user_min_right"]
+          rbac_role_name?: string
           updated_at?: string
         }
         Relationships: [
@@ -3614,24 +3608,7 @@ export type Database = {
         Args: { p_apikey: string; p_permission_key: string }
         Returns: boolean
       }
-      apikey_permission_for_keymode: {
-        Args: {
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          scope_type: string
-        }
-        Returns: string
-      }
       app_has_real_bundle: { Args: { p_app_id: string }; Returns: boolean }
-      app_versions_has_app_permission: {
-        Args: {
-          p_apikey: string
-          p_app_id: string
-          p_min_right: Database["public"]["Enums"]["user_min_right"]
-          p_owner_org: string
-          p_user_id: string
-        }
-        Returns: boolean
-      }
       app_versions_readable_app_ids: { Args: never; Returns: string[] }
       apply_usage_overage: {
         Args: {
@@ -3703,46 +3680,6 @@ export type Database = {
           org_id: string
           provider_id: string
         }[]
-      }
-      check_min_rights:
-        | {
-            Args: {
-              app_id: string
-              channel_id: number
-              min_right: Database["public"]["Enums"]["user_min_right"]
-              org_id: string
-            }
-            Returns: boolean
-          }
-        | {
-            Args: {
-              app_id: string
-              channel_id: number
-              min_right: Database["public"]["Enums"]["user_min_right"]
-              org_id: string
-              user_id: string
-            }
-            Returns: boolean
-          }
-      check_min_rights_legacy: {
-        Args: {
-          app_id: string
-          channel_id: number
-          min_right: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-          user_id: string
-        }
-        Returns: boolean
-      }
-      check_min_rights_legacy_no_password_policy: {
-        Args: {
-          app_id: string
-          channel_id: number
-          min_right: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-          user_id: string
-        }
-        Returns: boolean
       }
       check_org_encrypted_bundle_enforcement: {
         Args: { org_id: string; session_key: string }
@@ -3857,6 +3794,7 @@ export type Database = {
         Returns: string
       }
       delete_user: { Args: never; Returns: undefined }
+      exist_app: { Args: { appid: string }; Returns: boolean }
       exist_app_v2: { Args: { appid: string }; Returns: boolean }
       exist_app_versions:
         | { Args: { appid: string; name_version: string }; Returns: boolean }
@@ -4075,39 +4013,6 @@ export type Database = {
               uninstall: number
             }[]
           }
-      get_identity:
-        | { Args: never; Returns: string }
-        | {
-            Args: { keymode: Database["public"]["Enums"]["key_mode"][] }
-            Returns: string
-          }
-      get_identity_apikey_only: {
-        Args: { keymode: Database["public"]["Enums"]["key_mode"][] }
-        Returns: string
-      }
-      get_identity_for_apikey_creation: { Args: never; Returns: string }
-      get_identity_org_allowed: {
-        Args: {
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          org_id: string
-        }
-        Returns: string
-      }
-      get_identity_org_allowed_apikey_only: {
-        Args: {
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          org_id: string
-        }
-        Returns: string
-      }
-      get_identity_org_appid: {
-        Args: {
-          app_id: string
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          org_id: string
-        }
-        Returns: string
-      }
       get_invite_by_magic_lookup: {
         Args: { lookup: string }
         Returns: {
@@ -4193,7 +4098,7 @@ export type Database = {
               email: string
               image_url: string
               is_tmp: boolean
-              role: Database["public"]["Enums"]["user_min_right"]
+              role: string
               uid: string
             }[]
           }
@@ -4204,7 +4109,7 @@ export type Database = {
               email: string
               image_url: string
               is_tmp: boolean
-              role: Database["public"]["Enums"]["user_min_right"]
+              role: string
               uid: string
             }[]
           }
@@ -4222,10 +4127,6 @@ export type Database = {
           role_name: string
           user_id: string
         }[]
-      }
-      get_org_owner_id: {
-        Args: { apikey: string; app_id: string }
-        Returns: string
       }
       get_org_perm_for_apikey: {
         Args: { apikey: string; app_id: string }
@@ -4262,47 +4163,25 @@ export type Database = {
         Args: { cli_version: string; orgid: string }
         Returns: Json[]
       }
-      get_orgs_v6:
-        | {
-            Args: never
-            Returns: {
-              app_count: number
-              can_use_more: boolean
-              created_by: string
-              gid: string
-              is_canceled: boolean
-              is_yearly: boolean
-              logo: string
-              management_email: string
-              name: string
-              paying: boolean
-              role: string
-              subscription_end: string
-              subscription_start: string
-              trial_left: number
-              use_new_rbac: boolean
-            }[]
-          }
-        | {
-            Args: { userid: string }
-            Returns: {
-              app_count: number
-              can_use_more: boolean
-              created_by: string
-              gid: string
-              is_canceled: boolean
-              is_yearly: boolean
-              logo: string
-              management_email: string
-              name: string
-              paying: boolean
-              role: string
-              subscription_end: string
-              subscription_start: string
-              trial_left: number
-              use_new_rbac: boolean
-            }[]
-          }
+      get_orgs_v6: {
+        Args: never
+        Returns: {
+          app_count: number
+          can_use_more: boolean
+          created_by: string
+          gid: string
+          is_canceled: boolean
+          is_yearly: boolean
+          logo: string
+          management_email: string
+          name: string
+          paying: boolean
+          role: string
+          subscription_end: string
+          subscription_start: string
+          trial_left: number
+        }[]
+      }
       get_orgs_v7:
         | {
             Args: never
@@ -4320,6 +4199,7 @@ export type Database = {
               enforcing_2fa: boolean
               gid: string
               is_canceled: boolean
+              is_invite: boolean
               is_yearly: boolean
               logo: string
               management_email: string
@@ -4337,7 +4217,6 @@ export type Database = {
               subscription_end: string
               subscription_start: string
               trial_left: number
-              use_new_rbac: boolean
               website: string
             }[]
           }
@@ -4357,6 +4236,7 @@ export type Database = {
               enforcing_2fa: boolean
               gid: string
               is_canceled: boolean
+              is_invite: boolean
               is_yearly: boolean
               logo: string
               management_email: string
@@ -4374,7 +4254,6 @@ export type Database = {
               subscription_end: string
               subscription_start: string
               trial_left: number
-              use_new_rbac: boolean
               website: string
             }[]
           }
@@ -4552,41 +4431,9 @@ export type Database = {
       has_2fa_enabled:
         | { Args: never; Returns: boolean }
         | { Args: { user_id: string }; Returns: boolean }
-      has_app_right: {
-        Args: {
-          appid: string
-          right: Database["public"]["Enums"]["user_min_right"]
-        }
-        Returns: boolean
-      }
-      has_app_right_apikey: {
-        Args: {
-          apikey: string
-          appid: string
-          right: Database["public"]["Enums"]["user_min_right"]
-          userid: string
-        }
-        Returns: boolean
-      }
-      has_app_right_userid: {
-        Args: {
-          appid: string
-          right: Database["public"]["Enums"]["user_min_right"]
-          userid: string
-        }
-        Returns: boolean
-      }
       has_seeded_demo_data: { Args: { p_app_id: string }; Returns: boolean }
       internal_request_db_user_names: { Args: never; Returns: string[] }
       internal_request_role_names: { Args: never; Returns: string[] }
-      invite_user_to_org: {
-        Args: {
-          email: string
-          invite_type: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-        }
-        Returns: string
-      }
       invite_user_to_org_rbac: {
         Args: { email: string; org_id: string; role_name: string }
         Returns: string
@@ -4617,15 +4464,15 @@ export type Database = {
         | {
             Args: {
               apikey: string
-              keymode: Database["public"]["Enums"]["key_mode"][]
+              keymode: string[]
             }
             Returns: boolean
           }
         | {
             Args: {
               apikey: string
-              app_id: string
-              keymode: Database["public"]["Enums"]["key_mode"][]
+              appid: string
+              keymode: string[]
             }
             Returns: boolean
           }
@@ -4706,21 +4553,9 @@ export type Database = {
         }
         Returns: undefined
       }
-      modify_permissions_tmp: {
-        Args: {
-          email: string
-          new_role: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-        }
-        Returns: string
-      }
       one_month_ahead: { Args: never; Returns: string }
       org_member_readable_org_ids: { Args: never; Returns: string[] }
       orgs_readable_org_ids: { Args: never; Returns: string[] }
-      orgs_with_min_right: {
-        Args: { p_min_right: Database["public"]["Enums"]["user_min_right"] }
-        Returns: string[]
-      }
       parse_cron_field: {
         Args: { current_val: number; field: string; max_val: number }
         Returns: number
@@ -4817,10 +4652,6 @@ export type Database = {
         }
         Returns: boolean
       }
-      rbac_enable_for_org: {
-        Args: { p_granted_by?: string; p_org_id: string }
-        Returns: Json
-      }
       rbac_has_permission: {
         Args: {
           p_app_id: string
@@ -4831,31 +4662,6 @@ export type Database = {
           p_principal_type: string
         }
         Returns: boolean
-      }
-      rbac_is_enabled_for_org: { Args: { p_org_id: string }; Returns: boolean }
-      rbac_legacy_right_for_org_role: {
-        Args: { p_role_name: string }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_legacy_right_for_permission: {
-        Args: { p_permission_key: string }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_legacy_role_hint: {
-        Args: {
-          p_app_id: string
-          p_channel_id: number
-          p_user_right: Database["public"]["Enums"]["user_min_right"]
-        }
-        Returns: string
-      }
-      rbac_migrate_org_users_to_bindings: {
-        Args: { p_granted_by?: string; p_org_id: string }
-        Returns: Json
-      }
-      rbac_org_role_for_legacy_right: {
-        Args: { legacy_right: Database["public"]["Enums"]["user_min_right"] }
-        Returns: string
       }
       rbac_perm_app_build_native: { Args: never; Returns: string }
       rbac_perm_app_create_channel: { Args: never; Returns: string }
@@ -4904,66 +4710,9 @@ export type Database = {
       rbac_perm_platform_manage_orgs_any: { Args: never; Returns: string }
       rbac_perm_platform_read_all_audit: { Args: never; Returns: string }
       rbac_perm_platform_run_maintenance_jobs: { Args: never; Returns: string }
-      rbac_permission_for_legacy: {
-        Args: {
-          p_min_right: Database["public"]["Enums"]["user_min_right"]
-          p_scope: string
-        }
-        Returns: string
-      }
-      rbac_preview_migration: {
-        Args: { p_org_id: string }
-        Returns: {
-          app_id: string
-          channel_id: number
-          org_user_id: number
-          scope_type: string
-          skip_reason: string
-          suggested_role: string
-          user_id: string
-          user_right: string
-          will_migrate: boolean
-        }[]
-      }
       rbac_principal_apikey: { Args: never; Returns: string }
       rbac_principal_group: { Args: never; Returns: string }
       rbac_principal_user: { Args: never; Returns: string }
-      rbac_right_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_super_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_upload: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_write: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_read: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_super_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_upload: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_write: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
       rbac_role_apikey_org_reader: { Args: never; Returns: string }
       rbac_role_app_admin: { Args: never; Returns: string }
       rbac_role_app_developer: { Args: never; Returns: string }
@@ -4978,7 +4727,6 @@ export type Database = {
       rbac_role_org_member: { Args: never; Returns: string }
       rbac_role_org_super_admin: { Args: never; Returns: string }
       rbac_role_platform_super_admin: { Args: never; Returns: string }
-      rbac_rollback_org: { Args: { p_org_id: string }; Returns: Json }
       rbac_scope_app: { Args: never; Returns: string }
       rbac_scope_bundle: { Args: never; Returns: string }
       rbac_scope_channel: { Args: never; Returns: string }
@@ -5119,6 +4867,7 @@ export type Database = {
         Returns: boolean
       }
       remove_old_jobs: { Args: never; Returns: undefined }
+      request_actor_user_id: { Args: never; Returns: string }
       request_app_chart_refresh: {
         Args: { app_id: string }
         Returns: {
@@ -5142,10 +4891,6 @@ export type Database = {
           skipped_count: number
         }[]
       }
-      request_read_key_modes: {
-        Args: never
-        Returns: Database["public"]["Enums"]["key_mode"][]
-      }
       rescind_invitation: {
         Args: { email: string; org_id: string }
         Returns: string
@@ -5155,10 +4900,6 @@ export type Database = {
         Returns: undefined
       }
       restore_deleted_account: { Args: never; Returns: undefined }
-      resync_org_user_role_bindings: {
-        Args: { p_org_id: string; p_user_id: string }
-        Returns: undefined
-      }
       role_bindings_readable_ids: { Args: never; Returns: string[] }
       seed_get_app_metrics_caches: {
         Args: { p_end_date: string; p_org_id: string; p_start_date: string }
@@ -5237,14 +4978,6 @@ export type Database = {
         Args: { p_app_id: string; p_new_org_id: string }
         Returns: undefined
       }
-      transform_role_to_invite: {
-        Args: { role_input: Database["public"]["Enums"]["user_min_right"] }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      transform_role_to_non_invite: {
-        Args: { role_input: Database["public"]["Enums"]["user_min_right"] }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
       update_app_versions_retention: { Args: never; Returns: undefined }
       update_org_invite_role_rbac: {
         Args: { p_new_role_name: string; p_org_id: string; p_user_id: string }
@@ -5293,7 +5026,6 @@ export type Database = {
         | "refund"
       cron_task_type: "function" | "queue" | "function_queue"
       disable_update: "major" | "minor" | "patch" | "version_number" | "none"
-      key_mode: "read" | "write" | "all" | "upload"
       platform_os: "ios" | "android" | "electron"
       stats_action:
         | "delete"
@@ -5394,17 +5126,6 @@ export type Database = {
         | "failed"
         | "deleted"
         | "canceled"
-      user_min_right:
-        | "invite_read"
-        | "invite_upload"
-        | "invite_write"
-        | "invite_admin"
-        | "invite_super_admin"
-        | "read"
-        | "upload"
-        | "write"
-        | "admin"
-        | "super_admin"
       user_role: "read" | "upload" | "write" | "admin"
       version_action: "get" | "fail" | "install" | "uninstall"
     }
@@ -5578,7 +5299,6 @@ export const Constants = {
       ],
       cron_task_type: ["function", "queue", "function_queue"],
       disable_update: ["major", "minor", "patch", "version_number", "none"],
-      key_mode: ["read", "write", "all", "upload"],
       platform_os: ["ios", "android", "electron"],
       stats_action: [
         "delete",
@@ -5680,18 +5400,6 @@ export const Constants = {
         "failed",
         "deleted",
         "canceled",
-      ],
-      user_min_right: [
-        "invite_read",
-        "invite_upload",
-        "invite_write",
-        "invite_admin",
-        "invite_super_admin",
-        "read",
-        "upload",
-        "write",
-        "admin",
-        "super_admin",
       ],
       user_role: ["read", "upload", "write", "admin"],
       version_action: ["get", "fail", "install", "uninstall"],

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1528,8 +1528,6 @@ export type Database = {
       }
       global_stats: {
         Row: {
-          above_plan_with_credits: number | null
-          above_plan_without_credits: number | null
           active_canceled_orgs: number
           active_past_due_orgs: number
           apps: number
@@ -1574,6 +1572,8 @@ export type Database = {
           longest_ltv: number
           mrr: number
           need_upgrade: number | null
+          above_plan_with_credits: number | null
+          above_plan_without_credits: number | null
           new_paying_orgs: number
           not_paying: number | null
           nrr: number
@@ -1625,8 +1625,6 @@ export type Database = {
           users_active: number | null
         }
         Insert: {
-          above_plan_with_credits?: number | null
-          above_plan_without_credits?: number | null
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps: number
@@ -1671,6 +1669,8 @@ export type Database = {
           longest_ltv?: number
           mrr?: number
           need_upgrade?: number | null
+          above_plan_with_credits?: number | null
+          above_plan_without_credits?: number | null
           new_paying_orgs?: number
           not_paying?: number | null
           nrr?: number
@@ -1722,8 +1722,6 @@ export type Database = {
           users_active?: number | null
         }
         Update: {
-          above_plan_with_credits?: number | null
-          above_plan_without_credits?: number | null
           active_canceled_orgs?: number
           active_past_due_orgs?: number
           apps?: number
@@ -1768,6 +1766,8 @@ export type Database = {
           longest_ltv?: number
           mrr?: number
           need_upgrade?: number | null
+          above_plan_with_credits?: number | null
+          above_plan_without_credits?: number | null
           new_paying_orgs?: number
           not_paying?: number | null
           nrr?: number
@@ -2281,33 +2281,33 @@ export type Database = {
           channel_id: number | null
           created_at: string | null
           id: number
+          is_invite: boolean
           org_id: string
           rbac_role_name: string | null
           updated_at: string | null
           user_id: string
-          user_right: Database["public"]["Enums"]["user_min_right"] | null
         }
         Insert: {
           app_id?: string | null
           channel_id?: number | null
           created_at?: string | null
           id?: number
+          is_invite?: boolean
           org_id: string
           rbac_role_name?: string | null
           updated_at?: string | null
           user_id: string
-          user_right?: Database["public"]["Enums"]["user_min_right"] | null
         }
         Update: {
           app_id?: string | null
           channel_id?: number | null
           created_at?: string | null
           id?: number
+          is_invite?: boolean
           org_id?: string
           rbac_role_name?: string | null
           updated_at?: string | null
           user_id?: string
-          user_right?: Database["public"]["Enums"]["user_min_right"] | null
         }
         Relationships: [
           {
@@ -2363,7 +2363,6 @@ export type Database = {
           stats_refresh_requested_at: string | null
           stats_updated_at: string | null
           updated_at: string | null
-          use_new_rbac: boolean
           website: string | null
         }
         Insert: {
@@ -2388,7 +2387,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Update: {
@@ -2413,7 +2411,6 @@ export type Database = {
           stats_refresh_requested_at?: string | null
           stats_updated_at?: string | null
           updated_at?: string | null
-          use_new_rbac?: boolean
           website?: string | null
         }
         Relationships: [
@@ -2942,8 +2939,7 @@ export type Database = {
           invite_magic_string: string
           last_name: string
           org_id: string
-          rbac_role_name: string | null
-          role: Database["public"]["Enums"]["user_min_right"]
+          rbac_role_name: string
           updated_at: string
         }
         Insert: {
@@ -2956,8 +2952,7 @@ export type Database = {
           invite_magic_string?: string
           last_name: string
           org_id: string
-          rbac_role_name?: string | null
-          role: Database["public"]["Enums"]["user_min_right"]
+          rbac_role_name?: string
           updated_at?: string
         }
         Update: {
@@ -2970,8 +2965,7 @@ export type Database = {
           invite_magic_string?: string
           last_name?: string
           org_id?: string
-          rbac_role_name?: string | null
-          role?: Database["public"]["Enums"]["user_min_right"]
+          rbac_role_name?: string
           updated_at?: string
         }
         Relationships: [
@@ -3614,24 +3608,7 @@ export type Database = {
         Args: { p_apikey: string; p_permission_key: string }
         Returns: boolean
       }
-      apikey_permission_for_keymode: {
-        Args: {
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          scope_type: string
-        }
-        Returns: string
-      }
       app_has_real_bundle: { Args: { p_app_id: string }; Returns: boolean }
-      app_versions_has_app_permission: {
-        Args: {
-          p_apikey: string
-          p_app_id: string
-          p_min_right: Database["public"]["Enums"]["user_min_right"]
-          p_owner_org: string
-          p_user_id: string
-        }
-        Returns: boolean
-      }
       app_versions_readable_app_ids: { Args: never; Returns: string[] }
       apply_usage_overage: {
         Args: {
@@ -3703,46 +3680,6 @@ export type Database = {
           org_id: string
           provider_id: string
         }[]
-      }
-      check_min_rights:
-        | {
-            Args: {
-              app_id: string
-              channel_id: number
-              min_right: Database["public"]["Enums"]["user_min_right"]
-              org_id: string
-            }
-            Returns: boolean
-          }
-        | {
-            Args: {
-              app_id: string
-              channel_id: number
-              min_right: Database["public"]["Enums"]["user_min_right"]
-              org_id: string
-              user_id: string
-            }
-            Returns: boolean
-          }
-      check_min_rights_legacy: {
-        Args: {
-          app_id: string
-          channel_id: number
-          min_right: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-          user_id: string
-        }
-        Returns: boolean
-      }
-      check_min_rights_legacy_no_password_policy: {
-        Args: {
-          app_id: string
-          channel_id: number
-          min_right: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-          user_id: string
-        }
-        Returns: boolean
       }
       check_org_encrypted_bundle_enforcement: {
         Args: { org_id: string; session_key: string }
@@ -3857,6 +3794,7 @@ export type Database = {
         Returns: string
       }
       delete_user: { Args: never; Returns: undefined }
+      exist_app: { Args: { appid: string }; Returns: boolean }
       exist_app_v2: { Args: { appid: string }; Returns: boolean }
       exist_app_versions:
         | { Args: { appid: string; name_version: string }; Returns: boolean }
@@ -4075,39 +4013,6 @@ export type Database = {
               uninstall: number
             }[]
           }
-      get_identity:
-        | { Args: never; Returns: string }
-        | {
-            Args: { keymode: Database["public"]["Enums"]["key_mode"][] }
-            Returns: string
-          }
-      get_identity_apikey_only: {
-        Args: { keymode: Database["public"]["Enums"]["key_mode"][] }
-        Returns: string
-      }
-      get_identity_for_apikey_creation: { Args: never; Returns: string }
-      get_identity_org_allowed: {
-        Args: {
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          org_id: string
-        }
-        Returns: string
-      }
-      get_identity_org_allowed_apikey_only: {
-        Args: {
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          org_id: string
-        }
-        Returns: string
-      }
-      get_identity_org_appid: {
-        Args: {
-          app_id: string
-          keymode: Database["public"]["Enums"]["key_mode"][]
-          org_id: string
-        }
-        Returns: string
-      }
       get_invite_by_magic_lookup: {
         Args: { lookup: string }
         Returns: {
@@ -4193,7 +4098,7 @@ export type Database = {
               email: string
               image_url: string
               is_tmp: boolean
-              role: Database["public"]["Enums"]["user_min_right"]
+              role: string
               uid: string
             }[]
           }
@@ -4204,7 +4109,7 @@ export type Database = {
               email: string
               image_url: string
               is_tmp: boolean
-              role: Database["public"]["Enums"]["user_min_right"]
+              role: string
               uid: string
             }[]
           }
@@ -4222,10 +4127,6 @@ export type Database = {
           role_name: string
           user_id: string
         }[]
-      }
-      get_org_owner_id: {
-        Args: { apikey: string; app_id: string }
-        Returns: string
       }
       get_org_perm_for_apikey: {
         Args: { apikey: string; app_id: string }
@@ -4262,47 +4163,25 @@ export type Database = {
         Args: { cli_version: string; orgid: string }
         Returns: Json[]
       }
-      get_orgs_v6:
-        | {
-            Args: never
-            Returns: {
-              app_count: number
-              can_use_more: boolean
-              created_by: string
-              gid: string
-              is_canceled: boolean
-              is_yearly: boolean
-              logo: string
-              management_email: string
-              name: string
-              paying: boolean
-              role: string
-              subscription_end: string
-              subscription_start: string
-              trial_left: number
-              use_new_rbac: boolean
-            }[]
-          }
-        | {
-            Args: { userid: string }
-            Returns: {
-              app_count: number
-              can_use_more: boolean
-              created_by: string
-              gid: string
-              is_canceled: boolean
-              is_yearly: boolean
-              logo: string
-              management_email: string
-              name: string
-              paying: boolean
-              role: string
-              subscription_end: string
-              subscription_start: string
-              trial_left: number
-              use_new_rbac: boolean
-            }[]
-          }
+      get_orgs_v6: {
+        Args: never
+        Returns: {
+          app_count: number
+          can_use_more: boolean
+          created_by: string
+          gid: string
+          is_canceled: boolean
+          is_yearly: boolean
+          logo: string
+          management_email: string
+          name: string
+          paying: boolean
+          role: string
+          subscription_end: string
+          subscription_start: string
+          trial_left: number
+        }[]
+      }
       get_orgs_v7:
         | {
             Args: never
@@ -4320,6 +4199,7 @@ export type Database = {
               enforcing_2fa: boolean
               gid: string
               is_canceled: boolean
+              is_invite: boolean
               is_yearly: boolean
               logo: string
               management_email: string
@@ -4337,7 +4217,6 @@ export type Database = {
               subscription_end: string
               subscription_start: string
               trial_left: number
-              use_new_rbac: boolean
               website: string
             }[]
           }
@@ -4357,6 +4236,7 @@ export type Database = {
               enforcing_2fa: boolean
               gid: string
               is_canceled: boolean
+              is_invite: boolean
               is_yearly: boolean
               logo: string
               management_email: string
@@ -4374,7 +4254,6 @@ export type Database = {
               subscription_end: string
               subscription_start: string
               trial_left: number
-              use_new_rbac: boolean
               website: string
             }[]
           }
@@ -4552,41 +4431,9 @@ export type Database = {
       has_2fa_enabled:
         | { Args: never; Returns: boolean }
         | { Args: { user_id: string }; Returns: boolean }
-      has_app_right: {
-        Args: {
-          appid: string
-          right: Database["public"]["Enums"]["user_min_right"]
-        }
-        Returns: boolean
-      }
-      has_app_right_apikey: {
-        Args: {
-          apikey: string
-          appid: string
-          right: Database["public"]["Enums"]["user_min_right"]
-          userid: string
-        }
-        Returns: boolean
-      }
-      has_app_right_userid: {
-        Args: {
-          appid: string
-          right: Database["public"]["Enums"]["user_min_right"]
-          userid: string
-        }
-        Returns: boolean
-      }
       has_seeded_demo_data: { Args: { p_app_id: string }; Returns: boolean }
       internal_request_db_user_names: { Args: never; Returns: string[] }
       internal_request_role_names: { Args: never; Returns: string[] }
-      invite_user_to_org: {
-        Args: {
-          email: string
-          invite_type: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-        }
-        Returns: string
-      }
       invite_user_to_org_rbac: {
         Args: { email: string; org_id: string; role_name: string }
         Returns: string
@@ -4617,15 +4464,15 @@ export type Database = {
         | {
             Args: {
               apikey: string
-              keymode: Database["public"]["Enums"]["key_mode"][]
+              keymode: string[]
             }
             Returns: boolean
           }
         | {
             Args: {
               apikey: string
-              app_id: string
-              keymode: Database["public"]["Enums"]["key_mode"][]
+              appid: string
+              keymode: string[]
             }
             Returns: boolean
           }
@@ -4706,21 +4553,9 @@ export type Database = {
         }
         Returns: undefined
       }
-      modify_permissions_tmp: {
-        Args: {
-          email: string
-          new_role: Database["public"]["Enums"]["user_min_right"]
-          org_id: string
-        }
-        Returns: string
-      }
       one_month_ahead: { Args: never; Returns: string }
       org_member_readable_org_ids: { Args: never; Returns: string[] }
       orgs_readable_org_ids: { Args: never; Returns: string[] }
-      orgs_with_min_right: {
-        Args: { p_min_right: Database["public"]["Enums"]["user_min_right"] }
-        Returns: string[]
-      }
       parse_cron_field: {
         Args: { current_val: number; field: string; max_val: number }
         Returns: number
@@ -4817,10 +4652,6 @@ export type Database = {
         }
         Returns: boolean
       }
-      rbac_enable_for_org: {
-        Args: { p_granted_by?: string; p_org_id: string }
-        Returns: Json
-      }
       rbac_has_permission: {
         Args: {
           p_app_id: string
@@ -4831,31 +4662,6 @@ export type Database = {
           p_principal_type: string
         }
         Returns: boolean
-      }
-      rbac_is_enabled_for_org: { Args: { p_org_id: string }; Returns: boolean }
-      rbac_legacy_right_for_org_role: {
-        Args: { p_role_name: string }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_legacy_right_for_permission: {
-        Args: { p_permission_key: string }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_legacy_role_hint: {
-        Args: {
-          p_app_id: string
-          p_channel_id: number
-          p_user_right: Database["public"]["Enums"]["user_min_right"]
-        }
-        Returns: string
-      }
-      rbac_migrate_org_users_to_bindings: {
-        Args: { p_granted_by?: string; p_org_id: string }
-        Returns: Json
-      }
-      rbac_org_role_for_legacy_right: {
-        Args: { legacy_right: Database["public"]["Enums"]["user_min_right"] }
-        Returns: string
       }
       rbac_perm_app_build_native: { Args: never; Returns: string }
       rbac_perm_app_create_channel: { Args: never; Returns: string }
@@ -4904,66 +4710,9 @@ export type Database = {
       rbac_perm_platform_manage_orgs_any: { Args: never; Returns: string }
       rbac_perm_platform_read_all_audit: { Args: never; Returns: string }
       rbac_perm_platform_run_maintenance_jobs: { Args: never; Returns: string }
-      rbac_permission_for_legacy: {
-        Args: {
-          p_min_right: Database["public"]["Enums"]["user_min_right"]
-          p_scope: string
-        }
-        Returns: string
-      }
-      rbac_preview_migration: {
-        Args: { p_org_id: string }
-        Returns: {
-          app_id: string
-          channel_id: number
-          org_user_id: number
-          scope_type: string
-          skip_reason: string
-          suggested_role: string
-          user_id: string
-          user_right: string
-          will_migrate: boolean
-        }[]
-      }
       rbac_principal_apikey: { Args: never; Returns: string }
       rbac_principal_group: { Args: never; Returns: string }
       rbac_principal_user: { Args: never; Returns: string }
-      rbac_right_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_super_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_upload: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_invite_write: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_read: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_super_admin: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_upload: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      rbac_right_write: {
-        Args: never
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
       rbac_role_apikey_org_reader: { Args: never; Returns: string }
       rbac_role_app_admin: { Args: never; Returns: string }
       rbac_role_app_developer: { Args: never; Returns: string }
@@ -4978,7 +4727,6 @@ export type Database = {
       rbac_role_org_member: { Args: never; Returns: string }
       rbac_role_org_super_admin: { Args: never; Returns: string }
       rbac_role_platform_super_admin: { Args: never; Returns: string }
-      rbac_rollback_org: { Args: { p_org_id: string }; Returns: Json }
       rbac_scope_app: { Args: never; Returns: string }
       rbac_scope_bundle: { Args: never; Returns: string }
       rbac_scope_channel: { Args: never; Returns: string }
@@ -5119,6 +4867,7 @@ export type Database = {
         Returns: boolean
       }
       remove_old_jobs: { Args: never; Returns: undefined }
+      request_actor_user_id: { Args: never; Returns: string }
       request_app_chart_refresh: {
         Args: { app_id: string }
         Returns: {
@@ -5142,10 +4891,6 @@ export type Database = {
           skipped_count: number
         }[]
       }
-      request_read_key_modes: {
-        Args: never
-        Returns: Database["public"]["Enums"]["key_mode"][]
-      }
       rescind_invitation: {
         Args: { email: string; org_id: string }
         Returns: string
@@ -5155,10 +4900,6 @@ export type Database = {
         Returns: undefined
       }
       restore_deleted_account: { Args: never; Returns: undefined }
-      resync_org_user_role_bindings: {
-        Args: { p_org_id: string; p_user_id: string }
-        Returns: undefined
-      }
       role_bindings_readable_ids: { Args: never; Returns: string[] }
       seed_get_app_metrics_caches: {
         Args: { p_end_date: string; p_org_id: string; p_start_date: string }
@@ -5237,14 +4978,6 @@ export type Database = {
         Args: { p_app_id: string; p_new_org_id: string }
         Returns: undefined
       }
-      transform_role_to_invite: {
-        Args: { role_input: Database["public"]["Enums"]["user_min_right"] }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
-      transform_role_to_non_invite: {
-        Args: { role_input: Database["public"]["Enums"]["user_min_right"] }
-        Returns: Database["public"]["Enums"]["user_min_right"]
-      }
       update_app_versions_retention: { Args: never; Returns: undefined }
       update_org_invite_role_rbac: {
         Args: { p_new_role_name: string; p_org_id: string; p_user_id: string }
@@ -5293,7 +5026,6 @@ export type Database = {
         | "refund"
       cron_task_type: "function" | "queue" | "function_queue"
       disable_update: "major" | "minor" | "patch" | "version_number" | "none"
-      key_mode: "read" | "write" | "all" | "upload"
       platform_os: "ios" | "android" | "electron"
       stats_action:
         | "delete"
@@ -5394,17 +5126,6 @@ export type Database = {
         | "failed"
         | "deleted"
         | "canceled"
-      user_min_right:
-        | "invite_read"
-        | "invite_upload"
-        | "invite_write"
-        | "invite_admin"
-        | "invite_super_admin"
-        | "read"
-        | "upload"
-        | "write"
-        | "admin"
-        | "super_admin"
       user_role: "read" | "upload" | "write" | "admin"
       version_action: "get" | "fail" | "install" | "uninstall"
     }
@@ -5578,7 +5299,6 @@ export const Constants = {
       ],
       cron_task_type: ["function", "queue", "function_queue"],
       disable_update: ["major", "minor", "patch", "version_number", "none"],
-      key_mode: ["read", "write", "all", "upload"],
       platform_os: ["ios", "android", "electron"],
       stats_action: [
         "delete",
@@ -5680,18 +5400,6 @@ export const Constants = {
         "failed",
         "deleted",
         "canceled",
-      ],
-      user_min_right: [
-        "invite_read",
-        "invite_upload",
-        "invite_write",
-        "invite_admin",
-        "invite_super_admin",
-        "read",
-        "upload",
-        "write",
-        "admin",
-        "super_admin",
       ],
       user_role: ["read", "upload", "write", "admin"],
       version_action: ["get", "fail", "install", "uninstall"],

--- a/tests/read-replica-data-api-response.unit.test.ts
+++ b/tests/read-replica-data-api-response.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { assertCloudSqlDataApiResponseSucceeded } from '../read_replicate/cloud_sql_data_api_response.ts'
+
+function cloudSqlDataApiError(message: string) {
+  return new Error(`Cloud SQL Data API query failed: ${message}`)
+}
+
+describe('read-replica Cloud SQL Data API response handling', () => {
+  it.concurrent('rejects a failed SQL response even when gcloud exited successfully', () => {
+    expect(() => assertCloudSqlDataApiResponseSucceeded({
+      status: {
+        code: 3,
+        message: 'Execution failed. Details: pq: must be owner of table apps',
+      },
+    }, cloudSqlDataApiError)).toThrow(
+      'Cloud SQL Data API query failed: Execution failed. Details: pq: must be owner of table apps',
+    )
+  })
+
+  it.concurrent('accepts a successful SQL response', () => {
+    expect(() => assertCloudSqlDataApiResponseSucceeded({
+      status: { code: 0 },
+    }, cloudSqlDataApiError)).not.toThrow()
+  })
+})

--- a/tests/read-replica-schema-additive-sync.unit.test.ts
+++ b/tests/read-replica-schema-additive-sync.unit.test.ts
@@ -483,6 +483,42 @@ describe('read-replica additive schema sync', () => {
     expect(statements.join('\n')).not.toContain('RESTART')
   })
 
+  it.concurrent('escapes enum labels and rejects NUL labels', () => {
+    const actual = { types: [] }
+
+    expect(planReadReplicaSchemaSync({
+      types: [{
+        name: 'replica_enum',
+        kind: 'e',
+        definition: ['safe', String.raw`slash\and'quote`],
+      }],
+    }, actual)).toEqual({
+      statements: [{
+        kind: 'type',
+        table: 'public',
+        name: 'replica_enum',
+        sql: String.raw`CREATE TYPE public."replica_enum" AS ENUM (E'safe', E'slash\\and''quote')`,
+      }],
+      skipped: [],
+    })
+
+    expect(planReadReplicaSchemaSync({
+      types: [{
+        name: 'invalid_enum',
+        kind: 'e',
+        definition: ['contains\0nul'],
+      }],
+    }, actual)).toEqual({
+      statements: [],
+      skipped: [{
+        kind: 'type',
+        table: 'public',
+        name: 'invalid_enum',
+        reason: 'unsupported_type_creation',
+      }],
+    })
+  })
+
   it.concurrent('does not reconcile existing column defaults', () => {
     const { expected } = catalogs()
     const current = structuredClone(expected)

--- a/tests/read-replica-schema-additive-sync.unit.test.ts
+++ b/tests/read-replica-schema-additive-sync.unit.test.ts
@@ -382,7 +382,7 @@ describe('read-replica additive schema sync', () => {
     ]))
   })
 
-  it.concurrent('adds a missing selected check constraint', async () => {
+  it.concurrent('does not add a missing selected CHECK constraint', () => {
     const expected = {
       tables: [{ name: 'apps' }],
       columns: [],
@@ -397,62 +397,11 @@ describe('read-replica additive schema sync', () => {
     }
     const current = structuredClone(expected)
     current.constraints = []
-    const client = {
-      query: async (text: string) => {
-        if (text === READ_REPLICA_SCHEMA_CATALOG_SQL)
-          return { rows: [{ catalog: current }] }
 
-        if (text.startsWith('ALTER TABLE') && text.includes('ADD CONSTRAINT'))
-          current.constraints.push(expected.constraints[0])
-        return { rows: [] }
-      },
-    }
-
-    await expect(
-      applyReadReplicaAdditiveSchemaSync(client, expected),
-    ).resolves.toEqual({
-      applied: [{ kind: 'constraint', table: 'apps', name: 'apps_id_check' }],
+    expect(planReadReplicaSchemaSync(expected, current)).toEqual({
+      statements: [],
       skipped: [],
     })
-  })
-
-  it.concurrent('validates an existing selected check constraint when the primary is valid', async () => {
-    const expected = {
-      tables: [{ name: 'apps' }],
-      columns: [],
-      constraints: [{
-        table: 'apps',
-        name: 'apps_id_check',
-        type: 'c' as const,
-        definition: 'CHECK (id IS NOT NULL)',
-        valid: true,
-      }],
-      indexes: [],
-    }
-    const current = structuredClone(expected)
-    current.constraints[0].valid = false
-    const statements: string[] = []
-    const client = {
-      query: async (text: string) => {
-        if (text === READ_REPLICA_SCHEMA_CATALOG_SQL)
-          return { rows: [{ catalog: current }] }
-
-        statements.push(text)
-        if (text.includes('VALIDATE CONSTRAINT'))
-          current.constraints[0].valid = true
-        return { rows: [] }
-      },
-    }
-
-    await expect(
-      applyReadReplicaAdditiveSchemaSync(client, expected),
-    ).resolves.toEqual({
-      applied: [{ kind: 'constraint', table: 'apps', name: 'apps_id_check' }],
-      skipped: [],
-    })
-    expect(statements).toContain(
-      'ALTER TABLE public."apps" VALIDATE CONSTRAINT "apps_id_check"',
-    )
   })
 
   it.concurrent('replaces the selected helper function from the primary catalog', async () => {
@@ -534,41 +483,17 @@ describe('read-replica additive schema sync', () => {
     expect(statements.join('\n')).not.toContain('RESTART')
   })
 
-  it.concurrent('aligns existing column defaults and nullability from the primary catalog', async () => {
+  it.concurrent('does not reconcile existing column defaults', () => {
     const { expected } = catalogs()
     const current = structuredClone(expected)
     current.columns[0] = {
       ...current.columns[0],
       default: 'gen_random_uuid()',
-      notNull: false,
-    }
-    const statements: string[] = []
-    const client = {
-      query: async (text: string) => {
-        if (text === READ_REPLICA_SCHEMA_CATALOG_SQL)
-          return { rows: [{ catalog: current }] }
-
-        statements.push(text)
-        if (text.includes('DROP DEFAULT'))
-          current.columns[0].default = null
-        if (text.endsWith('SET NOT NULL'))
-          current.columns[0].notNull = true
-        return { rows: [] }
-      },
     }
 
-    await expect(
-      applyReadReplicaAdditiveSchemaSync(client, expected),
-    ).resolves.toEqual({
-      applied: [
-        { kind: 'column_default', table: 'apps', name: 'id' },
-        { kind: 'column_not_null', table: 'apps', name: 'id' },
-      ],
+    expect(planReadReplicaSchemaSync(expected, current)).toEqual({
+      statements: [],
       skipped: [],
     })
-    expect(statements).toEqual(expect.arrayContaining([
-      'ALTER TABLE public."apps" ALTER COLUMN "id" DROP DEFAULT',
-      'ALTER TABLE public."apps" ALTER COLUMN "id" SET NOT NULL',
-    ]))
   })
 })

--- a/tests/read-replica-schema-compatibility.unit.test.ts
+++ b/tests/read-replica-schema-compatibility.unit.test.ts
@@ -76,6 +76,24 @@ describe('read-replica schema compatibility', () => {
     expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual([])
   })
 
+  it.concurrent('ignores existing column defaults and missing publisher CHECK constraints', () => {
+    const expected = catalog()
+    const actual = catalog()
+    actual.columns[0] = {
+      ...actual.columns[0],
+      default: null,
+    }
+    actual.columns[1] = {
+      ...actual.columns[1],
+      default: '\'replica\'',
+    }
+    actual.constraints = actual.constraints.filter(
+      constraint => constraint.type !== 'c',
+    )
+
+    expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual([])
+  })
+
   it.concurrent('rejects structural drift across selected schema objects', () => {
     const expected = catalog()
     const actual = catalog()
@@ -107,7 +125,6 @@ describe('read-replica schema compatibility', () => {
     expect(readReplicaSchemaCompatibilityIssues(expected, actual)).toEqual(expect.arrayContaining([
       expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'expected type text, found integer' }),
       expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'subscriber is NOT NULL while publisher accepts NULL' }),
-      expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'expected default null, found 0' }),
       expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'expected identity kind none, found a' }),
       expect.objectContaining({ kind: 'column', object: 'apps.name', reason: 'expected generated kind none, found s' }),
       expect.objectContaining({ kind: 'constraint', object: 'apps.apps_pkey', reason: 'expected type p, found u' }),


### PR DESCRIPTION
## Summary

- Ignore existing-column defaults and missing publisher CHECK constraints that do not affect a read-only logical subscriber.
- Preserve the safety gate for physical columns, types, keys, indexes, and subscriber-only/different CHECK constraints.
- Fail immediately when Cloud SQL Data API returns a nonzero JSON status even if `gcloud` exits successfully.
- Restore generated types to the committed post-migration contract after the pre-migration auto-sync overwrote them; leave `supabase/schemas/prod.sql` as the actual-state dump.

## Validation

- `bun lint`
- `bun typecheck`
- `bun test tests/read-replica-data-api-response.unit.test.ts tests/read-replica-schema-additive-sync.unit.test.ts tests/read-replica-schema-compatibility.unit.test.ts tests/read-replica-release-workflow.unit.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter production read-replica reconciliation and compatibility rules; mistakes could hide real drift or skip needed DDL, while the regenerated DB types may break callers still referencing removed legacy RBAC symbols.
> 
> **Overview**
> Narrows the read-replica schema contract for a **read-only logical subscriber**: additive sync and compatibility checks no longer treat **column default drift** or **missing publisher CHECK constraints** as problems, and sync stops emitting DDL to **alter defaults**, **add/validate CHECKs**, or reconcile defaults on existing columns. **Primary/unique keys, indexes, types, and subscriber-only CHECK mismatches** still gate safety.
> 
> The Cloud SQL Data API path now **fails on nonzero JSON `status.code`** even when `gcloud` exits 0, via shared `assertCloudSqlDataApiResponseSucceeded`; the sync script only runs `main` under **`import.meta.main`**.
> 
> Regenerated **Supabase types** reflect post-migration RBAC (e.g. `is_invite`, dropped `user_min_right` / legacy permission RPCs). Enum DDL quoting in sync uses corrected escape handling, with unit tests updated for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46d1fd120c99cdf491c2f945c03934156128168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated role and invitation data across organization and member records.
  * Added support for checking application existence and identifying the requesting actor.
  * Improved Cloud SQL response error reporting.

* **Bug Fixes**
  * Schema compatibility checks no longer flag column default differences.
  * Missing publisher CHECK constraints are no longer treated as incompatibilities.
  * Improved SQL escaping for enum values.

* **Refactor**
  * Simplified legacy permission and role interfaces to align with the updated authorization model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->