### PR TITLE
fix(ops): make Capgo-EU reclaim SQL Editor safe

### DIFF
--- a/scripts/ops/reclaim_supabase_swap.sql
+++ b/scripts/ops/reclaim_supabase_swap.sql
@@ -1,26 +1,28 @@
--- Capgo-EU Phase A reclaim (run manually in a maintenance window).
--- REQUIRED: psql for VACUUM (cannot run inside a transaction / SQL-editor tx).
--- Prefer ~/.pgpass / PGPASSFILE instead of putting the password on the CLI.
+-- Capgo-EU Phase A reclaim — safe for Supabase SQL Editor.
+-- Paste this whole file into SQL Editor and run.
 --
--- Schema source of truth: migration 20260722154010_app_versions_manifest_present_idx.
--- Optional non-blocking prebuild before that migration deploys:
---   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/ops/reclaim_supabase_swap_index.sql
+-- Prerequisites (deploy first, or this script fails the preflight):
+--   - 20260722082019_fix_supabase_swap_memory
+--   - 20260722154010_app_versions_manifest_present_idx
 --
--- Example:
---   psql "postgresql://postgres@HOST:5432/postgres?sslmode=require" -v ON_ERROR_STOP=1 -f scripts/ops/reclaim_supabase_swap.sql
--- Safe order: truncate -> archives -> null manifests -> audit trim.
--- Re-run the FULL script until cleanup notices report deleted/updated = 0
--- (functions always emit a notice, including zero totals).
+-- Re-run until Notices show deleted/updated = 0 (functions always raise a notice).
+-- VACUUM is NOT here: SQL Editor wraps work in a transaction and rejects VACUUM.
+-- Optional later via psql: scripts/ops/reclaim_supabase_swap_vacuum.sql
 
 SET lock_timeout = '5s';
+SET statement_timeout = '180s';
 
 -- ---------------------------------------------------------------------------
--- 0) Baseline sizes + require a valid candidate index
+-- 0) Preflight + baseline sizes
 -- ---------------------------------------------------------------------------
-SELECT pg_size_pretty(pg_database_size(current_database())::bigint) AS db_size;
-
 DO $$
 BEGIN
+  IF to_regprocedure('public.null_migrated_app_version_manifests()') IS NULL
+     OR to_regprocedure('public.cleanup_net_http_response()') IS NULL THEN
+    RAISE EXCEPTION
+      'Missing reclaim functions. Deploy migration 20260722082019_fix_supabase_swap_memory first.';
+  END IF;
+
   IF NOT EXISTS (
     SELECT 1
     FROM pg_catalog.pg_class AS idx
@@ -32,9 +34,12 @@ BEGIN
       AND i.indisvalid
   ) THEN
     RAISE EXCEPTION
-      'Missing or invalid app_versions_manifest_present_idx. Deploy migration 20260722154010 (or run scripts/ops/reclaim_supabase_swap_index.sql alone first if the index is invalid/missing).';
+      'Missing or invalid app_versions_manifest_present_idx. Deploy migration 20260722154010 first.';
   END IF;
-END $$;
+END
+$$;
+
+SELECT pg_size_pretty(pg_database_size(current_database())::bigint) AS db_size;
 
 SELECT
   relname,
@@ -54,44 +59,24 @@ WHERE (schemaname, relname) IN (
 ORDER BY pg_total_relation_size(format('%I.%I', schemaname, relname)::regclass) DESC;
 
 -- ---------------------------------------------------------------------------
--- 1) Truncate pg_net response bloat
+-- 1) Truncate pg_net response bloat (biggest immediate win)
 -- ---------------------------------------------------------------------------
 TRUNCATE TABLE net._http_response;
 
 -- ---------------------------------------------------------------------------
--- 2) Purge pgmq archives/stuck messages.
---    Re-run the FULL script until archived_deleted=0 and stuck_deleted=0.
+-- 2) Purge pgmq archives/stuck messages (batched; re-run until notice = 0)
 -- ---------------------------------------------------------------------------
 SELECT public.cleanup_queue_messages();
 
-VACUUM (VERBOSE) pgmq.a_on_version_update;
-VACUUM (VERBOSE) pgmq.a_on_manifest_create;
-VACUUM (VERBOSE) pgmq.a_webhook_dispatcher;
-VACUUM (VERBOSE) pgmq.a_on_channel_update;
-VACUUM (VERBOSE) pgmq.q_on_version_update;
-VACUUM (VERBOSE) pgmq.q_on_manifest_create;
-VACUUM (VERBOSE) pgmq.q_webhook_dispatcher;
-VACUUM (VERBOSE) pgmq.q_on_channel_update;
-
 -- ---------------------------------------------------------------------------
--- 3) Null fully migrated app_versions.manifest arrays (s3_path + file_hash).
---    Re-run the FULL script until updated=0.
+-- 3) Null fully migrated app_versions.manifest arrays (re-run until notice = 0)
 -- ---------------------------------------------------------------------------
 SELECT public.null_migrated_app_version_manifests();
 
