### PR TITLE
fix(db): enforce app creator ownership on insert

### DIFF
--- a/supabase/migrations/20260715213016_enforce_valid_user_id_on_app_create.sql
+++ b/supabase/migrations/20260715213016_enforce_valid_user_id_on_app_create.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE TRIGGER "force_valid_user_id_on_app"
+BEFORE INSERT ON "public"."apps"
+FOR EACH ROW
+EXECUTE FUNCTION "public"."force_valid_user_id_on_app"();

--- a/supabase/tests/61_test_force_valid_user_id_on_app.sql
+++ b/supabase/tests/61_test_force_valid_user_id_on_app.sql
@@ -1,0 +1,40 @@
+BEGIN;
+
+SELECT plan(1);
+
+SELECT tests.create_supabase_user('app_owner_enforcement_owner', 'app_owner_enforcement_owner@test.local');
+SELECT tests.create_supabase_user('app_owner_enforcement_other', 'app_owner_enforcement_other@test.local');
+
+INSERT INTO public.users (id, email, created_at, updated_at)
+VALUES
+  (tests.get_supabase_uid('app_owner_enforcement_owner'), 'app_owner_enforcement_owner@test.local', NOW(), NOW()),
+  (tests.get_supabase_uid('app_owner_enforcement_other'), 'app_owner_enforcement_other@test.local', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.orgs (id, created_by, name, management_email)
+VALUES (
+  '61000000-0000-4000-8000-000000000001',
+  tests.get_supabase_uid('app_owner_enforcement_owner'),
+  'App owner enforcement org',
+  'app-owner-enforcement@test.local'
+);
+
+INSERT INTO public.apps (id, app_id, icon_url, user_id, name, owner_org)
+VALUES (
+  '61000000-0000-4000-8000-000000000002',
+  'com.test.app-owner-enforcement',
+  '',
+  tests.get_supabase_uid('app_owner_enforcement_other'),
+  'App owner enforcement',
+  '61000000-0000-4000-8000-000000000001'
+);
+
+SELECT is(
+  (SELECT user_id FROM public.apps WHERE app_id = 'com.test.app-owner-enforcement'),
+  tests.get_supabase_uid('app_owner_enforcement_owner'),
+  'app user_id is enforced from the organization creator on insert'
+);
+
+SELECT * FROM finish(); -- noqa: AM04
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

- attach the existing `force_valid_user_id_on_app` trigger function to `public.apps` inserts
- enforce `apps.user_id` from the owning organization creator
- add a pgTAP regression test covering an attempted mismatched user assignment

## Root cause

The trigger function existed in the production schema but no trigger invoked it, so app inserts could retain a caller-provided `user_id`.

## Validation

- `bun lint`
- `bun run supabase:db:reset`
- targeted pgTAP test: pass
- full pgTAP suite: 723/724 pass; existing unrelated `generate_org_user_on_org_create` legacy-rights audit failure remains

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app ownership assignment on insert (authorization-sensitive), but only activates existing trigger logic rather than new behavior.
> 
> **Overview**
> Wires the existing **`force_valid_user_id_on_app`** trigger onto **`public.apps`** **BEFORE INSERT**, so new rows no longer keep a caller-supplied **`user_id`**.
> 
> On insert, **`apps.user_id`** is overwritten from the owning org’s **`created_by`** (via **`owner_org`**). A pgTAP test inserts an app with a mismatched **`user_id`** and asserts it is corrected to the org creator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ceaee44e827f8ac4b000397746b116f7a4fc9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->