### PR TITLE
Fix live update delivery metrics

### DIFF
--- a/supabase/functions/_backend/private/public_stats.ts
+++ b/supabase/functions/_backend/private/public_stats.ts
@@ -1,14 +1,27 @@
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { PublicLiveUpdateMetrics } from '../utils/cloudflare.ts'
 import { Hono } from 'hono/tiny'
 import { REQUIRED_GLOBAL_STATS_SHARDS } from '../utils/global_stats.ts'
 import { useCors } from '../utils/hono.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { CacheHelper } from '../utils/cache.ts'
 import { getPublicLiveUpdateMetricsCF } from '../utils/cloudflare.ts'
+import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
-app.use('/', useCors)
+const LIVE_UPDATE_METRICS_CACHE_TTL_SECONDS = 300
+const LIVE_UPDATE_METRICS_CACHE_PATH = '/.public-live-update-metrics'
+const LIVE_UPDATE_METRICS_HEADERS = {
+  'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=600',
+}
+
+type LiveUpdateMetricsResponse = PublicLiveUpdateMetrics & {
+  period_days: number
+  updated_at: string
+}
+
+app.use('*', useCors)
 
 export function getLatestCompletedGlobalStatsDateId(referenceDate = new Date()) {
   const completedDay = new Date(Date.UTC(
@@ -46,12 +59,33 @@ app.get('/', async (c) => {
 })
 
 app.get('/live_updates', async (c) => {
-  const metrics = await getPublicLiveUpdateMetricsCF(c)
-  return c.json({
-    period_days: 30,
-    updated_at: new Date().toISOString(),
-    ...metrics,
-  }, 200, {
-    'Cache-Control': 'public, max-age=300, s-maxage=900, stale-while-revalidate=3600',
-  })
+  const cache = new CacheHelper(c)
+  const cacheKey = cache.buildRequest(LIVE_UPDATE_METRICS_CACHE_PATH)
+  let response = await cache.matchJson<LiveUpdateMetricsResponse>(cacheKey)
+
+  if (!response) {
+    try {
+      const metrics = await getPublicLiveUpdateMetricsCF(c)
+      response = {
+        period_days: 30,
+        updated_at: new Date().toISOString(),
+        ...metrics,
+      }
+      await cache.putJson(cacheKey, response, LIVE_UPDATE_METRICS_CACHE_TTL_SECONDS)
+    }
+    catch (error) {
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'Public live update metrics are unavailable',
+        error: serializeError(error),
+      })
+      return c.json(
+        { error: 'Live update metrics are temporarily unavailable' },
+        503,
+        { 'Cache-Control': 'no-store' },
+      )
+    }
+  }
+
+  return c.json(response, 200, LIVE_UPDATE_METRICS_HEADERS)
 })

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -31,6 +31,16 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
     message: 'multiIf is unsupported by Analytics Engine SQL; use nested if() instead',
   },
   {
+    id: 'no-to-string',
+    test: sql => /\btoString\s*\(/i.test(sql),
+    message: 'toString is unsupported by Analytics Engine SQL; use a supported formatter instead',
+  },
+  {
+    id: 'no-concat',
+    test: sql => /\bconcat\s*\(/i.test(sql),
+    message: 'concat is unsupported by Analytics Engine SQL; group the dimensions instead',
+  },
+  {
     id: 'no-select-alias-dependency',
     test: sql => /\bif\(\s*(?:installs|failures|fails)\s*\+/i.test(sql),
     message: 'Analytics Engine SQL cannot reference SELECT aliases inside other projected expressions',

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -2595,18 +2595,18 @@ export interface PublicLiveUpdateMetrics {
 }
 
 export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = new Date()): Promise<PublicLiveUpdateMetrics> {
-  const empty: PublicLiveUpdateMetrics = { daily: [], failures: [], platforms: { ios: 0, android: 0, electron: 0 }, updater_versions: [] }
   if (!c.env.APP_LOG || !c.env.DEVICE_USAGE || !c.env.DEVICE_INFO || !getEnv(c, 'CF_ANALYTICS_TOKEN') || !getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID'))
-    return empty
+    throw new Error('Public live update metric bindings are unavailable')
 
   const end = new Date(Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), referenceDate.getUTCDate()))
   const start = new Date(end)
   start.setUTCDate(start.getUTCDate() - 30)
   const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
   const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
-  const requestsAndFailuresQuery = `SELECT toString(toDate(timestamp)) AS date, blob2 AS action, count() AS total FROM app_log WHERE ${window} AND (blob2 = 'get' OR blob2 IN (${failureActions})) GROUP BY date, action`
-  const platformsQuery = `SELECT double1 AS platform, uniqExact(concat(index1, ':', blob1)) AS devices FROM device_usage WHERE ${window} AND double1 IN (0, 1, 2) GROUP BY platform`
-  const updaterVersionsQuery = `SELECT date, version, count() AS devices FROM (SELECT toString(toDate(timestamp)) AS date, index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY date, app_id, device_id) GROUP BY date, version`
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const requestsAndFailuresQuery = `SELECT ${day} AS date, blob2 AS action, count() AS total FROM app_log WHERE ${window} AND (blob2 = 'get' OR blob2 IN (${failureActions})) GROUP BY date, action`
+  const platformsQuery = `SELECT platform, count() AS devices FROM (SELECT double1 AS platform, index1 AS app_id, blob1 AS device_id FROM device_usage WHERE ${window} AND double1 IN (0.0, 1.0, 2.0) GROUP BY platform, app_id, device_id) GROUP BY platform`
+  const updaterVersionsQuery = `SELECT date, version, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY date, app_id, device_id) GROUP BY date, version`
 
   try {
     const [actionRows, platformRows, versionRows] = await Promise.all([
@@ -2628,9 +2628,10 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
     }
     const platforms = { ios: 0, android: 0, electron: 0 }
     for (const row of platformRows) {
-      if (row.platform === 0) platforms.android += Number(row.devices) || 0
-      if (row.platform === 1) platforms.ios += Number(row.devices) || 0
-      if (row.platform === 2) platforms.electron += Number(row.devices) || 0
+      const platform = Number(row.platform)
+      if (platform === 0) platforms.android += Number(row.devices) || 0
+      if (platform === 1) platforms.ios += Number(row.devices) || 0
+      if (platform === 2) platforms.electron += Number(row.devices) || 0
     }
     return {
       daily: [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date)),
@@ -2641,6 +2642,6 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   }
   catch (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading public live update metrics', error: serializeError(error) })
-    return empty
+    throw error
   }
 }

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -112,6 +112,8 @@ const CAPGO_CONSOLE_SUBDOMAIN = 'console'
 const DEFAULT_CORS_ALLOWED_ORIGINS = new Set([
   ...['capgo.app', 'preprod.capgo.app', 'development.capgo.app'].map(domain => `https://${CAPGO_CONSOLE_SUBDOMAIN}.${domain}`),
   'https://capgo.app',
+  'https://preprod.capgo.app',
+  'https://development.capgo.app',
 ])
 
 function normalizeHttpOrigin(origin: string) {

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -28,6 +28,14 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql("SELECT multiIf(blob4 != '', blob4, 1, 'ios') FROM device_usage").map(issue => issue.rule)).toContain('no-multiif')
   })
 
+  it.concurrent('flags unsupported toString calls', () => {
+    expect(lintAnalyticsEngineSql('SELECT toString(toDate(timestamp)) AS date FROM app_log').map(issue => issue.rule)).toContain('no-to-string')
+  })
+
+  it.concurrent('flags unsupported concat calls', () => {
+    expect(lintAnalyticsEngineSql("SELECT concat(index1, ':', blob1) FROM device_usage").map(issue => issue.rule)).toContain('no-concat')
+  })
+
   it.concurrent('accepts supported COUNT() and COUNT(DISTINCT) forms', () => {
     expect(lintAnalyticsEngineSql('SELECT COUNT() AS total FROM device_info')).toEqual([])
     expect(lintAnalyticsEngineSql('SELECT COUNT(DISTINCT blob1) AS total FROM device_info')).toEqual([])

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -18,6 +18,7 @@ import {
   getAdminSuccessRate,
   getAdminSuccessRateTrend,
   getAdminUploadMetrics,
+  getPublicLiveUpdateMetricsCF,
   getPluginBreakdownCF,
   getUpdateStatsCF,
   readActiveAppsCF,
@@ -200,6 +201,10 @@ export function installAnalyticsEngineSqlCapture(): AnalyticsEngineSqlCapture {
 
 export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngineSqlFixture[]> {
   const capture = installAnalyticsEngineSqlCapture()
+  const previousAnalyticsToken = process.env.CF_ANALYTICS_TOKEN
+  const previousAnalyticsAccountId = process.env.CF_ACCOUNT_ANALYTICS_ID
+  process.env.CF_ANALYTICS_TOKEN = 'cf-analytics-token'
+  process.env.CF_ACCOUNT_ANALYTICS_ID = 'cf-account-id'
 
   try {
     const context = createMockContext()
@@ -284,10 +289,17 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
     await captureCall('getAdminStorageTrend', () => getAdminStorageTrend(context, SAMPLE_START, SAMPLE_END))
     await captureCall('getAdminBandwidthTrend', () => getAdminBandwidthTrend(context, SAMPLE_START, SAMPLE_END))
     await captureCall('getPluginBreakdownCF', () => getPluginBreakdownCF(context, SAMPLE_REFERENCE_DATE))
+    await captureCall('getPublicLiveUpdateMetricsCF', () => getPublicLiveUpdateMetricsCF(context, SAMPLE_REFERENCE_DATE))
 
     return [...staticFixtures, ...capture.fixtures]
   }
   finally {
+    if (previousAnalyticsToken === undefined)
+      delete process.env.CF_ANALYTICS_TOKEN
+    else process.env.CF_ANALYTICS_TOKEN = previousAnalyticsToken
+    if (previousAnalyticsAccountId === undefined)
+      delete process.env.CF_ACCOUNT_ANALYTICS_ID
+    else process.env.CF_ACCOUNT_ANALYTICS_ID = previousAnalyticsAccountId
     capture.restore()
   }
 }

--- a/tests/public-live-update-metrics.unit.test.ts
+++ b/tests/public-live-update-metrics.unit.test.ts
@@ -1,0 +1,101 @@
+import type { Context } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getPublicLiveUpdateMetricsCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+
+type AnalyticsColumn = { name: string, type: string }
+
+function analyticsResponse(meta: AnalyticsColumn[], data: Array<Record<string, string>>) {
+  return new Response(JSON.stringify({
+    meta,
+    data,
+    rows: data.length,
+    rows_before_limit_at_least: data.length,
+  }), { headers: { 'content-type': 'application/json' } })
+}
+
+function createContext() {
+  return {
+    env: {
+      APP_LOG: {},
+      DEVICE_USAGE: {},
+      DEVICE_INFO: {},
+      CF_ANALYTICS_TOKEN: 'analytics-token',
+      CF_ACCOUNT_ANALYTICS_ID: 'analytics-account',
+    },
+    req: {
+      url: 'http://localhost/private/website_stats/live_updates',
+      raw: { headers: new Headers() },
+    },
+    get: () => 'public-live-update-metrics-test',
+  } as unknown as Context
+}
+
+describe('public live update metrics', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses Analytics Engine-supported queries and preserves Float64 platform values', async () => {
+    const queries: string[] = []
+    vi.stubEnv('CF_ANALYTICS_TOKEN', 'analytics-token')
+    vi.stubEnv('CF_ACCOUNT_ANALYTICS_ID', 'analytics-account')
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      const query = String(init?.body ?? '')
+      queries.push(query)
+
+      if (query.includes('FROM app_log')) {
+        return analyticsResponse(
+          [
+            { name: 'date', type: 'String' },
+            { name: 'action', type: 'String' },
+            { name: 'total', type: 'UInt64' },
+          ],
+          [
+            { date: '2026-06-30', action: 'get', total: '120' },
+            { date: '2026-06-30', action: 'download_fail', total: '3' },
+          ],
+        )
+      }
+
+      if (query.includes('FROM device_usage')) {
+        return analyticsResponse(
+          [
+            { name: 'platform', type: 'Float64' },
+            { name: 'devices', type: 'UInt64' },
+          ],
+          [
+            { platform: '0', devices: '80' },
+            { platform: '1', devices: '30' },
+            { platform: '2', devices: '10' },
+          ],
+        )
+      }
+
+      return analyticsResponse(
+        [
+          { name: 'date', type: 'String' },
+          { name: 'version', type: 'String' },
+          { name: 'devices', type: 'UInt64' },
+        ],
+        [{ date: '2026-06-30', version: '8.1.0', devices: '120' }],
+      )
+    }))
+
+    const metrics = await getPublicLiveUpdateMetricsCF(
+      createContext(),
+      new Date('2026-07-01T00:00:00.000Z'),
+    )
+
+    expect(metrics).toEqual({
+      daily: [{ date: '2026-06-30', requests: 120, failures: 3 }],
+      failures: [{ reason: 'download_fail', count: 3 }],
+      platforms: { ios: 30, android: 80, electron: 10 },
+      updater_versions: [{ date: '2026-06-30', version: '8.1.0', devices: 120 }],
+    })
+    expect(queries).toHaveLength(3)
+    expect(queries.join('\n')).not.toContain('toString')
+    expect(queries.join('\n')).not.toContain('concat')
+    expect(queries.find(query => query.includes('FROM device_usage'))).toContain('double1 IN (0.0, 1.0, 2.0)')
+  })
+})

