### PR TITLE
feat(updates): Bento emails for upgrade/downgrade version blocks

### DIFF
--- a/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
+++ b/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
@@ -127,7 +127,7 @@ Tag does NOT contain: bundle_deployed_disabled
 
 **Events**: `device:upgrade_blocked`, `device:downgrade_blocked`
 
-Emitted from `/updates` when a device is blocked by channel auto-update version policy (upgrade: major/minor/patch/metadata; downgrade: under-native). Delivery uses `sendNotifToOrgMembersCached` with preference key `device_error` (Cloudflare plugin KV queue in production).
+Emitted from `/updates` when a device is blocked by channel auto-update version policy (upgrade: major/minor/patch/metadata; downgrade: under_native). Delivery uses `sendNotifToOrgMembersCached` with preference key `device_error` (Cloudflare plugin KV queue in production).
 
 **Payload fields** (`event.details`):
 

--- a/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
+++ b/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
@@ -127,6 +127,25 @@ Tag does NOT contain: bundle_deployed_disabled
 
 **Events**: `device:upgrade_blocked`, `device:downgrade_blocked`
 
+Emitted from `/updates` when a device is blocked by channel auto-update version policy (upgrade: major/minor/patch/metadata; downgrade: under-native). Delivery uses `sendNotifToOrgMembersCached` with preference key `device_error` (Cloudflare plugin KV queue in production).
+
+**Payload fields** (`event.details`):
+
+| Field | Description |
+|-------|-------------|
+| `app_id` | App identifier |
+| `app_id_url` | Same as `app_id` (for console URL segments) |
+| `device_id` | Device UUID |
+| `platform` | `ios` / `android` / `electron` |
+| `channel_name` | Channel name |
+| `channel_id` | Channel numeric id (console channel link) |
+| `version` | Cloud/channel target bundle version name |
+| `version_build` | Device native version used in the policy check |
+| `version_name` | Device current OTA version name |
+| `reason` | `major` \| `minor` \| `patch` \| `metadata` \| `under_native` |
+
+Bundle / `version_id` numeric IDs are intentionally omitted — build console links from version names in the Bento template.
+
 **Filter to add**:
 ```text
 Tag does NOT contain: device_error_disabled

--- a/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
+++ b/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
@@ -125,7 +125,7 @@ Tag does NOT contain: bundle_deployed_disabled
 
 #### 10. Device Error Notifications
 
-**Events**: `user:update_fail`
+**Events**: `device:upgrade_blocked`, `device:downgrade_blocked`
 
 **Filter to add**:
 ```text

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -448,6 +448,21 @@ export async function updateWithPG(
   }
 
   if (channelData) {
+    const notifyVersionBlocked = (
+      kind: 'upgrade' | 'downgrade',
+      reason: AutoUpdateBlockReason,
+    ) => notifyAutoUpdateVersionBlocked(c, kind, reason, {
+      appId: app_id,
+      deviceId: device_id,
+      platform,
+      orgId: appOwner.owner_org,
+      channelName: channelData.channels.name,
+      channelId: channelData.channels.id,
+      version: version.name,
+      versionBuild: version_build,
+      versionName: version_name,
+      drizzleClient,
+    })
     // cloudlog(c.get('requestId'), 'check disableAutoUpdateToMajor', device_id)
     if (!channelData.channels.ios && platform === 'ios') {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, ios is disabled', id: device_id, date: new Date().toISOString() })
@@ -477,18 +492,7 @@ export async function updateWithPG(
     if (!isInternalVersionName(version.name) && channelData?.channels.disable_auto_update === 'major' && parse(version.name).major > parse(version_build).major) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade major version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateToMajor', versionName: version.name }])
-      await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'major', {
-        appId: app_id,
-        deviceId: device_id,
-        platform,
-        orgId: appOwner.owner_org,
-        channelName: channelData.channels.name,
-        channelId: channelData.channels.id,
-        version: version.name,
-        versionBuild: version_build,
-        versionName: version_name,
-        drizzleClient,
-      })
+      await notifyVersionBlocked('upgrade', 'major')
       return updateError200(c, 'disable_auto_update_to_major', 'Cannot upgrade major version', {
         major: true,
         version: version.name,
@@ -511,18 +515,7 @@ export async function updateWithPG(
     )) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade minor version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateToMinor', versionName: version.name }])
-      await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'minor', {
-        appId: app_id,
-        deviceId: device_id,
-        platform,
-        orgId: appOwner.owner_org,
-        channelName: channelData.channels.name,
-        channelId: channelData.channels.id,
-        version: version.name,
-        versionBuild: version_build,
-        versionName: version_name,
-        drizzleClient,
-      })
+      await notifyVersionBlocked('upgrade', 'minor')
       return updateError200(c, 'disable_auto_update_to_minor', 'Cannot upgrade minor version', {
         major: true,
         version: version.name,
@@ -538,18 +531,7 @@ export async function updateWithPG(
     )) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade patch version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateToPatch', versionName: version.name }])
-      await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'patch', {
-        appId: app_id,
-        deviceId: device_id,
-        platform,
-        orgId: appOwner.owner_org,
-        channelName: channelData.channels.name,
-        channelId: channelData.channels.id,
-        version: version.name,
-        versionBuild: version_build,
-        versionName: version_name,
-        drizzleClient,
-      })
+      await notifyVersionBlocked('upgrade', 'patch')
       return updateError200(c, 'disable_auto_update_to_patch', 'Cannot upgrade patch version', {
         major: true,
         version: version.name,
@@ -574,18 +556,7 @@ export async function updateWithPG(
       if (greaterThan(parse(minUpdateVersion), parse(version_build))) {
         cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade, metadata > current version', id: device_id, min: minUpdateVersion, old: version_name, date: new Date().toISOString() })
         await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateMetadata', versionName: version.name }])
-        await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'metadata', {
-          appId: app_id,
-          deviceId: device_id,
-          platform,
-          orgId: appOwner.owner_org,
-          channelName: channelData.channels.name,
-          channelId: channelData.channels.id,
-          version: version.name,
-          versionBuild: version_build,
-          versionName: version_name,
-          drizzleClient,
-        })
+        await notifyVersionBlocked('upgrade', 'metadata')
         return updateError200(c, 'disable_auto_update_to_metadata', 'Cannot upgrade version, min update version > current version', {
           major: true,
           version: version.name,
@@ -598,18 +569,7 @@ export async function updateWithPG(
     if (!isInternalVersionName(version.name) && channelData.channels.disable_auto_update_under_native && lessThan(parse(version.name), parse(version_build))) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot revert under native version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateUnderNative', versionName: version.name }])
-      await notifyAutoUpdateVersionBlocked(c, 'downgrade', 'under_native', {
-        appId: app_id,
-        deviceId: device_id,
-        platform,
-        orgId: appOwner.owner_org,
-        channelName: channelData.channels.name,
-        channelId: channelData.channels.id,
-        version: version.name,
-        versionBuild: version_build,
-        versionName: version_name,
-        drizzleClient,
-      })
+      await notifyVersionBlocked('downgrade', 'under_native')
       return updateError200(c, 'disable_auto_update_under_native', 'Cannot revert under native version', {
         version: version.name,
         old: version_name,

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -20,6 +20,7 @@ import { getClientIP } from './rate_limit.ts'
 import { sendNotifOrgCached } from './notifications.ts'
 import { sendNotifToOrgMembersCached } from './org_email_notifications.ts'
 import { closeClient, getAppBlockProviderInfraRequestsPostgres, getAppOwnerPostgres, getDrizzleClient, getPgClient, requestInfosPostgres, setReplicationLagHeader } from './pg.ts'
+import { shouldQueuePluginNotifications } from './supabase_write_guard.ts'
 import { makeDevice } from './plugin_parser.ts'
 import { s3 } from './s3.ts'
 import { createStatsBandwidth, createStatsMau, createStatsVersion, onPremStats, sendStatsAndDevice } from './stats.ts'
@@ -48,31 +49,58 @@ function notifyAutoUpdateVersionBlocked(
     version: string
     versionBuild: string
     versionName: string
-    drizzleClient: ReturnType<typeof getDrizzleClient>
   },
 ) {
   const eventName = kind === 'upgrade' ? 'device:upgrade_blocked' : 'device:downgrade_blocked'
-  return backgroundTask(c, sendNotifToOrgMembersCached(
-    c,
-    eventName,
-    'device_error',
-    {
-      app_id: args.appId,
-      app_id_url: args.appId,
-      device_id: args.deviceId,
-      platform: args.platform,
-      channel_name: args.channelName,
-      channel_id: args.channelId,
-      version: args.version,
-      version_build: args.versionBuild,
-      version_name: args.versionName,
-      reason,
-    },
-    args.orgId,
-    args.appId,
-    '0 0 * * 0',
-    args.drizzleClient,
-  ))
+  const eventData = {
+    app_id: args.appId,
+    app_id_url: args.appId,
+    device_id: args.deviceId,
+    platform: args.platform,
+    channel_name: args.channelName,
+    channel_id: args.channelId,
+    version: args.version,
+    version_build: args.versionBuild,
+    version_name: args.versionName,
+    reason,
+  }
+  return backgroundTask(c, (async () => {
+    // Cloudflare plugin sets queuePluginNotifications — enqueue only, no request DB client.
+    if (shouldQueuePluginNotifications(c)) {
+      await sendNotifToOrgMembersCached(
+        c,
+        eventName,
+        'device_error',
+        eventData,
+        args.orgId,
+        args.appId,
+        '0 0 * * 0',
+        // Unused on the queued path; avoid borrowing the request-scoped client.
+        null as unknown as ReturnType<typeof getDrizzleClient>,
+      )
+      return
+    }
+
+    // Non-queued fallback (local/Supabase): own a short-lived client so the request
+    // pool can close without cancelling the Bento send.
+    const pgClient = getPgClient(c)
+    const drizzleClient = getDrizzleClient(pgClient)
+    try {
+      await sendNotifToOrgMembersCached(
+        c,
+        eventName,
+        'device_error',
+        eventData,
+        args.orgId,
+        args.appId,
+        '0 0 * * 0',
+        drizzleClient,
+      )
+    }
+    finally {
+      await closeClient(c, pgClient)
+    }
+  })())
 }
 
 type InvalidIpInfo = {
@@ -461,7 +489,6 @@ export async function updateWithPG(
       version: version.name,
       versionBuild: version_build,
       versionName: version_name,
-      drizzleClient,
     })
     // cloudlog(c.get('requestId'), 'check disableAutoUpdateToMajor', device_id)
     if (!channelData.channels.ios && platform === 'ios') {

--- a/supabase/functions/_backend/utils/update.ts
+++ b/supabase/functions/_backend/utils/update.ts
@@ -18,6 +18,7 @@ import { simpleError200 } from './hono.ts'
 import { cloudlog } from './logging.ts'
 import { getClientIP } from './rate_limit.ts'
 import { sendNotifOrgCached } from './notifications.ts'
+import { sendNotifToOrgMembersCached } from './org_email_notifications.ts'
 import { closeClient, getAppBlockProviderInfraRequestsPostgres, getAppOwnerPostgres, getDrizzleClient, getPgClient, requestInfosPostgres, setReplicationLagHeader } from './pg.ts'
 import { makeDevice } from './plugin_parser.ts'
 import { s3 } from './s3.ts'
@@ -30,6 +31,49 @@ const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
 const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
 const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
 const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
+
+type AutoUpdateBlockReason = 'major' | 'minor' | 'patch' | 'metadata' | 'under_native'
+
+function notifyAutoUpdateVersionBlocked(
+  c: Context,
+  kind: 'upgrade' | 'downgrade',
+  reason: AutoUpdateBlockReason,
+  args: {
+    appId: string
+    deviceId: string
+    platform: string
+    orgId: string
+    channelName: string
+    channelId: number
+    version: string
+    versionBuild: string
+    versionName: string
+    drizzleClient: ReturnType<typeof getDrizzleClient>
+  },
+) {
+  const eventName = kind === 'upgrade' ? 'device:upgrade_blocked' : 'device:downgrade_blocked'
+  return backgroundTask(c, sendNotifToOrgMembersCached(
+    c,
+    eventName,
+    'device_error',
+    {
+      app_id: args.appId,
+      app_id_url: args.appId,
+      device_id: args.deviceId,
+      platform: args.platform,
+      channel_name: args.channelName,
+      channel_id: args.channelId,
+      version: args.version,
+      version_build: args.versionBuild,
+      version_name: args.versionName,
+      reason,
+    },
+    args.orgId,
+    args.appId,
+    '0 0 * * 0',
+    args.drizzleClient,
+  ))
+}
 
 type InvalidIpInfo = {
   blocked: boolean
@@ -433,6 +477,18 @@ export async function updateWithPG(
     if (!isInternalVersionName(version.name) && channelData?.channels.disable_auto_update === 'major' && parse(version.name).major > parse(version_build).major) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade major version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateToMajor', versionName: version.name }])
+      await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'major', {
+        appId: app_id,
+        deviceId: device_id,
+        platform,
+        orgId: appOwner.owner_org,
+        channelName: channelData.channels.name,
+        channelId: channelData.channels.id,
+        version: version.name,
+        versionBuild: version_build,
+        versionName: version_name,
+        drizzleClient,
+      })
       return updateError200(c, 'disable_auto_update_to_major', 'Cannot upgrade major version', {
         major: true,
         version: version.name,
@@ -455,6 +511,18 @@ export async function updateWithPG(
     )) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade minor version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateToMinor', versionName: version.name }])
+      await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'minor', {
+        appId: app_id,
+        deviceId: device_id,
+        platform,
+        orgId: appOwner.owner_org,
+        channelName: channelData.channels.name,
+        channelId: channelData.channels.id,
+        version: version.name,
+        versionBuild: version_build,
+        versionName: version_name,
+        drizzleClient,
+      })
       return updateError200(c, 'disable_auto_update_to_minor', 'Cannot upgrade minor version', {
         major: true,
         version: version.name,
@@ -470,6 +538,18 @@ export async function updateWithPG(
     )) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade patch version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateToPatch', versionName: version.name }])
+      await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'patch', {
+        appId: app_id,
+        deviceId: device_id,
+        platform,
+        orgId: appOwner.owner_org,
+        channelName: channelData.channels.name,
+        channelId: channelData.channels.id,
+        version: version.name,
+        versionBuild: version_build,
+        versionName: version_name,
+        drizzleClient,
+      })
       return updateError200(c, 'disable_auto_update_to_patch', 'Cannot upgrade patch version', {
         major: true,
         version: version.name,
@@ -494,6 +574,18 @@ export async function updateWithPG(
       if (greaterThan(parse(minUpdateVersion), parse(version_build))) {
         cloudlog({ requestId: c.get('requestId'), message: 'Cannot upgrade, metadata > current version', id: device_id, min: minUpdateVersion, old: version_name, date: new Date().toISOString() })
         await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateMetadata', versionName: version.name }])
+        await notifyAutoUpdateVersionBlocked(c, 'upgrade', 'metadata', {
+          appId: app_id,
+          deviceId: device_id,
+          platform,
+          orgId: appOwner.owner_org,
+          channelName: channelData.channels.name,
+          channelId: channelData.channels.id,
+          version: version.name,
+          versionBuild: version_build,
+          versionName: version_name,
+          drizzleClient,
+        })
         return updateError200(c, 'disable_auto_update_to_metadata', 'Cannot upgrade version, min update version > current version', {
           major: true,
           version: version.name,
@@ -506,6 +598,18 @@ export async function updateWithPG(
     if (!isInternalVersionName(version.name) && channelData.channels.disable_auto_update_under_native && lessThan(parse(version.name), parse(version_build))) {
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot revert under native version', id: device_id, date: new Date().toISOString() })
       await sendStatsAndDevice(c, device, [{ action: 'disableAutoUpdateUnderNative', versionName: version.name }])
+      await notifyAutoUpdateVersionBlocked(c, 'downgrade', 'under_native', {
+        appId: app_id,
+        deviceId: device_id,
+        platform,
+        orgId: appOwner.owner_org,
+        channelName: channelData.channels.name,
+        channelId: channelData.channels.id,
+        version: version.name,
+        versionBuild: version_build,
+        versionName: version_name,
+        drizzleClient,
+      })
       return updateError200(c, 'disable_auto_update_under_native', 'Cannot revert under native version', {
         version: version.name,
         old: version_name,

--- a/tests/update-channel-self-store.unit.test.ts
+++ b/tests/update-channel-self-store.unit.test.ts
@@ -26,6 +26,10 @@ vi.mock('../supabase/functions/_backend/utils/notifications.ts', () => ({
   sendNotifOrgCached: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock('../supabase/functions/_backend/utils/org_email_notifications.ts', () => ({
+  sendNotifToOrgMembersCached: vi.fn(() => Promise.resolve()),
+}))
+
 vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
   closeClient: vi.fn(() => Promise.resolve()),
   getAppOwnerPostgres: getAppOwnerPostgresMock,

--- a/tests/update-response-shaping.unit.test.ts
+++ b/tests/update-response-shaping.unit.test.ts
@@ -1,6 +1,10 @@
 import type { Database } from '../supabase/functions/_backend/utils/supabase.types.ts'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { resToVersion } from '../supabase/functions/_backend/utils/update.ts'
+
+vi.mock('../supabase/functions/_backend/utils/org_email_notifications.ts', () => ({
+  sendNotifToOrgMembersCached: vi.fn(() => Promise.resolve()),
+}))
 
 const appVersion = {
   name: '1.2.3',

--- a/tests/update-version-mismatch-notif.unit.test.ts
+++ b/tests/update-version-mismatch-notif.unit.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getAppOwnerPostgresMock = vi.fn()
 const requestInfosPostgresMock = vi.fn()
-const sendNotifToOrgMembersCachedMock = vi.fn(() => Promise.resolve(true))
+const sendNotifToOrgMembersCachedMock = vi.fn<(...args: any[]) => Promise<boolean>>(() => Promise.resolve(true))
 const sendStatsAndDeviceMock = vi.fn(() => Promise.resolve())
 
 ;(globalThis as any).EdgeRuntime = undefined
@@ -125,7 +125,7 @@ describe('updates version mismatch bento notifications', () => {
     })
 
     const res = await runUpdate({ version_build: '1.0.0', version_name: '1.0.0' })
-    const json = await res.json()
+    const json = await res.json() as { error?: string }
     expect(json.error).toBe('disable_auto_update_to_major')
     expect(sendNotifToOrgMembersCachedMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -149,7 +149,8 @@ describe('updates version mismatch bento notifications', () => {
       expect.anything(),
     )
     // payload must not expose numeric bundle ids
-    const payload = sendNotifToOrgMembersCachedMock.mock.calls[0][3]
+    const firstCall = sendNotifToOrgMembersCachedMock.mock.calls[0] as unknown as unknown[]
+    const payload = firstCall[3] as Record<string, unknown>
     expect(payload).not.toHaveProperty('version_id')
     expect(Object.values(payload)).not.toContain(12345)
   })
@@ -177,7 +178,7 @@ describe('updates version mismatch bento notifications', () => {
     })
 
     const res = await runUpdate({ version_build: '2.0.0', version_name: '2.0.0' })
-    const json = await res.json()
+    const json = await res.json() as { error?: string }
     expect(json.error).toBe('disable_auto_update_under_native')
     expect(sendNotifToOrgMembersCachedMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/update-version-mismatch-notif.unit.test.ts
+++ b/tests/update-version-mismatch-notif.unit.test.ts
@@ -1,0 +1,198 @@
+import { Hono } from 'hono/tiny'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getAppOwnerPostgresMock = vi.fn()
+const requestInfosPostgresMock = vi.fn()
+const sendNotifToOrgMembersCachedMock = vi.fn(() => Promise.resolve(true))
+const sendStatsAndDeviceMock = vi.fn(() => Promise.resolve())
+
+;(globalThis as any).EdgeRuntime = undefined
+
+vi.mock('../supabase/functions/_backend/utils/appStatus.ts', () => ({
+  getAppStatus: vi.fn(() => Promise.resolve({ status: null, allow_device_custom_id: true })),
+  setAppStatus: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/channelSelfStore.ts', () => ({
+  getChannelSelfOverride: vi.fn(() => Promise.resolve(null)),
+  isChannelSelfStoreEnabled: vi.fn(() => false),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/downloadUrl.ts', () => ({
+  getBundleUrl: vi.fn(),
+  getManifestUrl: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/notifications.ts', () => ({
+  sendNotifOrgCached: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/org_email_notifications.ts', () => ({
+  sendNotifToOrgMembersCached: sendNotifToOrgMembersCachedMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: vi.fn(() => Promise.resolve()),
+  getAppOwnerPostgres: getAppOwnerPostgresMock,
+  getDrizzleClient: vi.fn(() => ({})),
+  getPgClient: vi.fn(() => ({ client: 'pg' })),
+  requestInfosPostgres: requestInfosPostgresMock,
+  setReplicationLagHeader: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/s3.ts', () => ({
+  s3: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/stats.ts', () => ({
+  createStatsBandwidth: vi.fn(() => Promise.resolve()),
+  createStatsMau: vi.fn(() => Promise.resolve()),
+  createStatsVersion: vi.fn(() => Promise.resolve()),
+  onPremStats: vi.fn(() => Promise.resolve(new Response('{}'))),
+  sendStatsAndDevice: sendStatsAndDeviceMock,
+}))
+
+function baseChannel(overrides: Record<string, unknown> = {}) {
+  return {
+    channels: {
+      id: 99,
+      name: 'production',
+      public: true,
+      allow_device_self_set: true,
+      allow_dev: true,
+      allow_prod: true,
+      allow_emulator: true,
+      ios: true,
+      android: true,
+      electron: true,
+      disable_auto_update: 'major',
+      disable_auto_update_under_native: false,
+      ...overrides,
+    },
+    version: {
+      id: 12345,
+      name: '2.0.0',
+      min_update_version: null,
+      session_key: null,
+      storage_provider: 'r2',
+      checksum: null,
+      r2_path: 'orgs/org-1/apps/com.test.app/2.0.0.zip',
+      link: null,
+      comment: null,
+    },
+    manifestEntries: [],
+  }
+}
+
+describe('updates version mismatch bento notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAppOwnerPostgresMock.mockResolvedValue({
+      allow_device_custom_id: true,
+      channel_device_count: 0,
+      expose_metadata: false,
+      manifest_bundle_count: 0,
+      owner_org: 'org-1',
+      orgs: { management_email: 'owner@example.com' },
+      plan_valid: true,
+    })
+  })
+
+  async function runUpdate(bodyOverrides: Record<string, unknown> = {}) {
+    const { updateWithPG } = await import('../supabase/functions/_backend/utils/update.ts')
+    const app = new Hono()
+    const body = {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+      platform: 'ios',
+      version_build: '1.0.0',
+      version_name: '1.0.0',
+      version_os: '17.0',
+      plugin_version: '7.34.0',
+      defaultChannel: '',
+      is_emulator: false,
+      is_prod: true,
+      ...bodyOverrides,
+    }
+    app.get('/', c => updateWithPG(c, body as any, {} as any))
+    return app.fetch(new Request('http://localhost/'), {}, { waitUntil: () => {} } as any)
+  }
+
+  it('emits device:upgrade_blocked when major auto-update is blocked', async () => {
+    requestInfosPostgresMock.mockResolvedValue({
+      channelData: baseChannel({ disable_auto_update: 'major' }),
+      channelOverride: undefined,
+    })
+
+    const res = await runUpdate({ version_build: '1.0.0', version_name: '1.0.0' })
+    const json = await res.json()
+    expect(json.error).toBe('disable_auto_update_to_major')
+    expect(sendNotifToOrgMembersCachedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'device:upgrade_blocked',
+      'device_error',
+      expect.objectContaining({
+        app_id: 'com.test.app',
+        app_id_url: 'com.test.app',
+        device_id: '11111111-1111-4111-8111-111111111111',
+        platform: 'ios',
+        channel_name: 'production',
+        channel_id: 99,
+        version: '2.0.0',
+        version_build: '1.0.0',
+        version_name: '1.0.0',
+        reason: 'major',
+      }),
+      'org-1',
+      'com.test.app',
+      '0 0 * * 0',
+      expect.anything(),
+    )
+    // payload must not expose numeric bundle ids
+    const payload = sendNotifToOrgMembersCachedMock.mock.calls[0][3]
+    expect(payload).not.toHaveProperty('version_id')
+    expect(Object.values(payload)).not.toContain(12345)
+  })
+
+  it('emits device:downgrade_blocked when under-native auto-update is blocked', async () => {
+    requestInfosPostgresMock.mockResolvedValue({
+      channelData: {
+        ...baseChannel({
+          disable_auto_update: 'none',
+          disable_auto_update_under_native: true,
+        }),
+        version: {
+          id: 12345,
+          name: '1.0.0',
+          min_update_version: null,
+          session_key: null,
+          storage_provider: 'r2',
+          checksum: null,
+          r2_path: 'orgs/org-1/apps/com.test.app/1.0.0.zip',
+          link: null,
+          comment: null,
+        },
+      },
+      channelOverride: undefined,
+    })
+
+    const res = await runUpdate({ version_build: '2.0.0', version_name: '2.0.0' })
+    const json = await res.json()
+    expect(json.error).toBe('disable_auto_update_under_native')
+    expect(sendNotifToOrgMembersCachedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'device:downgrade_blocked',
+      'device_error',
+      expect.objectContaining({
+        version: '1.0.0',
+        version_build: '2.0.0',
+        version_name: '2.0.0',
+        reason: 'under_native',
+      }),
+      'org-1',
+      'com.test.app',
+      '0 0 * * 0',
+      expect.anything(),
+    )
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Emit two Bento events from `/updates` when a device is blocked by channel auto-update version policy:
  - `device:upgrade_blocked` (major / minor / patch / metadata)
  - `device:downgrade_blocked` (under-native)
- Reuse `sendNotifToOrgMembersCached` + preference key `device_error` (plugin KV queue on Cloudflare, background send otherwise)
- Payload includes device + channel info and **version names only** (no bundle IDs) so Bento templates can build console links
- Document the events in `docs/BENTO_EMAIL_PREFERENCES_SETUP.md`
- Add unit coverage for both event paths

## Motivation (AI generated)

Customers ship a new channel update, then devices fail silently when native/channel semver policy rejects the download. Org admins need actionable email alerts (upgrade vs downgrade) without putting Bento I/O on the hot `/updates` path.

## Business Impact (AI generated)

Faster self-serve recovery when updates are blocked by version policy, fewer support tickets about “update not installing”, and better visibility into misconfigured channel auto-update settings.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/update-version-mismatch-notif.unit.test.ts tests/update-channel-self-store.unit.test.ts tests/update-response-shaping.unit.test.ts`
- [ ] Confirm Cloudflare plugin path enqueues via `queuePluginOrgMembersNotification` (existing `queuePluginNotifications` flag)
- [ ] In Bento, create automations for `device:upgrade_blocked` and `device:downgrade_blocked` with filter `Tag does NOT contain: device_error_disabled`
- [ ] Verify payload fields in a staged send: `app_id`, `device_id`, `platform`, `channel_name`, `channel_id`, `version`, `version_build`, `version_name`, `reason`

### Bento payload (AI generated)

```json
{
  "app_id": "com.example.app",
  "app_id_url": "com.example.app",
  "device_id": "…",
  "platform": "ios",
  "channel_name": "production",
  "channel_id": 99,
  "version": "2.0.0",
  "version_build": "1.0.0",
  "version_name": "1.0.0",
  "reason": "major"
}
```

Suggested console links in the email template:
- Device: `https://console.capgo.app/app/{{ event.details.app_id }}/device/{{ event.details.device_id }}`
- Channel: `https://console.capgo.app/app/{{ event.details.app_id }}/channel/{{ event.details.channel_id }}`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send cached email notifications to organization members when device auto-updates are blocked due to upgrade/downgrade restrictions, including structured app/device/channel/version details and the blocking reason.
* **Documentation**
  * Updated automation setup guidance to use `device:upgrade_blocked` and `device:downgrade_blocked` events (replacing the prior event).
* **Tests**
  * Added/updated unit tests to verify blocked-update notification behavior and payload shaping, including correct event selection and field inclusion/exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->