### PR TITLE
fix(replica): exclude primary-only manifest_present index

### DIFF
--- a/read_replicate/schema_catalog.ts
+++ b/read_replicate/schema_catalog.ts
@@ -33,6 +33,9 @@ export const REPLICA_FUNCTIONS = ['one_month_ahead'] as const
 export const REPLICA_EXCLUDED_INDEXES = [
   // replicate_prepare.sh intentionally omits this source-only customer lookup index from the replica DDL.
   'idx_stripe_info_customer_id',
+  // Primary-only reclaim helper for null_migrated_app_version_manifests; not needed on subscribers
+  // and Cloud SQL server-side import cannot apply CREATE INDEX before primary migrations.
+  'app_versions_manifest_present_idx',
 ] as const
 
 export function replicaConfigPattern(values: readonly string[]): string {

--- a/read_replicate/schema_replicate.catalog.json
+++ b/read_replicate/schema_replicate.catalog.json
@@ -1983,13 +1983,6 @@
       "valid": true
     },
     {
-      "constraintOwned": false,
-      "definition": "CREATE INDEX app_versions_manifest_present_idx ON public.app_versions USING btree (id) WHERE (manifest IS NOT NULL)",
-      "name": "app_versions_manifest_present_idx",
-      "table": "app_versions",
-      "valid": true
-    },
-    {
       "constraintOwned": true,
       "definition": "CREATE UNIQUE INDEX app_versions_name_app_id_key ON public.app_versions USING btree (name, app_id)",
       "name": "app_versions_name_app_id_key",
@@ -2056,20 +2049,6 @@
       "constraintOwned": false,
       "definition": "CREATE INDEX idx_app_versions_deleted_at ON public.app_versions USING btree (deleted_at) WHERE (deleted_at IS NOT NULL)",
       "name": "idx_app_versions_deleted_at",
-      "table": "app_versions",
-      "valid": true
-    },
-    {
-      "constraintOwned": false,
-      "definition": "CREATE INDEX idx_app_versions_deleted_at_id ON public.app_versions USING btree (deleted_at, id) WHERE (deleted = true)",
-      "name": "idx_app_versions_deleted_at_id",
-      "table": "app_versions",
-      "valid": true
-    },
-    {
-      "constraintOwned": false,
-      "definition": "CREATE INDEX idx_app_versions_deleted_with_manifest ON public.app_versions USING btree (id) WHERE ((deleted = true) AND (manifest_count > 0))",
-      "name": "idx_app_versions_deleted_with_manifest",
       "table": "app_versions",
       "valid": true
     },

--- a/read_replicate/schema_replicate.catalog.json
+++ b/read_replicate/schema_replicate.catalog.json
@@ -2054,6 +2054,20 @@
     },
     {
       "constraintOwned": false,
+      "definition": "CREATE INDEX idx_app_versions_deleted_at_id ON public.app_versions USING btree (deleted_at, id) WHERE (deleted = true)",
+      "name": "idx_app_versions_deleted_at_id",
+      "table": "app_versions",
+      "valid": true
+    },
+    {
+      "constraintOwned": false,
+      "definition": "CREATE INDEX idx_app_versions_deleted_with_manifest ON public.app_versions USING btree (id) WHERE ((deleted = true) AND (manifest_count > 0))",
+      "name": "idx_app_versions_deleted_with_manifest",
+      "table": "app_versions",
+      "valid": true
+    },
+    {
+      "constraintOwned": false,
       "definition": "CREATE INDEX idx_app_versions_id ON public.app_versions USING btree (id)",
       "name": "idx_app_versions_id",
       "table": "app_versions",

--- a/read_replicate/schema_replicate.sql
+++ b/read_replicate/schema_replicate.sql
@@ -608,13 +608,6 @@ CREATE INDEX app_versions_cli_version_idx ON public.app_versions USING btree (cl
 
 
 --
--- Name: app_versions_manifest_present_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX app_versions_manifest_present_idx ON public.app_versions USING btree (id) WHERE (manifest IS NOT NULL);
-
-
---
 -- Name: app_versions_r2_path_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -773,20 +766,6 @@ CREATE INDEX idx_app_versions_deleted ON public.app_versions USING btree (delete
 --
 
 CREATE INDEX idx_app_versions_deleted_at ON public.app_versions USING btree (deleted_at) WHERE (deleted_at IS NOT NULL);
-
-
---
--- Name: idx_app_versions_deleted_at_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_app_versions_deleted_at_id ON public.app_versions USING btree (deleted_at, id) WHERE (deleted = true);
-
-
---
--- Name: idx_app_versions_deleted_with_manifest; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_app_versions_deleted_with_manifest ON public.app_versions USING btree (id) WHERE ((deleted = true) AND (manifest_count > 0));
 
 
 --

--- a/read_replicate/schema_replicate.sql
+++ b/read_replicate/schema_replicate.sql
@@ -769,6 +769,20 @@ CREATE INDEX idx_app_versions_deleted_at ON public.app_versions USING btree (del
 
 
 --
+-- Name: idx_app_versions_deleted_at_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_app_versions_deleted_at_id ON public.app_versions USING btree (deleted_at, id) WHERE (deleted = true);
+
+
+--
+-- Name: idx_app_versions_deleted_with_manifest; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_app_versions_deleted_with_manifest ON public.app_versions USING btree (id) WHERE ((deleted = true) AND (manifest_count > 0));
+
+
+--
 -- Name: idx_app_versions_id; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
## Summary (AI generated)

- Add `app_versions_manifest_present_idx` to `REPLICA_EXCLUDED_INDEXES`
- Regenerate read-replica schema snapshot without that index

## Motivation (AI generated)

Release CI fails with `Cloud SQL server-side import cannot atomically apply index app_versions.app_versions_manifest_present_idx before primary migrations`. That index is primary-only reclaim helper SQL; subscribers do not need it, and the Google import path cannot create indexes.

## Business Impact (AI generated)

Unblocks release schema reconciliation after the manifest_present index migration without weakening replica import safety.

## Test Plan (AI generated)

- [x] `replicate_prepare.sh` omits the index (53 indexes)
- [ ] CI green, including read-replica schema sync dry-run/import path

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

