### PR TITLE
fix(db): add small batch budgets for reclaim cleanups

### DIFF
--- a/scripts/ops/reclaim_supabase_swap.sql
+++ b/scripts/ops/reclaim_supabase_swap.sql
@@ -1,101 +1,21 @@
--- Capgo-EU Phase A reclaim — safe for Supabase SQL Editor.
--- Paste this whole file into SQL Editor and run.
+-- Capgo-EU reclaim — Supabase SQL Editor.
+-- Run ONE statement at a time. Re-run the same statement until its Notice shows 0.
+-- Tiny budgets avoid dashboard statement timeouts.
 --
--- Prerequisites (deploy first, or this script fails the preflight):
---   - 20260722082019_fix_supabase_swap_memory
---   - 20260722154010_app_versions_manifest_present_idx
---
--- Re-run until Notices show deleted/updated = 0 (functions always raise a notice).
--- VACUUM is NOT here: SQL Editor wraps work in a transaction and rejects VACUUM.
--- Optional later via psql: scripts/ops/reclaim_supabase_swap_vacuum.sql
+-- Prerequisites: migrations through 20260723113958_cleanup_batch_budget_args
+-- (or paste that migration once in SQL Editor first).
 
-SET lock_timeout = '5s';
-SET statement_timeout = '180s';
+-- Step 0 (once): free http response bloat
+-- TRUNCATE TABLE net._http_response;
 
--- ---------------------------------------------------------------------------
--- 0) Preflight + baseline sizes
--- ---------------------------------------------------------------------------
-DO $$
-BEGIN
-  IF to_regprocedure('public.null_migrated_app_version_manifests()') IS NULL
-     OR to_regprocedure('public.cleanup_net_http_response()') IS NULL THEN
-    RAISE EXCEPTION
-      'Missing reclaim functions. Deploy migration 20260722082019_fix_supabase_swap_memory first.';
-  END IF;
+-- Step 1: queues — re-run until archived_deleted=0 and stuck_deleted=0
+SELECT public.cleanup_queue_messages(1, 500);
 
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_catalog.pg_class AS idx
-    JOIN pg_catalog.pg_namespace AS ns ON ns.oid = idx.relnamespace
-    JOIN pg_catalog.pg_index AS i ON i.indexrelid = idx.oid
-    WHERE ns.nspname = 'public'
-      AND idx.relname = 'app_versions_manifest_present_idx'
-      AND i.indrelid = 'public.app_versions'::pg_catalog.regclass
-      AND i.indisvalid
-  ) THEN
-    RAISE EXCEPTION
-      'Missing or invalid app_versions_manifest_present_idx. Deploy migration 20260722154010 first.';
-  END IF;
-END
-$$;
+-- Step 2: dual-storage manifests — re-run until updated=0
+-- SELECT public.null_migrated_app_version_manifests(3, 25);
 
-SELECT pg_size_pretty(pg_database_size(current_database())::bigint) AS db_size;
+-- Step 3: old audit logs — re-run until deleted=0
+-- SELECT public.cleanup_old_audit_logs(2, 200);
 
