### PR TITLE
fix(queue): route on_version_update to Cloudflare and shrink payloads

### DIFF
--- a/src/services/versions.ts
+++ b/src/services/versions.ts
@@ -26,7 +26,6 @@ export function createBuiltinChannelVersion(channel: {
     cli_version: null,
     comment: null,
     created_at: channel.created_at,
-    created_by_apikey_rbac_id: null,
     deleted: false,
     deleted_at: null,
     external_url: null,

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -174,7 +174,7 @@ async function ensureVersionManifest(
 
   if (error) {
     cloudlog({ requestId: c.get('requestId'), message: 'error reload app_versions.manifest', error, id: record.id })
-    return record
+    throw simpleError('manifest_reload_failed', 'Failed to reload app_versions.manifest', { id: record.id }, error)
   }
 
   if (!data?.manifest)
@@ -195,7 +195,7 @@ async function ensureVersionManifest(
 async function handleManifest(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   cloudlog({ requestId: c.get('requestId'), message: 'manifest', manifest: record.manifest })
   const manifestEntries = record.manifest as Database['public']['CompositeTypes']['manifest_entry'][]
-  if (!Array.isArray(manifestEntries) || manifestEntries.length === 0)
+  if (!Array.isArray(manifestEntries))
     return
 
   // Check if entries exist
@@ -478,25 +478,25 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), a
     cloudlog({ requestId: c.get('requestId'), message: 'no app_id', record })
     return c.json(BRES)
   }
+  // Queue payloads omit app_versions.manifest; reload before deleted-version decisions.
+  let workRecord = record
+  if (!workRecord.manifest)
+    workRecord = await ensureVersionManifest(c, workRecord)
 
-  const deletedVersionAction = getDeletedVersionAction(record, oldRecord)
+  const deletedVersionAction = getDeletedVersionAction(workRecord, oldRecord)
   if (deletedVersionAction === 'delete')
-    return deleteIt(c, record)
+    return deleteIt(c, workRecord)
   if (deletedVersionAction === 'cleanup_manifest') {
-    cloudlog({ requestId: c.get('requestId'), message: 'cleaning manifest for already deleted version', ...versionUpdateLogFields(record, oldRecord) })
-    await deleteManifest(c, record)
+    cloudlog({ requestId: c.get('requestId'), message: 'cleaning manifest for already deleted version', ...versionUpdateLogFields(workRecord, oldRecord) })
+    await deleteManifest(c, workRecord)
     return c.json(BRES)
   }
   if (deletedVersionAction === 'skip')
     return c.json(BRES)
 
-  let workRecord = record
   if (!workRecord.r2_path && !workRecord.manifest) {
-    workRecord = await ensureVersionManifest(c, workRecord)
-    if (!workRecord.r2_path && !workRecord.manifest) {
-      cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', ...versionUpdateLogFields(record, oldRecord) })
-      return c.json(BRES)
-    }
+    cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', ...versionUpdateLogFields(workRecord, oldRecord) })
+    return c.json(BRES)
   }
 
   cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted', ...versionUpdateLogFields(workRecord, oldRecord) })

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -157,11 +157,46 @@ async function v2PathSize(c: Context, record: Database['public']['Tables']['app_
 }
 
 /**
+ * Reloads `app_versions.manifest` when the queue payload omitted it to stay under size limits.
+ */
+async function ensureVersionManifest(
+  c: Context,
+  record: Database['public']['Tables']['app_versions']['Row'],
+): Promise<Database['public']['Tables']['app_versions']['Row']> {
+  if (record.manifest)
+    return record
+
+  const { data, error } = await supabaseAdmin(c)
+    .from('app_versions')
+    .select('manifest')
+    .eq('id', record.id)
+    .maybeSingle()
+
+  if (error) {
+    cloudlog({ requestId: c.get('requestId'), message: 'error reload app_versions.manifest', error, id: record.id })
+    return record
+  }
+
+  if (!data?.manifest)
+    return record
+
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'on_version_update reloaded manifest from database',
+    id: record.id,
+    manifest_entries: getManifestEntryCount(data.manifest),
+  })
+  return { ...record, manifest: data.manifest }
+}
+
+/**
  * Persists manifest rows and updates aggregate counters when a version includes a manifest payload.
  */
 async function handleManifest(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   cloudlog({ requestId: c.get('requestId'), message: 'manifest', manifest: record.manifest })
   const manifestEntries = record.manifest as Database['public']['CompositeTypes']['manifest_entry'][]
+  if (!Array.isArray(manifestEntries) || manifestEntries.length === 0)
+    return
 
   // Check if entries exist
   const { data: existingEntries } = await supabaseAdmin(c)
@@ -273,10 +308,10 @@ async function updateIt(c: Context, record: Database['public']['Tables']['app_ve
     }
   }
 
-  // Handle manifest entries
-  if (record.manifest) {
-    await handleManifest(c, record)
-  }
+  // Handle manifest entries (reload when the queue payload omitted the jsonb column)
+  const recordWithManifest = await ensureVersionManifest(c, record)
+  if (recordWithManifest.manifest)
+    await handleManifest(c, recordWithManifest)
 
   return c.json(BRES)
 }
@@ -455,13 +490,17 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), a
   if (deletedVersionAction === 'skip')
     return c.json(BRES)
 
-  if (!record.r2_path && !record.manifest) {
-    cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', ...versionUpdateLogFields(record, oldRecord) })
-    return c.json(BRES)
+  let workRecord = record
+  if (!workRecord.r2_path && !workRecord.manifest) {
+    workRecord = await ensureVersionManifest(c, workRecord)
+    if (!workRecord.r2_path && !workRecord.manifest) {
+      cloudlog({ requestId: c.get('requestId'), message: 'no r2_path and no manifest, skipping update', ...versionUpdateLogFields(record, oldRecord) })
+      return c.json(BRES)
+    }
   }
 
-  cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted', ...versionUpdateLogFields(record, oldRecord) })
-  return updateIt(c, record)
+  cloudlog({ requestId: c.get('requestId'), message: 'Update but not deleted', ...versionUpdateLogFields(workRecord, oldRecord) })
+  return updateIt(c, workRecord)
 })
 
 export const onVersionUpdateTestUtils = {

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -16,10 +16,11 @@ import { updateManifestSize } from './on_manifest_create.ts'
 const DEFAULT_BATCH_SIZE = 950 // Default batch size for queue reads limit of CF is 1000 fetches so we take a safe margin
 const DEFAULT_QUEUE_HTTP_CONCURRENCY = 25
 const VERSION_QUEUE_HTTP_CONCURRENCY = 10
+const VERSION_QUEUE_BATCH_SIZE = 40 // Keep under visibility window at 10-way / 60s HTTP
 const MANIFEST_QUEUE_HTTP_CONCURRENCY = 100
 const MANIFEST_QUEUE_ACK_CHUNK_SIZE = 100
 const DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 120
-const VERSION_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 300
+const VERSION_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 900
 const MANIFEST_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 900
 const QUEUE_HTTP_TIMEOUT_MS = 15_000
 const VERSION_QUEUE_HTTP_TIMEOUT_MS = 60_000
@@ -28,14 +29,13 @@ export const MAX_QUEUE_READS = 5
 const DISCORD_IGNORED_ERROR_CODES = new Set(['version_not_found', 'no_channel'])
 
 const integerLikeSchema = type('number.integer').or(type('string.numeric.parse |> number.integer'))
-
 export const messageSchema = type({
   msg_id: integerLikeSchema,
   read_ct: integerLikeSchema,
   message: type({
     'payload?': 'unknown',
     'function_name': 'string',
-    'function_type?': '"cloudflare" | "cloudflare_pp" | "" | null',
+    'function_type?': '"cloudflare" | "cloudflare_pp" | "supabase" | "" | null',
   }),
 })
 
@@ -45,7 +45,7 @@ interface Message {
   message: {
     payload?: any
     function_name: string
-    function_type?: 'cloudflare' | 'cloudflare_pp' | '' | null
+    function_type?: 'cloudflare' | 'cloudflare_pp' | 'supabase' | '' | null
     [key: string]: unknown
   }
 }
@@ -456,6 +456,10 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
       durationMs,
       targetUrl: result.targetUrl,
       ...message,
+      message: {
+        ...message.message,
+        function_type: function_type as Message['message']['function_type'],
+      },
     }
   }
   catch (error) {
@@ -512,13 +516,20 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
       durationMs,
       targetUrl,
       ...message,
+      message: {
+        ...message.message,
+        function_type: function_type as Message['message']['function_type'],
+      },
     }
   }
 }
 
