### PR TITLE
chore(typescript): adopt typescript-native-bridge (tsgo under vue-tsc)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,7 @@
   },
   "editor.formatOnSave": true,
   "SQL-Formatter-VSCode.dialect": "postgresql",
-  "SQL-Formatter-VSCode.linesBetweenQueries": 1
+  "SQL-Formatter-VSCode.linesBetweenQueries": 1,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/bun.lock
+++ b/bun.lock
@@ -191,7 +191,7 @@
         "supabase": "^2.109.1",
         "tailwindcss": "^4.3.3",
         "tinbase": "^0.10.0",
-        "typescript": "6.0.3",
+        "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2",
         "unplugin-auto-import": "^21.0.0",
         "unplugin-formkit": "^0.3.0",
         "unplugin-icons": "23.0.1",
@@ -266,7 +266,7 @@
         "prettyjson": "^1.2.5",
         "tmp": "^0.2.7",
         "tus-js-client": "^4.3.1",
-        "typescript": "6.0.3",
+        "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2",
         "ws": "^8.21.1",
         "zod": "^4.4.3",
       },
@@ -282,7 +282,7 @@
       "devDependencies": {
         "@capacitor/android": "^8.4.2",
         "@capacitor/ios": "^8.4.2",
-        "typescript": "6.0.3",
+        "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2",
       },
       "peerDependencies": {
         "@capacitor/core": "^8.4.2",
@@ -296,6 +296,9 @@
   "trustedDependencies": [
     "supabase",
   ],
+  "overrides": {
+    "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2",
+  },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
 
@@ -1344,6 +1347,20 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.65.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
+
+    "@typescript-native-bridge/darwin-arm64": ["@typescript-native-bridge/darwin-arm64@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-odo538uhOuD6PZT4gY8955l/r1xTLfVoyeU1RQ8O7QxISRbS90sYeQBNCts4VUyvcVa/1yBClgjgEbBYXZbDyg=="],
+
+    "@typescript-native-bridge/darwin-x64": ["@typescript-native-bridge/darwin-x64@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-LMJSZZXLNh7otRZoMH2+algHWupo3EcYnEXdxwH6+AAZJL7FZAiRA2h+nGNc0j3f0lRrw5qeFLcE2Rhtzk6Kpw=="],
+
+    "@typescript-native-bridge/linux-arm": ["@typescript-native-bridge/linux-arm@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-28OCjw/dpf5NV8glXnVsdMbCSImhInCe49jVIH3ICKYf9Re8QFnqz5fLVI8+3SUVproaFT7PQfuAKGt0sUuePQ=="],
+
+    "@typescript-native-bridge/linux-arm64": ["@typescript-native-bridge/linux-arm64@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-uPSbphc1Z7VMSVTs9wVuaqxK1jpkGwkMwcg7UvXwUUBdVrIv/zdFq349RkbG4IB0G0i78EWDDFDSkGs/aL/WEg=="],
+
+    "@typescript-native-bridge/linux-x64": ["@typescript-native-bridge/linux-x64@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kVJXTkXx3GWSGKJXZak6IhSiiR+HuKX4F6H74Dr96kqKS4Jopx0dqBbZ1+05xizCShJsw6gFP1tmWtYwt/V63A=="],
+
+    "@typescript-native-bridge/win32-arm64": ["@typescript-native-bridge/win32-arm64@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-xvNNBTKogTyvd1rFogt/dreCsx1kvbqLidBeoTuGDOjOCXjLRGuz1ym6woVXUwiVi3KdtwsaXqYE9CoURxNyCA=="],
+
+    "@typescript-native-bridge/win32-x64": ["@typescript-native-bridge/win32-x64@6.0.3-bridge.1.tsgo.7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5HegdRz7LXB61YdtJ0/F6tgTv4A4WfT0Uz0BQma6fPVhwK6UHdYOWosFW05ZEZOAZMQ9MgFsryvd8nNZNvUjVg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260707.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg=="],
 
@@ -2741,7 +2758,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2", "", { "optionalDependencies": { "@typescript-native-bridge/darwin-arm64": "6.0.3-bridge.1.tsgo.7.0.2", "@typescript-native-bridge/darwin-x64": "6.0.3-bridge.1.tsgo.7.0.2", "@typescript-native-bridge/linux-arm": "6.0.3-bridge.1.tsgo.7.0.2", "@typescript-native-bridge/linux-arm64": "6.0.3-bridge.1.tsgo.7.0.2", "@typescript-native-bridge/linux-x64": "6.0.3-bridge.1.tsgo.7.0.2", "@typescript-native-bridge/win32-arm64": "6.0.3-bridge.1.tsgo.7.0.2", "@typescript-native-bridge/win32-x64": "6.0.3-bridge.1.tsgo.7.0.2" }, "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vBtvhFVhjwUBIo4xZE6CNr3C1J1VSAvV7kLBRAPqs29HuL5bvxsOTRq+KxXODSEyp/TCWn/TeE0Bzd0D7k1UWg=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -261,7 +261,7 @@
     "prettyjson": "^1.2.5",
     "tmp": "^0.2.7",
     "tus-js-client": "^4.3.1",
-    "typescript": "6.0.3",
+    "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2",
     "ws": "^8.21.1",
     "zod": "^4.4.3"
   }

--- a/package.json
+++ b/package.json
@@ -379,7 +379,7 @@
     "supabase": "^2.109.1",
     "tailwindcss": "^4.3.3",
     "tinbase": "^0.10.0",
-    "typescript": "6.0.3",
+    "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2",
     "unplugin-auto-import": "^21.0.0",
     "unplugin-formkit": "^0.3.0",
     "unplugin-icons": "23.0.1",
@@ -409,5 +409,8 @@
   "trustedDependencies": [
     "supabase",
     "core-js"
-  ]
+  ],
+  "overrides": {
+    "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2"
+  }
 }

--- a/packages/capacitor-notifications/package.json
+++ b/packages/capacitor-notifications/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@capacitor/android": "^8.4.2",
     "@capacitor/ios": "^8.4.2",
-    "typescript": "6.0.3"
+    "typescript": "npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2"
   },
   "keywords": [
     "capacitor",


### PR DESCRIPTION
## Summary (AI generated)

- Alias `typescript` to [`typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2`](https://github.com/johnsoncodehk/typescript-native-bridge) in root, CLI, and notifications package
- Add a Bun `overrides` entry so every `typescript` consumer resolves the fork
- Point the workspace editor TypeScript SDK at `node_modules/typescript/lib`

## Motivation (AI generated)

Stock `typescript@7` breaks `vue-tsc` (classic Compiler API / `./lib/tsc` export mismatch). TNB keeps the classic TypeScript 6 package surface and runs the tsgo 7 checker in-process, so frontend typecheck can use the Go engine without waiting for vue-tsc to support the new TS7 API.

## Business Impact (AI generated)

Faster/cheaper CI and local frontend typechecks, with one TypeScript resolution path for `vue-tsc`, `tsc`, and editor tooling. No product behavior change intended.

## Test Plan (AI generated)

- [x] `require.resolve('typescript')` points at `typescript-native-bridge`
- [x] `bun run typecheck:frontend` prints `TNB ACTIVE` and passes (~5s wall)
- [x] `bun run typecheck` (cli + backend + frontend)
- [x] `bun run lint`
- [x] `bun run test:unit` (162 files / 1082 tests)
- [x] `bun run cli:build` (TNB ACTIVE under `tsc`)
- [x] notifications package `tsc -p tsconfig.json` build
- [ ] CI green on draft PR
- [ ] Confirm editor uses workspace TypeScript version after pull

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

