### PR TITLE
fix(email): correct weekly/monthly/24h stats email calculations

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -389,9 +389,17 @@ function convertDataToJsTypes<T>(apiResponse: AnalyticsApiResponse) {
   const { meta, data } = apiResponse
 
   // cloudlog(c.get('requestId'), 'meta', meta)
-  const converters = {
+  const toNumber = (value: string) => Number(value)
+  const converters: Record<string, (value: string) => unknown> = {
     String: (value: string) => String(value),
-    UInt64: (value: string) => Number(value),
+    // Analytics Engine returns aggregate sums as Float64 string values.
+    // Without conversion, callers that do `sum + row.install` string-concatenate.
+    Float64: toNumber,
+    Float32: toNumber,
+    Int64: toNumber,
+    Int32: toNumber,
+    UInt64: toNumber,
+    UInt32: toNumber,
     DateTime: (value: string) => new Date(value),
   }
 
@@ -399,7 +407,7 @@ function convertDataToJsTypes<T>(apiResponse: AnalyticsApiResponse) {
     const convertedRow = {} as any
     meta.forEach((column) => {
       const { name, type } = column
-      convertedRow[name] = (converters as any)[type] ? (converters as any)[type](row[name]) : row[name]
+      convertedRow[name] = converters[type] ? converters[type](row[name]) : row[name]
     })
     return convertedRow as T
   })

--- a/supabase/functions/_backend/triggers/cron_email.ts
+++ b/supabase/functions/_backend/triggers/cron_email.ts
@@ -162,19 +162,33 @@ async function handleMonthlyCreateStats(c: Context, appId: string) {
   const { startIso, endExclusiveIso, monthName } = getPreviousMonthUtcRange()
 
   // Fetch stats for bundle creation and publishing
-  const { data: appVersions, error: _appVersionsError } = await supabase
+  const { data: appVersions, error: appVersionsError } = await supabase
     .from('app_versions')
     .select('id, created_at')
     .eq('app_id', appId)
     .gte('created_at', startIso)
     .lt('created_at', endExclusiveIso)
 
-  const { data: deployHistory, error: _deployHistoryError } = await supabase
+  if (appVersionsError) {
+    throw simpleError('cannot_fetch_monthly_bundles', 'Cannot fetch monthly bundle stats', {
+      error: appVersionsError,
+      appId,
+    })
+  }
+
+  const { data: deployHistory, error: deployHistoryError } = await supabase
     .from('deploy_history')
     .select('id, deployed_at')
     .eq('app_id', appId)
     .gte('deployed_at', startIso)
     .lt('deployed_at', endExclusiveIso)
+
+  if (deployHistoryError) {
+    throw simpleError('cannot_fetch_monthly_publishes', 'Cannot fetch monthly publish stats', {
+      error: deployHistoryError,
+      appId,
+    })
+  }
 
   const bundleCount = appVersions?.length ?? 0
   const publishCount = deployHistory?.length ?? 0
@@ -286,14 +300,19 @@ async function handleDeployInstallStats(
         error: releaseError,
         metadata: { appId, deployId, installs },
       })
-    }
-    else {
-      cloudlog({
-        requestId: c.get('requestId'),
-        message: 'Released deploy install stats email claim for retry',
-        metadata: { appId, deployId, installs },
+      // Fail the job so the queue can retry instead of permanently keeping the claim.
+      throw simpleError('cannot_release_deploy_stats_claim', 'Cannot release deploy install stats email claim', {
+        error: releaseError,
+        appId,
+        deployId,
+        installs,
       })
     }
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Released deploy install stats email claim for retry',
+      metadata: { appId, deployId, installs },
+    })
   }
 
   return c.json({ status: 'Not enough installs for deploy stats email', installs }, 200)

--- a/supabase/functions/_backend/triggers/cron_email.ts
+++ b/supabase/functions/_backend/triggers/cron_email.ts
@@ -2,9 +2,11 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { Hono } from 'hono/tiny'
 import {
+  buildWeeklyEmailMetadata,
   computeWeeklyInstallStats,
   getPreviousMonthUtcRange,
   shouldRetryDeployInstallStats,
+  shouldSendDeployInstallStatsEmail,
   sumVersionInstalls,
 } from '../utils/cron_email_stats.ts'
 import { BRES, middlewareAPISecret, parseBody, simpleError } from '../utils/hono.ts'
@@ -13,68 +15,6 @@ import { sendEmailToOrgMembers } from '../utils/org_email_notifications.ts'
 import { findBestPlan } from '../utils/plans.ts'
 import { readStatsVersion } from '../utils/stats.ts'
 import { getCurrentPlanNameOrg, supabaseAdmin } from '../utils/supabase.ts'
-
-const thresholds = {
-  // Number of updates in plain number
-  updates: [
-    100,
-    1000,
-    10000,
-  ],
-  // Percentage in decimal form (0.9 ==== 90%)
-  failRate: [
-    // Failure rate bands (0 = 0% failures, 0.3 = 30% failures)
-    0,
-    0.10,
-    0.20,
-    0.30,
-  ],
-  // Number of app opens in plain number
-  appOpen: [
-    500,
-    1500,
-    5000,
-  ],
-}
-
-const funComparisons = {
-  updates: [
-    'a cupcake to every student in a small school!',
-    'a pizza to every resident of a small town!',
-    'a burger to everyone in a big city!',
-  ],
-  failRate: [
-    'Flawless streak—no failed updates this week! 🏅',
-    'Roughly one in ten updates failed; a quick health check could help.',
-    'About one in five updates failed; let\'s squash those errors.',
-    'Heads up: nearly a third of updates are failing—worth a closer look.',
-  ],
-  appOpen: [
-    'Your app was opened more times than a popular local bakery\'s door!',
-    'Your app was more popular than the latest episode of a hit TV show!',
-    'Your app was opened more times than a blockbuster movie on its opening weekend!',
-  ],
-}
-
-// Check what threshold does the stat qualify for and return the fun comparison
-function getFunComparison(comparison: keyof typeof funComparisons, stat: number): string {
-  const thresholdsForComparisons = thresholds[comparison]
-  // Choose the highest threshold that is <= stat so that bigger stats map to
-  // the more impressive comparison string (including 100% success rate).
-  let chosenIndex = 0
-  for (let i = thresholdsForComparisons.length - 1; i >= 0; i -= 1) {
-    if (stat >= thresholdsForComparisons[i]) {
-      chosenIndex = i
-      break
-    }
-  }
-
-  const comparisonStrings = funComparisons[comparison]
-  if (!comparisonStrings[chosenIndex])
-    throw new Error(`Cannot find index for fun comparison, ${chosenIndex}`)
-
-  return comparisonStrings[chosenIndex]
-}
 
 export const app = new Hono<MiddlewareKeyVariables>()
 
@@ -208,27 +148,7 @@ async function handleWeeklyInstallStats(c: Context, appId: string) {
     return c.json({ status: 'No updates this week' }, 200)
   }
 
-  // Calculate week number and month name for the reported period
-  const now = new Date()
-  const monthName = now.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' })
-  // Calculate ISO week number
-  const startOfYear = new Date(Date.UTC(now.getUTCFullYear(), 0, 1))
-  const days = Math.floor((now.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000))
-  const weekNumber = Math.ceil((days + startOfYear.getUTCDay() + 1) / 7)
-
-  const metadata = {
-    app_id: appId,
-    month_name: monthName,
-    week_number: weekNumber.toString(),
-    weekly_updates: stats.totalUpdates.toString(),
-    fun_comparison: getFunComparison('updates', stats.totalUpdates),
-    weekly_install: stats.successfulInstalls.toString(),
-    weekly_install_success: (stats.successPercentage * 100).toString(),
-    fun_comparison_2: getFunComparison('failRate', stats.failureRate),
-    weekly_fail: stats.failedUpdates.toString(),
-    weekly_open: stats.openApp.toString(),
-    fun_comparison_3: getFunComparison('appOpen', stats.openApp),
-  }
+  const metadata = buildWeeklyEmailMetadata(appId, stats)
 
   await sendEmailToOrgMembers(c, 'user:weekly_stats', 'weekly_stats', metadata, await getOrgIdForApp(c, appId))
 
@@ -346,7 +266,7 @@ async function handleDeployInstallStats(
     window_hours: '24',
   }
 
