### PR TITLE
feat: /data breakdowns by country, platform, version

### DIFF
--- a/src/services/versions.ts
+++ b/src/services/versions.ts
@@ -26,7 +26,6 @@ export function createBuiltinChannelVersion(channel: {
     cli_version: null,
     comment: null,
     created_at: channel.created_at,
-    created_by_apikey_rbac_id: null,
     deleted: false,
     deleted_at: null,
     external_url: null,

--- a/supabase/functions/_backend/private/public_stats.ts
+++ b/supabase/functions/_backend/private/public_stats.ts
@@ -21,6 +21,45 @@ type LiveUpdateMetricsResponse = PublicLiveUpdateMetrics & {
   updated_at: string
 }
 
+function sanitizePublicPercent(value: number) {
+  return Number(Number(value).toFixed(1))
+}
+
+function sanitizeBreakdown(rows: PublicLiveUpdateMetrics['platforms']) {
+  return rows.map(row => ({
+    key: row.key,
+    share: sanitizePublicPercent(row.share),
+    success_rate: row.success_rate === null || row.success_rate === undefined
+      ? null
+      : sanitizePublicPercent(row.success_rate),
+    top_failure: row.top_failure
+      ? {
+          reason: row.top_failure.reason,
+          share: sanitizePublicPercent(row.top_failure.share),
+        }
+      : null,
+  }))
+}
+
+/** Strip anything that is not a ratio/percent for the public /data page. */
+function sanitizePublicLiveUpdateMetrics(metrics: PublicLiveUpdateMetrics): PublicLiveUpdateMetrics {
+  return {
+    success_rate: sanitizePublicPercent(metrics.success_rate),
+    daily: metrics.daily.map(row => ({
+      date: row.date,
+      success_rate: sanitizePublicPercent(row.success_rate),
+    })),
+    failures: metrics.failures.map(row => ({
+      reason: row.reason,
+      share: sanitizePublicPercent(row.share),
+    })),
+    platforms: sanitizeBreakdown(metrics.platforms),
+    countries: sanitizeBreakdown(metrics.countries),
+    updater_versions: sanitizeBreakdown(metrics.updater_versions),
+  }
+}
+
+
 app.use('*', useCors)
 
 export function getLatestCompletedGlobalStatsDateId(referenceDate = new Date()) {
@@ -65,7 +104,7 @@ app.get('/live_updates', async (c) => {
 
   if (!response) {
     try {
-      const metrics = await getPublicLiveUpdateMetricsCF(c)
+      const metrics = sanitizePublicLiveUpdateMetrics(await getPublicLiveUpdateMetricsCF(c))
       response = {
         period_days: 30,
         updated_at: new Date().toISOString(),

--- a/supabase/functions/_backend/private/public_stats.ts
+++ b/supabase/functions/_backend/private/public_stats.ts
@@ -42,7 +42,7 @@ function sanitizeBreakdown(rows: PublicLiveUpdateMetrics['platforms']) {
 }
 
 /** Strip anything that is not a ratio/percent for the public /data page. */
-function sanitizePublicLiveUpdateMetrics(metrics: PublicLiveUpdateMetrics): PublicLiveUpdateMetrics {
+export function sanitizePublicLiveUpdateMetrics(metrics: PublicLiveUpdateMetrics): PublicLiveUpdateMetrics {
   return {
     success_rate: sanitizePublicPercent(metrics.success_rate),
     daily: metrics.daily.map(row => ({

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -203,24 +203,48 @@ function parseStatsMetadata(metadata: unknown): StatsMetadata | null {
   }
 }
 
-export function trackLogsCF(c: Context, app_id: string, device_id: string, action: string, version_name: string, metadata?: StatsMetadata) {
+export interface AppLogDimensions {
+  platform?: string | null
+  country_code?: string | null
+  plugin_version?: string | null
+}
+
+function normalizeAppLogDimension(value: string | null | undefined, maxLength: number) {
+  if (!value)
+    return ''
+  const normalized = value.trim()
+  if (!normalized)
+    return ''
+  return normalized.slice(0, maxLength)
+}
+
+function appLogDimensionBlobs(dimensions?: AppLogDimensions) {
+  // blob5=platform, blob6=country_code, blob7=plugin_version (denormalized for public /data breakdowns)
+  return [
+    normalizeAppLogDimension(dimensions?.platform, 16),
+    normalizeAppLogDimension(dimensions?.country_code, 2).toUpperCase(),
+    normalizeAppLogDimension(dimensions?.plugin_version, 32),
+  ]
+}
+
+export function trackLogsCF(c: Context, app_id: string, device_id: string, action: string, version_name: string, metadata?: StatsMetadata, dimensions?: AppLogDimensions) {
   if (!c.env.APP_LOG)
     return Promise.resolve()
 
   c.env.APP_LOG.writeDataPoint({
-    blobs: [device_id, action, version_name, serializeStatsMetadata(metadata)],
+    blobs: [device_id, action, version_name, serializeStatsMetadata(metadata), ...appLogDimensionBlobs(dimensions)],
     indexes: [app_id],
   })
 
   return Promise.resolve()
 }
 
-export function trackLogsCFExternal(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], version_name: string, metadata?: StatsMetadata) {
+export function trackLogsCFExternal(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], version_name: string, metadata?: StatsMetadata, dimensions?: AppLogDimensions) {
   if (!c.env.APP_LOG_EXTERNAL)
     return Promise.resolve()
 
   c.env.APP_LOG_EXTERNAL.writeDataPoint({
-    blobs: [device_id, action, version_name, serializeStatsMetadata(metadata)],
+    blobs: [device_id, action, version_name, serializeStatsMetadata(metadata), ...appLogDimensionBlobs(dimensions)],
     indexes: [app_id],
   })
 
@@ -2587,12 +2611,81 @@ export async function getPluginBreakdownCF(c: Context, referenceDate?: Date): Pr
 
 const PUBLIC_FAILURE_ACTIONS = ['set_fail', 'update_fail', 'download_fail', 'windows_path_fail', 'canonical_path_fail', 'directory_path_fail', 'unzip_fail', 'low_mem_fail', 'download_manifest_file_fail', 'download_manifest_checksum_fail', 'download_manifest_brotli_fail', 'finish_download_fail', 'manifest_path_fail', 'decrypt_fail', 'insufficient_disk_space', 'cannotGetBundle', 'checksum_fail', 'blocked_by_server_url', 'backend_refusal'] as const
 
+export interface PublicBreakdownMetric {
+  key: string
+  share: number
+  success_rate: number | null
+  top_failure: { reason: string, share: number } | null
+}
+
 export interface PublicLiveUpdateMetrics {
   success_rate: number
   daily: Array<{ date: string, success_rate: number }>
   failures: Array<{ reason: string, share: number }>
-  platforms: { ios: number, android: number, electron: number }
-  updater_versions: Array<{ date: string, version: string, share: number }>
+  platforms: PublicBreakdownMetric[]
+  countries: PublicBreakdownMetric[]
+  updater_versions: PublicBreakdownMetric[]
+}
+
+const PUBLIC_MIN_DIMENSION_OUTCOMES = 50
+const PUBLIC_TOP_COUNTRIES = 12
+const PUBLIC_TOP_VERSIONS = 10
+
+function toShare(part: number, total: number) {
+  return total > 0 ? (part / total) * 100 : 0
+}
+
+function buildBreakdownMetrics(
+  shareRows: Array<{ key: string, devices: number }>,
+  outcomeRows: Array<{ key: string, successes: number, failures: number }>,
+  failureRows: Array<{ key: string, action: string, devices: number }>,
+  limit: number,
+): PublicBreakdownMetric[] {
+  const shareTotal = shareRows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
+  const outcomesByKey = new Map<string, { successes: number, failures: number }>()
+  for (const row of outcomeRows) {
+    const key = String(row.key || '').trim()
+    if (!key)
+      continue
+    outcomesByKey.set(key, {
+      successes: Number(row.successes) || 0,
+      failures: Number(row.failures) || 0,
+    })
+  }
+  const failuresByKey = new Map<string, Array<{ reason: string, devices: number }>>()
+  for (const row of failureRows) {
+    const key = String(row.key || '').trim()
+    if (!key)
+      continue
+    const list = failuresByKey.get(key) ?? []
+    list.push({ reason: row.action, devices: Number(row.devices) || 0 })
+    failuresByKey.set(key, list)
+  }
+
+  return shareRows
+    .map((row) => {
+      const key = String(row.key || '').trim()
+      const devices = Number(row.devices) || 0
+      const outcomes = outcomesByKey.get(key)
+      const totalOutcomes = outcomes ? outcomes.successes + outcomes.failures : 0
+      const success_rate = totalOutcomes >= PUBLIC_MIN_DIMENSION_OUTCOMES
+        ? (outcomes!.successes / totalOutcomes) * 100
+        : null
+      const dimFailures = failuresByKey.get(key) ?? []
+      const failureTotal = dimFailures.reduce((sum, item) => sum + item.devices, 0)
+      const top = [...dimFailures].sort((a, b) => b.devices - a.devices)[0]
+      return {
+        key,
+        share: toShare(devices, shareTotal),
+        success_rate,
+        top_failure: top && failureTotal
+          ? { reason: top.reason, share: toShare(top.devices, failureTotal) }
+          : null,
+      }
+    })
+    .filter(row => row.key && row.share > 0)
+    .sort((a, b) => b.share - a.share || (b.success_rate ?? -1) - (a.success_rate ?? -1))
+    .slice(0, limit)
 }
 
 export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = new Date()): Promise<PublicLiveUpdateMetrics> {
@@ -2605,17 +2698,44 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
   const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
   const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
-  const outcomesQuery = `SELECT date, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id) GROUP BY date`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed, argMax(blob5, timestamp) AS platform, argMax(blob6, timestamp) AS country, argMax(blob7, timestamp) AS plugin_version FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const outcomesQuery = `SELECT date, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) GROUP BY date`
   const failuresQuery = `SELECT action, count() AS devices FROM (SELECT ${day} AS date, blob2 AS action, index1 AS app_id, blob1 AS device_id FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, action, app_id, device_id) GROUP BY action`
-  const platformsQuery = `SELECT platform, count() AS devices FROM (SELECT double1 AS platform, index1 AS app_id, blob1 AS device_id FROM device_usage WHERE ${window} AND double1 IN (0.0, 1.0, 2.0) GROUP BY platform, app_id, device_id) GROUP BY platform`
-  const updaterVersionsQuery = `SELECT date, version, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY date, app_id, device_id) GROUP BY date, version`
+  const platformsShareQuery = `SELECT platform, count() AS devices FROM (SELECT double1 AS platform, index1 AS app_id, blob1 AS device_id FROM device_usage WHERE ${window} AND double1 IN (0.0, 1.0, 2.0) GROUP BY platform, app_id, device_id) GROUP BY platform`
+  const platformsOutcomeQuery = `SELECT platform AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE platform IN ('ios', 'android', 'electron') GROUP BY platform`
+  const platformsFailureQuery = `SELECT platform AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob5, timestamp) AS platform FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE platform IN ('ios', 'android', 'electron') GROUP BY platform, action`
+  const countriesShareQuery = `SELECT country AS key, count() AS devices FROM (SELECT index1 AS app_id, blob1 AS device_id, argMax(blob10, timestamp) AS country FROM device_info WHERE ${window} AND blob10 != '' GROUP BY app_id, device_id) WHERE country != '' GROUP BY country`
+  const countriesOutcomeQuery = `SELECT country AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE country != '' GROUP BY country`
+  const countriesFailureQuery = `SELECT country AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob6, timestamp) AS country FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE country != '' GROUP BY country, action`
+  const versionsShareQuery = `SELECT version AS key, count() AS devices FROM (SELECT index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY app_id, device_id) WHERE version != '' GROUP BY version`
+  const versionsOutcomeQuery = `SELECT plugin_version AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE plugin_version != '' GROUP BY plugin_version`
+  const versionsFailureQuery = `SELECT plugin_version AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob7, timestamp) AS plugin_version FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE plugin_version != '' GROUP BY plugin_version, action`
 
   try {
-    const [outcomeRows, failureRows, platformRows, versionRows] = await Promise.all([
+    const [
+      outcomeRows,
+      failureRows,
+      platformShareRows,
+      platformOutcomeRows,
+      platformFailureRows,
+      countryShareRows,
+      countryOutcomeRows,
+      countryFailureRows,
+      versionShareRows,
+      versionOutcomeRows,
+      versionFailureRows,
+    ] = await Promise.all([
       runQueryToCFA<{ date: string, successes: number, failures: number }>(c, outcomesQuery),
       runQueryToCFA<{ action: string, devices: number }>(c, failuresQuery),
-      runQueryToCFA<{ platform: number, devices: number }>(c, platformsQuery),
-      runQueryToCFA<{ date: string, version: string, devices: number }>(c, updaterVersionsQuery),
+      runQueryToCFA<{ platform: number, devices: number }>(c, platformsShareQuery),
+      runQueryToCFA<{ key: string, successes: number, failures: number }>(c, platformsOutcomeQuery),
+      runQueryToCFA<{ key: string, action: string, devices: number }>(c, platformsFailureQuery),
+      runQueryToCFA<{ key: string, devices: number }>(c, countriesShareQuery),
+      runQueryToCFA<{ key: string, successes: number, failures: number }>(c, countriesOutcomeQuery),
+      runQueryToCFA<{ key: string, action: string, devices: number }>(c, countriesFailureQuery),
+      runQueryToCFA<{ key: string, devices: number }>(c, versionsShareQuery),
+      runQueryToCFA<{ key: string, successes: number, failures: number }>(c, versionsOutcomeQuery),
+      runQueryToCFA<{ key: string, action: string, devices: number }>(c, versionsFailureQuery),
     ])
     const daily = outcomeRows.map((row) => {
       const successes = Number(row.successes) || 0
@@ -2632,33 +2752,20 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
       .map(row => ({ reason: row.action, share: failureTotal ? ((Number(row.devices) || 0) / failureTotal) * 100 : 0 }))
       .sort((a, b) => b.share - a.share)
       .slice(0, 8)
-    const platformCounts = { ios: 0, android: 0, electron: 0 }
-    for (const row of platformRows) {
+
+    const platformShareMapped = platformShareRows.map((row) => {
       const platform = Number(row.platform)
-      if (platform === 0)
-        platformCounts.android += Number(row.devices) || 0
-      if (platform === 1)
-        platformCounts.ios += Number(row.devices) || 0
-      if (platform === 2)
-        platformCounts.electron += Number(row.devices) || 0
-    }
-    const platformTotal = Object.values(platformCounts).reduce((sum, count) => sum + count, 0)
-    const platforms = {
-      ios: platformTotal ? (platformCounts.ios / platformTotal) * 100 : 0,
-      android: platformTotal ? (platformCounts.android / platformTotal) * 100 : 0,
-      electron: platformTotal ? (platformCounts.electron / platformTotal) * 100 : 0,
-    }
-    const versionTotals = new Map<string, number>()
-    for (const row of versionRows)
-      versionTotals.set(row.date, (versionTotals.get(row.date) ?? 0) + (Number(row.devices) || 0))
+      const key = platform === 0 ? 'android' : platform === 1 ? 'ios' : platform === 2 ? 'electron' : ''
+      return { key, devices: Number(row.devices) || 0 }
+    }).filter(row => row.key)
+
     return {
       success_rate,
       daily,
       failures,
-      platforms,
-      updater_versions: versionRows
-        .map(row => ({ date: row.date, version: row.version, share: versionTotals.get(row.date) ? ((Number(row.devices) || 0) / versionTotals.get(row.date)!) * 100 : 0 }))
-        .sort((a, b) => a.date.localeCompare(b.date) || b.share - a.share),
+      platforms: buildBreakdownMetrics(platformShareMapped, platformOutcomeRows, platformFailureRows, 3),
+      countries: buildBreakdownMetrics(countryShareRows, countryOutcomeRows, countryFailureRows, PUBLIC_TOP_COUNTRIES),
+      updater_versions: buildBreakdownMetrics(versionShareRows, versionOutcomeRows, versionFailureRows, PUBLIC_TOP_VERSIONS),
     }
   }
   catch (error) {

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -2631,13 +2631,13 @@ const PUBLIC_MIN_DIMENSION_OUTCOMES = 50
 const PUBLIC_TOP_COUNTRIES = 12
 const PUBLIC_TOP_VERSIONS = 10
 
-function toShare(part: number, total: number) {
-  return total > 0 ? roundPublicPercent((part / total) * 100) : 0
-}
-
 /** Public /data metrics are percentage-only — never expose raw counts. */
 function roundPublicPercent(value: number) {
   return Number(value.toFixed(1))
+}
+
+function rawShare(part: number, total: number) {
+  return total > 0 ? (part / total) * 100 : 0
 }
 
 function buildBreakdownMetrics(
@@ -2667,6 +2667,7 @@ function buildBreakdownMetrics(
     failuresByKey.set(key, list)
   }
 
+  // Rank/limit on raw volume first, then round percentages for the public payload.
   return shareRows
     .map((row) => {
       const key = String(row.key || '').trim()
@@ -2681,16 +2682,22 @@ function buildBreakdownMetrics(
       const top = [...dimFailures].sort((a, b) => b.devices - a.devices)[0]
       return {
         key,
-        share: toShare(devices, shareTotal),
+        devices,
         success_rate,
         top_failure: top && failureTotal
-          ? { reason: top.reason, share: toShare(top.devices, failureTotal) }
+          ? { reason: top.reason, share: roundPublicPercent(rawShare(top.devices, failureTotal)) }
           : null,
       }
     })
-    .filter(row => row.key && row.share > 0)
-    .sort((a, b) => b.share - a.share || (b.success_rate ?? -1) - (a.success_rate ?? -1))
+    .filter(row => row.key && row.devices > 0)
+    .sort((a, b) => b.devices - a.devices || (b.success_rate ?? -1) - (a.success_rate ?? -1))
     .slice(0, limit)
+    .map(({ key, devices, success_rate, top_failure }) => ({
+      key,
+      share: roundPublicPercent(rawShare(devices, shareTotal)),
+      success_rate,
+      top_failure,
+    }))
 }
 
 export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = new Date()): Promise<PublicLiveUpdateMetrics> {
@@ -2753,10 +2760,14 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
     const totalOutcomes = totalSuccesses + totalFailures
     const success_rate = totalOutcomes ? roundPublicPercent((totalSuccesses / totalOutcomes) * 100) : 0
     const failureTotal = failureRows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
-    const failures = failureRows
-      .map(row => ({ reason: row.action, share: failureTotal ? roundPublicPercent(((Number(row.devices) || 0) / failureTotal) * 100) : 0 }))
-      .sort((a, b) => b.share - a.share)
+    const failures = [...failureRows]
+      .map(row => ({ reason: row.action, devices: Number(row.devices) || 0 }))
+      .sort((a, b) => b.devices - a.devices)
       .slice(0, 8)
+      .map(row => ({
+        reason: row.reason,
+        share: failureTotal ? roundPublicPercent(rawShare(row.devices, failureTotal)) : 0,
+      }))
 
     const platformShareMapped = platformShareRows.map((row) => {
       const platform = Number(row.platform)

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -2632,7 +2632,12 @@ const PUBLIC_TOP_COUNTRIES = 12
 const PUBLIC_TOP_VERSIONS = 10
 
 function toShare(part: number, total: number) {
-  return total > 0 ? (part / total) * 100 : 0
+  return total > 0 ? roundPublicPercent((part / total) * 100) : 0
+}
+
+/** Public /data metrics are percentage-only — never expose raw counts. */
+function roundPublicPercent(value: number) {
+  return Number(value.toFixed(1))
 }
 
 function buildBreakdownMetrics(
@@ -2669,7 +2674,7 @@ function buildBreakdownMetrics(
       const outcomes = outcomesByKey.get(key)
       const totalOutcomes = outcomes ? outcomes.successes + outcomes.failures : 0
       const success_rate = totalOutcomes >= PUBLIC_MIN_DIMENSION_OUTCOMES
-        ? (outcomes!.successes / totalOutcomes) * 100
+        ? roundPublicPercent((outcomes!.successes / totalOutcomes) * 100)
         : null
       const dimFailures = failuresByKey.get(key) ?? []
       const failureTotal = dimFailures.reduce((sum, item) => sum + item.devices, 0)
@@ -2741,15 +2746,15 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
       const successes = Number(row.successes) || 0
       const failures = Number(row.failures) || 0
       const outcomes = successes + failures
-      return { date: row.date, success_rate: outcomes ? (successes / outcomes) * 100 : 0 }
+      return { date: row.date, success_rate: outcomes ? roundPublicPercent((successes / outcomes) * 100) : 0 }
     }).sort((a, b) => a.date.localeCompare(b.date))
     const totalSuccesses = outcomeRows.reduce((sum, row) => sum + (Number(row.successes) || 0), 0)
     const totalFailures = outcomeRows.reduce((sum, row) => sum + (Number(row.failures) || 0), 0)
     const totalOutcomes = totalSuccesses + totalFailures
-    const success_rate = totalOutcomes ? (totalSuccesses / totalOutcomes) * 100 : 0
+    const success_rate = totalOutcomes ? roundPublicPercent((totalSuccesses / totalOutcomes) * 100) : 0
     const failureTotal = failureRows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
     const failures = failureRows
-      .map(row => ({ reason: row.action, share: failureTotal ? ((Number(row.devices) || 0) / failureTotal) * 100 : 0 }))
+      .map(row => ({ reason: row.action, share: failureTotal ? roundPublicPercent(((Number(row.devices) || 0) / failureTotal) * 100) : 0 }))
       .sort((a, b) => b.share - a.share)
       .slice(0, 8)
 

--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -49,7 +49,15 @@ export async function onPremStats(c: Context, app_id: string, action: string, de
   })
 
   // save stats of unknown sources in our analytic DB
-  await createStatsLogsExternal(c, device.app_id, device.device_id, 'get', device.version_name, metadata)
+  await createStatsLogsExternal(
+    c,
+    device.app_id,
+    device.device_id,
+    'get',
+    device.version_name,
+    metadata,
+    getStatsLogDimensions(c, device),
+  )
   cloudlog({ requestId: c.get('requestId'), message: 'App is external (onPremise), returning 429', app_id: device.app_id, country: c.req.raw.cf?.country, user_agent: c.req.raw.headers.get('user-agent') })
   // Return 429 to prevent device from retrying until next app kill (DDOS prevention)
   return c.json({ error: 'on_premise_app', message: 'On-premise app detected' }, 429)
@@ -161,14 +169,18 @@ export function createStatsDevices(c: Context, device: DeviceWithoutCreatedAt, o
   return backgroundTask(c, trackDevicesSB(c, deviceWithCountry))
 }
 
-export function sendStatsAndDevice(c: Context, device: DeviceWithoutCreatedAt, statsActions: StatsActions[], isFailedStat = false) {
+function getStatsLogDimensions(c: Context, device: DeviceWithoutCreatedAt): StatsLogDimensions {
   const requestCountry = c.req.raw?.cf?.country
   const countryCode = normalizeDeviceCountryCode(typeof requestCountry === 'string' ? requestCountry : device.country_code)
-  const dimensions: StatsLogDimensions = {
+  return {
     platform: device.platform,
     country_code: countryCode,
     plugin_version: device.plugin_version,
   }
+}
+
+export function sendStatsAndDevice(c: Context, device: DeviceWithoutCreatedAt, statsActions: StatsActions[], isFailedStat = false) {
+  const dimensions = getStatsLogDimensions(c, device)
   const jobs = []
   statsActions.forEach(({ action, versionName, metadata }) => {
     jobs.push(createStatsLogs(c, device.app_id, device.device_id, action, versionName ?? device.version_name, metadata, dimensions))

--- a/supabase/functions/_backend/utils/stats.ts
+++ b/supabase/functions/_backend/utils/stats.ts
@@ -101,7 +101,13 @@ export function normalizeStatsMetadata(metadata?: StatsMetadata): StatsMetadata 
   return Object.keys(normalized).length > 0 ? normalized : undefined
 }
 
-export function createStatsLogsExternal(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], versionName?: string, metadata?: StatsMetadata) {
+export interface StatsLogDimensions {
+  platform?: string | null
+  country_code?: string | null
+  plugin_version?: string | null
+}
+
+export function createStatsLogsExternal(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], versionName?: string, metadata?: StatsMetadata, dimensions?: StatsLogDimensions) {
   const lowerDeviceId = device_id
   const finalVersionName = versionName && versionName !== '' ? versionName : 'unknown'
   const finalMetadata = normalizeStatsMetadata(metadata)
@@ -113,10 +119,10 @@ export function createStatsLogsExternal(c: Context, app_id: string, device_id: s
     }
     return backgroundTask(c, trackLogsSB(c, app_id, lowerDeviceId, action, finalVersionName, finalMetadata))
   }
-  return trackLogsCFExternal(c, app_id, lowerDeviceId, action, finalVersionName, finalMetadata)
+  return trackLogsCFExternal(c, app_id, lowerDeviceId, action, finalVersionName, finalMetadata, dimensions)
 }
 
-export function createStatsLogs(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], versionName?: string, metadata?: StatsMetadata) {
+export function createStatsLogs(c: Context, app_id: string, device_id: string, action: Database['public']['Enums']['stats_action'], versionName?: string, metadata?: StatsMetadata, dimensions?: StatsLogDimensions) {
   const lowerDeviceId = device_id
   const finalVersionName = versionName && versionName !== '' ? versionName : 'unknown'
   const finalMetadata = normalizeStatsMetadata(metadata)
@@ -128,7 +134,7 @@ export function createStatsLogs(c: Context, app_id: string, device_id: string, a
     }
     return backgroundTask(c, trackLogsSB(c, app_id, lowerDeviceId, action, finalVersionName, finalMetadata))
   }
-  return trackLogsCF(c, app_id, lowerDeviceId, action, finalVersionName, finalMetadata)
+  return trackLogsCF(c, app_id, lowerDeviceId, action, finalVersionName, finalMetadata, dimensions)
 }
 
 interface CreateStatsDevicesOptions {
@@ -156,9 +162,16 @@ export function createStatsDevices(c: Context, device: DeviceWithoutCreatedAt, o
 }
 
 export function sendStatsAndDevice(c: Context, device: DeviceWithoutCreatedAt, statsActions: StatsActions[], isFailedStat = false) {
+  const requestCountry = c.req.raw?.cf?.country
+  const countryCode = normalizeDeviceCountryCode(typeof requestCountry === 'string' ? requestCountry : device.country_code)
+  const dimensions: StatsLogDimensions = {
+    platform: device.platform,
+    country_code: countryCode,
+    plugin_version: device.plugin_version,
+  }
   const jobs = []
   statsActions.forEach(({ action, versionName, metadata }) => {
-    jobs.push(createStatsLogs(c, device.app_id, device.device_id, action, versionName ?? device.version_name, metadata))
+    jobs.push(createStatsLogs(c, device.app_id, device.device_id, action, versionName ?? device.version_name, metadata, dimensions))
   })
 
   if (!isFailedStat)

--- a/tests/public-live-update-metrics.unit.test.ts
+++ b/tests/public-live-update-metrics.unit.test.ts
@@ -36,7 +36,7 @@ describe('public live update metrics', () => {
     vi.unstubAllGlobals()
   })
 
-  it('uses Analytics Engine-supported queries and preserves Float64 platform values', async () => {
+  it('returns usage shares plus dimensional success when denormalized log fields exist', async () => {
     const queries: string[] = []
     vi.stubEnv('CF_ANALYTICS_TOKEN', 'analytics-token')
     vi.stubEnv('CF_ACCOUNT_ANALYTICS_ID', 'analytics-account')
@@ -44,18 +44,18 @@ describe('public live update metrics', () => {
       const query = String(init?.body ?? '')
       queries.push(query)
 
-      if (query.includes('sum(succeeded)')) {
+      if (query.includes('SELECT date, sum(succeeded) AS successes') && query.includes('GROUP BY date')) {
         return analyticsResponse(
           [
             { name: 'date', type: 'String' },
             { name: 'successes', type: 'UInt64' },
             { name: 'failures', type: 'UInt64' },
           ],
-          [{ date: '2026-06-30', successes: '117', failures: '3' }],
+          [{ date: '2026-06-30', successes: '90', failures: '10' }],
         )
       }
 
-      if (query.includes('SELECT action, count() AS devices')) {
+      if (query.includes('SELECT action, count() AS devices') && !query.includes('AS key')) {
         return analyticsResponse(
           [
             { name: 'action', type: 'String' },
@@ -79,14 +79,115 @@ describe('public live update metrics', () => {
         )
       }
 
-      return analyticsResponse(
-        [
-          { name: 'date', type: 'String' },
-          { name: 'version', type: 'String' },
-          { name: 'devices', type: 'UInt64' },
-        ],
-        [{ date: '2026-06-30', version: '8.1.0', devices: '120' }],
-      )
+      if (query.includes('platform AS key') && query.includes('sum(succeeded)')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'successes', type: 'UInt64' },
+            { name: 'failures', type: 'UInt64' },
+          ],
+          [
+            { key: 'ios', successes: '80', failures: '5' },
+            { key: 'android', successes: '40', failures: '20' },
+          ],
+        )
+      }
+
+      if (query.includes('platform AS key') && query.includes('action, count()')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'action', type: 'String' },
+            { name: 'devices', type: 'UInt64' },
+          ],
+          [
+            { key: 'android', action: 'download_fail', devices: '12' },
+            { key: 'ios', action: 'checksum_fail', devices: '2' },
+          ],
+        )
+      }
+
+      if (query.includes('FROM device_info') && query.includes('blob10')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'devices', type: 'UInt64' },
+          ],
+          [
+            { key: 'US', devices: '70' },
+            { key: 'IQ', devices: '20' },
+            { key: 'DE', devices: '10' },
+          ],
+        )
+      }
+
+      if (query.includes('country AS key') && query.includes('sum(succeeded)')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'successes', type: 'UInt64' },
+            { name: 'failures', type: 'UInt64' },
+          ],
+          [
+            { key: 'US', successes: '90', failures: '5' },
+            { key: 'IQ', successes: '20', failures: '40' },
+          ],
+        )
+      }
+
+      if (query.includes('country AS key') && query.includes('action, count()')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'action', type: 'String' },
+            { name: 'devices', type: 'UInt64' },
+          ],
+          [
+            { key: 'IQ', action: 'download_fail', devices: '30' },
+            { key: 'US', action: 'unzip_fail', devices: '2' },
+          ],
+        )
+      }
+
+      if (query.includes('FROM device_info') && query.includes('blob3')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'devices', type: 'UInt64' },
+          ],
+          [
+            { key: '8.1.0', devices: '60' },
+            { key: '7.34.2', devices: '40' },
+          ],
+        )
+      }
+
+      if (query.includes('plugin_version AS key') && query.includes('sum(succeeded)')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'successes', type: 'UInt64' },
+            { name: 'failures', type: 'UInt64' },
+          ],
+          [
+            { key: '8.1.0', successes: '70', failures: '5' },
+            { key: '7.34.2', successes: '30', failures: '20' },
+          ],
+        )
+      }
+
+      if (query.includes('plugin_version AS key') && query.includes('action, count()')) {
+        return analyticsResponse(
+          [
+            { name: 'key', type: 'String' },
+            { name: 'action', type: 'String' },
+            { name: 'devices', type: 'UInt64' },
+          ],
+          [{ key: '7.34.2', action: 'download_fail', devices: '15' }],
+        )
+      }
+
+      return analyticsResponse([], [])
     }))
 
     const metrics = await getPublicLiveUpdateMetricsCF(
@@ -94,18 +195,22 @@ describe('public live update metrics', () => {
       new Date('2026-07-01T00:00:00.000Z'),
     )
 
-    expect(metrics).toEqual({
-      success_rate: 97.5,
-      daily: [{ date: '2026-06-30', success_rate: 97.5 }],
-      failures: [{ reason: 'download_fail', share: 100 }],
-      platforms: { ios: 25, android: 66.66666666666666, electron: 8.333333333333332 },
-      updater_versions: [{ date: '2026-06-30', version: '8.1.0', share: 100 }],
+    expect(metrics.success_rate).toBe(90)
+    expect(metrics.failures).toEqual([{ reason: 'download_fail', share: 100 }])
+    expect(metrics.platforms.map(row => row.key)).toEqual(['android', 'ios', 'electron'])
+    expect(metrics.platforms.find(row => row.key === 'android')?.success_rate).toBeCloseTo((40 / 60) * 100)
+    expect(metrics.platforms.find(row => row.key === 'android')?.top_failure).toEqual({
+      reason: 'download_fail',
+      share: 100,
     })
-    expect(queries).toHaveLength(4)
-    expect(queries.join('\n')).not.toContain('toString')
-    expect(queries.join('\n')).not.toContain('concat')
-    expect(queries.find(query => query.includes('FROM device_usage'))).toContain('double1 IN (0.0, 1.0, 2.0)')
-    expect(queries.find(query => query.includes('sum(succeeded)'))).toContain('GROUP BY date, app_id, device_id')
-    expect(queries.find(query => query.includes('sum(succeeded)'))).toContain('sum(if(succeeded = 0, failed, 0))')
+    expect(metrics.countries[0]).toMatchObject({ key: 'US', share: 70 })
+    expect(metrics.countries.find(row => row.key === 'US')?.success_rate).toBeCloseTo((90 / 95) * 100)
+    expect(metrics.countries.find(row => row.key === 'IQ')?.success_rate).toBeCloseTo((20 / 60) * 100)
+    expect(metrics.updater_versions[0]).toMatchObject({ key: '8.1.0', share: 60 })
+    expect(metrics.updater_versions.find(row => row.key === '8.1.0')?.success_rate).toBeCloseTo((70 / 75) * 100)
+    expect(queries.length).toBe(11)
+    expect(queries.join('\n')).toContain('blob6')
+    expect(queries.join('\n')).toContain('blob7')
+    expect(queries.join('\n')).toContain('blob10')
   })
 })

--- a/tests/public-live-update-metrics.unit.test.ts
+++ b/tests/public-live-update-metrics.unit.test.ts
@@ -198,16 +198,16 @@ describe('public live update metrics', () => {
     expect(metrics.success_rate).toBe(90)
     expect(metrics.failures).toEqual([{ reason: 'download_fail', share: 100 }])
     expect(metrics.platforms.map(row => row.key)).toEqual(['android', 'ios', 'electron'])
-    expect(metrics.platforms.find(row => row.key === 'android')?.success_rate).toBeCloseTo((40 / 60) * 100)
+    expect(metrics.platforms.find(row => row.key === 'android')?.success_rate).toBe(66.7)
     expect(metrics.platforms.find(row => row.key === 'android')?.top_failure).toEqual({
       reason: 'download_fail',
       share: 100,
     })
     expect(metrics.countries[0]).toMatchObject({ key: 'US', share: 70 })
-    expect(metrics.countries.find(row => row.key === 'US')?.success_rate).toBeCloseTo((90 / 95) * 100)
-    expect(metrics.countries.find(row => row.key === 'IQ')?.success_rate).toBeCloseTo((20 / 60) * 100)
+    expect(metrics.countries.find(row => row.key === 'US')?.success_rate).toBe(94.7)
+    expect(metrics.countries.find(row => row.key === 'IQ')?.success_rate).toBe(33.3)
     expect(metrics.updater_versions[0]).toMatchObject({ key: '8.1.0', share: 60 })
-    expect(metrics.updater_versions.find(row => row.key === '8.1.0')?.success_rate).toBeCloseTo((70 / 75) * 100)
+    expect(metrics.updater_versions.find(row => row.key === '8.1.0')?.success_rate).toBe(93.3)
     expect(queries.length).toBe(11)
     expect(queries.join('\n')).toContain('blob6')
     expect(queries.join('\n')).toContain('blob7')

--- a/tests/public-stats.unit.test.ts
+++ b/tests/public-stats.unit.test.ts
@@ -88,8 +88,18 @@ describe('public stats endpoint', () => {
       success_rate: 97.5,
       daily: [{ date: '2026-05-10', success_rate: 97.5 }],
       failures: [{ reason: 'download_fail', share: 100 }],
-      platforms: { ios: 25, android: 66.7, electron: 8.3 },
-      updater_versions: [{ date: '2026-05-10', version: '8.1.0', share: 100 }],
+      platforms: [
+        { key: 'android', share: 66.7, success_rate: 80, top_failure: { reason: 'download_fail', share: 100 } },
+        { key: 'ios', share: 25, success_rate: 90, top_failure: null },
+        { key: 'electron', share: 8.3, success_rate: null, top_failure: null },
+      ],
+      countries: [
+        { key: 'US', share: 55, success_rate: 92, top_failure: null },
+        { key: 'IQ', share: 10, success_rate: 48, top_failure: { reason: 'download_fail', share: 80 } },
+      ],
+      updater_versions: [
+        { key: '8.1.0', share: 60, success_rate: 93, top_failure: null },
+      ],
     })
 
     const res = await app.request('http://localhost/live_updates', {
@@ -105,8 +115,18 @@ describe('public stats endpoint', () => {
       success_rate: 97.5,
       daily: [{ date: '2026-05-10', success_rate: 97.5 }],
       failures: [{ reason: 'download_fail', share: 100 }],
-      platforms: { ios: 25, android: 66.7, electron: 8.3 },
-      updater_versions: [{ date: '2026-05-10', version: '8.1.0', share: 100 }],
+      platforms: [
+        { key: 'android', share: 66.7, success_rate: 80, top_failure: { reason: 'download_fail', share: 100 } },
+        { key: 'ios', share: 25, success_rate: 90, top_failure: null },
+        { key: 'electron', share: 8.3, success_rate: null, top_failure: null },
+      ],
+      countries: [
+        { key: 'US', share: 55, success_rate: 92, top_failure: null },
+        { key: 'IQ', share: 10, success_rate: 48, top_failure: { reason: 'download_fail', share: 80 } },
+      ],
+      updater_versions: [
+        { key: '8.1.0', share: 60, success_rate: 93, top_failure: null },
+      ],
     })
     expect(mocks.getPublicLiveUpdateMetricsCF).toHaveBeenCalledOnce()
   })

--- a/tests/public-stats.unit.test.ts
+++ b/tests/public-stats.unit.test.ts
@@ -40,7 +40,7 @@ vi.mock('../supabase/functions/_backend/utils/cloudflare.ts', () => ({
   getPublicLiveUpdateMetricsCF: mocks.getPublicLiveUpdateMetricsCF,
 }))
 
-const { app, getLatestCompletedGlobalStatsDateId } = await import('../supabase/functions/_backend/private/public_stats.ts')
+const { app, getLatestCompletedGlobalStatsDateId, sanitizePublicLiveUpdateMetrics } = await import('../supabase/functions/_backend/private/public_stats.ts')
 
 describe('public stats endpoint', () => {
   beforeEach(() => {
@@ -149,6 +149,41 @@ describe('public stats endpoint', () => {
       message: 'Public live update metrics are unavailable',
       requestId: undefined,
     })
+  })
+
+  it('sanitizes public live update metrics to rounded percentages only', () => {
+    const dirty = {
+      success_rate: 84.246,
+      daily: [{ date: '2026-05-10', success_rate: 91.999 }],
+      failures: [{ reason: 'download_fail', share: 37.94 }],
+      platforms: [
+        { key: 'ios', share: 66.666, success_rate: 90.04, top_failure: { reason: 'download_fail', share: 55.55 } },
+      ],
+      countries: [
+        { key: 'US', share: 34.21, success_rate: 93.14, top_failure: null },
+      ],
+      updater_versions: [
+        { key: '8.1.0', share: 22.19, success_rate: 94.21, top_failure: null },
+      ],
+      devices: 12345,
+    }
+    const sanitized = sanitizePublicLiveUpdateMetrics(dirty as typeof dirty & { devices: number })
+
+    expect(sanitized).toEqual({
+      success_rate: 84.2,
+      daily: [{ date: '2026-05-10', success_rate: 92 }],
+      failures: [{ reason: 'download_fail', share: 37.9 }],
+      platforms: [
+        { key: 'ios', share: 66.7, success_rate: 90, top_failure: { reason: 'download_fail', share: 55.5 } },
+      ],
+      countries: [
+        { key: 'US', share: 34.2, success_rate: 93.1, top_failure: null },
+      ],
+      updater_versions: [
+        { key: '8.1.0', share: 22.2, success_rate: 94.2, top_failure: null },
+      ],
+    })
+    expect(sanitized).not.toHaveProperty('devices')
   })
 
   it('keeps the fallback counters when no completed stats row exists', async () => {


### PR DESCRIPTION
## Summary
- Denormalize `platform`, `country_code`, and `plugin_version` onto `app_log` writes.
- Expand `/private/website_stats/live_updates` with per-dimension **usage share**, **success rate**, and **top failure**.
- Replaces the old “leading updater version per day” series with top updater versions + success.

Pairs with Cap-go/website feat/data-page-delivery-breakdowns.

## Note
Country/platform/version **success rates** need the enriched log fields, so they fill in after deploy as new stats arrive. Usage shares (device_info / device_usage) work immediately.

## Test plan
- [ ] Unit tests for public live update metrics
- [ ] After deploy, confirm API returns `countries`, array `platforms`, and version rows with `share` + `success_rate`
- [ ] Confirm US (and other high-volume regions) show success rates once enriched traffic accumulates

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