-VACUUM (ANALYZE, VERBOSE) public.app_versions;
--- Optional TOAST compaction after updated=0:
--- VACUUM (FULL, VERBOSE) public.app_versions;
-
 -- ---------------------------------------------------------------------------
--- 4) Trim audit_logs older than 30 days.
---    Re-run the FULL script until deleted=0.
+-- 4) Trim audit_logs older than 30 days (re-run until notice = 0)
 -- ---------------------------------------------------------------------------
 SELECT public.cleanup_old_audit_logs();
-
-VACUUM (ANALYZE, VERBOSE) public.audit_logs;
--- Optional TOAST compaction after deleted=0:
--- VACUUM (FULL, VERBOSE) public.audit_logs;
 
 -- ---------------------------------------------------------------------------
 -- 5) Final sizes

--- a/scripts/ops/reclaim_supabase_swap_index.sql
+++ b/scripts/ops/reclaim_supabase_swap_index.sql
@@ -1,12 +1,10 @@
 -- Optional Capgo-EU pre-deploy: build the candidate index without blocking writes.
--- Run this ALONE (one statement) before applying migration
--- 20260722154010_app_versions_manifest_present_idx so the migration's
--- CREATE INDEX IF NOT EXISTS becomes a no-op.
+-- Prefer deploying migration 20260722154010 instead.
+-- If you still need this: run the SINGLE statement below alone in SQL Editor
+-- (or psql). Do not mix with other statements in one Editor run if the Editor
+-- wraps a transaction — CREATE INDEX CONCURRENTLY cannot run in a transaction.
 --
--- REQUIRED: psql (CREATE INDEX CONCURRENTLY cannot run inside a transaction).
--- SQL Editor: paste ONLY the CREATE INDEX statement below.
---
--- Example:
+-- Example (psql):
 --   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/ops/reclaim_supabase_swap_index.sql
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS app_versions_manifest_present_idx

--- a/scripts/ops/reclaim_supabase_swap_truncate_http.sql
+++ b/scripts/ops/reclaim_supabase_swap_truncate_http.sql
@@ -1,0 +1,5 @@
+-- Capgo-EU immediate reclaim — safe for Supabase SQL Editor.
+-- Single statement. Run alone. No migration required.
+-- Frees net._http_response bloat (~5GB on Capgo-EU when empty/stale).
+
+TRUNCATE TABLE net._http_response;

--- a/scripts/ops/reclaim_supabase_swap_vacuum.sql
+++ b/scripts/ops/reclaim_supabase_swap_vacuum.sql
@@ -1,0 +1,22 @@
+-- Optional Capgo-EU reclaim VACUUM — psql only (NOT SQL Editor).
+-- Run after scripts/ops/reclaim_supabase_swap.sql when deleted/updated notices are 0.
+--
+-- Example:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/ops/reclaim_supabase_swap_vacuum.sql
+
+VACUUM (VERBOSE) pgmq.a_on_version_update;
+VACUUM (VERBOSE) pgmq.a_on_manifest_create;
+VACUUM (VERBOSE) pgmq.a_webhook_dispatcher;
+VACUUM (VERBOSE) pgmq.a_on_channel_update;
+VACUUM (VERBOSE) pgmq.q_on_version_update;
+VACUUM (VERBOSE) pgmq.q_on_manifest_create;
+VACUUM (VERBOSE) pgmq.q_webhook_dispatcher;
+VACUUM (VERBOSE) pgmq.q_on_channel_update;
+
+VACUUM (ANALYZE, VERBOSE) public.app_versions;
+-- Optional TOAST compaction after dual-storage nulling is done:
+-- VACUUM (FULL, VERBOSE) public.app_versions;
+
+VACUUM (ANALYZE, VERBOSE) public.audit_logs;
+-- Optional TOAST compaction after audit trim is done:
+-- VACUUM (FULL, VERBOSE) public.audit_logs;

--- a/scripts/ops/verify_supabase_swap.sql
+++ b/scripts/ops/verify_supabase_swap.sql
@@ -1,6 +1,5 @@
--- Post-deploy / post-reclaim verification for Capgo-EU swap pressure.
--- REQUIRED: psql (uses \gexec). Example:
---   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/ops/verify_supabase_swap.sql
+-- Capgo-EU post-reclaim verification — safe for Supabase SQL Editor.
+-- Paste into SQL Editor and run (no psql meta-commands).
 
 SELECT pg_size_pretty(pg_database_size(current_database())::bigint) AS db_size;
 
@@ -52,6 +51,10 @@ FROM (
     )
 ) AS eligible;
 
+SELECT count(*)::bigint AS non_null_manifest_versions
+FROM public.app_versions
+WHERE manifest IS NOT NULL;
+
 SELECT
   name,
   enabled,
@@ -70,7 +73,15 @@ WHERE name IN (
 )
 ORDER BY name;
 