-  if (installs > 1) {
+  if (shouldSendDeployInstallStatsEmail(installs)) {
     await sendEmailToOrgMembers(c, 'bundle:install_stats_24h', 'deploy_stats_24h', metadata, orgId ?? await getOrgIdForApp(c, appId))
     return c.json(BRES)
   }

--- a/supabase/functions/_backend/triggers/cron_email.ts
+++ b/supabase/functions/_backend/triggers/cron_email.ts
@@ -1,6 +1,12 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import { Hono } from 'hono/tiny'
+import {
+  computeWeeklyInstallStats,
+  getPreviousMonthUtcRange,
+  shouldRetryDeployInstallStats,
+  sumVersionInstalls,
+} from '../utils/cron_email_stats.ts'
 import { BRES, middlewareAPISecret, parseBody, simpleError } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { sendEmailToOrgMembers } from '../utils/org_email_notifications.ts'
@@ -194,40 +200,34 @@ async function handleWeeklyInstallStats(c: Context, appId: string) {
     throw simpleError('cannot_generate_stats', 'Cannot generate stats', { error: generateStatsError })
   }
 
-  if (weeklyStats.all_updates === 0) {
+  // get_weekly_stats.all_updates is SUM(install); failed_updates is SUM(fail).
+  // Those are independent counters, so rates use install / (install + fail).
+  const stats = computeWeeklyInstallStats(weeklyStats)
+
+  if (stats.totalUpdates === 0) {
     return c.json({ status: 'No updates this week' }, 200)
   }
 
-  const successUpdates = weeklyStats.all_updates - weeklyStats.failed_updates
-  if (successUpdates < 0) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Cannot send email for app, successUpdates < 0', error: weeklyStats, metadata: { app_id: appId } })
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Invalid stats detected', error: weeklyStats, metadata: { app_id: appId } })
-    return c.json({ status: 'No valid stats available' }, 200)
-  }
-
-  const successPercentage = Math.round((successUpdates / weeklyStats.all_updates) * 10_000) / 10_000
-  const failureRate = Math.round((weeklyStats.failed_updates / weeklyStats.all_updates) * 10_000) / 10_000
-
   // Calculate week number and month name for the reported period
   const now = new Date()
-  const monthName = now.toLocaleString('en-US', { month: 'long' })
+  const monthName = now.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' })
   // Calculate ISO week number
-  const startOfYear = new Date(now.getFullYear(), 0, 1)
+  const startOfYear = new Date(Date.UTC(now.getUTCFullYear(), 0, 1))
   const days = Math.floor((now.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000))
-  const weekNumber = Math.ceil((days + startOfYear.getDay() + 1) / 7)
+  const weekNumber = Math.ceil((days + startOfYear.getUTCDay() + 1) / 7)
 
   const metadata = {
     app_id: appId,
     month_name: monthName,
     week_number: weekNumber.toString(),
-    weekly_updates: (weeklyStats.all_updates).toString(),
-    fun_comparison: getFunComparison('updates', weeklyStats.all_updates),
-    weekly_install: successUpdates.toString(),
-    weekly_install_success: (successPercentage * 100).toString(),
-    fun_comparison_2: getFunComparison('failRate', failureRate),
-    weekly_fail: (weeklyStats.failed_updates).toString(),
-    weekly_open: (weeklyStats.open_app).toString(),
-    fun_comparison_3: getFunComparison('appOpen', weeklyStats.open_app),
+    weekly_updates: stats.totalUpdates.toString(),
+    fun_comparison: getFunComparison('updates', stats.totalUpdates),
+    weekly_install: stats.successfulInstalls.toString(),
+    weekly_install_success: (stats.successPercentage * 100).toString(),
+    fun_comparison_2: getFunComparison('failRate', stats.failureRate),
+    weekly_fail: stats.failedUpdates.toString(),
+    weekly_open: stats.openApp.toString(),
+    fun_comparison_3: getFunComparison('appOpen', stats.openApp),
   }
 
   await sendEmailToOrgMembers(c, 'user:weekly_stats', 'weekly_stats', metadata, await getOrgIdForApp(c, appId))
@@ -238,28 +238,23 @@ async function handleWeeklyInstallStats(c: Context, appId: string) {
 async function handleMonthlyCreateStats(c: Context, appId: string) {
   const supabase = await supabaseAdmin(c)
 
-  // Calculate the previous month's date range
-  const now = new Date()
-  const previousMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
-  const previousMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0) // Last day of previous month
-
-  // Get full month name for the reported period
-  const monthName = previousMonth.toLocaleString('en-US', { month: 'long' })
+  // Previous calendar month in UTC: [start, nextMonthStart)
+  const { startIso, endExclusiveIso, monthName } = getPreviousMonthUtcRange()
 
   // Fetch stats for bundle creation and publishing
   const { data: appVersions, error: _appVersionsError } = await supabase
     .from('app_versions')
     .select('id, created_at')
     .eq('app_id', appId)
-    .gte('created_at', previousMonth.toISOString())
-    .lte('created_at', previousMonthEnd.toISOString())
+    .gte('created_at', startIso)
+    .lt('created_at', endExclusiveIso)
 
   const { data: deployHistory, error: _deployHistoryError } = await supabase
     .from('deploy_history')
     .select('id, deployed_at')
     .eq('app_id', appId)
-    .gte('deployed_at', previousMonth.toISOString())
-    .lte('deployed_at', previousMonthEnd.toISOString())
+    .gte('deployed_at', startIso)
+    .lt('deployed_at', endExclusiveIso)
 
   const bundleCount = appVersions?.length ?? 0
   const publishCount = deployHistory?.length ?? 0
@@ -330,13 +325,12 @@ async function handleDeployInstallStats(
 
   const windowStart = deployTime.toISOString()
   const windowEnd = new Date(deployTime.getTime() + 24 * 60 * 60 * 1000).toISOString()
+  // Do not filter by channel here: older VERSION_USAGE rows may lack channel blobs,
+  // and this email counts installs for the deployed version across the app.
   const versionStats = await readStatsVersion(c, appId, windowStart, windowEnd)
-  // Filter by version_name (new format) OR version_id as string (old Cloudflare format)
-  // This handles backwards compatibility during the transition period
-  const versionIdStr = versionId ? String(versionId) : null
-  const installs = versionStats
-    .filter(row => row.version_name === versionName || (versionIdStr && row.version_name === versionIdStr))
-    .reduce((sum, row) => sum + (row.install ?? 0), 0)
+  // Filter by version_name (new format) OR version_id as string (old Cloudflare format).
+  // Coerce installs with Number() — Analytics Engine sum() can arrive as stringy Float64.
+  const installs = sumVersionInstalls(versionStats, versionName, versionId)
 
   const metadata = {
     app_id: appId,
@@ -354,9 +348,35 @@ async function handleDeployInstallStats(
 
   if (installs > 1) {
     await sendEmailToOrgMembers(c, 'bundle:install_stats_24h', 'deploy_stats_24h', metadata, orgId ?? await getOrgIdForApp(c, appId))
+    return c.json(BRES)
   }
 
-  return c.json(BRES)
+  // SQL claims install_stats_email_sent_at before the worker runs. If analytics
+  // lagged or returned unusable counts, release the claim so cron can retry
+  // while this deploy is still the latest within the retry window.
+  if (deployId && shouldRetryDeployInstallStats(deployTime)) {
+    const { error: releaseError } = await supabaseAdmin(c)
+      .from('deploy_history')
+      .update({ install_stats_email_sent_at: null })
+      .eq('id', deployId)
+    if (releaseError) {
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'Failed to release deploy install stats email claim for retry',
+        error: releaseError,
+        metadata: { appId, deployId, installs },
+      })
+    }
+    else {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Released deploy install stats email claim for retry',
+        metadata: { appId, deployId, installs },
+      })
+    }
+  }
+
+  return c.json({ status: 'Not enough installs for deploy stats email', installs }, 200)
 }
 
 /**

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -389,9 +389,17 @@ function convertDataToJsTypes<T>(apiResponse: AnalyticsApiResponse) {
   const { meta, data } = apiResponse
 
   // cloudlog(c.get('requestId'), 'meta', meta)
-  const converters = {
+  const toNumber = (value: string) => Number(value)
+  const converters: Record<string, (value: string) => unknown> = {
     String: (value: string) => String(value),
-    UInt64: (value: string) => Number(value),
+    // Analytics Engine returns aggregate sums as Float64 string values.
+    // Without conversion, callers that do `sum + row.install` string-concatenate.
+    Float64: toNumber,
+    Float32: toNumber,
+    Int64: toNumber,
+    Int32: toNumber,
+    UInt64: toNumber,
+    UInt32: toNumber,
     DateTime: (value: string) => new Date(value),
   }
 
@@ -399,7 +407,7 @@ function convertDataToJsTypes<T>(apiResponse: AnalyticsApiResponse) {
     const convertedRow = {} as any
     meta.forEach((column) => {
       const { name, type } = column
-      convertedRow[name] = (converters as any)[type] ? (converters as any)[type](row[name]) : row[name]
+      convertedRow[name] = converters[type] ? converters[type](row[name]) : row[name]
     })
     return convertedRow as T
   })

--- a/supabase/functions/_backend/utils/cron_email_stats.ts
+++ b/supabase/functions/_backend/utils/cron_email_stats.ts
@@ -18,6 +18,46 @@ export interface VersionInstallRow {
   install?: number | string | null
 }
 
+export interface WeeklyEmailMetadata {
+  app_id: string
+  month_name: string
+  week_number: string
+  weekly_updates: string
+  fun_comparison: string
+  weekly_install: string
+  weekly_install_success: string
+  fun_comparison_2: string
+  weekly_fail: string
+  weekly_open: string
+  fun_comparison_3: string
+}
+
+const thresholds = {
+  updates: [100, 1000, 10000],
+  // Non-zero fail bands only. Zero fails uses an explicit flawless message.
+  failRate: [0.10, 0.20, 0.30],
+  appOpen: [500, 1500, 5000],
+}
+
+const funComparisons = {
+  updates: [
+    'a cupcake to every student in a small school!',
+    'a pizza to every resident of a small town!',
+    'a burger to everyone in a big city!',
+  ],
+  failRate: [
+    'Flawless streak—no failed updates this week! 🏅',
+    'Under one in ten updates failed; looking solid overall.',
+    'About one in five updates failed; let\'s squash those errors.',
+    'Heads up: nearly a third of updates are failing—worth a closer look.',
+  ],
+  appOpen: [
+    'Your app was opened more times than a popular local bakery\'s door!',
+    'Your app was more popular than the latest episode of a hit TV show!',
+    'Your app was opened more times than a blockbuster movie on its opening weekend!',
+  ],
+}
+
 /** Coerce analytics/SQL numeric fields that may arrive as strings. */
 export function toStatNumber(value: number | string | null | undefined): number {
   const parsed = Number(value ?? 0)
@@ -28,6 +68,7 @@ export function toStatNumber(value: number | string | null | undefined): number 
  * Weekly email stats.
  * `daily_version.install` and `daily_version.fail` are independent action counters,
  * so success/failure rates must use install / (install + fail), never install - fail.
+ * This matches admin success_rate: installs / (installs + fails).
  */
 export function computeWeeklyInstallStats(input: WeeklyInstallStatsInput): WeeklyInstallStatsResult {
   const successfulInstalls = Math.max(0, Math.round(toStatNumber(input.all_updates)))
@@ -59,6 +100,65 @@ export function computeWeeklyInstallStats(input: WeeklyInstallStatsInput): Weekl
   }
 }
 
