### PR TITLE
fix(analytics): stop PostHog event spam from CLI and onboarding

### DIFF
--- a/cli/src/analytics/track.ts
+++ b/cli/src/analytics/track.ts
@@ -278,8 +278,16 @@ const CLI_PERF_CHANNEL = 'cli-perf'
 /**
  * Turns a raw timed-fetch observation into a fire-and-forget `Supabase Call`
  * event. Injected into supabase-perf so that module stays a leaf (no cycle).
+ *
+ * Only slow or failed calls are emitted. Successful fast calls were ~50% of
+ * PostHog volume (mostly CI `bundle upload`) and added little beyond the
+ * existing CLI command lifecycle events.
  */
 function recordSupabaseCall(info: SupabaseCallInfo): void {
+  const slow = info.durationMs > SLOW_THRESHOLD_MS
+  if (info.ok && !slow)
+    return
+
   // MCP tool calls scope their path via the async-local store; the CLI uses the
   // module-level value set in trackCommandInvoked.
   const commandPath = mcpCommandPathStore.getStore() ?? currentCommandPath
@@ -289,7 +297,7 @@ function recordSupabaseCall(info: SupabaseCallInfo): void {
     status_code: info.status,
     duration_ms: info.durationMs,
     ok: info.ok,
-    slow: info.durationMs > SLOW_THRESHOLD_MS,
+    slow,
   }
   if (info.source)
     tags.source = info.source

--- a/cli/test/test-supabase-perf.mjs
+++ b/cli/test/test-supabase-perf.mjs
@@ -85,20 +85,13 @@ try {
   }
   const findPerfEvent = reqs => reqs.find(r => r.url.endsWith('/private/events') && JSON.parse(r.init.body).event === 'Supabase Call')
 
-  // success path → ok:true, operation, channel cli-perf, command_path
+  // fast success path → no Supabase Call event (volume guard)
   trackCommandInvoked('bundle upload', { flags: [], positional_arg_count: 0 })
   let reqs = stubPerf()
   const tf3 = createTimedFetch()
   await withSupabaseSource('apps.list', () => tf3('https://db.co/rest/v1/apps?select=*', { method: 'GET' }))
   await flushAnalytics()
-  let ev = JSON.parse(findPerfEvent(reqs).init.body)
-  assert.equal(ev.event, 'Supabase Call')
-  assert.equal(ev.channel, 'cli-perf')
-  assert.equal(ev.tags.operation, 'GET apps')
-  assert.equal(ev.tags.ok, true)
-  assert.equal(ev.tags.source, 'apps.list')
-  assert.equal(ev.tags.command_path, 'bundle upload')
-  assert.equal(ev.tags.error_category, undefined, 'no error_category on success')
+  assert.equal(findPerfEvent(reqs), undefined, 'fast success => no perf event')
 
   // HTTP failure path → ok:false, error_category from status (504 => timeout)
   reqs = []
@@ -108,12 +101,34 @@ try {
       return new Response('', { status: 504 })
     return new Response('{}', { status: 200 })
   }
-  await tf3('https://db.co/rest/v1/rpc/get_user_id', { method: 'POST' })
+  await withSupabaseSource('apps.list', () => tf3('https://db.co/rest/v1/rpc/get_user_id', { method: 'POST' }))
   await flushAnalytics()
-  ev = JSON.parse(findPerfEvent(reqs).init.body)
+  let ev = JSON.parse(findPerfEvent(reqs).init.body)
+  assert.equal(ev.event, 'Supabase Call')
+  assert.equal(ev.channel, 'cli-perf')
   assert.equal(ev.tags.ok, false)
   assert.equal(ev.tags.operation, 'rpc:get_user_id')
+  assert.equal(ev.tags.source, 'apps.list')
+  assert.equal(ev.tags.command_path, 'bundle upload')
   assert.equal(ev.tags.error_category, 'timeout')
+
+  // slow success path → still emitted with slow:true
+  reqs = []
+  const realNow = Date.now
+  let now = realNow()
+  Date.now = () => now
+  globalThis.fetch = async (url, init) => {
+    reqs.push({ url: String(url), init })
+    now += SLOW_THRESHOLD_MS + 1
+    return new Response('{}', { status: 200 })
+  }
+  await withSupabaseSource('apps.list', () => tf3('https://db.co/rest/v1/apps?select=*', { method: 'GET' }))
+  await flushAnalytics()
+  Date.now = realNow
+  ev = JSON.parse(findPerfEvent(reqs).init.body)
+  assert.equal(ev.tags.ok, true)
+  assert.equal(ev.tags.slow, true)
+  assert.equal(ev.tags.operation, 'GET apps')
 
   process.env.CAPGO_TOKEN = originalToken
   if (originalDisable !== undefined) process.env.CAPGO_DISABLE_TELEMETRY = originalDisable
@@ -148,15 +163,31 @@ try {
   await flushAnalytics()
   assert.equal(findPerf(creqs), undefined, 'disabled => no perf event')
 
-  // enabled: timed fetch attached → Supabase Call event with operation
+  // enabled + fast success: timed fetch attached, but no event (volume guard)
   enableSupabaseInstrumentation()
   creqs = stubClient()
   sb = await createSupabaseClient('perf-key', 'https://db.co', 'anon')
   await sb.from('demo').select('*')
   await flushAnalytics()
+  assert.equal(findPerf(creqs), undefined, 'enabled fast success => no perf event')
+
+  // enabled + HTTP failure: Supabase Call event with operation
+  creqs = []
+  globalThis.fetch = async (url, init) => {
+    creqs.push({ url: String(url), init })
+    if (String(url).endsWith('/private/config'))
+      return new Response(JSON.stringify({ supaHost: 'https://db.co', supaKey: 'anon' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    if (String(url).includes('/rest/v1/'))
+      return new Response('', { status: 500, headers: { 'Content-Type': 'application/json' } })
+    return new Response('{}', { status: 200 })
+  }
+  sb = await createSupabaseClient('perf-key', 'https://db.co', 'anon')
+  await sb.from('demo').select('*')
+  await flushAnalytics()
   const cev = findPerf(creqs)
-  assert.ok(cev, 'enabled => perf event')
+  assert.ok(cev, 'enabled failure => perf event')
   assert.equal(JSON.parse(cev.init.body).tags.operation, 'GET demo')
+  assert.equal(JSON.parse(cev.init.body).tags.ok, false)
 
   // recursion guard: org-resolver must build an UNinstrumented client
   let capturedInstrument
@@ -176,9 +207,17 @@ try {
   assert.equal(orgId, 'org-x')
   assert.equal(capturedInstrument, false, 'org-resolver must create an uninstrumented client')
 
-  // --- Task 6: source label flows into the event ---
+  // --- Task 6: source label flows into failed events ---
   process.env.CAPGO_TOKEN = 'perf-key'
-  let lreqs = stubClient()
+  let lreqs = []
+  globalThis.fetch = async (url, init) => {
+    lreqs.push({ url: String(url), init })
+    if (String(url).endsWith('/private/config'))
+      return new Response(JSON.stringify({ supaHost: 'https://db.co', supaKey: 'anon' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    if (String(url).includes('/rest/v1/'))
+      return new Response('', { status: 503, headers: { 'Content-Type': 'application/json' } })
+    return new Response('{}', { status: 200 })
+  }
   enableSupabaseInstrumentation()
   const lsb = await createSupabaseClient('perf-key', 'https://db.co', 'anon')
   await withSupabaseSource('apps.list', () => lsb
@@ -187,10 +226,11 @@ try {
     .order('created_at', { ascending: false }))
   await flushAnalytics()
   const lev = findPerf(lreqs)
-  assert.ok(lev, 'labeled query emits a perf event')
+  assert.ok(lev, 'labeled failed query emits a perf event')
   const ltags = JSON.parse(lev.init.body).tags
   assert.equal(ltags.source, 'apps.list')
   assert.equal(ltags.operation, 'GET apps')
+  assert.equal(ltags.ok, false)
 
   // --- Codex P2: perf telemetry uses the key from the request's capgkey header ---
   // (so events fire for --apikey usage, not just env / saved-file keys)
@@ -198,7 +238,7 @@ try {
   const hreqs = []
   globalThis.fetch = async (url, init) => {
     hreqs.push({ url: String(url), init })
-    return new Response('{}', { status: 200 })
+    return new Response('', { status: 500 })
   }
   const tfHeader = createTimedFetch()
   await tfHeader('https://db.co/rest/v1/apps?select=*', { method: 'GET', headers: { capgkey: 'header-key' } })
@@ -213,7 +253,7 @@ try {
   const mreqs = []
   globalThis.fetch = async (url, init) => {
     mreqs.push({ url: String(url), init })
-    return new Response('{}', { status: 200 })
+    return new Response('', { status: 500 })
   }
   const tickMs = () => new Promise(r => setTimeout(r, 5))
   const tfMcp = createTimedFetch()

--- a/cli/test/test-supabase-perf.mjs
+++ b/cli/test/test-supabase-perf.mjs
@@ -117,18 +117,22 @@ try {
   const realNow = Date.now
   let now = realNow()
   Date.now = () => now
-  globalThis.fetch = async (url, init) => {
-    reqs.push({ url: String(url), init })
-    now += SLOW_THRESHOLD_MS + 1
-    return new Response('{}', { status: 200 })
+  try {
+    globalThis.fetch = async (url, init) => {
+      reqs.push({ url: String(url), init })
+      now += SLOW_THRESHOLD_MS + 1
+      return new Response('{}', { status: 200 })
+    }
+    await withSupabaseSource('apps.list', () => tf3('https://db.co/rest/v1/apps?select=*', { method: 'GET' }))
+    await flushAnalytics()
+    ev = JSON.parse(findPerfEvent(reqs).init.body)
+    assert.equal(ev.tags.ok, true)
+    assert.equal(ev.tags.slow, true)
+    assert.equal(ev.tags.operation, 'GET apps')
   }
-  await withSupabaseSource('apps.list', () => tf3('https://db.co/rest/v1/apps?select=*', { method: 'GET' }))
-  await flushAnalytics()
-  Date.now = realNow
-  ev = JSON.parse(findPerfEvent(reqs).init.body)
-  assert.equal(ev.tags.ok, true)
-  assert.equal(ev.tags.slow, true)
-  assert.equal(ev.tags.operation, 'GET apps')
+  finally {
+    Date.now = realNow
+  }
 
   process.env.CAPGO_TOKEN = originalToken
   if (originalDisable !== undefined) process.env.CAPGO_DISABLE_TELEMETRY = originalDisable

--- a/supabase/functions/_backend/utils/plans.ts
+++ b/supabase/functions/_backend/utils/plans.ts
@@ -550,21 +550,14 @@ export async function handleOrgNotificationsAndEvents(c: Context, org: any, orgI
   }
   else if (!is_onboarded && is_onboarding_needed) {
     const onboardingIntent = parseOrgOnboardingIntent(org.onboarding)
-    const sent = await sendNotifToOrgMembersOnce(c, 'user:need_onboarding', 'onboarding', buildOnboardingIntentBentoEventData(c, onboardingIntent, {
+    // Email reminder stays once-per-org via sendNotifToOrgMembersOnce.
+    // Do not mirror to PostHog: Once returns true for already-claimed orgs, so a
+    // daily cron re-emitted ~5k identified "User need onboarding" events/day.
+    await sendNotifToOrgMembersOnce(c, 'user:need_onboarding', 'onboarding', buildOnboardingIntentBentoEventData(c, onboardingIntent, {
       id: orgId,
       name: org.name ?? '',
       website: org.website ?? null,
     }), orgId, orgId, drizzleClient)
-    if (sent) {
-      await sendEventToTracking(c, {
-        channel: 'usage',
-        event: 'User need onboarding',
-        icon: '🥲',
-        user_id: orgId,
-        groups: { organization: orgId },
-        notify: false,
-      }).catch()
-    }
   }
   else if (is_good_plan && is_onboarded) {
     await userIsAtPlanUsage(c, orgId, org.customer_id, percentUsage, drizzleClient)

--- a/tests/plans-onboarding-reminder.unit.test.ts
+++ b/tests/plans-onboarding-reminder.unit.test.ts
@@ -127,14 +127,7 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
       orgId,
       expect.anything(),
     )
-    expect(sendEventToTrackingMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        channel: 'usage',
-        event: 'User need onboarding',
-        user_id: orgId,
-      }),
-    )
+    expect(trackingCalls(orgId)).toHaveLength(0)
   })
 
   it.concurrent('does not send plan usage alerts from stale total percent alone', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- CLI `Supabase Call` telemetry now emits only for **slow** (>5s) or **failed** Supabase requests (was ~50% of PostHog volume, mostly CI `bundle upload`)
- Removed the daily PostHog mirror of `User need onboarding` from the plan cron; Bento once-per-org email reminder is unchanged
- Updated CLI perf + onboarding unit tests for the new behavior

## Motivation (AI generated)

PostHog was burning ~1.5M events / identified events largely from:
1. Capgo CLI recording every Supabase REST/RPC call
2. Plan cron treating `sendNotifToOrgMembersOnce` `true` (including already-claimed) as a reason to re-emit PostHog daily (~4.7k/day)

## Business Impact (AI generated)

Cuts PostHog billable volume sharply while keeping useful failure/latency signal for CLI and keeping onboarding email reminders intact.

## Test Plan (AI generated)

- [x] `bun test/test-supabase-perf.mjs` (from `cli/`)
- [x] `bunx vitest run tests/plans-onboarding-reminder.unit.test.ts`
- [ ] Confirm PostHog `Supabase Call` daily volume drops after CLI publish
- [ ] Confirm `User need onboarding` events stop while Bento reminder still works once per org

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding reminder handling to prevent duplicate tracking activity while preserving one-time reminder delivery.
  * Corrected performance reporting so fast, successful backend requests no longer generate unnecessary events.
  * Improved reporting accuracy for slow or failed requests, including operation, source, timeout, and success-status details.
* **Tests**
  * Expanded coverage for request timing, failure reporting, onboarding reminders, and event attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->