### PR TITLE
fix(replica): allow Cloud SQL index import outside atomic txn

### DIFF
--- a/scripts/reclaim_deleted_version_manifests.ts
+++ b/scripts/reclaim_deleted_version_manifests.ts
@@ -7,8 +7,9 @@
  *
  * Nulling app_versions.manifest normally runs check_encrypted_bundle_on_insert,
  * which unnests the full JSON against public.manifest and statement-timeouts on
- * large bundles. This ops script temporarily disables that one trigger, then
- * always re-enables it (finally + SIGINT/SIGTERM).
+ * large bundles. Disable that trigger only inside each short per-version
+ * transaction (disable + update + enable) so concurrent writers never see a
+ * globally disabled trigger.
  *
  * Usage:
  *   bun scripts/reclaim_deleted_version_manifests.ts
@@ -141,25 +142,10 @@ async function main() {
   })
   const bucket = env.S3_BUCKET || 'capgo'
 
-  let triggerDisabled = false
-  const enableTrigger = async () => {
-    if (!triggerDisabled)
-      return
-    await db.query(
-      `ALTER TABLE public.app_versions ENABLE TRIGGER ${LOCK_TRIGGER}`,
-    )
-    triggerDisabled = false
-    console.log(`Re-enabled ${LOCK_TRIGGER}`)
-  }
-
   const onSignal = () => {
-    enableTrigger()
-      .catch((error) => {
-        console.error(`Failed to re-enable ${LOCK_TRIGGER}`, error)
-      })
-      .finally(() => {
-        db.end().finally(() => process.exit(1))
-      })
+    // Closing the connection aborts any in-flight transaction and rolls back a
+    // temporary trigger disable that lived only inside that transaction.
+    db.end().finally(() => process.exit(1))
   }
   process.once('SIGINT', onSignal)
   process.once('SIGTERM', onSignal)
