### PR TITLE
ci: optimize full-history checkouts

### DIFF
--- a/.github/workflows/builder_onboarding_tui_preview.yml
+++ b/.github/workflows/builder_onboarding_tui_preview.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 0
+          filter: blob:none
           submodules: recursive
           token: ${{ secrets.CLI_MCP_TESTS_TOKEN || secrets.PERSONAL_ACCESS_TOKEN || github.token }}
           persist-credentials: false

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Setup bun
         run: bash scripts/setup-bun.sh
       - name: Resolve Capgo release scope
@@ -85,6 +86,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
@@ -209,6 +211,7 @@ jobs:
           ref: main
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
+          filter: blob:none
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/deepsec.yml
+++ b/.github/workflows/deepsec.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          filter: blob:none
           path: scanner
           persist-credentials: false
       - name: Setup bun

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           # Keep a stable merge base for paths-filter on long-lived branches.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Detect changed paths
         if: github.event_name != 'workflow_call'

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup bun
         run: bash scripts/setup-bun.sh


### PR DESCRIPTION
## Summary

- add blob-less filtering to checkout steps that explicitly require complete Git history
- leave shallow and normal checkout steps unchanged

## Validation

- `bunx yaml valid` for every changed workflow
- `git diff --check`
- commit hook: CLI, backend, and frontend typechecks

CI is running; this PR will be marked ready after all required checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only checkout tuning; behavior should match prior full-history clones, with blobs fetched on demand when jobs read files.
> 
> **Overview**
> Adds **`filter: blob:none`** to `actions/checkout` steps that already use **`fetch-depth: 0`**, so CI still has full Git history for path filters, release scope, visual diff base/head, and similar work, but avoids downloading every blob up front.
> 
> Touched workflows include **builder onboarding TUI preview**, **bump version** (three jobs), **DeepSec** (trusted scanner checkout), **tests** (path-filter `changes` job only), and **visual diff**. Checkouts that stay shallow or use default depth are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c00b42610fe342b9060cb7b5d42ff66b32be36d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->