### PR TITLE
fix(dashboard): consolidate period selectors

### DIFF
--- a/src/components/dashboard/DeliveryLatencyPanel.vue
+++ b/src/components/dashboard/DeliveryLatencyPanel.vue
@@ -6,6 +6,7 @@ import { computed, ref, watch } from 'vue'
 import { Line } from 'vue-chartjs'
 import { useI18n } from 'vue-i18n'
 import IconTimer from '~icons/lucide/timer'
+import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
 import Spinner from '~/components/Spinner.vue'
 import { buildDemoUpdateDeliveryStats, useUpdateDeliveryStats } from '~/composables/useUpdateDeliveryStats'
 import { formatLocalDateShort } from '~/services/date'
@@ -18,7 +19,7 @@ const props = withDefaults(defineProps<{
   appId?: string
   orgId?: string
   forceDemo?: boolean
-  days?: PeriodDayOption
+  days?: number
   hidePeriodSelector?: boolean
 }>(), {
   appId: '',
@@ -31,8 +32,7 @@ Chart.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, L
 
 const { t } = useI18n()
 const localDays = ref<PeriodDayOption>(7)
-const days = computed<PeriodDayOption>(() => props.days ?? localDays.value)
-const periodDayOptions: PeriodDayOption[] = [1, 3, 7, 30]
+const days = computed(() => props.days ?? localDays.value)
 
 const { stats, statsLoading, statsError, fetchStats } = useUpdateDeliveryStats(() => ({
   scope: props.scope,
@@ -160,16 +160,6 @@ function formatCount(value: number | null | undefined) {
   return formatNumberValue(value ?? 0)
 }
 
-function periodButtonLabel(option: PeriodDayOption) {
-  if (option === 1)
-    return t('one-day')
-  if (option === 3)
-    return t('three-days')
-  if (option === 7)
-    return t('seven-days')
-  return t('thirty-days')
-}
-
 function selectPeriod(option: PeriodDayOption) {
   if (props.days !== undefined || localDays.value === option)
     return
@@ -207,22 +197,11 @@ watch(
           {{ t('update-delivery-latency-help') }}
         </p>
       </div>
-      <fieldset v-if="!hidePeriodSelector && props.days === undefined" class="d-join shrink-0">
-        <legend class="sr-only">
-          {{ t('selected-period') }}
-        </legend>
-        <button
-          v-for="option in periodDayOptions"
-          :key="option"
-          type="button"
-          :aria-pressed="days === option"
-          class="d-btn d-btn-sm d-join-item min-w-12"
-          :class="days === option ? 'd-btn-primary' : 'd-btn-outline'"
-          @click="selectPeriod(option)"
-        >
-          {{ periodButtonLabel(option) }}
-        </button>
-      </fieldset>
+      <PeriodDaySelector
+        v-if="!hidePeriodSelector && props.days === undefined"
+        :model-value="localDays"
+        @update:model-value="selectPeriod"
+      />
     </div>
 
     <div v-if="statsLoading && !forceDemo && !stats && !statsError" class="flex items-center justify-center h-64 bg-white border rounded-lg shadow-sm dark:bg-slate-800 border-slate-200 dark:border-slate-700">

--- a/src/components/dashboard/PeriodDaySelector.vue
+++ b/src/components/dashboard/PeriodDaySelector.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export type PeriodDayOption = 1 | 3 | 7 | 30
+
+const props = withDefaults(defineProps<{
+  modelValue: PeriodDayOption
+  labels?: Partial<Record<PeriodDayOption, string>>
+}>(), {
+  labels: () => ({}),
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: PeriodDayOption]
+}>()
+
+const { t } = useI18n()
+const options: PeriodDayOption[] = [1, 3, 7, 30]
+const defaultLabels: Record<PeriodDayOption, string> = {
+  1: 'one-day',
+  3: 'three-days',
+  7: 'seven-days',
+  30: 'thirty-days',
+}
+
+const selectedLabel = computed(() => props.labels[props.modelValue] ?? defaultLabels[props.modelValue])
+
+function select(option: PeriodDayOption) {
+  if (option !== props.modelValue)
+    emit('update:modelValue', option)
+}
+</script>
+
+<template>
+  <fieldset class="d-join shrink-0">
+    <legend class="sr-only">
+      {{ t('selected-period') }}: {{ t(selectedLabel) }}
+    </legend>
+    <button
+      v-for="option in options"
+      :key="option"
+      type="button"
+      :aria-pressed="modelValue === option"
+      class="d-btn d-btn-sm d-join-item min-w-12"
+      :class="modelValue === option ? 'd-btn-primary' : 'd-btn-outline'"
+      @click="select(option)"
+    >
+      {{ t(labels[option] ?? defaultLabels[option]) }}
+    </button>
+  </fieldset>
+</template>

--- a/src/components/dashboard/PeriodDaySelector.vue
+++ b/src/components/dashboard/PeriodDaySelector.vue
@@ -41,12 +41,12 @@ function select(option: PeriodDayOption) {
       v-for="option in options"
       :key="option"
       type="button"
-      :aria-pressed="modelValue === option"
+      :aria-pressed="props.modelValue === option"
       class="d-btn d-btn-sm d-join-item min-w-12"
-      :class="modelValue === option ? 'd-btn-primary' : 'd-btn-outline'"
+      :class="props.modelValue === option ? 'd-btn-primary' : 'd-btn-outline'"
       @click="select(option)"
     >
-      {{ t(labels[option] ?? defaultLabels[option]) }}
+      {{ t(props.labels[option] ?? defaultLabels[option]) }}
     </button>
   </fieldset>
 </template>

--- a/src/composables/useUpdateDeliveryStats.ts
+++ b/src/composables/useUpdateDeliveryStats.ts
@@ -10,7 +10,7 @@ export interface UpdateDeliveryStatsResponse {
   scope: UpdateDeliveryScope
   labels: string[]
   period: {
-    requested_days: 1 | 3 | 7 | 30
+    requested_days: number
     actual_days: number
     start: string
     end: string
@@ -37,7 +37,7 @@ export function useUpdateDeliveryStats(
     scope: UpdateDeliveryScope
     app_id?: string
     org_id?: string
-    days: 1 | 3 | 7 | 30
+    days: number
   },
   logContext = 'update delivery stats',
 ) {
@@ -122,7 +122,7 @@ export function useUpdateDeliveryStats(
   return { stats, statsLoading, statsError, fetchStats }
 }
 
-export function buildDemoUpdateDeliveryStats(days: 1 | 3 | 7 | 30): UpdateDeliveryStatsResponse {
+export function buildDemoUpdateDeliveryStats(days: number): UpdateDeliveryStatsResponse {
   const labels: string[] = []
   const end = new Date()
   for (let i = days - 1; i >= 0; i -= 1) {

--- a/src/pages/admin/dashboard/updates.vue
+++ b/src/pages/admin/dashboard/updates.vue
@@ -49,6 +49,10 @@ const globalStatsTrendData = ref<Array<{
 }>>([])
 
 const isLoadingGlobalStatsTrend = ref(false)
+const deliveryLatencyDays = computed(() => {
+  const { start, end } = adminStore.activeDateRange
+  return Math.max(1, Math.min(365, Math.ceil((end.getTime() - start.getTime()) / 86_400_000)))
+})
 
 async function loadGlobalStatsTrend() {
   isLoadingGlobalStatsTrend.value = true
@@ -292,7 +296,7 @@ displayStore.defaultBack = '/dashboard'
             </ChartCard>
           </div>
 
-          <DeliveryLatencyPanel scope="platform" />
+          <DeliveryLatencyPanel scope="platform" :days="deliveryLatencyDays" hide-period-selector />
         </div>
       </div>
     </div>

--- a/src/pages/app/[app].channel.[channel].statistics.vue
+++ b/src/pages/app/[app].channel.[channel].statistics.vue
@@ -12,6 +12,7 @@ import IconAlertCircle from '~icons/lucide/alert-circle'
 import IconAlertTriangle from '~icons/lucide/alert-triangle'
 import IconCheckCircle from '~icons/lucide/check-circle'
 import IconTrendingUp from '~icons/lucide/trending-up'
+import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
 import { createTooltipConfig } from '~/services/chartTooltip'
 import { formatDistanceToNow, formatLocalDate, formatLocalDateShort } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
@@ -112,7 +113,6 @@ const statsLoading = ref(true)
 const channel = ref<Database['public']['Tables']['channels']['Row'] & Channel>()
 type PeriodDayOption = 1 | 3 | 7 | 30
 const days = ref<PeriodDayOption>(30)
-const periodDayOptions: PeriodDayOption[] = [1, 3, 7, 30]
 const stats = ref<ChannelStatsResponse | null>(null)
 const bundleIdCache = ref<Record<string, number>>({})
 let latestStatsRequest = 0
@@ -230,17 +230,6 @@ const currentVersionDataset = computed(() => {
   return stats.value.datasets.find(dataset => dataset.label === stats.value?.currentVersion) ?? null
 })
 
-function periodButtonLabel(option: PeriodDayOption) {
-  if (option === 1)
-    return t('one-day')
-  if (option === 3)
-    return t('three-days')
-  if (option === 7)
-    return t('seven-days')
-  if (option === 30)
-    return t('max-period')
-  return t('max-period')
-}
 const selectedPeriodLabel = computed(() => {
   if (days.value === 1)
     return t('last-one-day')
@@ -596,29 +585,11 @@ watchEffect(async () => {
               {{ t('selected-period-applies-to-stats') }}
             </p>
           </div>
-          <div class="d-join shrink-0" role="group" :aria-label="t('selected-period')">
-            <button
-              v-for="d in periodDayOptions"
-              :key="d"
-              type="button"
-              :aria-describedby="d === 30 ? 'max-period-tooltip' : undefined"
-              :aria-pressed="days === d"
-              class="relative overflow-visible d-btn d-btn-sm d-join-item min-w-12 border-slate-500 bg-transparent text-slate-300 group hover:border-slate-400 hover:bg-slate-800 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-azure-500"
-              :class="days === d ? '!border-slate-200 !bg-slate-600 text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12)] hover:!bg-slate-500' : ''"
-              @click="selectPeriod(d)"
-            >
-              {{ periodButtonLabel(d) }}
-              <span
-                v-if="d === 30"
-                id="max-period-tooltip"
-                role="tooltip"
-                class="invisible absolute right-0 top-full z-50 mt-2 w-64 px-3 py-2 text-xs font-normal leading-relaxed text-left text-white normal-case transition-opacity bg-gray-900 rounded-lg shadow-lg opacity-0 pointer-events-none dark:bg-gray-700 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
-              >
-                {{ t('max-period-tooltip') }}
-                <span class="absolute bottom-full w-0 h-0 border-4 border-transparent right-4 border-b-gray-900 dark:border-b-gray-700" />
-              </span>
-            </button>
-          </div>
+          <PeriodDaySelector
+            :model-value="days"
+            :labels="{ 30: 'max-period' }"
+            @update:model-value="selectPeriod"
+          />
         </div>
 
         <!-- Selected Period Adoption Status -->

--- a/src/pages/app/[app].logs.insights.vue
+++ b/src/pages/app/[app].logs.insights.vue
@@ -10,6 +10,7 @@ import IconBug from '~icons/lucide/bug'
 import IconExternalLink from '~icons/lucide/external-link'
 import IconLayers from '~icons/lucide/layers'
 import IconSmartphone from '~icons/lucide/smartphone'
+import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
 import { formatLocalDateShort, formatLocalDateTime } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { actionToFilter } from '~/services/statsActions'
@@ -82,7 +83,6 @@ const lastPath = ref('')
 const isLoading = ref(false)
 const insightsLoading = ref(false)
 const selectedDays = ref<PeriodDayOption>(7)
-const periodDayOptions: PeriodDayOption[] = [1, 3, 7, 30]
 const app = ref<Database['public']['Tables']['apps']['Row']>()
 const insights = ref<LogInsightsResponse | null>(null)
 let latestInsightsRequest = 0
@@ -146,16 +146,6 @@ function formatCount(value: number | null | undefined) {
 
 function formatPercent(value: number | null | undefined) {
   return `${formatNumberValue(value ?? 0, { maximumFractionDigits: 1 })}%`
-}
-
-function periodButtonLabel(option: PeriodDayOption) {
-  if (option === 1)
-    return t('one-day')
-  if (option === 3)
-    return t('three-days')
-  if (option === 7)
-    return t('seven-days')
-  return t('30-days')
 }
 
 function formatLastSeen(value: string | null | undefined) {
@@ -289,22 +279,7 @@ watchEffect(async () => {
               {{ t('log-insights-period-help') }}
             </p>
           </div>
-          <fieldset class="d-join shrink-0">
-            <legend class="sr-only">
-              {{ t('selected-period') }}
-            </legend>
-            <button
-              v-for="option in periodDayOptions"
-              :key="option"
-              type="button"
-              :aria-pressed="selectedDays === option"
-              class="d-btn d-btn-sm d-join-item min-w-12"
-              :class="selectedDays === option ? 'd-btn-primary' : 'd-btn-outline'"
-              @click="selectPeriod(option)"
-            >
-              {{ periodButtonLabel(option) }}
-            </button>
-          </fieldset>
+          <PeriodDaySelector :model-value="selectedDays" @update:model-value="selectPeriod" />
         </div>
 
         <div

--- a/src/pages/app/[app].observe.vue
+++ b/src/pages/app/[app].observe.vue
@@ -11,6 +11,7 @@ import IconExternalLink from '~icons/lucide/external-link'
 import IconRocket from '~icons/lucide/rocket'
 import IconTimer from '~icons/lucide/timer'
 import DeliveryLatencyPanel from '~/components/dashboard/DeliveryLatencyPanel.vue'
+import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
 import { useNativeObserveStats } from '~/composables/useNativeObserveStats'
 import { formatLocalDateShort } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
@@ -90,7 +91,6 @@ const packageId = computed(() => {
 })
 const appRouteSegment = computed(() => route.path.match(/^\/app\/([^/]+)/)?.[1] ?? encodeURIComponent(packageId.value))
 const days = ref<PeriodDayOption>(7)
-const periodDayOptions: PeriodDayOption[] = [1, 3, 7, 30]
 const { stats, statsLoading, fetchStats } = useNativeObserveStats<NativeObserveStatsResponse>(
   packageId,
   () => ({ days: days.value }),
@@ -229,16 +229,6 @@ const eventChartOptions = computed<ChartOptions<'bar'>>(() => ({
   },
 }))
 
-function periodButtonLabel(option: PeriodDayOption) {
-  if (option === 1)
-    return t('one-day')
-  if (option === 3)
-    return t('three-days')
-  if (option === 7)
-    return t('seven-days')
-  return t('thirty-days')
-}
-
 function formatShortDate(value: string | null | undefined) {
   if (!value)
     return '-'
@@ -314,22 +304,7 @@ watch([packageId, days], async () => {
             {{ observeScopeLabel }}
           </p>
         </div>
-        <fieldset class="d-join shrink-0">
-          <legend class="sr-only">
-            {{ t('selected-period') }}
-          </legend>
-          <button
-            v-for="option in periodDayOptions"
-            :key="option"
-            type="button"
-            :aria-pressed="days === option"
-            class="d-btn d-btn-sm d-join-item min-w-12"
-            :class="days === option ? 'd-btn-primary' : 'd-btn-outline'"
-            @click="selectPeriod(option)"
-          >
-            {{ periodButtonLabel(option) }}
-          </button>
-        </fieldset>
+        <PeriodDaySelector :model-value="days" @update:model-value="selectPeriod" />
       </div>
 
       <div v-if="statsLoading && !stats" class="flex items-center justify-center h-80">

--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -11,8 +11,8 @@ import { supabaseClient as useSupabaseClient } from '../utils/supabase.ts'
 
 dayjs.extend(utc)
 
-const supportedPeriodDays = [1, 3, 7, 30] as const
-type UpdateDeliveryPeriodDays = typeof supportedPeriodDays[number]
+const maxPeriodDays = 365
+type UpdateDeliveryPeriodDays = number
 type UpdateDeliveryScope = 'app' | 'org' | 'platform'
 
 interface UpdateDeliveryStatsRequest {
@@ -194,7 +194,7 @@ SELECT
 }
 
 function normalizePeriodDays(days: number | undefined = 7): UpdateDeliveryPeriodDays | null {
-  if (!Number.isInteger(days) || !supportedPeriodDays.includes(days as UpdateDeliveryPeriodDays))
+  if (!Number.isInteger(days) || days < 1 || days > maxPeriodDays)
     return null
   return days as UpdateDeliveryPeriodDays
 }
@@ -379,7 +379,7 @@ app.post('/', middlewareAuth, async (c) => {
 
   const days = normalizePeriodDays(body.days)
   if (!days)
-    throw simpleError('invalid_days', 'days must be one of 1, 3, 7, or 30')
+    throw simpleError('invalid_days', `days must be an integer from 1 to ${maxPeriodDays}`)
 
   if (scope === 'platform') {
     await assertPlatformAdmin(c)

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { updateDeliveryStatsTestUtils } from '../supabase/functions/_backend/private/update_delivery_stats.ts'
 
 describe('update delivery stats helpers', () => {
-  it.concurrent('normalizes supported period presets', () => {
+  it.concurrent('normalizes bounded period days', () => {
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(undefined)).toBe(7)
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(1)).toBe(1)
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(3)).toBe(3)
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(7)).toBe(7)
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(30)).toBe(30)
-    expect(updateDeliveryStatsTestUtils.normalizePeriodDays(2)).toBeNull()
+    expect(updateDeliveryStatsTestUtils.normalizePeriodDays(2)).toBe(2)
+    expect(updateDeliveryStatsTestUtils.normalizePeriodDays(365)).toBe(365)
+    expect(updateDeliveryStatsTestUtils.normalizePeriodDays(0)).toBeNull()
+    expect(updateDeliveryStatsTestUtils.normalizePeriodDays(366)).toBeNull()
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(7.5)).toBeNull()
   })
 


### PR DESCRIPTION
## Summary
- use one shared period selector across dashboard and app analytics surfaces
- remove the duplicate selector from Admin Updates and bind delivery latency to the page range
- allow delivery latency to use the bounded admin date range

## Validation
- changed-file ESLint passed
- focused Vitest and full local typecheck are blocked by the local environment (missing Vitest modules / typecheck process killed); GitHub CI will be followed through

## Visual
- screenshot will be attached after the local preview is available

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Backend stats queries can scan up to 365 days of data (load/performance), and channel statistics drops its custom period control styling and 30-day tooltip when switching to the shared component.
> 
> **Overview**
> Introduces a shared **`PeriodDaySelector`** (1/3/7/30 presets, optional label overrides) and replaces duplicated period button groups on **DeliveryLatencyPanel**, channel statistics, log insights, and native observe.
> 
> **Admin Updates** no longer shows a separate latency period control: platform **delivery latency** follows **`adminStore.activeDateRange`** via a computed day count (clamped 1–365) with **`hide-period-selector`**.
> 
> **Update delivery stats** API and **`useUpdateDeliveryStats`** now accept any integer **`days`** from 1–365 instead of only 1, 3, 7, or 30, with unit tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02c9d53baf96d4938a0a2dab2c486e664e85320b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->