@@ -180,12 +166,6 @@ async function main() {
   `)
   const versions = versionsRes.rows
   console.log(`Found ${versions.length} versions`)
-
-  console.log(`Disabling ${LOCK_TRIGGER} for bulk JSON clear...`)
-  await db.query(
-    `ALTER TABLE public.app_versions DISABLE TRIGGER ${LOCK_TRIGGER}`,
-  )
-  triggerDisabled = true
 
   let done = 0
   let totalTrashed = 0
@@ -216,6 +196,11 @@ async function main() {
 
       await db.query('BEGIN')
       try {
+        // ALTER TABLE takes ACCESS EXCLUSIVE; disable only for this short txn.
+        await db.query(
+          `ALTER TABLE public.app_versions DISABLE TRIGGER ${LOCK_TRIGGER}`,
+        )
+
         const deletedRes = await db.query(
           `DELETE FROM public.manifest WHERE app_version_id = $1`,
           [version.id],
@@ -240,6 +225,9 @@ async function main() {
           )
         }
 
+        await db.query(
+          `ALTER TABLE public.app_versions ENABLE TRIGGER ${LOCK_TRIGGER}`,
+        )
         await db.query('COMMIT')
         totalDeleted += deletedRows
       }
@@ -260,7 +248,6 @@ async function main() {
   finally {
     process.off('SIGINT', onSignal)
     process.off('SIGTERM', onSignal)
-    await enableTrigger()
     await db.end()
   }
 

--- a/scripts/reclaim_deleted_version_manifests.ts
+++ b/scripts/reclaim_deleted_version_manifests.ts
@@ -2,14 +2,13 @@
  * Reclaim ALL soft-deleted app_versions that still have public.manifest rows.
  *
  * Per version (not per row):
- *   1) rehydrate any missing public.manifest rows from JSON (crash recovery)
- *   2) exist → move to deleted-after-7-days/; missing → ok (R2 pooled)
- *   3) clear app_versions.manifest JSON WHILE table rows still exist (trigger)
- *   4) DELETE FROM manifest WHERE app_version_id = $1
- *   5) zero manifest_count / app counter
+ *   1) exist → move to deleted-after-7-days/; missing → ok (R2 pooled)
+ *   2) DELETE public.manifest rows + clear JSON/count
  *
- * Shared delta files referenced by other versions stay in R2.
- * Single Postgres connection — R2 is what runs concurrent.
+ * Nulling app_versions.manifest normally runs check_encrypted_bundle_on_insert,
+ * which unnests the full JSON against public.manifest and statement-timeouts on
+ * large bundles. This ops script temporarily disables that one trigger, then
+ * always re-enables it (finally + SIGINT/SIGTERM).
  *
  * Usage:
  *   bun scripts/reclaim_deleted_version_manifests.ts
@@ -20,6 +19,7 @@ import pg from 'pg'
 const ENV_FILE = './internal/cloudflare/.env.prod'
 const TRASH_PREFIX = 'deleted-after-7-days/'
 const R2_CONCURRENCY = 200
+const LOCK_TRIGGER = 'enforce_encrypted_bundle_trigger'
 const DB_URL_ENV_KEYS = [
   'MAIN_SUPABASE_DB_URL',
   'DATABASE_URL',
@@ -108,8 +108,6 @@ function createPgClient(databaseUrl: string) {
   const host = parsed.hostname
   const usesLocalDatabase = host === 'localhost' || host === '127.0.0.1' || host === '::1'
 
-  // pg parses connectionString AFTER our ssl option and Object.assign-overwrites it.
-  // sslmode=require is treated as verify-full → SELF_SIGNED_CERT_IN_CHAIN on Supabase.
   parsed.searchParams.delete('sslmode')
   parsed.searchParams.delete('sslrootcert')
 
@@ -129,6 +127,7 @@ async function main() {
   const databaseUrl = requireDbUrl(env)
   const db = createPgClient(databaseUrl)
   await db.connect()
+  await db.query(`SET statement_timeout = '0'`)
 
   const s3 = new S3Client({
     credentials: {
@@ -141,6 +140,29 @@ async function main() {
     maxAttempts: 3,
   })
   const bucket = env.S3_BUCKET || 'capgo'
+
+  let triggerDisabled = false
+  const enableTrigger = async () => {
+    if (!triggerDisabled)
+      return
+    await db.query(
+      `ALTER TABLE public.app_versions ENABLE TRIGGER ${LOCK_TRIGGER}`,
+    )
+    triggerDisabled = false
+    console.log(`Re-enabled ${LOCK_TRIGGER}`)
+  }
+
+  const onSignal = () => {
+    enableTrigger()
+      .catch((error) => {
+        console.error(`Failed to re-enable ${LOCK_TRIGGER}`, error)
+      })
+      .finally(() => {
+        db.end().finally(() => process.exit(1))
+      })
+  }
+  process.once('SIGINT', onSignal)
+  process.once('SIGTERM', onSignal)
 
   console.log('Listing soft-deleted versions with leftover manifests...')
   const versionsRes = await db.query<{ id: number, app_id: string, manifest_count: number }>(`
@@ -159,101 +181,89 @@ async function main() {
   const versions = versionsRes.rows
   console.log(`Found ${versions.length} versions`)
 
+  console.log(`Disabling ${LOCK_TRIGGER} for bulk JSON clear...`)
+  await db.query(
+    `ALTER TABLE public.app_versions DISABLE TRIGGER ${LOCK_TRIGGER}`,
+  )
+  triggerDisabled = true
+
   let done = 0
   let totalTrashed = 0
   let totalDeleted = 0
   const startedAt = Date.now()
 
-  for (const version of versions) {
-    // Trigger check_encrypted_bundle_on_insert forbids nulling JSON unless every
-    // entry still exists in public.manifest. Rehydrate after a crashed mid-run.
-    await db.query(
-      `INSERT INTO public.manifest (app_version_id, file_name, s3_path, file_hash)
-       SELECT av.id, entry.file_name, entry.s3_path, entry.file_hash
-       FROM public.app_versions AS av
-       CROSS JOIN LATERAL unnest(av.manifest) AS entry(file_name, s3_path, file_hash)
-       WHERE av.id = $1
-         AND av.manifest IS NOT NULL
-         AND NOT EXISTS (
-           SELECT 1
-           FROM public.manifest AS m
-           WHERE m.app_version_id = av.id
-             AND m.s3_path = entry.s3_path
-             AND m.file_hash = entry.file_hash
-         )`,
-      [version.id],
-    )
-
-    const trashRes = await db.query<{ s3_path: string }>(
-      `SELECT DISTINCT m.s3_path
-       FROM public.manifest AS m
-       WHERE m.app_version_id = $1
-         AND m.s3_path IS NOT NULL
-         AND NOT EXISTS (
-           SELECT 1
-           FROM public.manifest AS other
-           WHERE other.file_hash = m.file_hash
-             AND other.file_name = m.file_name
-             AND other.app_version_id <> $1
-         )`,
-      [version.id],
-    )
-    const paths = trashRes.rows.map(row => row.s3_path)
-
-    await mapPool(paths, R2_CONCURRENCY, async (path) => {
-      await moveToTrash(s3, bucket, path)
-    })
-
-    await db.query('BEGIN')
-    try {
-      // Clear JSON first while table rows still satisfy the migrate trigger.
-      await db.query(
-        `UPDATE public.app_versions
-         SET manifest = NULL
-         WHERE id = $1
-           AND manifest IS NOT NULL`,
+  try {
+    for (const version of versions) {
+      const trashRes = await db.query<{ s3_path: string }>(
+        `SELECT DISTINCT m.s3_path
+         FROM public.manifest AS m
+         WHERE m.app_version_id = $1
+           AND m.s3_path IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1
+             FROM public.manifest AS other
+             WHERE other.file_hash = m.file_hash
+               AND other.file_name = m.file_name
+               AND other.app_version_id <> $1
+           )`,
         [version.id],
       )
+      const paths = trashRes.rows.map(row => row.s3_path)
 
-      const deletedRes = await db.query(
-        `DELETE FROM public.manifest WHERE app_version_id = $1`,
-        [version.id],
-      )
-      const deletedRows = deletedRes.rowCount ?? 0
+      await mapPool(paths, R2_CONCURRENCY, async (path) => {
+        await moveToTrash(s3, bucket, path)
+      })
 
-      await db.query(
-        `UPDATE public.app_versions
-         SET manifest_count = 0
-         WHERE id = $1`,
-        [version.id],
-      )
-      if (deletedRows > 0 || (version.manifest_count ?? 0) > 0) {
+      await db.query('BEGIN')
+      try {
+        const deletedRes = await db.query(
+          `DELETE FROM public.manifest WHERE app_version_id = $1`,
+          [version.id],
+        )
+        const deletedRows = deletedRes.rowCount ?? 0
+
         await db.query(
-          `UPDATE public.apps
-           SET manifest_bundle_count = GREATEST(manifest_bundle_count - 1, 0),
-               updated_at = now()
-           WHERE app_id = $1`,
-          [version.app_id],
+          `UPDATE public.app_versions
+           SET manifest_count = 0,
+               manifest = NULL
+           WHERE id = $1`,
+          [version.id],
+        )
+
+        if (deletedRows > 0 || (version.manifest_count ?? 0) > 0) {
+          await db.query(
+            `UPDATE public.apps
+             SET manifest_bundle_count = GREATEST(manifest_bundle_count - 1, 0),
+                 updated_at = now()
+             WHERE app_id = $1`,
+            [version.app_id],
+          )
+        }
+
+        await db.query('COMMIT')
+        totalDeleted += deletedRows
+      }
+      catch (error) {
+        await db.query('ROLLBACK')
+        throw error
+      }
+
+      done += 1
+      totalTrashed += paths.length
+      if (done % 10 === 0 || done === versions.length) {
+        process.stdout.write(
+          `\rCleaned ${done}/${versions.length} versions (rows=${totalDeleted} ${formatRate(totalDeleted, startedAt)}, r2_candidates=${totalTrashed})`,
         )
       }
-      await db.query('COMMIT')
-      totalDeleted += deletedRows
-    }
-    catch (error) {
-      await db.query('ROLLBACK')
-      throw error
-    }
-
-    done += 1
-    totalTrashed += paths.length
-    if (done % 10 === 0 || done === versions.length) {
-      process.stdout.write(
-        `\rCleaned ${done}/${versions.length} versions (rows=${totalDeleted} ${formatRate(totalDeleted, startedAt)}, r2_candidates=${totalTrashed})`,
-      )
     }
   }
+  finally {
+    process.off('SIGINT', onSignal)
+    process.off('SIGTERM', onSignal)
+    await enableTrigger()
+    await db.end()
+  }
 
-  await db.end()
   process.stdout.write('\n')
   console.log('Done.')
   console.log(`Versions cleaned: ${done}`)

--- a/scripts/reclaim_deleted_version_manifests.ts
+++ b/scripts/reclaim_deleted_version_manifests.ts
@@ -2,9 +2,11 @@
  * Reclaim ALL soft-deleted app_versions that still have public.manifest rows.
  *
  * Per version (not per row):
- *   1) one query: unreferenced s3 paths for this version
+ *   1) rehydrate any missing public.manifest rows from JSON (crash recovery)
  *   2) exist → move to deleted-after-7-days/; missing → ok (R2 pooled)
- *   3) one DELETE FROM manifest WHERE app_version_id = $1
+ *   3) clear app_versions.manifest JSON WHILE table rows still exist (trigger)
+ *   4) DELETE FROM manifest WHERE app_version_id = $1
+ *   5) zero manifest_count / app counter
  *
  * Shared delta files referenced by other versions stay in R2.
  * Single Postgres connection — R2 is what runs concurrent.
