### PR TITLE
fix(ci): release Capgo for replica schema sync script changes

### DIFF
--- a/scripts/release-scope.ts
+++ b/scripts/release-scope.ts
@@ -23,6 +23,7 @@ export const componentMatchers: Record<Component, RegExp[]> = {
     /^\.github\/workflows\/build_and_deploy\.yml$/,
     /^\.github\/workflows\/build_mobile_ios\.yml$/,
     /^scripts\/deploy-scope\.ts$/,
+    /^scripts\/(check-read-replica-hyperdrive-schema\.sh|sync-read-replica-schema\.ts)$/,
     /^aliproxy\//,
     /^android\//,
     /^assets\//,

--- a/scripts/sync-read-replica-schema.ts
+++ b/scripts/sync-read-replica-schema.ts
@@ -58,6 +58,7 @@ const GOOGLE_DATA_API_RESPONSE_LIMIT_BYTES = 10_000_000
 const IMPORT_CLEANUP_MAX_SECONDS = 60
 const POSTGRES_IMPORT_USER = 'postgres'
 const GCS_IMPORT_BUCKET = 'capgo-read-replica-schema-import-394818'
+// Included in Capgo release scope so replica schema sync fixes cut deploy tags.
 const GOOGLE_READ_REPLICA: GoogleDataApiConfig = {
   project: 'capgo-394818',
   instance: 'eu-2',

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -60,6 +60,17 @@ describe('release scope matching', () => {
     expect(matchesComponent('notifications', files)).toBe(false)
   })
 
+  it.concurrent('treats read-replica schema sync scripts as Capgo releases', () => {
+    const files = [
+      'scripts/sync-read-replica-schema.ts',
+      'scripts/check-read-replica-hyperdrive-schema.sh',
+    ]
+
+    expect(matchesComponent('capgo', files)).toBe(true)
+    expect(matchesComponent('cli', files)).toBe(false)
+    expect(matchesComponent('notifications', files)).toBe(false)
+  })
+
   it.concurrent('treats capgo deploy workflow changes as capgo-only releases', () => {
     const files = ['.github/workflows/build_and_deploy.yml', 'scripts/deploy-scope.ts']
 


### PR DESCRIPTION
## Summary (AI generated)

- Add `scripts/sync-read-replica-schema.ts` (and the matching hyperdrive check script) to Capgo `release-scope` matchers, aligned with `deploy-scope`
- Cover the matcher in `tests/release-scope.test.ts`
- Touch the sync script so this merge itself is in Capgo release scope and cuts a deploy tag

## Motivation (AI generated)

`#2742` landed on `main` but `bump_version` skipped the Capgo bump because only `scripts/` + `tests/` changed, and those paths were outside Capgo release scope. Production stayed on `capgo-12.201.6`, which still rejects additive index imports.

## Business Impact (AI generated)

Unblocks a Capgo release/deploy that includes the Cloud SQL index import fix, so read-replica schema reconcile can apply missing indexes instead of failing the release gate.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/release-scope.test.ts`
- [ ] CI passes on this PR
- [ ] After merge, `bump_version` sets `run_capgo=true` and creates a new `capgo-*` tag / deploy

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected release detection so read-replica schema synchronization changes are properly included in Capgo releases.

* **Tests**
  * Added coverage confirming these changes are classified correctly and excluded from unrelated release components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->