-SELECT
-  relname,
-  n_live_tup,
-  pg_size_pretty(pg_total_relation_size(format('%I.%I', schemaname, relname)::regclass)::bigint) AS total
-FROM pg_stat_user_tables
-WHERE (schemaname, relname) IN (
-  ('net', '_http_response'),
-  ('public', 'audit_logs'),
-  ('public', 'app_versions'),
-  ('public', 'manifest'),
-  ('pgmq', 'a_on_version_update'),
-  ('pgmq', 'a_on_manifest_create'),
-  ('pgmq', 'a_webhook_dispatcher'),
-  ('pgmq', 'a_on_channel_update')
-)
-ORDER BY pg_total_relation_size(format('%I.%I', schemaname, relname)::regclass) DESC;
-
--- ---------------------------------------------------------------------------
--- 1) Truncate pg_net response bloat (biggest immediate win)
--- ---------------------------------------------------------------------------
-TRUNCATE TABLE net._http_response;
-
--- ---------------------------------------------------------------------------
--- 2) Purge pgmq archives/stuck messages (batched; re-run until notice = 0)
--- ---------------------------------------------------------------------------
-SELECT public.cleanup_queue_messages();
-
--- ---------------------------------------------------------------------------
--- 3) Null fully migrated app_versions.manifest arrays (re-run until notice = 0)
--- ---------------------------------------------------------------------------
-SELECT public.null_migrated_app_version_manifests();
-
--- ---------------------------------------------------------------------------
--- 4) Trim audit_logs older than 30 days (re-run until notice = 0)
--- ---------------------------------------------------------------------------
-SELECT public.cleanup_old_audit_logs();
-
--- ---------------------------------------------------------------------------
--- 5) Final sizes
--- ---------------------------------------------------------------------------
-SELECT pg_size_pretty(pg_database_size(current_database())::bigint) AS db_size_after;
-
-SELECT
-  relname,
-  n_live_tup,
-  pg_size_pretty(pg_total_relation_size(format('%I.%I', schemaname, relname)::regclass)::bigint) AS total
-FROM pg_stat_user_tables
-WHERE (schemaname, relname) IN (
-  ('net', '_http_response'),
-  ('public', 'audit_logs'),
-  ('public', 'app_versions'),
-  ('public', 'manifest'),
-  ('pgmq', 'a_on_version_update'),
-  ('pgmq', 'a_on_manifest_create'),
-  ('pgmq', 'a_webhook_dispatcher'),
-  ('pgmq', 'a_on_channel_update')
-)
-ORDER BY pg_total_relation_size(format('%I.%I', schemaname, relname)::regclass) DESC;
+-- Optional size check:
+-- SELECT pg_size_pretty(pg_database_size(current_database())::bigint) AS db_size;

--- a/scripts/ops/reclaim_supabase_swap_step_audit.sql
+++ b/scripts/ops/reclaim_supabase_swap_step_audit.sql
@@ -1,0 +1,3 @@
+-- Capgo-EU reclaim step — audit_logs only. SQL Editor safe.
+-- Re-run until Notice: deleted=0
+SELECT public.cleanup_old_audit_logs(2, 200);

--- a/scripts/ops/reclaim_supabase_swap_step_manifest.sql
+++ b/scripts/ops/reclaim_supabase_swap_step_manifest.sql
@@ -1,0 +1,3 @@
+-- Capgo-EU reclaim step — dual-storage manifests only. SQL Editor safe.
+-- Re-run until Notice: updated=0
+SELECT public.null_migrated_app_version_manifests(3, 25);

--- a/scripts/ops/reclaim_supabase_swap_step_queue.sql
+++ b/scripts/ops/reclaim_supabase_swap_step_queue.sql
@@ -1,0 +1,3 @@
+-- Capgo-EU reclaim step — queues only. SQL Editor safe.
+-- Re-run until Notice: archived_deleted=0 and stuck_deleted=0
+SELECT public.cleanup_queue_messages(1, 500);