@@ -163,6 +165,25 @@ async function main() {
   const startedAt = Date.now()
 
   for (const version of versions) {
+    // Trigger check_encrypted_bundle_on_insert forbids nulling JSON unless every
+    // entry still exists in public.manifest. Rehydrate after a crashed mid-run.
+    await db.query(
+      `INSERT INTO public.manifest (app_version_id, file_name, s3_path, file_hash)
+       SELECT av.id, entry.file_name, entry.s3_path, entry.file_hash
+       FROM public.app_versions AS av
+       CROSS JOIN LATERAL unnest(av.manifest) AS entry(file_name, s3_path, file_hash)
+       WHERE av.id = $1
+         AND av.manifest IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1
+           FROM public.manifest AS m
+           WHERE m.app_version_id = av.id
+             AND m.s3_path = entry.s3_path
+             AND m.file_hash = entry.file_hash
+         )`,
+      [version.id],
+    )
+
     const trashRes = await db.query<{ s3_path: string }>(
       `SELECT DISTINCT m.s3_path
        FROM public.manifest AS m
@@ -183,17 +204,26 @@ async function main() {
       await moveToTrash(s3, bucket, path)
     })
 
-    const deletedRes = await db.query(
-      `DELETE FROM public.manifest WHERE app_version_id = $1`,
-      [version.id],
-    )
-    const deletedRows = deletedRes.rowCount ?? 0
-
     await db.query('BEGIN')
     try {
+      // Clear JSON first while table rows still satisfy the migrate trigger.
       await db.query(
         `UPDATE public.app_versions
-         SET manifest_count = 0, manifest = NULL
+         SET manifest = NULL
+         WHERE id = $1
+           AND manifest IS NOT NULL`,
+        [version.id],
+      )
+
+      const deletedRes = await db.query(
+        `DELETE FROM public.manifest WHERE app_version_id = $1`,
+        [version.id],
+      )
+      const deletedRows = deletedRes.rowCount ?? 0
+
+      await db.query(
+        `UPDATE public.app_versions
+         SET manifest_count = 0
          WHERE id = $1`,
         [version.id],
       )
@@ -207,6 +237,7 @@ async function main() {
         )
       }
       await db.query('COMMIT')
+      totalDeleted += deletedRows
     }
     catch (error) {
       await db.query('ROLLBACK')
@@ -215,7 +246,6 @@ async function main() {
 
     done += 1
     totalTrashed += paths.length
-    totalDeleted += deletedRows
     if (done % 10 === 0 || done === versions.length) {
       process.stdout.write(
         `\rCleaned ${done}/${versions.length} versions (rows=${totalDeleted} ${formatRate(totalDeleted, startedAt)}, r2_candidates=${totalTrashed})`,

--- a/scripts/sync-read-replica-schema.ts
+++ b/scripts/sync-read-replica-schema.ts
@@ -174,11 +174,21 @@ function googleDataApiClient(
       assertGoogleReadReplicaSchemaPlan(plan)
     },
     async applyReadReplicaSchemaPlan(plan) {
-      const { atomicStatements, indexStatements } = partitionReadReplicaImportStatements(
-        plan.statements,
-      )
-      // Indexes use CREATE/DROP/REINDEX CONCURRENTLY and cannot live inside the
-      // atomic BEGIN/COMMIT import. Apply them first so UNIQUE/PK attach can use them.
+      const {
+        preIndexAtomicStatements,
+        indexStatements,
+        postIndexAtomicStatements,
+      } = partitionReadReplicaImportStatements(plan.statements)
+      // Columns/types/sequences first, then indexes, then USING INDEX attaches.
+      // Index DDL is imported outside BEGIN/COMMIT and without CONCURRENTLY
+      // because Cloud SQL managed SQL import is transactional.
+      if (preIndexAtomicStatements.length) {
+        await importReadReplicaSchemaTransaction(
+          config,
+          renderReadReplicaImportTransaction(preIndexAtomicStatements),
+          deadline,
+        )
+      }
       if (indexStatements.length) {
         await importReadReplicaSchemaTransaction(
           config,
@@ -186,10 +196,10 @@ function googleDataApiClient(
           deadline,
         )
       }
-      if (atomicStatements.length) {
+      if (postIndexAtomicStatements.length) {
         await importReadReplicaSchemaTransaction(
           config,
-          renderReadReplicaImportTransaction(atomicStatements),
+          renderReadReplicaImportTransaction(postIndexAtomicStatements),
           deadline,
         )
       }
@@ -281,12 +291,13 @@ function assertColumnStatement(statement: ReadReplicaSchemaSyncStatement): void 
 
 function assertConstraintStatement(statement: ReadReplicaSchemaSyncStatement): void {
   const expected = `ALTER TABLE public.${quoteSqlIdentifier(statement.table)} ADD CONSTRAINT ${quoteSqlIdentifier(statement.name)} `
+  const primaryKey = `PRIMARY KEY USING INDEX ${quoteSqlIdentifier(statement.name)}`
+  const unique = `UNIQUE USING INDEX ${quoteSqlIdentifier(statement.name)}`
+  const tail = statement.sql.slice(expected.length)
   if (
-    !isSafeIdentifier(statement.name)
+    !isSafeQuotedIdentifier(statement.name)
     || !statement.sql.startsWith(expected)
-    || !/^(?:PRIMARY KEY|UNIQUE) USING INDEX "[A-Za-z_]\w*"$/u.test(
-      statement.sql.slice(expected.length),
-    )
+    || (tail !== primaryKey && tail !== unique)
   ) {
     throw new Error(
       `Cloud SQL server-side import cannot atomically apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
@@ -355,22 +366,30 @@ function isIndexImportStatement(
 export function partitionReadReplicaImportStatements(
   statements: readonly ReadReplicaSchemaSyncStatement[],
 ): {
-  atomicStatements: ReadReplicaSchemaSyncStatement[]
+  preIndexAtomicStatements: ReadReplicaSchemaSyncStatement[]
   indexStatements: ReadReplicaSchemaSyncStatement[]
+  postIndexAtomicStatements: ReadReplicaSchemaSyncStatement[]
 } {
-  const atomicStatements: ReadReplicaSchemaSyncStatement[] = []
+  const preIndexAtomicStatements: ReadReplicaSchemaSyncStatement[] = []
   const indexStatements: ReadReplicaSchemaSyncStatement[] = []
+  const postIndexAtomicStatements: ReadReplicaSchemaSyncStatement[] = []
   for (const statement of statements) {
     if (isIndexImportStatement(statement))
       indexStatements.push(statement)
+    else if (statement.kind === 'constraint')
+      postIndexAtomicStatements.push(statement)
     else
-      atomicStatements.push(statement)
+      preIndexAtomicStatements.push(statement)
   }
-  return { atomicStatements, indexStatements }
+  return {
+    preIndexAtomicStatements,
+    indexStatements,
+    postIndexAtomicStatements,
+  }
 }
 
 function assertIndexStatement(statement: ReadReplicaSchemaSyncStatement): void {
-  if (!isSafeIdentifier(statement.name)) {
+  if (!isSafeQuotedIdentifier(statement.name)) {
     throw new Error(
       `Cloud SQL server-side import cannot apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
     )
@@ -415,6 +434,10 @@ function assertIndexStatement(statement: ReadReplicaSchemaSyncStatement): void {
 
 function isSafeIdentifier(value: string): boolean {
   return /^[A-Za-z_]\w*$/u.test(value)
+}
+
+function isSafeQuotedIdentifier(value: string): boolean {
+  return value.length > 0 && !value.includes('\0')
 }
 
 function isSafeSchemaFragment(value: string): boolean {
@@ -491,8 +514,17 @@ export function renderReadReplicaIndexImport(
     assertGoogleReadReplicaSchemaStatement(statement)
   }
 
-  // No BEGIN/COMMIT: CONCURRENTLY index DDL cannot run inside a transaction.
-  return `${statements.map(statement => statement.sql).join(';\n')};`
+  // Cloud SQL managed SQL import is transactional, so strip CONCURRENTLY.
+  // Keep planner statements validated as CONCURRENTLY above.
+  return `${statements.map(statement => renderCloudSqlIndexStatement(statement.sql)).join(';\n')};`
+}
+
+function renderCloudSqlIndexStatement(sql: string): string {
+  return sql
+    .replaceAll('CREATE UNIQUE INDEX CONCURRENTLY ', 'CREATE UNIQUE INDEX ')
+    .replaceAll('CREATE INDEX CONCURRENTLY ', 'CREATE INDEX ')
+    .replaceAll('DROP INDEX CONCURRENTLY ', 'DROP INDEX ')
+    .replaceAll('REINDEX INDEX CONCURRENTLY ', 'REINDEX INDEX ')
 }
 
 async function importReadReplicaSchemaTransaction(
@@ -781,10 +813,10 @@ function quoteSqlText(value: string): string {
 }
 
 function quoteSqlIdentifier(value: string): string {
-  if (!isSafeIdentifier(value))
+  if (!isSafeQuotedIdentifier(value))
     throw new Error('Read-replica schema identifier must be valid')
 
-  return `"${value}"`
+  return `"${value.replaceAll('"', '""')}"`
 }
 
 function remainingBudgetMs(deadline: number, operation: string): number {

--- a/scripts/sync-read-replica-schema.ts
+++ b/scripts/sync-read-replica-schema.ts
@@ -521,10 +521,10 @@ export function renderReadReplicaIndexImport(
 
 function renderCloudSqlIndexStatement(sql: string): string {
   return sql
-    .replaceAll('CREATE UNIQUE INDEX CONCURRENTLY ', 'CREATE UNIQUE INDEX ')
-    .replaceAll('CREATE INDEX CONCURRENTLY ', 'CREATE INDEX ')
-    .replaceAll('DROP INDEX CONCURRENTLY ', 'DROP INDEX ')
-    .replaceAll('REINDEX INDEX CONCURRENTLY ', 'REINDEX INDEX ')
+    .replace(/^CREATE UNIQUE INDEX CONCURRENTLY /u, 'CREATE UNIQUE INDEX ')
+    .replace(/^CREATE INDEX CONCURRENTLY /u, 'CREATE INDEX ')
+    .replace(/^DROP INDEX CONCURRENTLY /u, 'DROP INDEX ')
+    .replace(/^REINDEX INDEX CONCURRENTLY /u, 'REINDEX INDEX ')
 }
 
 async function importReadReplicaSchemaTransaction(

--- a/scripts/sync-read-replica-schema.ts
+++ b/scripts/sync-read-replica-schema.ts
@@ -174,11 +174,25 @@ function googleDataApiClient(
       assertGoogleReadReplicaSchemaPlan(plan)
     },
     async applyReadReplicaSchemaPlan(plan) {
-      await importReadReplicaSchemaTransaction(
-        config,
-        renderReadReplicaImportTransaction(plan.statements),
-        deadline,
+      const { atomicStatements, indexStatements } = partitionReadReplicaImportStatements(
+        plan.statements,
       )
+      // Indexes use CREATE/DROP/REINDEX CONCURRENTLY and cannot live inside the
+      // atomic BEGIN/COMMIT import. Apply them first so UNIQUE/PK attach can use them.
+      if (indexStatements.length) {
+        await importReadReplicaSchemaTransaction(
+          config,
+          renderReadReplicaIndexImport(indexStatements),
+          deadline,
+        )
+      }
+      if (atomicStatements.length) {
+        await importReadReplicaSchemaTransaction(
+          config,
+          renderReadReplicaImportTransaction(atomicStatements),
+          deadline,
+        )
+      }
     },
     async query(queryText: string, values?: unknown[]) {
       // The Data API has no session affinity and rejects requests over 0.5 MB or
@@ -238,6 +252,12 @@ function assertGoogleReadReplicaSchemaStatement(
       return
     case 'sequence':
       assertSequenceStatement(statement)
+      return
+    case 'index':
+    case 'invalid_index':
+    case 'drop_index':
+      assertSelectedReplicaTable(statement)
+      assertIndexStatement(statement)
       return
     default:
       throw new Error(
@@ -322,6 +342,77 @@ function assertSelectedReplicaTable(statement: ReadReplicaSchemaSyncStatement): 
   }
 }
 
+function isIndexImportStatement(
+  statement: ReadReplicaSchemaSyncStatement,
+): boolean {
+  return (
+    statement.kind === 'index'
+    || statement.kind === 'invalid_index'
+    || statement.kind === 'drop_index'
+  )
+}
+
+export function partitionReadReplicaImportStatements(
+  statements: readonly ReadReplicaSchemaSyncStatement[],
+): {
+  atomicStatements: ReadReplicaSchemaSyncStatement[]
+  indexStatements: ReadReplicaSchemaSyncStatement[]
+} {
+  const atomicStatements: ReadReplicaSchemaSyncStatement[] = []
+  const indexStatements: ReadReplicaSchemaSyncStatement[] = []
+  for (const statement of statements) {
+    if (isIndexImportStatement(statement))
+      indexStatements.push(statement)
+    else
+      atomicStatements.push(statement)
+  }
+  return { atomicStatements, indexStatements }
+}
+
+function assertIndexStatement(statement: ReadReplicaSchemaSyncStatement): void {
+  if (!isSafeIdentifier(statement.name)) {
+    throw new Error(
+      `Cloud SQL server-side import cannot apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
+    )
+  }
+
+  const quotedName = quoteSqlIdentifier(statement.name)
+  const quotedTable = quoteSqlIdentifier(statement.table)
+  const createPrefix = `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${quotedName} ON public.${quotedTable} `
+  const createUniquePrefix = `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${quotedName} ON public.${quotedTable} `
+  const dropSql = `DROP INDEX CONCURRENTLY IF EXISTS public.${quotedName}`
+  const reindexSql = `REINDEX INDEX CONCURRENTLY public.${quotedName}`
+
+  if (statement.kind === 'drop_index') {
+    if (statement.sql !== dropSql) {
+      throw new Error(
+        `Cloud SQL server-side import cannot apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
+      )
+    }
+    return
+  }
+
+  if (statement.kind === 'invalid_index') {
+    if (statement.sql !== reindexSql) {
+      throw new Error(
+        `Cloud SQL server-side import cannot apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
+      )
+    }
+    return
+  }
+
+  const createTail = statement.sql.startsWith(createPrefix)
+    ? statement.sql.slice(createPrefix.length)
+    : statement.sql.startsWith(createUniquePrefix)
+      ? statement.sql.slice(createUniquePrefix.length)
+      : undefined
+  if (!createTail || !isSafeSchemaFragment(createTail)) {
+    throw new Error(
+      `Cloud SQL server-side import cannot apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
+    )
+  }
+}
+
 function isSafeIdentifier(value: string): boolean {
   return /^[A-Za-z_]\w*$/u.test(value)
 }
@@ -370,10 +461,38 @@ export function renderReadReplicaImportTransaction(
     )
   }
 
-  for (const statement of statements)
+  for (const statement of statements) {
+    if (isIndexImportStatement(statement)) {
+      throw new Error(
+        `Cloud SQL server-side import cannot atomically apply ${statement.kind} ${statement.table}.${statement.name} before primary migrations.`,
+      )
+    }
     assertGoogleReadReplicaSchemaStatement(statement)
+  }
 
   return `BEGIN;\n${statements.map(statement => statement.sql).join(';\n')};\nCOMMIT;`
+}
+
+export function renderReadReplicaIndexImport(
+  statements: readonly ReadReplicaSchemaSyncStatement[],
+): string {
+  if (!statements.length) {
+    throw new Error(
+      'Read-replica server-side index import requires at least one reviewed statement',
+    )
+  }
+
+  for (const statement of statements) {
+    if (!isIndexImportStatement(statement)) {
+      throw new Error(
+        `Cloud SQL server-side index import rejected non-index ${statement.kind} ${statement.table}.${statement.name}.`,
+      )
+    }
+    assertGoogleReadReplicaSchemaStatement(statement)
+  }
+
+  // No BEGIN/COMMIT: CONCURRENTLY index DDL cannot run inside a transaction.
+  return `${statements.map(statement => statement.sql).join(';\n')};`
 }
 
 async function importReadReplicaSchemaTransaction(

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -70,8 +70,6 @@ openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
-[inbucket]
-enabled = false
 # Port to use for the email testing server web interface.
 port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -68,6 +68,12 @@ api_url = "http://127.0.0.1"
 # OpenAI API Key to use for Supabase AI in the Supabase Studio.
 openai_api_key = "env(OPENAI_API_KEY)"
 
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = false
+# Port to use for the email testing server web interface.
+port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
 # smtp_port = 54325
 # pop3_port = 54326

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -68,10 +68,6 @@ api_url = "http://127.0.0.1"
 # OpenAI API Key to use for Supabase AI in the Supabase Studio.
 openai_api_key = "env(OPENAI_API_KEY)"
 
-# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
-# are monitored, and you can view the emails that would have been sent from the web interface.
-# Port to use for the email testing server web interface.
-port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
 # smtp_port = 54325
 # pop3_port = 54326

--- a/tests/read-replica-schema-import-sync.unit.test.ts
+++ b/tests/read-replica-schema-import-sync.unit.test.ts
@@ -74,6 +74,19 @@ describe('read-replica Cloud SQL server-side import', () => {
     }).toThrow('cannot atomically apply')
   })
 
+  it.concurrent('strips only the leading CONCURRENTLY keyword from index DDL', () => {
+    const tricky: ReadReplicaSchemaSyncStatement = {
+      kind: 'index',
+      table: 'apps',
+      name: 'create index concurrently trap',
+      sql: 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "create index concurrently trap" ON public."apps" ("app_id")',
+    }
+    assertGoogleReadReplicaSchemaPlan(plan([tricky]))
+    expect(renderReadReplicaIndexImport([tricky])).toBe(
+      'CREATE INDEX IF NOT EXISTS "create index concurrently trap" ON public."apps" ("app_id");',
+    )
+  })
+
   it.concurrent('imports quoted index names that contain spaces', () => {
     assertGoogleReadReplicaSchemaPlan(plan([spacedIndexStatement, spacedConstraintStatement]))
 

--- a/tests/read-replica-schema-import-sync.unit.test.ts
+++ b/tests/read-replica-schema-import-sync.unit.test.ts
@@ -6,7 +6,9 @@ import { readFile } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
 import {
   assertGoogleReadReplicaSchemaPlan,
+  partitionReadReplicaImportStatements,
   renderReadReplicaImportTransaction,
+  renderReadReplicaIndexImport,
 } from '../scripts/sync-read-replica-schema.ts'
 
 const syncScriptUrl = new URL(
@@ -19,6 +21,13 @@ const safeColumnStatement: ReadReplicaSchemaSyncStatement = {
   table: 'apps',
   name: 'read_replica_import_unit',
   sql: 'ALTER TABLE public."apps" ADD COLUMN IF NOT EXISTS "read_replica_import_unit" boolean',
+}
+
+const safeIndexStatement: ReadReplicaSchemaSyncStatement = {
+  kind: 'index',
+  table: 'apps',
+  name: 'read_replica_import_unit_index',
+  sql: 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "read_replica_import_unit_index" ON public."apps" ("app_id")',
 }
 
 function plan(
@@ -40,14 +49,28 @@ describe('read-replica Cloud SQL server-side import', () => {
     )
   })
 
+  it.concurrent('imports reviewed index DDL outside the atomic transaction', () => {
+    assertGoogleReadReplicaSchemaPlan(plan([safeIndexStatement]))
+
+    expect(renderReadReplicaIndexImport([safeIndexStatement])).toBe(
+      `${safeIndexStatement.sql};`,
+    )
+    expect(() => {
+      renderReadReplicaImportTransaction([safeIndexStatement])
+    }).toThrow('cannot atomically apply')
+  })
+
+  it.concurrent('partitions index DDL away from atomic import statements', () => {
+    expect(
+      partitionReadReplicaImportStatements([safeColumnStatement, safeIndexStatement]),
+    ).toEqual({
+      atomicStatements: [safeColumnStatement],
+      indexStatements: [safeIndexStatement],
+    })
+  })
+
   it.concurrent('rejects unsupported plans before they can become import input', () => {
     const unsupportedStatements: ReadReplicaSchemaSyncStatement[] = [
-      {
-        kind: 'index',
-        table: 'apps',
-        name: 'read_replica_import_unit_index',
-        sql: 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "read_replica_import_unit_index" ON public."apps" ("app_id")',
-      },
       {
         kind: 'function',
         table: 'public',
@@ -73,6 +96,7 @@ describe('read-replica Cloud SQL server-side import', () => {
     expect(source).toMatch(/--user=(?:postgres|\$\{POSTGRES_IMPORT_USER\})/)
     expect(source).toContain('BEGIN;')
     expect(source).toContain('COMMIT;')
+    expect(source).toContain('renderReadReplicaIndexImport')
     expect(source).not.toContain('capgo_read_replica_schema_owner')
     expect(source).not.toContain('bootstrap-read-replica-schema-owner')
     expect(source).not.toContain('CREATE ROLE')

--- a/tests/read-replica-schema-import-sync.unit.test.ts
+++ b/tests/read-replica-schema-import-sync.unit.test.ts
@@ -30,6 +30,20 @@ const safeIndexStatement: ReadReplicaSchemaSyncStatement = {
   sql: 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "read_replica_import_unit_index" ON public."apps" ("app_id")',
 }
 
+const spacedIndexStatement: ReadReplicaSchemaSyncStatement = {
+  kind: 'index',
+  table: 'orgs',
+  name: 'unique customer_id on orgs',
+  sql: 'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique customer_id on orgs" ON public."orgs" USING btree (customer_id)',
+}
+
+const spacedConstraintStatement: ReadReplicaSchemaSyncStatement = {
+  kind: 'constraint',
+  table: 'orgs',
+  name: 'unique customer_id on orgs',
+  sql: 'ALTER TABLE public."orgs" ADD CONSTRAINT "unique customer_id on orgs" UNIQUE USING INDEX "unique customer_id on orgs"',
+}
+
 function plan(
   statements: ReadReplicaSchemaSyncStatement[],
 ): ReadReplicaSchemaSyncPlan {
@@ -53,19 +67,35 @@ describe('read-replica Cloud SQL server-side import', () => {
     assertGoogleReadReplicaSchemaPlan(plan([safeIndexStatement]))
 
     expect(renderReadReplicaIndexImport([safeIndexStatement])).toBe(
-      `${safeIndexStatement.sql};`,
+      'CREATE INDEX IF NOT EXISTS "read_replica_import_unit_index" ON public."apps" ("app_id");',
     )
     expect(() => {
       renderReadReplicaImportTransaction([safeIndexStatement])
     }).toThrow('cannot atomically apply')
   })
 
-  it.concurrent('partitions index DDL away from atomic import statements', () => {
+  it.concurrent('imports quoted index names that contain spaces', () => {
+    assertGoogleReadReplicaSchemaPlan(plan([spacedIndexStatement, spacedConstraintStatement]))
+
+    expect(renderReadReplicaIndexImport([spacedIndexStatement])).toBe(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "unique customer_id on orgs" ON public."orgs" USING btree (customer_id);',
+    )
+    expect(renderReadReplicaImportTransaction([spacedConstraintStatement])).toContain(
+      spacedConstraintStatement.sql,
+    )
+  })
+
+  it.concurrent('partitions index DDL between column and constraint imports', () => {
     expect(
-      partitionReadReplicaImportStatements([safeColumnStatement, safeIndexStatement]),
+      partitionReadReplicaImportStatements([
+        safeColumnStatement,
+        safeIndexStatement,
+        spacedConstraintStatement,
+      ]),
     ).toEqual({
-      atomicStatements: [safeColumnStatement],
+      preIndexAtomicStatements: [safeColumnStatement],
       indexStatements: [safeIndexStatement],
+      postIndexAtomicStatements: [spacedConstraintStatement],
     })
   })
 
@@ -96,7 +126,10 @@ describe('read-replica Cloud SQL server-side import', () => {
     expect(source).toMatch(/--user=(?:postgres|\$\{POSTGRES_IMPORT_USER\})/)
     expect(source).toContain('BEGIN;')
     expect(source).toContain('COMMIT;')
-    expect(source).toContain('renderReadReplicaIndexImport')
+    expect(source).toContain('renderReadReplicaIndexImport(indexStatements)')
+    expect(source).toContain('preIndexAtomicStatements')
+    expect(source).toContain('postIndexAtomicStatements')
+    expect(source).toContain('renderCloudSqlIndexStatement')
     expect(source).not.toContain('capgo_read_replica_schema_owner')
     expect(source).not.toContain('bootstrap-read-replica-schema-owner')
     expect(source).not.toContain('CREATE ROLE')


### PR DESCRIPTION
## Summary (AI generated)

- Allow reviewed `index` / `invalid_index` / `drop_index` statements in the Cloud SQL read-replica schema sync
- Import those statements **outside** the atomic `BEGIN/COMMIT` bundle (CONCURRENTLY cannot run in a transaction)
- Keep column/constraint/type/sequence DDL on the existing atomic import path
- Update unit tests for the split import plan

## Motivation (AI generated)

Deploy failed in `Reconcile production read-replica schema` with:

`Cloud SQL server-side import cannot atomically apply index app_versions.idx_app_versions_deleted_at_id before primary migrations.`

Primary `supabase db push` was already up to date. The release gate was rejecting additive indexes only because they were forced through the atomic import path. Indexes do not need that atomicity.

## Business Impact (AI generated)

Unblocks production deploys after primary migrations that add subscriber-relevant indexes (for example the soft-deleted `app_versions` sweep indexes), so read-replica schema can stay aligned without manual ops workarounds.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/read-replica-schema-import-sync.unit.test.ts tests/read-replica-schema-additive-sync.unit.test.ts tests/read-replica-release-workflow.unit.test.ts`
- [ ] CI passes on this PR
- [ ] After merge/deploy, read-replica reconcile applies missing indexes instead of failing the gate

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-replica schema synchronization to apply index DDL separately from transactional schema updates, ensuring safe execution of index changes.
  * Tightened validation for index-related schema statements to prevent unsafe or malformed DDL from being applied.
  * Enhanced manifest cleanup by disabling/re-enabling the encrypted-bundle trigger as needed, adding SIGINT/SIGTERM handling, and performing version cleanup in an explicit transaction.
* **Tests**
  * Added coverage for index statement partitioning and rendering outside atomic transactions, updated supported-plan expectations, and verified the generated sync script includes the new index import path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->