+export function getThresholdFunComparison(
+  comparison: 'updates' | 'appOpen',
+  stat: number,
+): string {
+  const bands = thresholds[comparison]
+  let chosenIndex = 0
+  for (let i = bands.length - 1; i >= 0; i -= 1) {
+    if (stat >= bands[i]) {
+      chosenIndex = i
+      break
+    }
+  }
+  const text = funComparisons[comparison][chosenIndex]
+  if (!text)
+    throw new Error(`Cannot find index for fun comparison, ${chosenIndex}`)
+  return text
+}
+
+/**
+ * Flawless copy is reserved for zero failures.
+ * Any non-zero fail rate must never claim "no failed updates".
+ */
+export function getFailRateFunComparison(failedUpdates: number, failureRate: number): string {
+  if (failedUpdates <= 0 || failureRate <= 0)
+    return funComparisons.failRate[0]
+
+  if (failureRate < thresholds.failRate[0])
+    return funComparisons.failRate[1]
+  if (failureRate < thresholds.failRate[1])
+    return funComparisons.failRate[2]
+  return funComparisons.failRate[3]
+}
+
+export function getIsoLikeWeekNumber(now: Date = new Date()): number {
+  const startOfYear = new Date(Date.UTC(now.getUTCFullYear(), 0, 1))
+  const days = Math.floor((now.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000))
+  return Math.ceil((days + startOfYear.getUTCDay() + 1) / 7)
+}
+
+export function buildWeeklyEmailMetadata(
+  appId: string,
+  stats: WeeklyInstallStatsResult,
+  now: Date = new Date(),
+): WeeklyEmailMetadata {
+  return {
+    app_id: appId,
+    month_name: now.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' }),
+    week_number: getIsoLikeWeekNumber(now).toString(),
+    weekly_updates: stats.totalUpdates.toString(),
+    fun_comparison: getThresholdFunComparison('updates', stats.totalUpdates),
+    weekly_install: stats.successfulInstalls.toString(),
+    weekly_install_success: (stats.successPercentage * 100).toString(),
+    fun_comparison_2: getFailRateFunComparison(stats.failedUpdates, stats.failureRate),
+    weekly_fail: stats.failedUpdates.toString(),
+    weekly_open: stats.openApp.toString(),
+    fun_comparison_3: getThresholdFunComparison('appOpen', stats.openApp),
+  }
+}
+
 /** Previous calendar month as an inclusive UTC start / exclusive UTC end. */
 export function getPreviousMonthUtcRange(now: Date = new Date()): { startIso: string, endExclusiveIso: string, monthName: string } {
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1, 0, 0, 0, 0))
@@ -69,6 +169,12 @@ export function getPreviousMonthUtcRange(now: Date = new Date()): { startIso: st
     endExclusiveIso: endExclusive.toISOString(),
     monthName,
   }