-SELECT indexname
+SELECT indexname,
+       (
+         SELECT i.indisvalid
+         FROM pg_catalog.pg_class AS idx
+         JOIN pg_catalog.pg_namespace AS ns ON ns.oid = idx.relnamespace
+         JOIN pg_catalog.pg_index AS i ON i.indexrelid = idx.oid
+         WHERE ns.nspname = 'public'
+           AND idx.relname = 'app_versions_manifest_present_idx'
+       ) AS indisvalid
 FROM pg_indexes
 WHERE schemaname = 'public'
   AND indexname = 'app_versions_manifest_present_idx';
@@ -82,33 +93,44 @@ SELECT EXISTS (
   LIMIT 1
 ) AS has_audit_logs_older_than_30d;
 
-SELECT format(
-  $fmt$SELECT %L AS queue_name,
-         EXISTS (
-           SELECT 1
-           FROM pgmq.%I
-           WHERE archived_at < now() - interval '2 days'
-           LIMIT 1
-         ) AS has_rows_older_than_2d;$fmt$,
-  queue_name,
-  'a_' || pg_catalog.lower(queue_name)
-)
-FROM pgmq.list_queues()
-\gexec
+-- Fixed Capgo-EU queue set (no psql \gexec).
+SELECT 'a_on_manifest_create' AS queue_name,
+       EXISTS (
+         SELECT 1 FROM pgmq.a_on_manifest_create
+         WHERE archived_at < now() - interval '2 days' LIMIT 1
+       ) AS has_rows_older_than_2d
+UNION ALL SELECT 'a_on_version_update',
+       EXISTS (
+         SELECT 1 FROM pgmq.a_on_version_update
+         WHERE archived_at < now() - interval '2 days' LIMIT 1
+       )
+UNION ALL SELECT 'a_webhook_dispatcher',
+       EXISTS (
+         SELECT 1 FROM pgmq.a_webhook_dispatcher
+         WHERE archived_at < now() - interval '2 days' LIMIT 1
+       )
+UNION ALL SELECT 'a_on_channel_update',
+       EXISTS (
+         SELECT 1 FROM pgmq.a_on_channel_update
+         WHERE archived_at < now() - interval '2 days' LIMIT 1
+       );
 
-SELECT format(
-  $fmt$SELECT %L AS queue_name,
-         EXISTS (
-           SELECT 1
-           FROM pgmq.%I
-           WHERE read_ct > 5
-           LIMIT 1
-         ) AS has_stuck_read_ct_gt_5;$fmt$,
-  queue_name,
-  'q_' || pg_catalog.lower(queue_name)
-)
-FROM pgmq.list_queues()
-\gexec
+SELECT 'q_on_manifest_create' AS queue_name,
+       EXISTS (
+         SELECT 1 FROM pgmq.q_on_manifest_create WHERE read_ct > 5 LIMIT 1
+       ) AS has_stuck_read_ct_gt_5
+UNION ALL SELECT 'q_on_version_update',
+       EXISTS (
+         SELECT 1 FROM pgmq.q_on_version_update WHERE read_ct > 5 LIMIT 1
+       )
+UNION ALL SELECT 'q_webhook_dispatcher',
+       EXISTS (
+         SELECT 1 FROM pgmq.q_webhook_dispatcher WHERE read_ct > 5 LIMIT 1
+       )
+UNION ALL SELECT 'q_on_channel_update',
+       EXISTS (
+         SELECT 1 FROM pgmq.q_on_channel_update WHERE read_ct > 5 LIMIT 1
+       );
 
 SELECT
   'index hit rate' AS name,


### PR DESCRIPTION
## Summary (AI generated)

- Make `scripts/ops/reclaim_supabase_swap.sql` and `verify_supabase_swap.sql` safe to paste into Supabase SQL Editor (no `VACUUM`, no `\\gexec`)
- Move `VACUUM` to `reclaim_supabase_swap_vacuum.sql` (psql-only)
- Add one-statement `reclaim_supabase_swap_truncate_http.sql` for immediate `net._http_response` reclaim

## Motivation (AI generated)

SQL Editor wraps multi-statement runs in a transaction, so `VACUUM` / `CREATE INDEX CONCURRENTLY` / psql meta-commands fail. Ops needs a dashboard-runnable reclaim path.

## Business Impact (AI generated)

Unblocks Capgo-EU swap reclaim from the dashboard after migrations are deployed.

## Test Plan (AI generated)

- [ ] Paste `reclaim_supabase_swap_truncate_http.sql` in Capgo-EU SQL Editor and confirm `net._http_response` size drops
- [ ] After deploying swap migrations, paste `reclaim_supabase_swap.sql`, re-run until notices are 0
- [ ] Paste `verify_supabase_swap.sql` and confirm sizes/cron/index checks

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Supabase SQL Editor–compatible maintenance and verification scripts.
  * Added standalone storage reclamation for HTTP responses.
  * Added optional post-maintenance vacuum and compaction commands.
  * Added clearer guidance for creating the manifest index without blocking writes.

* **Bug Fixes**
  * Improved preflight validation, runtime safeguards, and transaction compatibility.
  * Enhanced verification of queue health, archived records, manifest data, and index validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->