--- a/supabase/migrations/20260723113958_cleanup_batch_budget_args.sql
+++ b/supabase/migrations/20260723113958_cleanup_batch_budget_args.sql
@@ -1,0 +1,207 @@
+-- Allow small per-call budgets so SQL Editor / short timeouts can reclaim
+-- iteratively: SELECT public.cleanup_queue_messages(1, 500); (re-run until notice 0)
+
+DROP FUNCTION IF EXISTS "public"."cleanup_queue_messages"();
+CREATE OR REPLACE FUNCTION "public"."cleanup_queue_messages"(
+  "max_batches_total" integer DEFAULT 40,
+  "batch_size" integer DEFAULT 10000
+) RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  queue_name text;
+  cutoff timestamptz := pg_catalog.now() - INTERVAL '2 days';
+  batches_used integer := 0;
+  deleted_batch integer;
+  deleted_archived_total bigint := 0;
+  deleted_stuck_total bigint := 0;
+  did_work boolean;
+  archive_rel regclass;
+  queue_rel regclass;
+  v_max_batches integer := GREATEST(1, COALESCE(max_batches_total, 40));
+  v_batch_size integer := GREATEST(1, COALESCE(batch_size, 10000));
+BEGIN
+  LOOP
+    EXIT WHEN batches_used >= v_max_batches;
+    did_work := false;
+
+    FOR queue_name IN (
+      SELECT q.queue_name FROM pgmq.list_queues() q
+    ) LOOP
+      EXIT WHEN batches_used >= v_max_batches;
+
+      archive_rel := to_regclass(pg_catalog.format('pgmq.a_%I', queue_name));
+      queue_rel := to_regclass(pg_catalog.format('pgmq.q_%I', queue_name));
+
+      IF archive_rel IS NOT NULL THEN
+        EXECUTE pg_catalog.format(
+          'DELETE FROM pgmq.a_%I
+           WHERE ctid IN (
+             SELECT ctid
+             FROM pgmq.a_%I
+             WHERE archived_at < $1
+             LIMIT $2
+           )',
+          queue_name,
+          queue_name
+        )
+        USING cutoff, v_batch_size;
+
+        GET DIAGNOSTICS deleted_batch = ROW_COUNT;
+        IF deleted_batch > 0 THEN
+          batches_used := batches_used + 1;
+          deleted_archived_total := deleted_archived_total + deleted_batch;
+          did_work := true;
+        END IF;
+      END IF;
+
+      IF batches_used >= v_max_batches THEN
+        EXIT;
+      END IF;
+
+      IF queue_rel IS NOT NULL THEN
+        EXECUTE pg_catalog.format(
+          'DELETE FROM pgmq.q_%I
+           WHERE ctid IN (
+             SELECT ctid
+             FROM pgmq.q_%I
+             WHERE read_ct > 5
+             LIMIT $1
+           )',
+          queue_name,
+          queue_name
+        )
+        USING v_batch_size;
+
+        GET DIAGNOSTICS deleted_batch = ROW_COUNT;
+        IF deleted_batch > 0 THEN
+          batches_used := batches_used + 1;
+          deleted_stuck_total := deleted_stuck_total + deleted_batch;
+          did_work := true;
+        END IF;
+      END IF;
+    END LOOP;
+
+    EXIT WHEN NOT did_work;
+  END LOOP;
+
+  RAISE NOTICE
+    'cleanup_queue_messages: archived_deleted=% stuck_deleted=% batches_used=%/% batch_size=%',
+    deleted_archived_total,
+    deleted_stuck_total,
+    batches_used,
+    v_max_batches,
+    v_batch_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."cleanup_queue_messages"(integer, integer) OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."cleanup_queue_messages"(integer, integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."cleanup_queue_messages"(integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."cleanup_old_audit_logs"();
+CREATE OR REPLACE FUNCTION "public"."cleanup_old_audit_logs"(
+  "max_batches" integer DEFAULT 40,
+  "batch_size" integer DEFAULT 5000
+) RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  cutoff timestamptz := pg_catalog.now() - INTERVAL '30 days';
+  batch_no integer := 0;
+  deleted_batch integer;
+  deleted_total bigint := 0;
+  v_max_batches integer := GREATEST(1, COALESCE(max_batches, 40));
+  v_batch_size integer := GREATEST(1, COALESCE(batch_size, 5000));
+BEGIN
+  LOOP
+    batch_no := batch_no + 1;
+    EXIT WHEN batch_no > v_max_batches;
+
+    DELETE FROM public.audit_logs
+    WHERE ctid IN (
+      SELECT ctid
+      FROM public.audit_logs
+      WHERE created_at < cutoff
+      LIMIT v_batch_size
+    );
+
+    GET DIAGNOSTICS deleted_batch = ROW_COUNT;
+    deleted_total := deleted_total + deleted_batch;
+    EXIT WHEN deleted_batch = 0;
+  END LOOP;
+
+  RAISE NOTICE
+    'cleanup_old_audit_logs: deleted=% batches=%/% batch_size=%',
+    deleted_total,
+    batch_no,
+    v_max_batches,
+    v_batch_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."cleanup_old_audit_logs"(integer, integer) OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."cleanup_old_audit_logs"(integer, integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."cleanup_old_audit_logs"(integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."null_migrated_app_version_manifests"();
+CREATE OR REPLACE FUNCTION "public"."null_migrated_app_version_manifests"(
+  "max_batches" integer DEFAULT 50,
+  "batch_size" integer DEFAULT 200
+) RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  batch_no integer := 0;
+  updated_batch integer;
+  updated_total bigint := 0;
+  v_max_batches integer := GREATEST(1, COALESCE(max_batches, 50));
+  v_batch_size integer := GREATEST(1, COALESCE(batch_size, 200));
+BEGIN
+  LOOP
+    batch_no := batch_no + 1;
+    EXIT WHEN batch_no > v_max_batches;
+
+    WITH doomed AS (
+      SELECT av.id
+      FROM public.app_versions AS av
+      WHERE av.manifest IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_catalog.unnest(av.manifest) AS entry(file_name, s3_path, file_hash)
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.manifest AS m
+            WHERE m.app_version_id = av.id
+              AND m.s3_path = entry.s3_path
+              AND m.file_hash = entry.file_hash
+          )
+        )
+      ORDER BY av.id
+      LIMIT v_batch_size
+    )
+    UPDATE public.app_versions AS av
+    SET manifest = NULL
+    FROM doomed
+    WHERE av.id = doomed.id;
+
+    GET DIAGNOSTICS updated_batch = ROW_COUNT;
+    updated_total := updated_total + updated_batch;
+    EXIT WHEN updated_batch = 0;
+  END LOOP;
+
+  RAISE NOTICE
+    'null_migrated_app_version_manifests: updated=% batches=%/% batch_size=%',
+    updated_total,
+    batch_no,
+    v_max_batches,
+    v_batch_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."null_migrated_app_version_manifests"(integer, integer) OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."null_migrated_app_version_manifests"(integer, integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."null_migrated_app_version_manifests"(integer, integer) TO "service_role";

--- a/tests/cleanup_swap_memory.test.ts
+++ b/tests/cleanup_swap_memory.test.ts
@@ -8,6 +8,44 @@ describe('swap memory cleanup functions', () => {
   })
 
 
+
+  it('cleanup_queue_messages respects a tiny max batch budget', async () => {
+    const marker = `swap-budget-${randomUUID()}`
+    const baseMsgId = BigInt(Date.now()) * 1000n
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      id: (baseMsgId + BigInt(i + 1)).toString(),
+      payload: JSON.stringify({ marker, i }),
+    }))
+
+    for (const row of rows) {
+      await executeSQL(
+        `INSERT INTO pgmq.a_on_version_update (msg_id, read_ct, enqueued_at, archived_at, vt, message)
+         VALUES ($1, 0, now() - interval '10 days', now() - interval '10 days', now(), $2::jsonb)`,
+        [row.id, row.payload],
+      )
+    }
+
+    await executeSQL(`SELECT public.cleanup_queue_messages(1, 2)`)
+
+    const left = await executeSQL(
+      `SELECT count(*)::int AS n
+       FROM pgmq.a_on_version_update
+       WHERE message->>'marker' = $1`,
+      [marker],
+    )
+    expect(left[0]?.n).toBeGreaterThan(0)
+    expect(left[0]?.n).toBeLessThan(5)
+
+    await executeSQL(`SELECT public.cleanup_queue_messages(20, 100)`)
+    const after = await executeSQL(
+      `SELECT count(*)::int AS n
+       FROM pgmq.a_on_version_update
+       WHERE message->>'marker' = $1`,
+      [marker],
+    )
+    expect(after[0]?.n).toBe(0)
+  })
+
   it('cleanup_queue_messages skips queues whose archive tables are missing', async () => {
     const queueName = `cleanup_missing_${randomUUID().slice(0, 8)}`
     await executeSQL(


### PR DESCRIPTION
## Summary (AI generated)

- Add optional `(max_batches, batch_size)` args to queue/audit/manifest cleanup functions (defaults keep cron behavior)
- Split dashboard reclaim into one-statement step scripts with tiny budgets
- Test that a small budget only deletes part of the work

## Motivation (AI generated)

Capgo-EU SQL Editor times out on full reclaim calls. Ops needs to clean part-by-part by re-running small statements.

## Business Impact (AI generated)

Unblocks Capgo-EU bloat reclaim without upgrading compute or needing long dashboard timeouts.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/cleanup_swap_memory.test.ts`
- [ ] Paste migration on Capgo-EU, then repeatedly run `SELECT public.cleanup_queue_messages(1, 500);` until notice is 0

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

