### PR TITLE
fix: aggregate public update stats by device

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1,9 +1,9 @@
 import type { AnalyticsEngineDataset, D1Database, Hyperdrive, KVNamespace, Queue } from '@cloudflare/workers-types'
 import type { Context } from 'hono'
 import type { DeviceComparable } from './deviceComparison.ts'
+import type { StatsInsightRawAction, StatsInsightRawDaily, StatsInsightRawDevice, StatsInsightRawSummary, StatsInsightRawVersion } from './statsInsights.ts'
 import type { Database } from './supabase.types.ts'
 import type { DeviceRes, DeviceWithoutCreatedAt, NativeVersionUsage, ReadDevicesParams, ReadStatsInsightsParams, ReadStatsParams, StatsInsightsResult, StatsMetadata, VersionUsage, VersionUsageChannel } from './types.ts'
-import type { StatsInsightRawAction, StatsInsightRawDaily, StatsInsightRawDevice, StatsInsightRawSummary, StatsInsightRawVersion } from './statsInsights.ts'
 import dayjs from 'dayjs'
 import { CacheHelper } from './cache.ts'
 import { hasComparableDeviceChanged, toComparableDevice } from './deviceComparison.ts'
@@ -2588,10 +2588,11 @@ export async function getPluginBreakdownCF(c: Context, referenceDate?: Date): Pr
 const PUBLIC_FAILURE_ACTIONS = ['set_fail', 'update_fail', 'download_fail', 'windows_path_fail', 'canonical_path_fail', 'directory_path_fail', 'unzip_fail', 'low_mem_fail', 'download_manifest_file_fail', 'download_manifest_checksum_fail', 'download_manifest_brotli_fail', 'finish_download_fail', 'manifest_path_fail', 'decrypt_fail', 'insufficient_disk_space', 'cannotGetBundle', 'checksum_fail', 'blocked_by_server_url', 'backend_refusal'] as const
 
 export interface PublicLiveUpdateMetrics {
-  daily: Array<{ date: string, requests: number, failures: number }>
-  failures: Array<{ reason: string, count: number }>
+  success_rate: number
+  daily: Array<{ date: string, success_rate: number }>
+  failures: Array<{ reason: string, share: number }>
   platforms: { ios: number, android: number, electron: number }
-  updater_versions: Array<{ date: string, version: string, devices: number }>
+  updater_versions: Array<{ date: string, version: string, share: number }>
 }
 
 export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = new Date()): Promise<PublicLiveUpdateMetrics> {
@@ -2604,40 +2605,60 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
   const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
   const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
-  const requestsAndFailuresQuery = `SELECT ${day} AS date, blob2 AS action, count() AS total FROM app_log WHERE ${window} AND (blob2 = 'get' OR blob2 IN (${failureActions})) GROUP BY date, action`
+  const outcomesQuery = `SELECT date, sum(succeeded) AS successes, sum(failed) AS failures FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id) GROUP BY date`
+  const failuresQuery = `SELECT action, count() AS devices FROM (SELECT ${day} AS date, blob2 AS action, index1 AS app_id, blob1 AS device_id FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, action, app_id, device_id) GROUP BY action`
   const platformsQuery = `SELECT platform, count() AS devices FROM (SELECT double1 AS platform, index1 AS app_id, blob1 AS device_id FROM device_usage WHERE ${window} AND double1 IN (0.0, 1.0, 2.0) GROUP BY platform, app_id, device_id) GROUP BY platform`
   const updaterVersionsQuery = `SELECT date, version, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY date, app_id, device_id) GROUP BY date, version`
 
   try {
-    const [actionRows, platformRows, versionRows] = await Promise.all([
-      runQueryToCFA<{ date: string, action: string, total: number }>(c, requestsAndFailuresQuery),
+    const [outcomeRows, failureRows, platformRows, versionRows] = await Promise.all([
+      runQueryToCFA<{ date: string, successes: number, failures: number }>(c, outcomesQuery),
+      runQueryToCFA<{ action: string, devices: number }>(c, failuresQuery),
       runQueryToCFA<{ platform: number, devices: number }>(c, platformsQuery),
       runQueryToCFA<{ date: string, version: string, devices: number }>(c, updaterVersionsQuery),
     ])
-    const byDate = new Map<string, { date: string, requests: number, failures: number }>()
-    const failures = new Map<string, number>()
-    for (const row of actionRows) {
-      const day = byDate.get(row.date) ?? { date: row.date, requests: 0, failures: 0 }
-      const total = Number(row.total) || 0
-      if (row.action === 'get') day.requests += total
-      else {
-        day.failures += total
-        failures.set(row.action, (failures.get(row.action) ?? 0) + total)
-      }
-      byDate.set(row.date, day)
-    }
-    const platforms = { ios: 0, android: 0, electron: 0 }
+    const daily = outcomeRows.map((row) => {
+      const successes = Number(row.successes) || 0
+      const failures = Number(row.failures) || 0
+      const outcomes = successes + failures
+      return { date: row.date, success_rate: outcomes ? (successes / outcomes) * 100 : 0 }
+    }).sort((a, b) => a.date.localeCompare(b.date))
+    const totalSuccesses = outcomeRows.reduce((sum, row) => sum + (Number(row.successes) || 0), 0)
+    const totalFailures = outcomeRows.reduce((sum, row) => sum + (Number(row.failures) || 0), 0)
+    const totalOutcomes = totalSuccesses + totalFailures
+    const success_rate = totalOutcomes ? (totalSuccesses / totalOutcomes) * 100 : 0
+    const failureTotal = failureRows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
+    const failures = failureRows
+      .map(row => ({ reason: row.action, share: failureTotal ? ((Number(row.devices) || 0) / failureTotal) * 100 : 0 }))
+      .sort((a, b) => b.share - a.share)
+      .slice(0, 8)
+    const platformCounts = { ios: 0, android: 0, electron: 0 }
     for (const row of platformRows) {
       const platform = Number(row.platform)
-      if (platform === 0) platforms.android += Number(row.devices) || 0
-      if (platform === 1) platforms.ios += Number(row.devices) || 0
-      if (platform === 2) platforms.electron += Number(row.devices) || 0
+      if (platform === 0)
+        platformCounts.android += Number(row.devices) || 0
+      if (platform === 1)
+        platformCounts.ios += Number(row.devices) || 0
+      if (platform === 2)
+        platformCounts.electron += Number(row.devices) || 0
     }
+    const platformTotal = Object.values(platformCounts).reduce((sum, count) => sum + count, 0)
+    const platforms = {
+      ios: platformTotal ? (platformCounts.ios / platformTotal) * 100 : 0,
+      android: platformTotal ? (platformCounts.android / platformTotal) * 100 : 0,
+      electron: platformTotal ? (platformCounts.electron / platformTotal) * 100 : 0,
+    }
+    const versionTotals = new Map<string, number>()
+    for (const row of versionRows)
+      versionTotals.set(row.date, (versionTotals.get(row.date) ?? 0) + (Number(row.devices) || 0))
     return {
-      daily: [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date)),
-      failures: [...failures.entries()].map(([reason, count]) => ({ reason, count })).sort((a, b) => b.count - a.count).slice(0, 8),
+      success_rate,
+      daily,
+      failures,
       platforms,
-      updater_versions: versionRows.map(row => ({ date: row.date, version: row.version, devices: Number(row.devices) || 0 })).sort((a, b) => a.date.localeCompare(b.date) || b.devices - a.devices),
+      updater_versions: versionRows
+        .map(row => ({ date: row.date, version: row.version, share: versionTotals.get(row.date) ? ((Number(row.devices) || 0) / versionTotals.get(row.date)!) * 100 : 0 }))
+        .sort((a, b) => a.date.localeCompare(b.date) || b.share - a.share),
     }
   }
   catch (error) {

--- a/tests/public-live-update-metrics.unit.test.ts
+++ b/tests/public-live-update-metrics.unit.test.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getPublicLiveUpdateMetricsCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
 
-type AnalyticsColumn = { name: string, type: string }
+interface AnalyticsColumn { name: string, type: string }
 
 function analyticsResponse(meta: AnalyticsColumn[], data: Array<Record<string, string>>) {
   return new Response(JSON.stringify({
@@ -44,17 +44,24 @@ describe('public live update metrics', () => {
       const query = String(init?.body ?? '')
       queries.push(query)
 
-      if (query.includes('FROM app_log')) {
+      if (query.includes('sum(succeeded)')) {
         return analyticsResponse(
           [
             { name: 'date', type: 'String' },
-            { name: 'action', type: 'String' },
-            { name: 'total', type: 'UInt64' },
+            { name: 'successes', type: 'UInt64' },
+            { name: 'failures', type: 'UInt64' },
           ],
+          [{ date: '2026-06-30', successes: '117', failures: '3' }],
+        )
+      }
+
+      if (query.includes('SELECT action, count() AS devices')) {
+        return analyticsResponse(
           [
-            { date: '2026-06-30', action: 'get', total: '120' },
-            { date: '2026-06-30', action: 'download_fail', total: '3' },
+            { name: 'action', type: 'String' },
+            { name: 'devices', type: 'UInt64' },
           ],
+          [{ action: 'download_fail', devices: '3' }],
         )
       }
 
@@ -88,14 +95,17 @@ describe('public live update metrics', () => {
     )
 
     expect(metrics).toEqual({
-      daily: [{ date: '2026-06-30', requests: 120, failures: 3 }],
-      failures: [{ reason: 'download_fail', count: 3 }],
-      platforms: { ios: 30, android: 80, electron: 10 },
-      updater_versions: [{ date: '2026-06-30', version: '8.1.0', devices: 120 }],
+      success_rate: 97.5,
+      daily: [{ date: '2026-06-30', success_rate: 97.5 }],
+      failures: [{ reason: 'download_fail', share: 100 }],
+      platforms: { ios: 25, android: 66.66666666666666, electron: 8.333333333333332 },
+      updater_versions: [{ date: '2026-06-30', version: '8.1.0', share: 100 }],
     })
-    expect(queries).toHaveLength(3)
+    expect(queries).toHaveLength(4)
     expect(queries.join('\n')).not.toContain('toString')
     expect(queries.join('\n')).not.toContain('concat')
     expect(queries.find(query => query.includes('FROM device_usage'))).toContain('double1 IN (0.0, 1.0, 2.0)')
+    expect(queries.find(query => query.includes('sum(succeeded)'))).toContain('GROUP BY date, app_id, device_id')
+    expect(queries.find(query => query.includes('SELECT action, count() AS devices'))).toContain('GROUP BY date, action, app_id, device_id')
   })
 })

--- a/tests/public-stats.unit.test.ts
+++ b/tests/public-stats.unit.test.ts
@@ -85,10 +85,11 @@ describe('public stats endpoint', () => {
 
   it('serves runtime live update metrics with browser CORS', async () => {
     mocks.getPublicLiveUpdateMetricsCF.mockResolvedValueOnce({
-      daily: [{ date: '2026-05-10', requests: 120, failures: 3 }],
-      failures: [{ reason: 'download_fail', count: 3 }],
-      platforms: { ios: 30, android: 80, electron: 10 },
-      updater_versions: [{ date: '2026-05-10', version: '8.1.0', devices: 120 }],
+      success_rate: 97.5,
+      daily: [{ date: '2026-05-10', success_rate: 97.5 }],
+      failures: [{ reason: 'download_fail', share: 100 }],
+      platforms: { ios: 25, android: 66.7, electron: 8.3 },
+      updater_versions: [{ date: '2026-05-10', version: '8.1.0', share: 100 }],
     })
 
     const res = await app.request('http://localhost/live_updates', {
@@ -101,10 +102,11 @@ describe('public stats endpoint', () => {
     expect(await res.json()).toEqual({
       period_days: 30,
       updated_at: '2026-05-11T12:00:00.000Z',
-      daily: [{ date: '2026-05-10', requests: 120, failures: 3 }],
-      failures: [{ reason: 'download_fail', count: 3 }],
-      platforms: { ios: 30, android: 80, electron: 10 },
-      updater_versions: [{ date: '2026-05-10', version: '8.1.0', devices: 120 }],
+      success_rate: 97.5,
+      daily: [{ date: '2026-05-10', success_rate: 97.5 }],
+      failures: [{ reason: 'download_fail', share: 100 }],
+      platforms: { ios: 25, android: 66.7, electron: 8.3 },
+      updater_versions: [{ date: '2026-05-10', version: '8.1.0', share: 100 }],
     })
     expect(mocks.getPublicLiveUpdateMetricsCF).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
## Summary

- deduplicate install success and failure outcomes by app, device, and UTC day
- calculate and expose success rate instead of failure event rate
- expose platform, updater version, and failure reason percentages only
- remove exact device counts from the public API contract

## Validation

- bunx vitest run tests/public-live-update-metrics.unit.test.ts tests/public-stats.unit.test.ts
- eslint on touched files

Website UI follows in a linked PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API contract changes (counts removed, semantics shift from event-based `get` to device-day `set` outcomes) can break consumers until the linked website PR ships; analytics SQL changes affect reported public metrics.
> 
> **Overview**
> **Breaking change to the public `/live_updates` API:** raw request/failure counts and device totals are replaced with **success rates** and **percentage shares**, computed after deduplicating outcomes per app, device, and UTC day.
> 
> `getPublicLiveUpdateMetricsCF` now runs separate Analytics Engine queries: outcomes use `set` vs failure actions with `GROUP BY date, app_id, device_id` (success is `max(if(blob2 = 'set', 1, 0))`), failure reasons count distinct device-days per action, and platforms/updater versions are normalized to % of their totals. The response adds top-level `success_rate`; `daily` is `{ date, success_rate }`; `failures` use `share`; `platforms` and `updater_versions` use `share` instead of counts.
> 
> Unit tests for the metrics helper and `public_stats` `/live_updates` were updated for the new shape and the fourth analytics query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b681c74ef6b3d0c5592e4c782a246980e5507405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live update metrics now show overall and daily success rates.
  * Failure reasons, platforms, and updater versions are reported as percentage shares for easier comparison.

* **Bug Fixes**
  * Updated live update statistics to accurately calculate success rates and percentage distributions.

* **Tests**
  * Updated metric validation to reflect the revised live update statistics and analytics results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->