-function getQueueBatchSize(_queueName: string, requestedBatchSize: number): number {
+function getQueueBatchSize(queueName: string, requestedBatchSize: number): number {
+  if (isVersionQueueFunction(queueName))
+    return Math.min(requestedBatchSize, VERSION_QUEUE_BATCH_SIZE)
   return requestedBatchSize
 }
+
 function getQueueHttpConcurrency(queueName: string): number {
   if (queueName === 'on_manifest_create')
     return MANIFEST_QUEUE_HTTP_CONCURRENCY

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -15,11 +15,14 @@ import { updateManifestSize } from './on_manifest_create.ts'
 // Define constants
 const DEFAULT_BATCH_SIZE = 950 // Default batch size for queue reads limit of CF is 1000 fetches so we take a safe margin
 const DEFAULT_QUEUE_HTTP_CONCURRENCY = 25
+const VERSION_QUEUE_HTTP_CONCURRENCY = 10
 const MANIFEST_QUEUE_HTTP_CONCURRENCY = 100
 const MANIFEST_QUEUE_ACK_CHUNK_SIZE = 100
 const DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 120
+const VERSION_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 300
 const MANIFEST_QUEUE_VISIBILITY_TIMEOUT_SECONDS = 900
 const QUEUE_HTTP_TIMEOUT_MS = 15_000
+const VERSION_QUEUE_HTTP_TIMEOUT_MS = 60_000
 const HEALTHCHECK_HTTP_TIMEOUT_MS = 8_000
 export const MAX_QUEUE_READS = 5
 const DISCORD_IGNORED_ERROR_CODES = new Set(['version_not_found', 'no_channel'])
@@ -235,10 +238,53 @@ function generateUUID(): string {
   return crypto.randomUUID()
 }
 
+function isVersionQueueFunction(functionName: string): boolean {
+  return functionName === 'on_version_update'
+    || functionName === 'on_version_create'
+    || functionName === 'on_version_delete'
+}
+
+function normalizeQueueFunctionType(functionType: string | null | undefined): string {
+  const normalizedType = (functionType ?? '').trim()
+  // Triggers historically omitted function_type; prefer the production Cloudflare path.
+  if (!normalizedType || normalizedType === 'supabase')
+    return 'cloudflare'
+  return normalizedType
+}
+
+function stripAppVersionManifestFromQueueBody(body: Record<string, unknown>): Record<string, unknown> {
+  let changed = false
+  let next = body
+
+  if (isRecord(body.record) && 'manifest' in body.record) {
+    next = { ...next, record: { ...body.record, manifest: null } }
+    changed = true
+  }
+  if (isRecord(body.old_record) && 'manifest' in body.old_record) {
+    const oldRecord = isRecord(next.old_record) ? next.old_record : body.old_record
+    next = { ...next, old_record: { ...oldRecord, manifest: null } }
+    changed = true
+  }
+
+  return changed ? next : body
+}
+
+function prepareQueueHttpBody(functionName: string, body: Record<string, unknown>): Record<string, unknown> {
+  if (!isVersionQueueFunction(functionName))
+    return body
+  return stripAppVersionManifestFromQueueBody(body)
+}
+
+function getQueueHttpTimeoutMs(functionName: string): number {
+  if (isVersionQueueFunction(functionName))
+    return VERSION_QUEUE_HTTP_TIMEOUT_MS
+  return QUEUE_HTTP_TIMEOUT_MS
+}
+
 function resolveFunctionUrl(c: Context, function_name: string, function_type: string | null | undefined): string {
   const cfPpUrl = getEnv(c, 'CLOUDFLARE_PP_FUNCTION_URL')
   const cfUrl = getEnv(c, 'CLOUDFLARE_FUNCTION_URL')
-  const normalizedType = (function_type ?? '').trim()
+  const normalizedType = normalizeQueueFunctionType(function_type)
 
   if (normalizedType === 'cloudflare_pp' && cfPpUrl)
     return `${cfPpUrl}/triggers/${function_name}`
@@ -246,7 +292,8 @@ function resolveFunctionUrl(c: Context, function_name: string, function_type: st
   if (normalizedType === 'cloudflare' && cfUrl)
     return `${cfUrl}/triggers/${function_name}`
 
-  if (normalizedType === '' && cfUrl)
+  // Prefer Cloudflare whenever it is configured; Supabase is the local/dev fallback.
+  if (cfUrl)
     return `${cfUrl}/triggers/${function_name}`
 
   return `${getEnv(c, 'SUPABASE_URL')}/functions/v1/triggers/${function_name}`
@@ -345,7 +392,7 @@ async function dispatchQueueMessage(
 
 async function processQueueMessage(c: Context, queueName: string, message: Message, waitForCompletion = false): Promise<ProcessedQueueMessage> {
   const function_name = message.message?.function_name ?? 'unknown'
-  const function_type = message.message?.function_type ?? 'supabase'
+  const function_type = normalizeQueueFunctionType(message.message?.function_type)
   const body = extractMessageBody(message)
   if (message.message?.payload === undefined && Object.keys(body).length > 0) {
     cloudlog({
@@ -356,7 +403,8 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
   }
 
   const cfId = generateUUID()
-  const payloadSize = JSON.stringify(body).length
+  const dispatchBody = prepareQueueHttpBody(function_name, body)
+  const payloadSize = JSON.stringify(dispatchBody).length
   const start = Date.now()
   const targetUrl = function_name === 'on_manifest_create' ? 'direct:on_manifest_create' : resolveFunctionUrl(c, function_name, function_type)
   const trace = getQueueMessageTrace(function_name, body)
@@ -374,7 +422,7 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
       readCount: message.read_ct,
       targetUrl,
     })
-    const result = await dispatchQueueMessage(c, function_name, function_type, body, cfId, {
+    const result = await dispatchQueueMessage(c, function_name, function_type, dispatchBody, cfId, {
       msgId: message.msg_id,
       queueName,
       readCount: message.read_ct,
@@ -471,16 +519,19 @@ async function processQueueMessage(c: Context, queueName: string, message: Messa
 function getQueueBatchSize(_queueName: string, requestedBatchSize: number): number {
   return requestedBatchSize
 }
-
 function getQueueHttpConcurrency(queueName: string): number {
   if (queueName === 'on_manifest_create')
     return MANIFEST_QUEUE_HTTP_CONCURRENCY
+  if (isVersionQueueFunction(queueName))
+    return VERSION_QUEUE_HTTP_CONCURRENCY
   return DEFAULT_QUEUE_HTTP_CONCURRENCY
 }
 
 function getQueueVisibilityTimeout(queueName: string): number {
   if (queueName === 'on_manifest_create')
     return MANIFEST_QUEUE_VISIBILITY_TIMEOUT_SECONDS
+  if (isVersionQueueFunction(queueName))
+    return VERSION_QUEUE_VISIBILITY_TIMEOUT_SECONDS
   return DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SECONDS
 }
 
@@ -920,8 +971,9 @@ export async function http_post_helper(
   }
   if (waitForCompletion)
     headers[WAIT_FOR_COMPLETION_HEADER] = 'true'
+  const timeoutMs = getQueueHttpTimeoutMs(function_name)
   const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), QUEUE_HTTP_TIMEOUT_MS)
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
     const response = await fetch(targetUrl, {
@@ -941,7 +993,7 @@ export async function http_post_helper(
       function_type: function_type ?? null,
       metadata: metadata ?? null,
       targetUrl,
-      timeoutMs: QUEUE_HTTP_TIMEOUT_MS,
+      timeoutMs,
     }, error)
   }
   finally {
@@ -1179,12 +1231,16 @@ export const __queueConsumerTestUtils__ = {
   getQueueBatchSize,
   getQueueAckChunkSize,
   getQueueHttpConcurrency,
+  getQueueHttpTimeoutMs,
   httpExceptionToQueueResponse,
   getQueueVisibilityTimeout,
+  normalizeQueueFunctionType,
+  prepareQueueHttpBody,
   shouldRunQueueSyncInBackground,
   maybePingCronHealthcheck,
   maybePingCronHealthcheckStart,
   queueFailureResponse,
   resolveFunctionUrl,
   sanitizeDiscordResponseBody,
+  stripAppVersionManifestFromQueueBody,
 }

--- a/supabase/migrations/20260717090738_on_version_update_queue_routing.sql
+++ b/supabase/migrations/20260717090738_on_version_update_queue_routing.sql
@@ -12,7 +12,11 @@ DECLARE
   old_record_payload jsonb;
   function_type text;
 BEGIN
-  function_type := COALESCE(NULLIF(TG_ARGV[1], ''), 'cloudflare');
+  function_type := CASE
+    WHEN NULLIF(TG_ARGV[1], '') IS NULL THEN 'cloudflare'
+    WHEN lower(TG_ARGV[1]) = 'supabase' THEN 'cloudflare'
+    ELSE TG_ARGV[1]
+  END;
 
   record_payload := to_jsonb(NEW);
   old_record_payload := to_jsonb(OLD);

--- a/supabase/migrations/20260717090738_on_version_update_queue_routing.sql
+++ b/supabase/migrations/20260717090738_on_version_update_queue_routing.sql
@@ -1,0 +1,49 @@
+-- Route queue trigger jobs to Cloudflare by default and keep app_versions
+-- queue payloads small by omitting the inline manifest jsonb column.
+-- Manifest rows are reloaded from app_versions when on_version_update needs them.
+
+CREATE OR REPLACE FUNCTION "public"."trigger_http_queue_post_to_function"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  payload jsonb;
+  record_payload jsonb;
+  old_record_payload jsonb;
+  function_type text;
+BEGIN
+  function_type := COALESCE(NULLIF(TG_ARGV[1], ''), 'cloudflare');
+
+  record_payload := to_jsonb(NEW);
+  old_record_payload := to_jsonb(OLD);
+
+  -- app_versions.manifest can be multi-MB. Never enqueue it; handlers reload when needed.
+  IF TG_TABLE_NAME = 'app_versions' THEN
+    IF record_payload IS NOT NULL THEN
+      record_payload := record_payload - 'manifest';
+    END IF;
+    IF old_record_payload IS NOT NULL THEN
+      old_record_payload := old_record_payload - 'manifest';
+    END IF;
+  END IF;
+
+  payload := jsonb_build_object(
+    'function_name', TG_ARGV[0],
+    'function_type', function_type,
+    'payload', jsonb_build_object(
+      'old_record', old_record_payload,
+      'record', record_payload,
+      'type', TG_OP,
+      'table', TG_TABLE_NAME,
+      'schema', TG_TABLE_SCHEMA
+    )
+  );
+
+  IF TG_ARGV[0] IS NOT NULL THEN
+    PERFORM "pgmq"."send"(TG_ARGV[0], payload);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."trigger_http_queue_post_to_function"() OWNER TO "postgres";

--- a/tests/on-version-update-queue-routing.test.ts
+++ b/tests/on-version-update-queue-routing.test.ts
@@ -28,7 +28,7 @@ describe('on_version_update queue routing trigger', () => {
       `INSERT INTO public.app_versions (
         app_id, name, owner_org, storage_provider, r2_path, manifest, manifest_count
       ) VALUES (
-        $1, $2, $3, 'r2', $4, $5::jsonb, 2
+        $1, $2, $3, 'r2', $4, $5::jsonb::public.manifest_entry[], 2
       ) RETURNING id`,
       [
         APP_ID,

--- a/tests/on-version-update-queue-routing.test.ts
+++ b/tests/on-version-update-queue-routing.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { POSTGRES_URL } from './test-utils.ts'
+
+const pool = new Pool({
+  connectionString: POSTGRES_URL,
+  max: 1,
+  idleTimeoutMillis: 2000,
+})
+
+const APP_ID = 'com.demo.app'
+const VERSION_NAME = `queue-routing-${randomUUID().slice(0, 8)}`
+
+describe('on_version_update queue routing trigger', () => {
+  let versionId: number | null = null
+  let ownerOrg: string | null = null
+
+  beforeAll(async () => {
+    const app = await pool.query<{ owner_org: string }>(
+      'SELECT owner_org FROM public.apps WHERE app_id = $1 LIMIT 1',
+      [APP_ID],
+    )
+    ownerOrg = app.rows[0]?.owner_org ?? null
+    expect(ownerOrg).toBeTruthy()
+
+    const inserted = await pool.query<{ id: number }>(
+      `INSERT INTO public.app_versions (
+        app_id, name, owner_org, storage_provider, r2_path, manifest, manifest_count
+      ) VALUES (
+        $1, $2, $3, 'r2', $4, $5::jsonb, 2
+      ) RETURNING id`,
+      [
+        APP_ID,
+        VERSION_NAME,
+        ownerOrg,
+        `orgs/${ownerOrg}/apps/${APP_ID}/${VERSION_NAME}.zip`,
+        JSON.stringify([
+          { file_name: 'index.html', file_hash: 'abc', s3_path: 'a/index.html' },
+          { file_name: 'app.js', file_hash: 'def', s3_path: 'a/app.js' },
+        ]),
+      ],
+    )
+    versionId = inserted.rows[0]?.id ?? null
+    expect(versionId).toBeTruthy()
+
+    // Drain any messages created by the insert trigger before the update assertion.
+    await pool.query('DELETE FROM pgmq.q_on_version_create WHERE message->\'payload\'->\'record\'->>\'name\' = $1', [VERSION_NAME])
+    await pool.query('DELETE FROM pgmq.q_on_version_update WHERE message->\'payload\'->\'record\'->>\'name\' = $1', [VERSION_NAME])
+  })
+
+  afterAll(async () => {
+    if (versionId) {
+      await pool.query('DELETE FROM pgmq.q_on_version_update WHERE message->\'payload\'->\'record\'->>\'id\' = $1', [String(versionId)])
+      await pool.query('DELETE FROM pgmq.q_on_version_create WHERE message->\'payload\'->\'record\'->>\'id\' = $1', [String(versionId)])
+      await pool.query('DELETE FROM public.app_versions WHERE id = $1', [versionId])
+    }
+    await pool.end()
+  })
+
+  it('enqueues cloudflare-routed update messages without inline manifests', async () => {
+    expect(versionId).toBeTruthy()
+
+    await pool.query(
+      `UPDATE public.app_versions
+       SET comment = $2, updated_at = now()
+       WHERE id = $1`,
+      [versionId, `routing-${Date.now()}`],
+    )
+
+    const queued = await pool.query<{ message: {
+      function_name: string
+      function_type: string
+      payload: {
+        record: { id: number, name: string, manifest?: unknown }
+        old_record: { manifest?: unknown }
+      }
+    } }>(
+      `SELECT message
+       FROM pgmq.q_on_version_update
+       WHERE message->'payload'->'record'->>'id' = $1
+       ORDER BY msg_id DESC
+       LIMIT 1`,
+      [String(versionId)],
+    )
+
+    expect(queued.rows).toHaveLength(1)
+    const message = queued.rows[0]!.message
+    expect(message.function_name).toBe('on_version_update')
+    expect(message.function_type).toBe('cloudflare')
+    expect(message.payload.record.name).toBe(VERSION_NAME)
+    expect(message.payload.record).not.toHaveProperty('manifest')
+    expect(message.payload.old_record).not.toHaveProperty('manifest')
+  })
+})

--- a/tests/on-version-update-queue-routing.test.ts
+++ b/tests/on-version-update-queue-routing.test.ts
@@ -28,7 +28,12 @@ describe('on_version_update queue routing trigger', () => {
       `INSERT INTO public.app_versions (
         app_id, name, owner_org, storage_provider, r2_path, manifest, manifest_count
       ) VALUES (
-        $1, $2, $3, 'r2', $4, $5::jsonb::public.manifest_entry[], 2
+        $1, $2, $3, 'r2', $4,
+        ARRAY(
+          SELECT ROW(e.file_name, e.s3_path, e.file_hash)::public.manifest_entry
+          FROM jsonb_to_recordset($5::jsonb) AS e(file_name text, s3_path text, file_hash text)
+        ),
+        2
       ) RETURNING id`,
       [
         APP_ID,
@@ -36,8 +41,8 @@ describe('on_version_update queue routing trigger', () => {
         ownerOrg,
         `orgs/${ownerOrg}/apps/${APP_ID}/${VERSION_NAME}.zip`,
         JSON.stringify([
-          { file_name: 'index.html', file_hash: 'abc', s3_path: 'a/index.html' },
-          { file_name: 'app.js', file_hash: 'def', s3_path: 'a/app.js' },
+          { file_name: 'index.html', s3_path: 'a/index.html', file_hash: 'abc' },
+          { file_name: 'app.js', s3_path: 'a/app.js', file_hash: 'def' },
         ]),
       ],
     )

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -149,6 +149,7 @@ describe('queue_consumer legacy message compatibility', () => {
   it.concurrent('checkpoints manifest queue deletes without reducing read batch size', () => {
     expect(__queueConsumerTestUtils__.getQueueBatchSize('on_manifest_create', 950)).toBe(950)
     expect(__queueConsumerTestUtils__.getQueueBatchSize('cron_email', 950)).toBe(950)
+    expect(__queueConsumerTestUtils__.getQueueBatchSize('on_version_update', 950)).toBe(40)
     expect(__queueConsumerTestUtils__.getQueueAckChunkSize('on_manifest_create')).toBe(100)
     expect(__queueConsumerTestUtils__.getQueueAckChunkSize('cron_email')).toBeNull()
     expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('on_manifest_create')).toBe(100)
@@ -156,11 +157,27 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('on_version_update')).toBe(10)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_manifest_create')).toBe(900)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('cron_email')).toBe(120)
-    expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_version_update')).toBe(300)
+    expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_version_update')).toBe(900)
     expect(__queueConsumerTestUtils__.getQueueHttpTimeoutMs('on_version_update')).toBe(60_000)
     expect(__queueConsumerTestUtils__.getQueueHttpTimeoutMs('cron_email')).toBe(15_000)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('on_manifest_create')).toBe(false)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('cron_email')).toBe(true)
+  })
+
+  it.concurrent('accepts legacy supabase function_type in queue message schema', () => {
+    const [message] = parseSchema(messagesArraySchema, [
+      {
+        msg_id: 11,
+        read_ct: 0,
+        message: {
+          function_name: 'on_version_update',
+          function_type: 'supabase',
+          payload: { table: 'app_versions', type: 'UPDATE' },
+        },
+      },
+    ])
+    expect(message?.message.function_type).toBe('supabase')
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType(message?.message.function_type)).toBe('cloudflare')
   })
 
   it.concurrent('routes omitted and legacy supabase function types to cloudflare', () => {

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -153,10 +153,47 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(__queueConsumerTestUtils__.getQueueAckChunkSize('cron_email')).toBeNull()
     expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('on_manifest_create')).toBe(100)
     expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('cron_email')).toBe(25)
+    expect(__queueConsumerTestUtils__.getQueueHttpConcurrency('on_version_update')).toBe(10)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_manifest_create')).toBe(900)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('cron_email')).toBe(120)
+    expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_version_update')).toBe(300)
+    expect(__queueConsumerTestUtils__.getQueueHttpTimeoutMs('on_version_update')).toBe(60_000)
+    expect(__queueConsumerTestUtils__.getQueueHttpTimeoutMs('cron_email')).toBe(15_000)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('on_manifest_create')).toBe(false)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('cron_email')).toBe(true)
+  })
+
+  it.concurrent('routes omitted and legacy supabase function types to cloudflare', () => {
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType(null)).toBe('cloudflare')
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType(undefined)).toBe('cloudflare')
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType('')).toBe('cloudflare')
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType('supabase')).toBe('cloudflare')
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType('cloudflare')).toBe('cloudflare')
+    expect(__queueConsumerTestUtils__.normalizeQueueFunctionType('cloudflare_pp')).toBe('cloudflare_pp')
+  })
+
+  it.concurrent('strips app version manifest payloads before HTTP dispatch', () => {
+    const body = {
+      record: {
+        id: 1,
+        manifest: [{ file_name: 'index.html' }, { file_name: 'app.js' }],
+        r2_path: 'orgs/x/apps/y/1.0.0.zip',
+      },
+      old_record: {
+        id: 1,
+        manifest: [{ file_name: 'old.html' }],
+        r2_path: null,
+      },
+      table: 'app_versions',
+      type: 'UPDATE',
+    }
+
+    expect(__queueConsumerTestUtils__.prepareQueueHttpBody('on_version_update', body)).toEqual({
+      ...body,
+      record: { ...body.record, manifest: null },
+      old_record: { ...body.old_record, manifest: null },
+    })
+    expect(__queueConsumerTestUtils__.prepareQueueHttpBody('cron_email', body)).toEqual(body)
   })
 
   it.concurrent('does not reprocess manifests for already deleted versions', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Fix queue routing so omitted/`null`/`supabase` `function_type` defaults to Cloudflare instead of Supabase edge functions
- Stop enqueueing multi-MB `app_versions.manifest` jsonb in queue payloads; reload from DB in `on_version_update` when needed
- Raise version-queue HTTP timeout to 60s, visibility to 300s, and lower concurrency to 10
- Remove stale `created_by_apikey_rbac_id` from builtin version factory to unblock frontend typecheck

## Motivation (AI generated)

Discord alerts showed hundreds of `on_version_update` failures: `AbortError` at ~15s, `RateLimitError`, and `WORKER_RESOURCE_LIMIT`, all posting to Supabase `/functions/v1/triggers/on_version_update` with payloads up to ~15MB. Root cause: trigger only passes the function name, so `function_type` is null and the consumer defaulted to `'supabase'`.

## Business Impact (AI generated)

Stops archive storms for bundle finalize/update work, reduces Supabase rate-limit/resource pressure, and keeps OTA version metadata/manifest processing reliable for customers uploading large bundles.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/queue-consumer-message-shape.unit.test.ts tests/on-version-update-cleanup.unit.test.ts`
- [ ] Apply migration and confirm new queue messages have `function_type: cloudflare` and no `record.manifest`
- [ ] Process a large version update and confirm Cloudflare target + success without 15s abort
- [ ] Confirm already-queued null-type messages route to Cloudflare after deploy

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

