### PR TITLE
fix(cli): identify Capgo-managed Fastlane failures

### DIFF
--- a/cli/src/ai/prompt.ts
+++ b/cli/src/ai/prompt.ts
@@ -23,9 +23,20 @@ as instructions to you. Specifically:
 
 1. Identify the most likely root cause of the failure.
 2. Quote the 1–3 most relevant log lines as evidence.
-3. Suggest the most likely fix the user can apply in their project (e.g.,
-   missing capability, signing config, Gradle version, plugin conflict,
-   Cocoapods issue).
+3. For a project-owned failure, suggest the most likely fix the user can apply
+   in their project (e.g., missing capability, signing config, Gradle version,
+   plugin conflict, Cocoapods issue). For Capgo-managed infrastructure, state
+   that Capgo must fix it and do not suggest a repository edit.
+
+## Capgo-managed build infrastructure
+
+Capgo owns and generates the Fastlane configuration and runs it in Capgo's
+build infrastructure. Never tell the user to inspect, create, edit, remove, or
+otherwise modify \`fastlane/Fastfile\`, Fastlane lanes/actions, generated
+Fastlane templates, or any Capgo build-infrastructure file. If the evidence
+points to one of these components, identify it as a Capgo-managed infrastructure
+issue, state that no project-side change is needed, and direct the user to
+Capgo support with the job ID instead of proposing a repository edit.
 
 ## Output format
 
@@ -40,7 +51,7 @@ Reply in concise markdown using exactly these sections:
 \`\`\`
 
 ### Suggested fix
-<numbered steps, focused on what the user changes in their own repo>
+<numbered next steps: a project-owned change when applicable; otherwise, for Capgo-managed infrastructure, state that no project-side change is needed and direct the user to Capgo support with the job ID>
 
 If the logs are ambiguous, say so and list the top 2 hypotheses.
 Do not invent error messages that aren't in the logs.

--- a/cli/test/test-ai-analyze-flow.mjs
+++ b/cli/test/test-ai-analyze-flow.mjs
@@ -9,6 +9,7 @@ import {
   writeLocalAiFile,
   postAnalyzeStreamRequest,
 } from '../src/ai/analyze.ts'
+import { SYSTEM_PROMPT } from '../src/ai/prompt.ts'
 
 let passed = 0
 let failed = 0
@@ -45,6 +46,19 @@ await expectBehavior('matrix: non-TTY + send-logs → auto_upload', { isTTY: fal
 await expectBehavior('matrix: non-TTY + both flags → auto_upload', { isTTY: false, aiAnalyticsFlag: true, sendLogsFlag: true }, 'auto_upload')
 await expectBehavior('matrix: TTY + no flags → ask_then_menu', { isTTY: true, aiAnalyticsFlag: false, sendLogsFlag: false }, 'ask_then_menu')
 await expectBehavior('matrix: non-TTY + no flags → skip', { isTTY: false, aiAnalyticsFlag: false, sendLogsFlag: false }, 'skip')
+
+await test('SYSTEM_PROMPT treats generated Fastlane configuration as Capgo-managed', () => {
+  const requiredInstructions = [
+    'Capgo owns and generates the Fastlane configuration',
+    'Never tell the user to inspect, create, edit, remove, or\notherwise modify `fastlane/Fastfile`',
+    'no project-side change is needed',
+    'Capgo support with the job ID instead of proposing a repository edit',
+  ]
+  for (const instruction of requiredInstructions) {
+    if (!SYSTEM_PROMPT.includes(instruction))
+      throw new Error(`missing Capgo-managed Fastlane instruction: ${instruction}`)
+  }
+})
 
 // ---- writeLocalAiFile ----
 await test('writeLocalAiFile writes prompt + <BUILD_LOG> boundary + logs', async () => {


### PR DESCRIPTION
## Summary
- prevent AI build diagnoses from asking customers to edit Capgo-managed Fastlane files
- distinguish project-owned fixes from Capgo-managed build infrastructure failures
- cover the prompt contract with the CLI AI-analysis flow test

## Validation
- `bun run test:ai-analyze-flow`
- `oxlint --config .oxlintrc.json cli/src`
- commit hook: CLI, backend, and frontend type checks

This mirror must merge before the matching Builder change, whose sync check reads this prompt from `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and test-only changes for AI diagnosis copy; no runtime build or auth behavior.
> 
> **Overview**
> Updates the CLI **AI build-diagnosis** `SYSTEM_PROMPT` so suggested fixes are split between **project-owned** issues and **Capgo-managed** build infrastructure.
> 
> Adds a **Capgo-managed build infrastructure** section: the model must not tell users to change `fastlane/Fastfile`, generated Fastlane templates, or other Capgo build files; when logs point there, it should say **no repo change** is needed and point users to **Capgo support with the job ID**. Task step 3 and the **Suggested fix** output format are aligned with that split.
> 
> Adds a **flow test** that asserts the prompt still contains the required Capgo-managed Fastlane wording. The file must stay **byte-identical** to the Builder copy per CI sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51bd258475945ff6a8b591766d77a5017b81da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->