### PR TITLE
feat(api): add updated_at filter and sort to GET /device

### DIFF
--- a/src/services/versions.ts
+++ b/src/services/versions.ts
@@ -26,6 +26,7 @@ export function createBuiltinChannelVersion(channel: {
     cli_version: null,
     comment: null,
     created_at: channel.created_at,
+    created_by_apikey_rbac_id: null,
     deleted: false,
     deleted_at: null,
     external_url: null,

--- a/supabase/functions/_backend/public/device/get.ts
+++ b/supabase/functions/_backend/public/device/get.ts
@@ -92,13 +92,6 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
 
-  const updatedAtGt = parseUpdatedAtFilter(body.updated_at)
-  const order = parseDevicesOrder(body.order)
-  const limit = body.limit == null ? fetchLimit : Number(body.limit)
-  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
-    throw simpleError('invalid_limit', 'limit must be a positive integer', { limit: body.limit })
-  }
-
   // Auth context is already set by middlewareKey
   if (!(await checkPermission(c, 'app.read_devices', { appId: body.app_id }))) {
     throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
@@ -148,6 +141,13 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
     return c.json(dataDevice)
   }
   else {
+    const updatedAtGt = parseUpdatedAtFilter(body.updated_at)
+    const order = parseDevicesOrder(body.order)
+    const limit = body.limit == null ? fetchLimit : Number(body.limit)
+    if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
+      throw simpleError('invalid_limit', 'limit must be a positive integer', { limit: body.limit })
+    }
+
     const res = await readDevices(c, {
       app_id: body.app_id,
       cursor: body.cursor,

--- a/supabase/functions/_backend/public/device/get.ts
+++ b/supabase/functions/_backend/public/device/get.ts
@@ -16,6 +16,10 @@ interface GetDevice {
   cursor?: string
   /** Limit for results (default uses fetchLimit) */
   limit?: number
+  /** ISO timestamp - only return devices with updated_at greater than this value */
+  updated_at?: string
+  /** Sort devices by updated_at: asc or desc */
+  order?: string
 }
 
 interface publicDevice {
@@ -44,6 +48,25 @@ export function filterDeviceKeys(devices: DeviceRes[]) {
   })
 }
 
+function parseUpdatedAtFilter(updatedAt: string | undefined): string | undefined {
+  if (!updatedAt)
+    return undefined
+
+  const parsed = new Date(updatedAt)
+  if (Number.isNaN(parsed.getTime()))
+    throw simpleError('invalid_updated_at', 'updated_at must be a valid ISO date', { updated_at: updatedAt })
+
+  return parsed.toISOString()
+}
+
+function parseDevicesOrder(order: string | undefined) {
+  if (!order)
+    return undefined
+  if (order !== 'asc' && order !== 'desc')
+    throw simpleError('invalid_order', 'order must be asc or desc', { order })
+  return [{ key: 'updated_at', sortable: order as 'asc' | 'desc' }]
+}
+
 export async function get(c: Context, body: GetDevice, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
   if (!body.app_id) {
     throw simpleError('missing_app_id', 'Missing app_id', { body })
@@ -51,6 +74,14 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
   if (!isValidAppId(body.app_id)) {
     throw simpleError('invalid_app_id', 'App ID must be a reverse domain string', { app_id: body.app_id })
   }
+
+  const updatedAtGt = parseUpdatedAtFilter(body.updated_at)
+  const order = parseDevicesOrder(body.order)
+  const limit = body.limit == null ? fetchLimit : Number(body.limit)
+  if (!Number.isFinite(limit) || limit < 1) {
+    throw simpleError('invalid_limit', 'limit must be a positive number', { limit: body.limit })
+  }
+
   // Auth context is already set by middlewareKey
   if (!(await checkPermission(c, 'app.read_devices', { appId: body.app_id }))) {
     throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id })
@@ -103,7 +134,9 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
     const res = await readDevices(c, {
       app_id: body.app_id,
       cursor: body.cursor,
-      limit: body.limit ?? fetchLimit,
+      limit,
+      updated_at_gt: updatedAtGt,
+      order,
     }, body.customIdMode ?? false)
 
     if (!res?.data) {

--- a/supabase/functions/_backend/public/device/get.ts
+++ b/supabase/functions/_backend/public/device/get.ts
@@ -41,23 +41,29 @@ interface publicDevice {
   channel?: string
 }
 
-export function filterDeviceKeys(devices: DeviceRes[]) {
-  return devices.map((device) => {
-    const { updated_at, device_id, custom_id, is_prod, is_emulator, install_source, version_name, version, app_id, platform, plugin_version, os_version, version_build, key_id, country_code } = device
-    return { updated_at, device_id, custom_id, is_prod, is_emulator, install_source, version_name, version, app_id, platform, plugin_version, os_version, version_build, key_id, country_code }
-  })
+function toPublicUpdatedAt(value: string): string {
+  // Cloudflare Analytics Engine returns UTC as "YYYY-MM-DD HH:mm:ss".
+  const cloudflareUtc = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})$/.exec(value)
+  const normalized = cloudflareUtc ? `${cloudflareUtc[1]}T${cloudflareUtc[2]}.000Z` : value
+  return new Date(normalized).toISOString()
 }
 
 function parseUpdatedAtFilter(updatedAt: string | undefined): string | undefined {
   if (!updatedAt)
     return undefined
 
-  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?Z$/.exec(updatedAt)
+  // Accept ISO-8601 UTC (Z) and the Cloudflare device timestamp format for sync round-trips.
+  const cloudflareUtc = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/.exec(updatedAt)
+  const normalized = cloudflareUtc
+    ? `${cloudflareUtc[1]}-${cloudflareUtc[2]}-${cloudflareUtc[3]}T${cloudflareUtc[4]}:${cloudflareUtc[5]}:${cloudflareUtc[6]}.000Z`
+    : updatedAt
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?Z$/.exec(normalized)
   if (!match) {
     throw simpleError('invalid_updated_at', 'updated_at must be a valid ISO date', { updated_at: updatedAt })
   }
 
-  const parsed = new Date(updatedAt)
+  const parsed = new Date(normalized)
   if (Number.isNaN(parsed.getTime()))
     throw simpleError('invalid_updated_at', 'updated_at must be a valid ISO date', { updated_at: updatedAt })
 
@@ -82,6 +88,29 @@ function parseDevicesOrder(order: string | undefined) {
   if (order !== 'asc' && order !== 'desc')
     throw simpleError('invalid_order', 'order must be asc or desc', { order })
   return [{ key: 'updated_at', sortable: order as 'asc' | 'desc' }]
+}
+
+export function filterDeviceKeys(devices: DeviceRes[]) {
+  return devices.map((device) => {
+    const { updated_at, device_id, custom_id, is_prod, is_emulator, install_source, version_name, version, app_id, platform, plugin_version, os_version, version_build, key_id, country_code } = device
+    return {
+      updated_at: updated_at ? toPublicUpdatedAt(updated_at) : updated_at,
+      device_id,
+      custom_id,
+      is_prod,
+      is_emulator,
+      install_source,
+      version_name,
+      version,
+      app_id,
+      platform,
+      plugin_version,
+      os_version,
+      version_build,
+      key_id,
+      country_code,
+    }
+  })
 }
 
 export async function get(c: Context, body: GetDevice, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {

--- a/supabase/functions/_backend/public/device/get.ts
+++ b/supabase/functions/_backend/public/device/get.ts
@@ -52,9 +52,26 @@ function parseUpdatedAtFilter(updatedAt: string | undefined): string | undefined
   if (!updatedAt)
     return undefined
 
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?Z$/.exec(updatedAt)
+  if (!match) {
+    throw simpleError('invalid_updated_at', 'updated_at must be a valid ISO date', { updated_at: updatedAt })
+  }
+
   const parsed = new Date(updatedAt)
   if (Number.isNaN(parsed.getTime()))
     throw simpleError('invalid_updated_at', 'updated_at must be a valid ISO date', { updated_at: updatedAt })
+
+  const [, year, month, day, hour, minute, second] = match
+  if (
+    parsed.getUTCFullYear() !== Number(year)
+    || parsed.getUTCMonth() + 1 !== Number(month)
+    || parsed.getUTCDate() !== Number(day)
+    || parsed.getUTCHours() !== Number(hour)
+    || parsed.getUTCMinutes() !== Number(minute)
+    || parsed.getUTCSeconds() !== Number(second)
+  ) {
+    throw simpleError('invalid_updated_at', 'updated_at must be a valid ISO date', { updated_at: updatedAt })
+  }
 
   return parsed.toISOString()
 }
@@ -78,8 +95,8 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
   const updatedAtGt = parseUpdatedAtFilter(body.updated_at)
   const order = parseDevicesOrder(body.order)
   const limit = body.limit == null ? fetchLimit : Number(body.limit)
-  if (!Number.isFinite(limit) || limit < 1) {
-    throw simpleError('invalid_limit', 'limit must be a positive number', { limit: body.limit })
+  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
+    throw simpleError('invalid_limit', 'limit must be a positive integer', { limit: body.limit })
   }
 
   // Auth context is already set by middlewareKey

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -959,8 +959,19 @@ function buildReadDevicesCFCursorCondition(cursor: string | undefined, devicesOr
   return `(updated_at ${comparison} toDateTime('${safeCursorTime}') OR (updated_at = toDateTime('${safeCursorTime}') AND device_id > '${safeCursorDeviceId}'))`
 }
 
+function buildReadDevicesCFUpdatedAtGtCondition(updatedAtGt: string | undefined) {
+  if (!updatedAtGt)
+    return ''
+
+  const safeUpdatedAtGt = escapeSqlString(formatDateCF(updatedAtGt))
+  return `updated_at > toDateTime('${safeUpdatedAtGt}')`
+}
+
 function buildReadDevicesCFOuterConditions(params: ReadDevicesParams, devicesOrder: DevicesOrderCF | null) {
-  const conditions = [buildReadDevicesCFCursorCondition(params.cursor, devicesOrder)]
+  const conditions = [
+    buildReadDevicesCFCursorCondition(params.cursor, devicesOrder),
+    buildReadDevicesCFUpdatedAtGtCondition(params.updated_at_gt),
+  ]
   return conditions.filter(Boolean)
 }
 

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1007,6 +1007,11 @@ export function buildReadDevicesCFQuery(params: ReadDevicesParams, customIdMode:
     conditions.push(`blob2 = '${escapeSqlString(params.version_name)}'`)
   }
 
+  if (params.updated_at_gt) {
+    const safeUpdatedAtGt = escapeSqlString(formatDateCF(params.updated_at_gt))
+    conditions.push(`timestamp > toDateTime('${safeUpdatedAtGt}')`)
+  }
+
   const devicesOrder = getReadDevicesCFOrder(params)
   const outerConditions = buildReadDevicesCFOuterConditions(params, devicesOrder)
   const includeCountryCode = !!params.deviceIds?.length

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1605,6 +1605,9 @@ export async function readDevicesSB(c: Context, params: ReadDevicesParams, custo
   if (params.installSources?.length)
     query = query.in('install_source', params.installSources)
 
+  if (params.updated_at_gt)
+    query = query.gt('updated_at', params.updated_at_gt)
+
   const devicesOrder = getDevicesOrder(params.order)
 
   if (params.cursor) {

--- a/supabase/functions/_backend/utils/types.ts
+++ b/supabase/functions/_backend/utils/types.ts
@@ -134,6 +134,8 @@ export interface ReadDevicesParams {
   installSources?: string[]
   search?: string
   order?: Order[]
+  /** Only return devices with updated_at greater than this ISO timestamp */
+  updated_at_gt?: string
   limit?: number
   /** Cursor for pagination - use the last updated_at from previous page */
   cursor?: string

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -141,10 +141,13 @@ describe('buildReadDevicesCFQuery', () => {
     }, false)
 
     const groupByIndex = query.indexOf('GROUP BY blob1')
-    const filterIndex = query.indexOf(`WHERE updated_at > toDateTime('2026-04-04 03:05:59')`)
+    const innerFilterIndex = query.indexOf(`timestamp > toDateTime('2026-04-04 03:05:59')`)
+    const outerFilterIndex = query.indexOf(`WHERE updated_at > toDateTime('2026-04-04 03:05:59')`)
 
     expect(groupByIndex).toBeGreaterThan(-1)
-    expect(filterIndex).toBeGreaterThan(groupByIndex)
+    expect(innerFilterIndex).toBeGreaterThan(-1)
+    expect(innerFilterIndex).toBeLessThan(groupByIndex)
+    expect(outerFilterIndex).toBeGreaterThan(groupByIndex)
   })
 
 })

--- a/tests/cloudflare-device-pagination.unit.test.ts
+++ b/tests/cloudflare-device-pagination.unit.test.ts
@@ -133,6 +133,20 @@ describe('buildReadDevicesCFQuery', () => {
     expect(query).toContain('GROUP BY blob1')
     expect(query).toContain(`install_source IN ('app_store', 'amazon_appstore')`)
   })
+  it.concurrent('filters devices with updated_at greater than the provided timestamp', () => {
+    const query = buildReadDevicesCFQuery({
+      app_id: 'com.example.app',
+      updated_at_gt: '2026-04-04T03:05:59.000Z',
+      limit: 1,
+    }, false)
+
+    const groupByIndex = query.indexOf('GROUP BY blob1')
+    const filterIndex = query.indexOf(`WHERE updated_at > toDateTime('2026-04-04 03:05:59')`)
+
+    expect(groupByIndex).toBeGreaterThan(-1)
+    expect(filterIndex).toBeGreaterThan(groupByIndex)
+  })
+
 })
 describe('countDevicesCF', () => {
   it('does not read install source blob on default device counts', async () => {
@@ -290,5 +304,32 @@ describe('readDevicesSB', () => {
     }, false)
 
     expect(query.in).toHaveBeenCalledWith('install_source', ['app_store', 'testflight'])
+  })
+
+  it('filters devices with updated_at greater than the provided timestamp', async () => {
+    const { client, query } = createReadDevicesQueryMock()
+    vi.mocked(createClient).mockReturnValue(client as unknown as ReturnType<typeof createClient>)
+
+    await readDevicesSB(createContextMock() as unknown as Context, {
+      app_id: 'com.example.app',
+      updated_at_gt: '2026-04-04T03:05:59.000Z',
+      limit: 1,
+    }, false)
+
+    expect(query.gt).toHaveBeenCalledWith('updated_at', '2026-04-04T03:05:59.000Z')
+  })
+
+  it('orders devices by updated_at when requested', async () => {
+    const { client, query } = createReadDevicesQueryMock()
+    vi.mocked(createClient).mockReturnValue(client as unknown as ReturnType<typeof createClient>)
+
+    await readDevicesSB(createContextMock() as unknown as Context, {
+      app_id: 'com.example.app',
+      order: [{ key: 'updated_at', sortable: 'desc' }],
+      limit: 1,
+    }, false)
+
+    expect(query.order).toHaveBeenCalledWith('updated_at', { ascending: false })
+    expect(query.order).toHaveBeenCalledWith('device_id', { ascending: true })
   })
 })

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -142,6 +142,20 @@ describe('[GET] /device updated_at filter and order', () => {
     expect(data.error).toBe('invalid_updated_at')
   })
 
+  it('rejects non-calendar ISO updated_at values', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      updated_at: '2024-02-31T00:00:00.000Z',
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ error?: string }>()
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('invalid_updated_at')
+  })
+
   it('rejects invalid order', async () => {
     const params = new URLSearchParams({
       app_id: APPNAME_DEVICE,

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -71,28 +71,37 @@ describe.concurrent('[GET] /device operations', () => {
 describe('[GET] /device updated_at filter and order', () => {
   it('filters devices by updated_at greater than ISO date', async () => {
     const supabase = getSupabaseClient()
-    const pastDeviceId = '00000000-0000-0000-0000-000000000000'
+    const pastDeviceId = randomUUID().toLowerCase()
     const futureDeviceId = randomUUID().toLowerCase()
     const cutoff = new Date('2026-01-01T00:00:00.000Z')
 
-    const { error: pastError } = await supabase.from('devices').update({
-      updated_at: '2025-06-01T00:00:00.000Z',
-    }).eq('app_id', APPNAME_DEVICE).eq('device_id', pastDeviceId)
-    expect(pastError).toBeNull()
-
-    const { error: futureError } = await supabase.from('devices').upsert({
-      app_id: APPNAME_DEVICE,
-      device_id: futureDeviceId,
-      platform: 'android',
-      plugin_version: '6.0.0',
-      os_version: '14',
-      version_build: '1.0.0',
-      version_name: '1.0.0',
-      is_prod: true,
-      is_emulator: false,
-      updated_at: '2026-06-01T00:00:00.000Z',
-    })
-    expect(futureError).toBeNull()
+    const { error: insertError } = await supabase.from('devices').upsert([
+      {
+        app_id: APPNAME_DEVICE,
+        device_id: pastDeviceId,
+        platform: 'ios',
+        plugin_version: '6.0.0',
+        os_version: '17.0',
+        version_build: '1.0.0',
+        version_name: '1.0.0',
+        is_prod: true,
+        is_emulator: false,
+        updated_at: '2025-06-01T00:00:00.000Z',
+      },
+      {
+        app_id: APPNAME_DEVICE,
+        device_id: futureDeviceId,
+        platform: 'android',
+        plugin_version: '6.0.0',
+        os_version: '14',
+        version_build: '1.0.0',
+        version_name: '1.0.0',
+        is_prod: true,
+        is_emulator: false,
+        updated_at: '2026-06-01T00:00:00.000Z',
+      },
+    ])
+    expect(insertError).toBeNull()
 
     const params = new URLSearchParams({
       app_id: APPNAME_DEVICE,

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -169,6 +169,23 @@ describe('[GET] /device updated_at filter and order', () => {
     expect(response.status).toBe(400)
     expect(data.error).toBe('invalid_order')
   })
+
+  it('ignores list-only params when fetching a specific device', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      device_id: '00000000-0000-0000-0000-000000000000',
+      order: 'sideways',
+      updated_at: 'not-a-date',
+      limit: '1.5',
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ device_id?: string, error?: string }>()
+    expect(response.status).toBe(200)
+    expect(data.device_id).toBe('00000000-0000-0000-0000-000000000000')
+  })
 })
 
 describe('[POST] /device operations', () => {

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -67,6 +67,96 @@ describe.concurrent('[GET] /device operations', () => {
   })
 })
 
+
+describe('[GET] /device updated_at filter and order', () => {
+  it('filters devices by updated_at greater than ISO date', async () => {
+    const supabase = getSupabaseClient()
+    const pastDeviceId = '00000000-0000-0000-0000-000000000000'
+    const futureDeviceId = randomUUID().toLowerCase()
+    const cutoff = new Date('2026-01-01T00:00:00.000Z')
+
+    const { error: pastError } = await supabase.from('devices').update({
+      updated_at: '2025-06-01T00:00:00.000Z',
+    }).eq('app_id', APPNAME_DEVICE).eq('device_id', pastDeviceId)
+    expect(pastError).toBeNull()
+
+    const { error: futureError } = await supabase.from('devices').upsert({
+      app_id: APPNAME_DEVICE,
+      device_id: futureDeviceId,
+      platform: 'android',
+      plugin_version: '6.0.0',
+      os_version: '14',
+      version_build: '1.0.0',
+      version_name: '1.0.0',
+      is_prod: true,
+      is_emulator: false,
+      updated_at: '2026-06-01T00:00:00.000Z',
+    })
+    expect(futureError).toBeNull()
+
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      updated_at: cutoff.toISOString(),
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ data: { device_id: string, updated_at: string }[], error?: string }>()
+    expect(response.status).toBe(200)
+    expect(data.error).toBeUndefined()
+    expect(data.data.some(device => device.device_id === futureDeviceId)).toBe(true)
+    expect(data.data.some(device => device.device_id === pastDeviceId)).toBe(false)
+    expect(data.data.every(device => new Date(device.updated_at).getTime() > cutoff.getTime())).toBe(true)
+  })
+
+  it('sorts devices by updated_at desc', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      order: 'desc',
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ data: { updated_at: string }[], error?: string }>()
+    expect(response.status).toBe(200)
+    expect(data.error).toBeUndefined()
+    expect(data.data.length).toBeGreaterThan(1)
+    for (let i = 1; i < data.data.length; i++) {
+      expect(new Date(data.data[i - 1].updated_at).getTime()).toBeGreaterThanOrEqual(new Date(data.data[i].updated_at).getTime())
+    }
+  })
+
+  it('rejects invalid updated_at filter', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      updated_at: 'not-a-date',
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ error?: string }>()
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('invalid_updated_at')
+  })
+
+  it('rejects invalid order', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      order: 'sideways',
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ error?: string }>()
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('invalid_order')
+  })
+})
+
 describe('[POST] /device operations', () => {
   it('link device', async () => {
     const deviceId = randomUUID().toLowerCase()


### PR DESCRIPTION
## Summary (AI generated)

- Add `updated_at` query param on public `GET /device` to return only devices with `updated_at` greater than an ISO timestamp
- Add `order=asc|desc` query param to sort device listings by `updated_at`
- Wire the filter through Supabase and Cloudflare Analytics Engine device readers
- Cover the new behavior with unit and integration tests

Closes https://github.com/Cap-go/capgo.app/issues/2714

## Motivation (AI generated)

The public devices list API previously had no way to filter or sort by `updated_at`, so callers had to page through every device and filter client-side. That is inefficient for apps with many devices.

## Business Impact (AI generated)

Makes the public devices API usable for incremental sync and monitoring workflows, reducing API traffic and improving integration efficiency for customers building on Capgo.

## Test Plan (AI generated)

- [x] Unit tests for CF/SB `updated_at_gt` filter and `updated_at` ordering
- [x] Integration tests for `GET /device?updated_at=...` and `GET /device?order=desc`
- [x] Integration tests reject invalid `updated_at` and `order` values with 400
- [ ] Verify in CI that device tests pass on both Supabase and Cloudflare paths where applicable

### Usage examples

```bash
# Devices updated after a timestamp
curl -H "authorization: <apikey>" \
  "https://api.capgo.app/device?app_id=com.example.app&updated_at=2026-01-01T00:00:00.000Z"

# Newest devices first
curl -H "authorization: <apikey>" \
  "https://api.capgo.app/device?app_id=com.example.app&order=desc"
```

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incremental device list fetching via an `updated_at_gt` filter.
  * Added validated sorting by update time (`order=asc|desc`) with consistent results.

* **Bug Fixes**
  * Improved request validation for `updated_at`, `order`, and `limit`, returning clear HTTP 400 errors for invalid values.
  * Enhanced pagination to apply the update-time constraint alongside existing cursor/ordering behavior.

* **Tests**
  * Added coverage for `updated_at_gt` filtering, ordering, tie-breakers, and malformed input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->