### PR TITLE
fix(analytics): emit User need onboarding once on first claim

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts
@@ -658,7 +658,9 @@ export async function sendNotifToOrgMembersOnce(
         orgId,
         uniqId,
       })
-      return true
+      // false = not newly sent this call. Callers that mirror to PostHog/etc must
+      // not treat idempotent "already claimed" as a fresh delivery.
+      return false
     }
 
     const { recipients, resolutionFailed } = await getPreparedEligibleEmailTargets(c, orgId, preferenceKey, writeClient, audience)

--- a/supabase/functions/_backend/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/utils/org_email_notifications.ts
@@ -653,7 +653,9 @@ export async function sendNotifToOrgMembersOnce(
         orgId,
         uniqId,
       })
-      return true
+      // false = not newly sent this call. Callers that mirror to PostHog/etc must
+      // not treat idempotent "already claimed" as a fresh delivery.
+      return false
     }
 
     const { recipients, resolutionFailed } = await getPreparedEligibleEmailTargets(c, orgId, preferenceKey, writeClient, audience)

--- a/supabase/functions/_backend/utils/plans.ts
+++ b/supabase/functions/_backend/utils/plans.ts
@@ -550,14 +550,22 @@ export async function handleOrgNotificationsAndEvents(c: Context, org: any, orgI
   }
   else if (!is_onboarded && is_onboarding_needed) {
     const onboardingIntent = parseOrgOnboardingIntent(org.onboarding)
-    // Email reminder stays once-per-org via sendNotifToOrgMembersOnce.
-    // Do not mirror to PostHog: Once returns true for already-claimed orgs, so a
-    // daily cron re-emitted ~5k identified "User need onboarding" events/day.
-    await sendNotifToOrgMembersOnce(c, 'user:need_onboarding', 'onboarding', buildOnboardingIntentBentoEventData(c, onboardingIntent, {
+    // Once returns true only on the first org claim (not on later cron passes).
+    const sent = await sendNotifToOrgMembersOnce(c, 'user:need_onboarding', 'onboarding', buildOnboardingIntentBentoEventData(c, onboardingIntent, {
       id: orgId,
       name: org.name ?? '',
       website: org.website ?? null,
     }), orgId, orgId, drizzleClient)
+    if (sent) {
+      await sendEventToTracking(c, {
+        channel: 'usage',
+        event: 'User need onboarding',
+        icon: '🥲',
+        user_id: orgId,
+        groups: { organization: orgId },
+        notify: false,
+      }).catch()
+    }
   }
   else if (is_good_plan && is_onboarded) {
     await userIsAtPlanUsage(c, orgId, org.customer_id, percentUsage, drizzleClient)

--- a/tests/org-email-notifications-send-once.unit.test.ts
+++ b/tests/org-email-notifications-send-once.unit.test.ts
@@ -166,7 +166,7 @@ describe('sendNotifToOrgMembersOnce', () => {
       {} as any,
     )
 
-    expect(sent).toBe(true)
+    expect(sent).toBe(false)
     expect(hasNotifOrgClaimMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ kind: 'write-client' }),

--- a/tests/plans-onboarding-reminder.unit.test.ts
+++ b/tests/plans-onboarding-reminder.unit.test.ts
@@ -20,7 +20,7 @@ const {
   isTrialOrgMock: vi.fn(async () => 0),
   sendEventToTrackingMock: vi.fn(async () => undefined),
   sendNotifToOrgMembersMock: vi.fn(async () => true),
-  sendNotifToOrgMembersOnceMock: vi.fn(async () => true),
+  sendNotifToOrgMembersOnceMock: vi.fn(async (_c: unknown, _event: string, _pref: string, _data: unknown, orgId: string) => !orgId.includes('already-claimed')),
   supabaseAdminMock: vi.fn(),
 }))
 
@@ -127,6 +127,41 @@ describe('handleOrgNotificationsAndEvents onboarding reminder', () => {
       orgId,
       expect.anything(),
     )
+    expect(trackingCalls(orgId)).toEqual([
+      [
+        expect.anything(),
+        expect.objectContaining({
+          channel: 'usage',
+          event: 'User need onboarding',
+          user_id: orgId,
+        }),
+      ],
+    ])
+  })
+
+  it.concurrent('does not re-emit User need onboarding when the once-helper finds an existing claim', async () => {
+    const { handleOrgNotificationsAndEvents } = await import('../supabase/functions/_backend/utils/plans.ts')
+    const orgId = 'org-onboarding-already-claimed'
+
+    await handleOrgNotificationsAndEvents(
+      createContext(),
+      {
+        customer_id: null,
+        name: 'Acme Mobile',
+        website: 'https://acme.example/',
+        onboarding: null,
+      },
+      orgId,
+      {
+        total_percent: 0,
+        mau_percent: 0,
+        bandwidth_percent: 0,
+        storage_percent: 0,
+        build_time_percent: 0,
+      },
+      {} as any,
+    )
+
     expect(trackingCalls(orgId)).toHaveLength(0)
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- Restore PostHog `User need onboarding` (removed entirely in #2747)
- Make `sendNotifToOrgMembersOnce` return `false` when the org claim already exists, so `true` means newly sent this call
- Emit the tracking event only when that first claim succeeds (once per org)

## Motivation (AI generated)

#2747 stopped the daily spam by deleting the PostHog event. Intent was once-per-org (same as the Bento email), not full removal. Root cause: `Once` returned `true` for already-claimed orgs, so `if (sent)` re-fired every cron pass.

## Business Impact (AI generated)

Keeps a useful onboarding funnel signal in PostHog without ~5k identified events/day from the cron.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/plans-onboarding-reminder.unit.test.ts tests/org-email-notifications-send-once.unit.test.ts`
- [ ] Confirm first onboarding reminder still sends Bento email + one PostHog event
- [ ] Confirm later cron passes send neither email nor PostHog for the same org

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate organization notifications from being reported as newly delivered.
  * Ensured onboarding tracking events are recorded only when a new notification is sent.
  * Avoided tracking events for notifications that were already claimed.

* **Tests**
  * Added coverage for duplicate notification claims and conditional onboarding tracking events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->