### PR TITLE
fix(types): remove duplicate social username fields

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -3329,7 +3329,6 @@ export type Database = {
           email_preferences: Json
           enable_notifications: boolean
           first_name: string | null
-          discord_username: string | null
           format_locale: string | null
           github_username: string | null
           id: string
@@ -3348,7 +3347,6 @@ export type Database = {
           email_preferences?: Json
           enable_notifications?: boolean
           first_name?: string | null
-          discord_username?: string | null
           format_locale?: string | null
           github_username?: string | null
           id: string
@@ -3367,7 +3365,6 @@ export type Database = {
           email_preferences?: Json
           enable_notifications?: boolean
           first_name?: string | null
-          discord_username?: string | null
           format_locale?: string | null
           github_username?: string | null
           id?: string

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -3329,7 +3329,6 @@ export type Database = {
           email_preferences: Json
           enable_notifications: boolean
           first_name: string | null
-          discord_username: string | null
           format_locale: string | null
           github_username: string | null
           id: string
@@ -3348,7 +3347,6 @@ export type Database = {
           email_preferences?: Json
           enable_notifications?: boolean
           first_name?: string | null
-          discord_username?: string | null
           format_locale?: string | null
           github_username?: string | null
           id: string
@@ -3367,7 +3365,6 @@ export type Database = {
           email_preferences?: Json
           enable_notifications?: boolean
           first_name?: string | null
-          discord_username?: string | null
           format_locale?: string | null
           github_username?: string | null
           id?: string


### PR DESCRIPTION
## Summary

Removes duplicate discord_username fields from generated Supabase user types.

## Root cause

A merge duplicated the field in Row, Insert, and Update in both generated type files.

## Validation

- bun typecheck
- bun lint -- src/types/supabase.types.ts supabase/functions/_backend/utils/supabase.types.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated-type cleanup only; no schema, API, or application logic changes.
> 
> **Overview**
> Fixes a **merge artifact** in generated Supabase `users` types where `discord_username` appeared twice on **Row**, **Insert**, and **Update**.
> 
> The extra declaration after `first_name` is removed in both `src/types/supabase.types.ts` and `supabase/functions/_backend/utils/supabase.types.ts`, leaving a single `discord_username` per shape. **No database or runtime behavior changes**—only TypeScript correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5325351055820fc87cafc4c973e38017ebffa8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->