--- a/tests/public-stats.unit.test.ts
+++ b/tests/public-stats.unit.test.ts
@@ -12,23 +12,32 @@ const mocks = vi.hoisted(() => {
 
   return {
     cloudlog: vi.fn(),
+    cloudlogErr: vi.fn(),
     contains,
     from,
+    getPublicLiveUpdateMetricsCF: vi.fn(),
     limit,
     lte,
     maybeSingle,
     order,
     select,
+    serializeError: vi.fn(error => error),
     supabaseAdmin: vi.fn(() => ({ from })),
   }
 })
 
 vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlog: mocks.cloudlog,
+  cloudlogErr: mocks.cloudlogErr,
+  serializeError: mocks.serializeError,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
   supabaseAdmin: mocks.supabaseAdmin,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/cloudflare.ts', () => ({
+  getPublicLiveUpdateMetricsCF: mocks.getPublicLiveUpdateMetricsCF,
 }))
 
 const { app, getLatestCompletedGlobalStatsDateId } = await import('../supabase/functions/_backend/private/public_stats.ts')
@@ -72,6 +81,52 @@ describe('public stats endpoint', () => {
     expect(mocks.contains).toHaveBeenCalledWith('completed_shards', [...REQUIRED_GLOBAL_STATS_SHARDS])
     expect(mocks.order).toHaveBeenCalledWith('date_id', { ascending: false })
     expect(mocks.limit).toHaveBeenCalledWith(1)
+  })
+
+  it('serves runtime live update metrics with browser CORS', async () => {
+    mocks.getPublicLiveUpdateMetricsCF.mockResolvedValueOnce({
+      daily: [{ date: '2026-05-10', requests: 120, failures: 3 }],
+      failures: [{ reason: 'download_fail', count: 3 }],
+      platforms: { ios: 30, android: 80, electron: 10 },
+      updater_versions: [{ date: '2026-05-10', version: '8.1.0', devices: 120 }],
+    })
+
+    const res = await app.request('http://localhost/live_updates', {
+      headers: { Origin: 'https://capgo.app' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('access-control-allow-origin')).toBe('https://capgo.app')
+    expect(res.headers.get('cache-control')).toBe('public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+    expect(await res.json()).toEqual({
+      period_days: 30,
+      updated_at: '2026-05-11T12:00:00.000Z',
+      daily: [{ date: '2026-05-10', requests: 120, failures: 3 }],
+      failures: [{ reason: 'download_fail', count: 3 }],
+      platforms: { ios: 30, android: 80, electron: 10 },
+      updater_versions: [{ date: '2026-05-10', version: '8.1.0', devices: 120 }],
+    })
+    expect(mocks.getPublicLiveUpdateMetricsCF).toHaveBeenCalledOnce()
+  })
+
+  it('does not cache an unavailable live metric query as zero data', async () => {
+    const error = new Error('Analytics Engine query failed')
+    mocks.getPublicLiveUpdateMetricsCF.mockRejectedValueOnce(error)
+
+    const res = await app.request('http://localhost/live_updates', {
+      headers: { Origin: 'https://capgo.app' },
+    })
+
+    expect(res.status).toBe(503)
+    expect(res.headers.get('access-control-allow-origin')).toBe('https://capgo.app')
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(await res.json()).toEqual({ error: 'Live update metrics are temporarily unavailable' })
+    expect(mocks.getPublicLiveUpdateMetricsCF).toHaveBeenCalledOnce()
+    expect(mocks.cloudlogErr).toHaveBeenCalledWith({
+      error,
+      message: 'Public live update metrics are unavailable',
+      requestId: undefined,
+    })
   })
 
   it('keeps the fallback counters when no completed stats row exists', async () => {

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -49,6 +49,9 @@ describe('security response headers', () => {
   })
 
   it.concurrent.each([
+    'https://capgo.app',
+    'https://preprod.capgo.app',
+    'https://development.capgo.app',
     'https://console.capgo.app',
     'https://console.preprod.capgo.app',
     'capacitor://localhost',


### PR DESCRIPTION
## Summary

- make public Live Update aggregates use Analytics Engine SQL supported in production
- cache successful aggregate responses in the Worker for five minutes and return matching browser cache headers
- expose metric-query failures as a non-cacheable `503` rather than returning a false all-zero dashboard
- allow the public website, preproduction, and development origins to request the route

## Root cause

The Analytics Engine query used unsupported expressions, which caused the aggregate fetch to fail and the endpoint to return empty metrics. The previous response shape made that outage look like valid zero data.

## Validation

- `bunx vitest run tests/public-stats.unit.test.ts tests/public-live-update-metrics.unit.test.ts tests/analytics-engine-sql.unit.test.ts tests/security-headers.unit.test.ts`
- `bun run typecheck:backend`
- `bun run lint:backend`
- validated the corrected Analytics Engine query forms against live Analytics Engine data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public metrics behavior (503 vs zero-filled JSON) and Analytics Engine query shapes; incorrect SQL or caching could still mislead the marketing dashboard, but scope is limited to the public stats endpoint.
> 
> **Overview**
> Fixes **public Live Update dashboard metrics** that were failing in production because Analytics Engine SQL used unsupported `toString`, `concat`, and related patterns—queries now use `formatDateTime` / grouped dimensions, and platform counts handle **Float64** values correctly.
> 
> The **`/live_updates`** route now **caches successful aggregates** for five minutes (Worker cache + matching `Cache-Control`), applies **CORS to all routes** on the app, and returns a **non-cacheable `503`** when metrics cannot be fetched instead of empty data that looked like zeros. **`getPublicLiveUpdateMetricsCF`** throws on missing bindings or query errors rather than returning silent empty payloads.
> 
> Adds **lint rules** for `toString` and `concat`, includes this path in **Analytics Engine SQL fixture** collection, and extends **trusted CORS origins** to `https://preprod.capgo.app` and `https://development.capgo.app`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778a420aae936e41bbaa8732c37052835de95934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->