+}
+
+/** Count whether an ISO timestamp falls in the previous-month email window. */
+export function isInPreviousMonthRange(isoTimestamp: string, now: Date = new Date()): boolean {
+  const { startIso, endExclusiveIso } = getPreviousMonthUtcRange(now)
+  return isoTimestamp >= startIso && isoTimestamp < endExclusiveIso
 }
 
 export function sumVersionInstalls(
@@ -87,4 +193,8 @@ export function shouldRetryDeployInstallStats(deployedAt: Date, now: Date = new 
   if (Number.isNaN(deployedAt.getTime()))
     return false
   return (now.getTime() - deployedAt.getTime()) < retryWindowMs
+}
+
+export function shouldSendDeployInstallStatsEmail(installs: number): boolean {
+  return installs > 1
 }

--- a/supabase/functions/_backend/utils/cron_email_stats.ts
+++ b/supabase/functions/_backend/utils/cron_email_stats.ts
@@ -50,7 +50,7 @@ const funComparisons = {
   ],
   failRate: [
     'Flawless streak—no failed updates this week! 🏅',
-    'Under one in ten updates failed; looking solid overall.',
+    'About one in ten updates failed; looking solid overall.',
     'About one in five updates failed; let\'s squash those errors.',
     'Heads up: nearly a third of updates are failing—worth a closer look.',
   ],

--- a/supabase/functions/_backend/utils/cron_email_stats.ts
+++ b/supabase/functions/_backend/utils/cron_email_stats.ts
@@ -34,8 +34,11 @@ export interface WeeklyEmailMetadata {
 
 const thresholds = {
   updates: [100, 1000, 10000],
-  // Non-zero fail bands only. Zero fails uses an explicit flawless message.
-  failRate: [0.10, 0.20, 0.30],
+  // Inclusive upper bounds for non-zero fail bands.
+  // 0 < rate <= 0.10 → under/about one in ten
+  // 0.10 < rate <= 0.20 → about one in five
+  // rate > 0.20 → nearly a third / worse
+  failRate: [0.10, 0.20],
   appOpen: [500, 1500, 5000],
 }
 
@@ -119,24 +122,28 @@ export function getThresholdFunComparison(
 }
 
 /**
- * Flawless copy is reserved for zero failures.
- * Any non-zero fail rate must never claim "no failed updates".
+ * Flawless copy is reserved for zero failures only.
+ * Do not use rounded failureRate === 0, or large weeks with 1 fail look "flawless".
  */
 export function getFailRateFunComparison(failedUpdates: number, failureRate: number): string {
-  if (failedUpdates <= 0 || failureRate <= 0)
+  if (failedUpdates <= 0)
     return funComparisons.failRate[0]
 
-  if (failureRate < thresholds.failRate[0])
+  if (failureRate <= thresholds.failRate[0])
     return funComparisons.failRate[1]
-  if (failureRate < thresholds.failRate[1])
+  if (failureRate <= thresholds.failRate[1])
     return funComparisons.failRate[2]
   return funComparisons.failRate[3]
 }
 
-export function getIsoLikeWeekNumber(now: Date = new Date()): number {
-  const startOfYear = new Date(Date.UTC(now.getUTCFullYear(), 0, 1))
-  const days = Math.floor((now.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000))
-  return Math.ceil((days + startOfYear.getUTCDay() + 1) / 7)
+/** ISO-8601 week number (UTC). */
+export function getIsoWeekNumber(now: Date = new Date()): number {
+  const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  // ISO weeks start on Monday; the Thursday of this week determines the ISO week year/number.
+  const day = date.getUTCDay() || 7
+  date.setUTCDate(date.getUTCDate() + 4 - day)
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
+  return Math.ceil((((date.getTime() - yearStart.getTime()) / 86_400_000) + 1) / 7)
 }
 
 export function buildWeeklyEmailMetadata(
@@ -147,7 +154,7 @@ export function buildWeeklyEmailMetadata(
   return {
     app_id: appId,
     month_name: now.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' }),
-    week_number: getIsoLikeWeekNumber(now).toString(),
+    week_number: getIsoWeekNumber(now).toString(),
     weekly_updates: stats.totalUpdates.toString(),
     fun_comparison: getThresholdFunComparison('updates', stats.totalUpdates),
     weekly_install: stats.successfulInstalls.toString(),
@@ -182,9 +189,17 @@ export function sumVersionInstalls(
   versionName?: string | null,
   versionId?: number | null,
 ): number {
+  const hasVersionName = typeof versionName === 'string' && versionName.length > 0
   const versionIdStr = versionId != null ? String(versionId) : null
   return versionStats
-    .filter(row => row.version_name === versionName || (versionIdStr != null && row.version_name === versionIdStr))
+    .filter((row) => {
+      if (hasVersionName && row.version_name === versionName)
+        return true
+      // Legacy Analytics Engine rows stored numeric version_id in blob2.
+      if (versionIdStr != null && row.version_name === versionIdStr)
+        return true
+      return false
+    })
     .reduce((sum, row) => sum + toStatNumber(row.install), 0)
 }
 
@@ -192,7 +207,8 @@ export function sumVersionInstalls(
 export function shouldRetryDeployInstallStats(deployedAt: Date, now: Date = new Date(), retryWindowMs = 48 * 60 * 60 * 1000): boolean {
   if (Number.isNaN(deployedAt.getTime()))
     return false
-  return (now.getTime() - deployedAt.getTime()) < retryWindowMs
+  const elapsedMs = now.getTime() - deployedAt.getTime()
+  return elapsedMs >= 0 && elapsedMs < retryWindowMs
 }
 
 export function shouldSendDeployInstallStatsEmail(installs: number): boolean {

--- a/supabase/functions/_backend/utils/cron_email_stats.ts
+++ b/supabase/functions/_backend/utils/cron_email_stats.ts
@@ -1,0 +1,90 @@
+export interface WeeklyInstallStatsInput {
+  all_updates: number | string | null | undefined
+  failed_updates: number | string | null | undefined
+  open_app?: number | string | null | undefined
+}
+
+export interface WeeklyInstallStatsResult {
+  successfulInstalls: number
+  failedUpdates: number
+  totalUpdates: number
+  successPercentage: number
+  failureRate: number
+  openApp: number
+}
+
+export interface VersionInstallRow {
+  version_name?: string | null
+  install?: number | string | null
+}
+
+/** Coerce analytics/SQL numeric fields that may arrive as strings. */
+export function toStatNumber(value: number | string | null | undefined): number {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/**
+ * Weekly email stats.
+ * `daily_version.install` and `daily_version.fail` are independent action counters,
+ * so success/failure rates must use install / (install + fail), never install - fail.
+ */
+export function computeWeeklyInstallStats(input: WeeklyInstallStatsInput): WeeklyInstallStatsResult {
+  const successfulInstalls = Math.max(0, Math.round(toStatNumber(input.all_updates)))
+  const failedUpdates = Math.max(0, Math.round(toStatNumber(input.failed_updates)))
+  const totalUpdates = successfulInstalls + failedUpdates
+  const openApp = Math.max(0, Math.round(toStatNumber(input.open_app)))
+
+  if (totalUpdates === 0) {
+    return {
+      successfulInstalls,
+      failedUpdates,
+      totalUpdates,
+      successPercentage: 0,
+      failureRate: 0,
+      openApp,
+    }
+  }
+
+  const successPercentage = Math.round((successfulInstalls / totalUpdates) * 10_000) / 10_000
+  const failureRate = Math.round((failedUpdates / totalUpdates) * 10_000) / 10_000
+
+  return {
+    successfulInstalls,
+    failedUpdates,
+    totalUpdates,
+    successPercentage,
+    failureRate,
+    openApp,
+  }
+}
+
+/** Previous calendar month as an inclusive UTC start / exclusive UTC end. */
+export function getPreviousMonthUtcRange(now: Date = new Date()): { startIso: string, endExclusiveIso: string, monthName: string } {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1, 0, 0, 0, 0))
+  const endExclusive = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0))
+  const monthName = start.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' })
+  return {
+    startIso: start.toISOString(),
+    endExclusiveIso: endExclusive.toISOString(),
+    monthName,
+  }
+}
+
+export function sumVersionInstalls(
+  versionStats: VersionInstallRow[],
+  versionName?: string | null,
+  versionId?: number | null,
+): number {
+  const versionIdStr = versionId != null ? String(versionId) : null
+  return versionStats
+    .filter(row => row.version_name === versionName || (versionIdStr != null && row.version_name === versionIdStr))
+    .reduce((sum, row) => sum + toStatNumber(row.install), 0)
+}
+
+/** Keep retrying 24h deploy emails while analytics may still be catching up. */
+export function shouldRetryDeployInstallStats(deployedAt: Date, now: Date = new Date(), retryWindowMs = 48 * 60 * 60 * 1000): boolean {
+  if (Number.isNaN(deployedAt.getTime()))
+    return false
+  return (now.getTime() - deployedAt.getTime()) < retryWindowMs
+}

--- a/supabase/migrations/20260725113045_fix_weekly_stats_date_window.sql
+++ b/supabase/migrations/20260725113045_fix_weekly_stats_date_window.sql
@@ -1,0 +1,27 @@
+-- get_weekly_stats previously used CURRENT_DATE - 7 days with an inclusive BETWEEN,
+-- which covers 8 calendar days. Use a 7-day inclusive window instead.
+CREATE OR REPLACE FUNCTION "public"."get_weekly_stats"("app_id" character varying)
+RETURNS TABLE("all_updates" bigint, "failed_updates" bigint, "open_app" bigint)
+LANGUAGE "plpgsql"
+SET "search_path" TO ''
+AS $$
+DECLARE
+  period_start DATE;
+BEGIN
+  -- Inclusive 7-day window: today and the previous 6 days.
+  period_start := CURRENT_DATE - INTERVAL '6 days';
+  SELECT COALESCE(SUM(install), 0) INTO all_updates
+  FROM public.daily_version
+  WHERE date BETWEEN period_start AND CURRENT_DATE
+    AND public.daily_version.app_id = get_weekly_stats.app_id;
+  SELECT COALESCE(SUM(fail), 0) INTO failed_updates
+  FROM public.daily_version
+  WHERE date BETWEEN period_start AND CURRENT_DATE
+    AND public.daily_version.app_id = get_weekly_stats.app_id;
+  SELECT COALESCE(SUM(get), 0) INTO open_app
+  FROM public.daily_version
+  WHERE date BETWEEN period_start AND CURRENT_DATE
+    AND public.daily_version.app_id = get_weekly_stats.app_id;
+  RETURN QUERY SELECT all_updates, failed_updates, open_app;
+END;
+$$;

--- a/supabase/tests/36_test_get_weekly_stats_window.sql
+++ b/supabase/tests/36_test_get_weekly_stats_window.sql
@@ -3,24 +3,24 @@ BEGIN;
 SELECT plan(2);
 
 DELETE FROM public.daily_version
-WHERE app_id = 'com.weekly.stats.window';
+WHERE app_id = 'com.test.getweeklystatswindow.app';
 
 -- Inside the 7-day inclusive window: today and 6 days ago.
 INSERT INTO public.daily_version (date, app_id, version_name, get, fail, install, uninstall)
 VALUES
-    (CURRENT_DATE, 'com.weekly.stats.window', '1.0.0', 0, 1, 10, 0),
-    (CURRENT_DATE - 6, 'com.weekly.stats.window', '1.0.0', 0, 2, 20, 0),
+    (CURRENT_DATE, 'com.test.getweeklystatswindow.app', '1.0.0', 0, 1, 10, 0),
+    (CURRENT_DATE - 6, 'com.test.getweeklystatswindow.app', '1.0.0', 0, 2, 20, 0),
     -- Outside the window: 7 days ago must be excluded.
-    (CURRENT_DATE - 7, 'com.weekly.stats.window', '1.0.0', 0, 99, 999, 0);
+    (CURRENT_DATE - 7, 'com.test.getweeklystatswindow.app', '1.0.0', 0, 99, 999, 0);
 
 SELECT is(
-    (SELECT all_updates FROM public.get_weekly_stats('com.weekly.stats.window')),
+    (SELECT all_updates FROM public.get_weekly_stats('com.test.getweeklystatswindow.app')),
     30::bigint,
     'get_weekly_stats sums installs for today and previous 6 days only'
 );
 
 SELECT is(
-    (SELECT failed_updates FROM public.get_weekly_stats('com.weekly.stats.window')),
+    (SELECT failed_updates FROM public.get_weekly_stats('com.test.getweeklystatswindow.app')),
     3::bigint,
     'get_weekly_stats excludes fails from 7 days ago'
 );

--- a/supabase/tests/36_test_get_weekly_stats_window.sql
+++ b/supabase/tests/36_test_get_weekly_stats_window.sql
@@ -6,21 +6,63 @@ DELETE FROM public.daily_version
 WHERE app_id = 'com.test.getweeklystatswindow.app';
 
 -- Inside the 7-day inclusive window: today and 6 days ago.
-INSERT INTO public.daily_version (date, app_id, version_name, get, fail, install, uninstall)
+INSERT INTO public.daily_version (
+    date,
+    app_id,
+    version_name,
+    get,
+    fail,
+    install,
+    uninstall
+)
 VALUES
-    (CURRENT_DATE, 'com.test.getweeklystatswindow.app', '1.0.0', 0, 1, 10, 0),
-    (CURRENT_DATE - 6, 'com.test.getweeklystatswindow.app', '1.0.0', 0, 2, 20, 0),
+    (
+        CURRENT_DATE,
+        'com.test.getweeklystatswindow.app',
+        '1.0.0',
+        0,
+        1,
+        10,
+        0
+    ),
+    (
+        CURRENT_DATE - 6,
+        'com.test.getweeklystatswindow.app',
+        '1.0.0',
+        0,
+        2,
+        20,
+        0
+    ),
     -- Outside the window: 7 days ago must be excluded.
-    (CURRENT_DATE - 7, 'com.test.getweeklystatswindow.app', '1.0.0', 0, 99, 999, 0);
+    (
+        CURRENT_DATE - 7,
+        'com.test.getweeklystatswindow.app',
+        '1.0.0',
+        0,
+        99,
+        999,
+        0
+    );
 
 SELECT is(
-    (SELECT all_updates FROM public.get_weekly_stats('com.test.getweeklystatswindow.app')),
+    (
+        SELECT all_updates
+        FROM public.get_weekly_stats(
+            'com.test.getweeklystatswindow.app'
+        )
+    ),
     30::bigint,
     'get_weekly_stats sums installs for today and previous 6 days only'
 );
 
 SELECT is(
-    (SELECT failed_updates FROM public.get_weekly_stats('com.test.getweeklystatswindow.app')),
+    (
+        SELECT failed_updates
+        FROM public.get_weekly_stats(
+            'com.test.getweeklystatswindow.app'
+        )
+    ),
     3::bigint,
     'get_weekly_stats excludes fails from 7 days ago'
 );

--- a/supabase/tests/36_test_get_weekly_stats_window.sql
+++ b/supabase/tests/36_test_get_weekly_stats_window.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+SELECT plan(2);
+
+DELETE FROM public.daily_version
+WHERE app_id = 'com.weekly.stats.window';
+
+-- Inside the 7-day inclusive window: today and 6 days ago.
+INSERT INTO public.daily_version (date, app_id, version_name, get, fail, install, uninstall)
+VALUES
+    (CURRENT_DATE, 'com.weekly.stats.window', '1.0.0', 0, 1, 10, 0),
+    (CURRENT_DATE - 6, 'com.weekly.stats.window', '1.0.0', 0, 2, 20, 0),
+    -- Outside the window: 7 days ago must be excluded.
+    (CURRENT_DATE - 7, 'com.weekly.stats.window', '1.0.0', 0, 99, 999, 0);
+
+SELECT is(
+    (SELECT all_updates FROM public.get_weekly_stats('com.weekly.stats.window')),
+    30::bigint,
+    'get_weekly_stats sums installs for today and previous 6 days only'
+);
+
+SELECT is(
+    (SELECT failed_updates FROM public.get_weekly_stats('com.weekly.stats.window')),
+    3::bigint,
+    'get_weekly_stats excludes fails from 7 days ago'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/tests/cron-email-stats-backtest.unit.test.ts
+++ b/tests/cron-email-stats-backtest.unit.test.ts
@@ -1,0 +1,270 @@
+import type { VersionInstallRow, WeeklyInstallStatsInput } from '../supabase/functions/_backend/utils/cron_email_stats.ts'
+import { describe, expect, it } from 'vitest'
+import {
+  buildWeeklyEmailMetadata,
+  computeWeeklyInstallStats,
+  getFailRateFunComparison,
+  getPreviousMonthUtcRange,
+  isInPreviousMonthRange,
+  shouldSendDeployInstallStatsEmail,
+  sumVersionInstalls,
+  toStatNumber,
+} from '../supabase/functions/_backend/utils/cron_email_stats.ts'
+
+/** Historical buggy weekly formula: install - fail. */
+function computeBuggyWeeklyInstallStats(input: WeeklyInstallStatsInput) {
+  const installs = toStatNumber(input.all_updates)
+  const fails = toStatNumber(input.failed_updates)
+  const successfulInstalls = installs - fails
+  return {
+    successfulInstalls,
+    totalUpdates: installs,
+    successPercentage: installs > 0 ? Math.round((successfulInstalls / installs) * 10_000) / 10_000 : 0,
+    failureRate: installs > 0 ? Math.round((fails / installs) * 10_000) / 10_000 : 0,
+  }
+}
+
+/** Historical buggy reduce: uncoerced Analytics Engine strings concatenate. */
+function sumVersionInstallsBuggy(
+  versionStats: VersionInstallRow[],
+  versionName?: string | null,
+  versionId?: number | null,
+): number | string {
+  const versionIdStr = versionId != null ? String(versionId) : null
+  let sum: number | string = 0
+  for (const row of versionStats) {
+    if (!(row.version_name === versionName || (versionIdStr != null && row.version_name === versionIdStr)))
+      continue
+    // Historical path: sum + (row.install ?? 0) with no Number() coercion.
+    // When install is a Float64 string from Analytics Engine, JS concatenates.
+    const raw = row.install ?? 0
+    sum = typeof sum === 'number' && typeof raw === 'number'
+      ? sum + raw
+      : `${sum}${raw}`
+  }
+  return sum
+}
+
+function assertCleanNumericString(value: string, label: string) {
+  expect(value, label).toMatch(/^\d+(\.\d+)?$/)
+  expect(value, `${label} must not have leading zeros trash`).not.toMatch(/^0\d/)
+  expect(Number(value), label).toBeGreaterThanOrEqual(0)
+  expect(Number.isFinite(Number(value)), label).toBe(true)
+}
+
+function adminSuccessRate(installs: number, fails: number): number {
+  const total = installs + fails
+  return total > 0 ? (installs / total) * 100 : 0
+}
+
+describe('cron email stats backtest', () => {
+  it('never reproduces the old install-fail negative/wrong-rate bug across production-like weeks', () => {
+    const weeks = [
+      { install: 0, fail: 0, get: 0 },
+      { install: 1, fail: 0, get: 10 },
+      { install: 100, fail: 0, get: 500 },
+      { install: 100, fail: 1, get: 500 },
+      { install: 100, fail: 9, get: 500 },
+      { install: 100, fail: 10, get: 500 },
+      { install: 100, fail: 20, get: 500 },
+      { install: 100, fail: 50, get: 500 },
+      { install: 100, fail: 150, get: 500 },
+      { install: 10, fail: 40, get: 20 },
+      { install: 250_000, fail: 12_500, get: 1_000_000 },
+      { install: '80', fail: '20', get: '10' },
+      { install: '0', fail: '5', get: '2' },
+    ] as const
+
+    for (const week of weeks) {
+      const fixed = computeWeeklyInstallStats({
+        all_updates: week.install,
+        failed_updates: week.fail,
+        open_app: week.get,
+      })
+      const buggy = computeBuggyWeeklyInstallStats({
+        all_updates: week.install,
+        failed_updates: week.fail,
+      })
+
+      const installs = Math.max(0, Math.round(toStatNumber(week.install)))
+      const fails = Math.max(0, Math.round(toStatNumber(week.fail)))
+
+      // Fixed formula invariants
+      expect(fixed.successfulInstalls).toBe(installs)
+      expect(fixed.failedUpdates).toBe(fails)
+      expect(fixed.totalUpdates).toBe(installs + fails)
+      expect(fixed.successfulInstalls).toBeGreaterThanOrEqual(0)
+      expect(fixed.failedUpdates).toBeGreaterThanOrEqual(0)
+      expect(fixed.successPercentage).toBeGreaterThanOrEqual(0)
+      expect(fixed.successPercentage).toBeLessThanOrEqual(1)
+      expect(fixed.failureRate).toBeGreaterThanOrEqual(0)
+      expect(fixed.failureRate).toBeLessThanOrEqual(1)
+      expect(Math.abs((fixed.successPercentage + fixed.failureRate) - (fixed.totalUpdates > 0 ? 1 : 0))).toBeLessThan(0.0002)
+
+      // Must match admin dashboard success_rate formula
+      const expectedAdmin = adminSuccessRate(installs, fails)
+      expect(fixed.successPercentage * 100).toBeCloseTo(expectedAdmin, 2)
+
+      // Prove old formula was wrong on the known bad cases
+      if (fails > installs) {
+        expect(buggy.successfulInstalls).toBeLessThan(0)
+        expect(fixed.successfulInstalls).toBeGreaterThanOrEqual(0)
+      }
+      if (fails > 0 && installs > 0 && fails !== installs) {
+        expect(fixed.successPercentage).not.toBe(buggy.successPercentage)
+      }
+    }
+  })
+
+  it('builds weekly email metadata that cannot look like trash numbers', () => {
+    const cases = [
+      { install: 100, fail: 0, get: 200 },
+      { install: 100, fail: 5, get: 200 },
+      { install: 100, fail: 50, get: 200 },
+      { install: 10, fail: 40, get: 5 },
+      { install: '250000', fail: '12500', get: '1000000' },
+    ]
+
+    for (const week of cases) {
+      const stats = computeWeeklyInstallStats({
+        all_updates: week.install,
+        failed_updates: week.fail,
+        open_app: week.get,
+      })
+      const metadata = buildWeeklyEmailMetadata('com.demo.app', stats, new Date('2026-07-25T12:00:00.000Z'))
+
+      assertCleanNumericString(metadata.weekly_updates, 'weekly_updates')
+      assertCleanNumericString(metadata.weekly_install, 'weekly_install')
+      assertCleanNumericString(metadata.weekly_fail, 'weekly_fail')
+      assertCleanNumericString(metadata.weekly_open, 'weekly_open')
+      assertCleanNumericString(metadata.weekly_install_success, 'weekly_install_success')
+
+      expect(Number(metadata.weekly_updates)).toBe(stats.totalUpdates)
+      expect(Number(metadata.weekly_install)).toBe(stats.successfulInstalls)
+      expect(Number(metadata.weekly_fail)).toBe(stats.failedUpdates)
+      expect(Number(metadata.weekly_open)).toBe(stats.openApp)
+      expect(Number(metadata.weekly_install_success)).toBeCloseTo(stats.successPercentage * 100, 4)
+
+      // Never claim installs > updates
+      expect(Number(metadata.weekly_install)).toBeLessThanOrEqual(Number(metadata.weekly_updates))
+      // Never claim fails > updates
+      expect(Number(metadata.weekly_fail)).toBeLessThanOrEqual(Number(metadata.weekly_updates))
+    }
+  })
+
+  it('never says flawless when there were failed updates', () => {
+    const flawless = getFailRateFunComparison(0, 0)
+    expect(flawless.toLowerCase()).toContain('flawless')
+
+    const tinyFail = getFailRateFunComparison(1, 0.01)
+    expect(tinyFail.toLowerCase()).not.toContain('flawless')
+    expect(tinyFail.toLowerCase()).not.toContain('no failed updates')
+
+    const tenPercent = getFailRateFunComparison(10, 0.10)
+    expect(tenPercent.toLowerCase()).not.toContain('flawless')
+
+    const highFail = getFailRateFunComparison(40, 0.4)
+    expect(highFail.toLowerCase()).toContain('failing')
+
+    // Metadata path must also obey this
+    const metadata = buildWeeklyEmailMetadata(
+      'com.demo.app',
+      computeWeeklyInstallStats({ all_updates: 100, failed_updates: 3, open_app: 10 }),
+    )
+    expect(metadata.fun_comparison_2.toLowerCase()).not.toContain('flawless')
+    expect(metadata.fun_comparison_2.toLowerCase()).not.toContain('no failed updates')
+  })
+
+  it('monthly window includes the last moment of previous month and excludes current month', () => {
+    const now = new Date('2026-07-01T00:30:00.000Z')
+    const range = getPreviousMonthUtcRange(now)
+
+    expect(range.startIso).toBe('2026-06-01T00:00:00.000Z')
+    expect(range.endExclusiveIso).toBe('2026-07-01T00:00:00.000Z')
+
+    // Old buggy end was June 30 00:00:00 → dropped almost all of June 30
+    const oldBuggyEnd = '2026-06-30T00:00:00.000Z'
+    const lastDayMorning = '2026-06-30T00:00:01.000Z'
+    const lastDayNight = '2026-06-30T23:59:59.999Z'
+    const nextMonthStart = '2026-07-01T00:00:00.000Z'
+    const nextMonthLater = '2026-07-01T00:00:00.001Z'
+
+    expect(isInPreviousMonthRange(lastDayMorning, now)).toBe(true)
+    expect(isInPreviousMonthRange(lastDayNight, now)).toBe(true)
+    expect(isInPreviousMonthRange(nextMonthStart, now)).toBe(false)
+    expect(isInPreviousMonthRange(nextMonthLater, now)).toBe(false)
+
+    // Prove the old lte(oldBuggyEnd) would have missed these
+    expect(lastDayMorning > oldBuggyEnd).toBe(true)
+    expect(lastDayNight > oldBuggyEnd).toBe(true)
+    expect(lastDayNight < range.endExclusiveIso).toBe(true)
+  })
+
+  it('backtests 24h install summing against the old string-concat trash path', () => {
+    const rows = [
+      { version_name: '1.2.3', install: '10' },
+      { version_name: '1.2.3', install: '20' },
+      { version_name: '1.2.3', install: '30' },
+      { version_name: '9.9.9', install: '999' },
+      { version_name: '55', install: '5' },
+    ]
+
+    const fixed = sumVersionInstalls(rows, '1.2.3', 55)
+    const buggy = sumVersionInstallsBuggy(rows, '1.2.3', 55)
+
+    expect(fixed).toBe(65) // 10+20+30+5
+    expect(typeof fixed).toBe('number')
+    expect(shouldSendDeployInstallStatsEmail(fixed)).toBe(true)
+
+    // Old path string-concatenated analytics Float64 values into junk like "01020305"
+    expect(buggy).toBe('01020305')
+    expect(String(buggy)).toMatch(/^0\d/)
+
+    // Empty / no match must not send and must stay a real number 0
+    expect(sumVersionInstalls([], '1.2.3', 1)).toBe(0)
+    expect(shouldSendDeployInstallStatsEmail(0)).toBe(false)
+    expect(shouldSendDeployInstallStatsEmail(1)).toBe(false)
+    expect(shouldSendDeployInstallStatsEmail(2)).toBe(true)
+  })
+
+  it('stress-tests random weeks so rates stay sane and email fields stay clean', () => {
+    let seed = 42
+    const rand = () => {
+      seed = (seed * 1664525 + 1013904223) % 4294967296
+      return seed / 4294967296
+    }
+
+    for (let i = 0; i < 250; i += 1) {
+      const installs = Math.floor(rand() * 50_000)
+      const fails = Math.floor(rand() * 50_000)
+      const gets = Math.floor(rand() * 100_000)
+      const asStrings = rand() > 0.5
+
+      const stats = computeWeeklyInstallStats({
+        all_updates: asStrings ? String(installs) : installs,
+        failed_updates: asStrings ? String(fails) : fails,
+        open_app: asStrings ? String(gets) : gets,
+      })
+      const metadata = buildWeeklyEmailMetadata('com.stress.app', stats)
+
+      expect(stats.totalUpdates).toBe(installs + fails)
+      expect(stats.successfulInstalls + stats.failedUpdates).toBe(stats.totalUpdates)
+      expect(stats.successPercentage).toBeGreaterThanOrEqual(0)
+      expect(stats.successPercentage).toBeLessThanOrEqual(1)
+      expect(Math.abs(stats.successPercentage * 100 - adminSuccessRate(installs, fails))).toBeLessThan(0.05)
+
+      assertCleanNumericString(metadata.weekly_updates, `week ${i} weekly_updates`)
+      assertCleanNumericString(metadata.weekly_install, `week ${i} weekly_install`)
+      assertCleanNumericString(metadata.weekly_fail, `week ${i} weekly_fail`)
+      assertCleanNumericString(metadata.weekly_install_success, `week ${i} weekly_install_success`)
+
+      if (fails > 0) {
+        expect(metadata.fun_comparison_2.toLowerCase()).not.toContain('flawless')
+        expect(metadata.fun_comparison_2.toLowerCase()).not.toContain('no failed updates')
+      }
+      else {
+        expect(metadata.fun_comparison_2.toLowerCase()).toContain('flawless')
+      }
+    }
+  })
+})

--- a/tests/cron-email-stats-backtest.unit.test.ts
+++ b/tests/cron-email-stats-backtest.unit.test.ts
@@ -166,7 +166,7 @@ describe('cron email stats backtest', () => {
     expect(roundedZero.toLowerCase()).not.toContain('no failed updates')
 
     const tenPercent = getFailRateFunComparison(10, 0.10)
-    expect(tenPercent.toLowerCase()).toContain('one in ten')
+    expect(tenPercent.toLowerCase()).toContain('about one in ten')
     expect(tenPercent.toLowerCase()).not.toContain('one in five')
 
     const twentyPercent = getFailRateFunComparison(20, 0.20)

--- a/tests/cron-email-stats-backtest.unit.test.ts
+++ b/tests/cron-email-stats-backtest.unit.test.ts
@@ -160,8 +160,18 @@ describe('cron email stats backtest', () => {
     expect(tinyFail.toLowerCase()).not.toContain('flawless')
     expect(tinyFail.toLowerCase()).not.toContain('no failed updates')
 
+    // Rounded rate can be 0 with nonzero fails on huge volume weeks.
+    const roundedZero = getFailRateFunComparison(1, 0)
+    expect(roundedZero.toLowerCase()).not.toContain('flawless')
+    expect(roundedZero.toLowerCase()).not.toContain('no failed updates')
+
     const tenPercent = getFailRateFunComparison(10, 0.10)
-    expect(tenPercent.toLowerCase()).not.toContain('flawless')
+    expect(tenPercent.toLowerCase()).toContain('one in ten')
+    expect(tenPercent.toLowerCase()).not.toContain('one in five')
+
+    const twentyPercent = getFailRateFunComparison(20, 0.20)
+    expect(twentyPercent.toLowerCase()).toContain('one in five')
+    expect(twentyPercent.toLowerCase()).not.toContain('third')
 
     const highFail = getFailRateFunComparison(40, 0.4)
     expect(highFail.toLowerCase()).toContain('failing')

--- a/tests/cron-email-stats-backtest.unit.test.ts
+++ b/tests/cron-email-stats-backtest.unit.test.ts
@@ -58,7 +58,7 @@ function adminSuccessRate(installs: number, fails: number): number {
 }
 
 describe('cron email stats backtest', () => {
-  it('never reproduces the old install-fail negative/wrong-rate bug across production-like weeks', () => {
+  it.concurrent('never reproduces the old install-fail negative/wrong-rate bug across production-like weeks', () => {
     const weeks = [
       { install: 0, fail: 0, get: 0 },
       { install: 1, fail: 0, get: 10 },
@@ -116,7 +116,7 @@ describe('cron email stats backtest', () => {
     }
   })
 
-  it('builds weekly email metadata that cannot look like trash numbers', () => {
+  it.concurrent('builds weekly email metadata that cannot look like trash numbers', () => {
     const cases = [
       { install: 100, fail: 0, get: 200 },
       { install: 100, fail: 5, get: 200 },
@@ -152,7 +152,7 @@ describe('cron email stats backtest', () => {
     }
   })
 
-  it('never says flawless when there were failed updates', () => {
+  it.concurrent('never says flawless when there were failed updates', () => {
     const flawless = getFailRateFunComparison(0, 0)
     expect(flawless.toLowerCase()).toContain('flawless')
 
@@ -185,7 +185,7 @@ describe('cron email stats backtest', () => {
     expect(metadata.fun_comparison_2.toLowerCase()).not.toContain('no failed updates')
   })
 
-  it('monthly window includes the last moment of previous month and excludes current month', () => {
+  it.concurrent('monthly window includes the last moment of previous month and excludes current month', () => {
     const now = new Date('2026-07-01T00:30:00.000Z')
     const range = getPreviousMonthUtcRange(now)
 
@@ -210,7 +210,7 @@ describe('cron email stats backtest', () => {
     expect(lastDayNight < range.endExclusiveIso).toBe(true)
   })
 
-  it('backtests 24h install summing against the old string-concat trash path', () => {
+  it.concurrent('backtests 24h install summing against the old string-concat trash path', () => {
     const rows = [
       { version_name: '1.2.3', install: '10' },
       { version_name: '1.2.3', install: '20' },
@@ -237,7 +237,7 @@ describe('cron email stats backtest', () => {
     expect(shouldSendDeployInstallStatsEmail(2)).toBe(true)
   })
 
-  it('stress-tests random weeks so rates stay sane and email fields stay clean', () => {
+  it.concurrent('stress-tests random weeks so rates stay sane and email fields stay clean', () => {
     let seed = 42
     const rand = () => {
       seed = (seed * 1664525 + 1013904223) % 4294967296

--- a/tests/cron-email-stats.unit.test.ts
+++ b/tests/cron-email-stats.unit.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeWeeklyInstallStats,
+  getPreviousMonthUtcRange,
+  shouldRetryDeployInstallStats,
+  sumVersionInstalls,
+  toStatNumber,
+} from '../supabase/functions/_backend/utils/cron_email_stats.ts'
+
+describe('toStatNumber', () => {
+  it.concurrent('coerces string numbers from analytics aggregates', () => {
+    expect(toStatNumber('12')).toBe(12)
+    expect(toStatNumber('0')).toBe(0)
+    expect(toStatNumber(null)).toBe(0)
+    expect(toStatNumber(undefined)).toBe(0)
+    expect(toStatNumber(Number.NaN)).toBe(0)
+  })
+})
+
+describe('computeWeeklyInstallStats', () => {
+  it.concurrent('uses install/(install+fail), not install-fail', () => {
+    const stats = computeWeeklyInstallStats({
+      all_updates: 100,
+      failed_updates: 50,
+      open_app: 200,
+    })
+
+    expect(stats.successfulInstalls).toBe(100)
+    expect(stats.failedUpdates).toBe(50)
+    expect(stats.totalUpdates).toBe(150)
+    expect(stats.successPercentage).toBe(0.6667)
+    expect(stats.failureRate).toBe(0.3333)
+    expect(stats.openApp).toBe(200)
+  })
+
+  it.concurrent('handles more fails than installs without negative success', () => {
+    const stats = computeWeeklyInstallStats({
+      all_updates: 10,
+      failed_updates: 40,
+      open_app: 0,
+    })
+
+    expect(stats.successfulInstalls).toBe(10)
+    expect(stats.totalUpdates).toBe(50)
+    expect(stats.successPercentage).toBe(0.2)
+    expect(stats.failureRate).toBe(0.8)
+  })
+
+  it.concurrent('returns zeros when there is no update activity', () => {
+    const stats = computeWeeklyInstallStats({
+      all_updates: 0,
+      failed_updates: 0,
+      open_app: 5,
+    })
+
+    expect(stats.totalUpdates).toBe(0)
+    expect(stats.successPercentage).toBe(0)
+    expect(stats.failureRate).toBe(0)
+    expect(stats.openApp).toBe(5)
+  })
+
+  it.concurrent('coerces stringy SQL/rpc values', () => {
+    const stats = computeWeeklyInstallStats({
+      all_updates: '80',
+      failed_updates: '20',
+      open_app: '10',
+    })
+
+    expect(stats.totalUpdates).toBe(100)
+    expect(stats.successPercentage).toBe(0.8)
+    expect(stats.failureRate).toBe(0.2)
+  })
+})
+
+describe('getPreviousMonthUtcRange', () => {
+  it.concurrent('covers the full previous UTC month with an exclusive end', () => {
+    const range = getPreviousMonthUtcRange(new Date('2026-07-25T12:00:00.000Z'))
+
+    expect(range.monthName).toBe('June')
+    expect(range.startIso).toBe('2026-06-01T00:00:00.000Z')
+    expect(range.endExclusiveIso).toBe('2026-07-01T00:00:00.000Z')
+  })
+
+  it.concurrent('handles January rollover into previous year', () => {
+    const range = getPreviousMonthUtcRange(new Date('2026-01-05T00:00:00.000Z'))
+
+    expect(range.monthName).toBe('December')
+    expect(range.startIso).toBe('2025-12-01T00:00:00.000Z')
+    expect(range.endExclusiveIso).toBe('2026-01-01T00:00:00.000Z')
+  })
+})
+
+describe('sumVersionInstalls', () => {
+  it.concurrent('sums numeric and string install counts for matching versions', () => {
+    const installs = sumVersionInstalls(
+      [
+        { version_name: '1.2.3', install: '10' },
+        { version_name: '1.2.3', install: 5 },
+        { version_name: '9.9.9', install: 100 },
+        { version_name: '42', install: '7' },
+      ],
+      '1.2.3',
+      42,
+    )
+
+    // Matches version name 1.2.3 (10+5) and legacy version_id blob "42" (7)
+    expect(installs).toBe(22)
+  })
+
+  it.concurrent('does not string-concatenate analytics Float64 values', () => {
+    const installs = sumVersionInstalls(
+      [
+        { version_name: '1.0.0', install: '10' },
+        { version_name: '1.0.0', install: '20' },
+      ],
+      '1.0.0',
+      null,
+    )
+
+    expect(installs).toBe(30)
+    expect(typeof installs).toBe('number')
+  })
+})
+
+describe('shouldRetryDeployInstallStats', () => {
+  it.concurrent('retries within 48 hours of deploy', () => {
+    const deployedAt = new Date('2026-07-25T00:00:00.000Z')
+    const now = new Date('2026-07-26T12:00:00.000Z')
+    expect(shouldRetryDeployInstallStats(deployedAt, now)).toBe(true)
+  })
+
+  it.concurrent('stops retrying after the retry window', () => {
+    const deployedAt = new Date('2026-07-25T00:00:00.000Z')
+    const now = new Date('2026-07-27T00:00:01.000Z')
+    expect(shouldRetryDeployInstallStats(deployedAt, now)).toBe(false)
+  })
+})

--- a/tests/cron-email-stats.unit.test.ts
+++ b/tests/cron-email-stats.unit.test.ts
@@ -3,6 +3,7 @@ import {
   buildWeeklyEmailMetadata,
   computeWeeklyInstallStats,
   getFailRateFunComparison,
+  getIsoWeekNumber,
   getPreviousMonthUtcRange,
   shouldRetryDeployInstallStats,
   shouldSendDeployInstallStatsEmail,
@@ -79,6 +80,21 @@ describe('getFailRateFunComparison', () => {
   it.concurrent('reserves flawless copy for zero failures only', () => {
     expect(getFailRateFunComparison(0, 0).toLowerCase()).toContain('flawless')
     expect(getFailRateFunComparison(1, 0.01).toLowerCase()).not.toContain('flawless')
+    // Rounded failureRate can be 0 for huge weeks with 1 fail — still not flawless.
+    expect(getFailRateFunComparison(1, 0).toLowerCase()).not.toContain('flawless')
+  })
+
+  it.concurrent('keeps threshold copy aligned at exact 10% and 20% boundaries', () => {
+    expect(getFailRateFunComparison(10, 0.10).toLowerCase()).toContain('one in ten')
+    expect(getFailRateFunComparison(20, 0.20).toLowerCase()).toContain('one in five')
+    expect(getFailRateFunComparison(21, 0.21).toLowerCase()).toContain('failing')
+  })
+})
+
+describe('getIsoWeekNumber', () => {
+  it.concurrent('uses ISO week rules around year boundaries', () => {
+    expect(getIsoWeekNumber(new Date('2021-01-01T00:00:00.000Z'))).toBe(53)
+    expect(getIsoWeekNumber(new Date('2022-01-03T00:00:00.000Z'))).toBe(1)
   })
 })
 
@@ -134,6 +150,19 @@ describe('sumVersionInstalls', () => {
     expect(installs).toBe(22)
   })
 
+  it.concurrent('does not match every nameless row when versionName is absent', () => {
+    const installs = sumVersionInstalls(
+      [
+        { version_name: undefined, install: 50 },
+        { version_name: null, install: 50 },
+        { version_name: '99', install: 3 },
+      ],
+      undefined,
+      99,
+    )
+    expect(installs).toBe(3)
+  })
+
   it.concurrent('does not string-concatenate analytics Float64 values', () => {
     const installs = sumVersionInstalls(
       [
@@ -160,6 +189,12 @@ describe('shouldRetryDeployInstallStats', () => {
   it.concurrent('stops retrying after the retry window', () => {
     const deployedAt = new Date('2026-07-25T00:00:00.000Z')
     const now = new Date('2026-07-27T00:00:01.000Z')
+    expect(shouldRetryDeployInstallStats(deployedAt, now)).toBe(false)
+  })
+
+  it.concurrent('does not retry future deploy timestamps', () => {
+    const deployedAt = new Date('2026-07-26T00:00:00.000Z')
+    const now = new Date('2026-07-25T00:00:00.000Z')
     expect(shouldRetryDeployInstallStats(deployedAt, now)).toBe(false)
   })
 })

--- a/tests/cron-email-stats.unit.test.ts
+++ b/tests/cron-email-stats.unit.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildWeeklyEmailMetadata,
   computeWeeklyInstallStats,
+  getFailRateFunComparison,
   getPreviousMonthUtcRange,
   shouldRetryDeployInstallStats,
+  shouldSendDeployInstallStatsEmail,
   sumVersionInstalls,
   toStatNumber,
 } from '../supabase/functions/_backend/utils/cron_email_stats.ts'
@@ -72,6 +75,30 @@ describe('computeWeeklyInstallStats', () => {
   })
 })
 
+describe('getFailRateFunComparison', () => {
+  it.concurrent('reserves flawless copy for zero failures only', () => {
+    expect(getFailRateFunComparison(0, 0).toLowerCase()).toContain('flawless')
+    expect(getFailRateFunComparison(1, 0.01).toLowerCase()).not.toContain('flawless')
+  })
+})
+
+describe('buildWeeklyEmailMetadata', () => {
+  it.concurrent('keeps install/fail/success fields consistent', () => {
+    const stats = computeWeeklyInstallStats({
+      all_updates: 90,
+      failed_updates: 10,
+      open_app: 300,
+    })
+    const metadata = buildWeeklyEmailMetadata('com.demo.app', stats, new Date('2026-07-25T00:00:00.000Z'))
+
+    expect(metadata.weekly_updates).toBe('100')
+    expect(metadata.weekly_install).toBe('90')
+    expect(metadata.weekly_fail).toBe('10')
+    expect(metadata.weekly_install_success).toBe('90')
+    expect(metadata.fun_comparison_2.toLowerCase()).not.toContain('flawless')
+  })
+})
+
 describe('getPreviousMonthUtcRange', () => {
   it.concurrent('covers the full previous UTC month with an exclusive end', () => {
     const range = getPreviousMonthUtcRange(new Date('2026-07-25T12:00:00.000Z'))
@@ -119,6 +146,7 @@ describe('sumVersionInstalls', () => {
 
     expect(installs).toBe(30)
     expect(typeof installs).toBe('number')
+    expect(shouldSendDeployInstallStatsEmail(installs)).toBe(true)
   })
 })
 

--- a/tests/cron-email-stats.unit.test.ts
+++ b/tests/cron-email-stats.unit.test.ts
@@ -85,7 +85,7 @@ describe('getFailRateFunComparison', () => {
   })
 
   it.concurrent('keeps threshold copy aligned at exact 10% and 20% boundaries', () => {
-    expect(getFailRateFunComparison(10, 0.10).toLowerCase()).toContain('one in ten')
+    expect(getFailRateFunComparison(10, 0.10).toLowerCase()).toContain('about one in ten')
     expect(getFailRateFunComparison(20, 0.20).toLowerCase()).toContain('one in five')
     expect(getFailRateFunComparison(21, 0.21).toLowerCase()).toContain('failing')
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Fixed weekly stats email math: `install` and `fail` are independent counters, so success/failure rates now use `install / (install + fail)` instead of the broken `install - fail` formula
- Fixed monthly create-stats date window so the full previous UTC month is included (was cutting off almost the entire last day)
- Fixed `bundle:install_stats_24h` trash counts by coercing Analytics Engine `Float64` aggregates to numbers (string concat bug)
- Release the deploy-email SQL claim for retry within 48h when installs are still too low / analytics lagged, so the email can actually send
- Tightened `get_weekly_stats` to a true 7-day inclusive window (was 8 days)

## Motivation (AI generated)

Weekly and monthly Capgo stats emails were reporting incorrect numbers, and `bundle:install_stats_24h` appeared to stop sending. Root cause was bad calculation/window logic plus Analytics Engine numeric values being left as strings and then concatenated, combined with permanently claiming `install_stats_email_sent_at` before a successful send.

## Business Impact (AI generated)

Customers get trustworthy weekly/monthly activity emails again, and 24h post-deploy install emails can resume instead of being silently skipped after bad/empty analytics reads.

## Test Plan (AI generated)

- [x] Unit tests for weekly rate math, monthly UTC range, install sum coercion, and deploy retry window (`bun test:unit -- tests/cron-email-stats.unit.test.ts`)
- [x] Lint changed files with eslint
- [ ] After deploy of migration + workers: verify a weekly stats email shows success rate = installs / (installs + fails)
- [ ] Verify monthly email includes bundles/publishes from the last day of the previous month
- [ ] Verify a public-channel deploy with >1 installs in 24h receives `bundle:install_stats_24h`
- [ ] Verify a deploy with temporarily empty analytics releases the claim and retries within 48h

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d7200ec-b53f-46a0-86d9-9de8ce1400b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d7200ec-b53f-46a0-86d9-9de8ce1400b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the weekly stats time window to consistently report exactly seven days.
  - Improved analytics numeric interpretation to ensure numeric aggregates are correctly converted for reporting.
  - Fixed monthly and deploy install stats date-range logic and aggregation accuracy.
  - Added safer retry behavior for eligible deploy stats emails, including clearer “not enough installs” results.

- **Improvements**
  - Weekly and deploy cron emails now generate more accurate totals, rates, and labels.

- **Tests**
  - Added unit coverage and backtests to prevent regressions in stats calculations and email formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->