### PR TITLE
feat(db): delete app versions 90 days after org cancel

### DIFF
--- a/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
+++ b/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
@@ -1,6 +1,11 @@
--- Soft-delete app versions for orgs that have been canceled (or Stripe-deleted)
--- for more than 90 days past period end / cancel / trial end.
--- Also mark never-converted expired trials as canceled so they enter the same path.
+-- Soft-delete app versions and purge audit_logs for orgs that have been
+-- canceled (or Stripe-deleted) for more than 90 days past period end / cancel /
+-- trial end. Also mark never-converted expired trials as canceled so they enter
+-- the same path.
+--
+-- Timeout safety: version soft-delete is limited by p_batch_size; audit delete
+-- uses ctid batches + max_runtime_ms (same pattern as cleanup_old_audit_logs).
+-- Catch-up continues on later cron ticks — no edge/queue fan-out needed.
 
 -- Expired free trials: mark canceled (NULL status never matched "<> succeeded").
 CREATE OR REPLACE FUNCTION public.process_free_trial_expired()
@@ -30,7 +35,7 @@ COMMENT ON FUNCTION public.process_free_trial_expired() IS
   'Marks expired never-converted trials as canceled (is_good_plan=false, status=canceled, canceled_at=trial_at) so they share the canceled-org retention path.';
 
 -- Soft-delete versions for long-canceled orgs. Reuses on_version_update +
--- delete_old_deleted_versions for storage cleanup and hard delete.
+-- delete_old_deleted_versions for storage/manifest cleanup and hard delete.
 CREATE OR REPLACE FUNCTION public.soft_delete_versions_for_long_canceled_orgs(
   p_batch_size integer DEFAULT 5000
 )
@@ -119,6 +124,102 @@ GRANT ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer
 COMMENT ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) IS
   'Soft-deletes app_versions for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Unlinks only channel targets pointing at deletion candidates. Bounded by p_batch_size.';
 
+-- Purge audit_logs for long-canceled orgs. Bounded by batch size + runtime budget
+-- so a large backlog cannot timeout the daily cron tick.
+CREATE OR REPLACE FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(
+  max_batches integer DEFAULT 1000000,
+  batch_size integer DEFAULT 1000,
+  max_runtime_ms integer DEFAULT 60000
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  batch_no integer := 0;
+  deleted_batch integer;
+  deleted_total bigint := 0;
+  v_max_batches integer := GREATEST(1, COALESCE(max_batches, 1000000));
+  v_batch_size integer := GREATEST(1, COALESCE(batch_size, 1000));
+  v_max_runtime_ms integer := GREATEST(1000, COALESCE(max_runtime_ms, 60000));
+  started_at timestamptz := pg_catalog.clock_timestamp();
+BEGIN
+  PERFORM pg_catalog.set_config('statement_timeout', '0', true);
+
+  LOOP
+    batch_no := batch_no + 1;
+    EXIT WHEN batch_no > v_max_batches;
+    EXIT WHEN (EXTRACT(EPOCH FROM (pg_catalog.clock_timestamp() - started_at)) * 1000) >= v_max_runtime_ms;
+
+    WITH eligible_orgs AS (
+      SELECT o.id AS org_id
+      FROM public.stripe_info AS si
+      JOIN public.orgs AS o ON o.customer_id = si.customer_id
+      WHERE si.status IN ('canceled', 'deleted')
+        AND COALESCE(si.canceled_at, si.subscription_anchor_end, si.trial_at)
+          <= pg_catalog.now() - INTERVAL '90 days'
+    )
+    DELETE FROM public.audit_logs AS al
+    WHERE al.ctid IN (
+      SELECT audit.ctid
+      FROM public.audit_logs AS audit
+      JOIN eligible_orgs AS e ON e.org_id = audit.org_id
+      ORDER BY audit.org_id, audit.created_at, audit.id
+      LIMIT v_batch_size
+    );
+
+    GET DIAGNOSTICS deleted_batch = ROW_COUNT;
+    deleted_total := deleted_total + deleted_batch;
+    EXIT WHEN deleted_batch = 0;
+  END LOOP;
+
+  IF deleted_total > 0 THEN
+    RAISE NOTICE
+      'cleanup_audit_logs_for_long_canceled_orgs: deleted=% batches=%/% batch_size=% runtime_ms=% budget_ms=%',
+      deleted_total,
+      LEAST(batch_no, v_max_batches),
+      v_max_batches,
+      v_batch_size,
+      (EXTRACT(EPOCH FROM (pg_catalog.clock_timestamp() - started_at)) * 1000)::bigint,
+      v_max_runtime_ms;
+  END IF;
+
+  RETURN deleted_total;
+END;
+$$;
+
+ALTER FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) FROM anon;
+REVOKE ALL ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) FROM authenticated;
+GRANT ALL ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) TO service_role;
+
+COMMENT ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) IS
+  'Deletes audit_logs for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Batched with a runtime budget to avoid cron timeouts.';
+
+-- One cron entry: versions first (may write audit rows), then purge org audit logs.
+CREATE OR REPLACE FUNCTION public.cleanup_long_canceled_org_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM public.soft_delete_versions_for_long_canceled_orgs();
+  PERFORM public.cleanup_audit_logs_for_long_canceled_orgs();
+END;
+$$;
+
+ALTER FUNCTION public.cleanup_long_canceled_org_data() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.cleanup_long_canceled_org_data() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.cleanup_long_canceled_org_data() FROM anon;
+REVOKE ALL ON FUNCTION public.cleanup_long_canceled_org_data() FROM authenticated;
+GRANT ALL ON FUNCTION public.cleanup_long_canceled_org_data() TO service_role;
+
+COMMENT ON FUNCTION public.cleanup_long_canceled_org_data() IS
+  'Daily canceled-org retention: soft-delete app versions then purge audit_logs for orgs past the 90-day grace window. Both steps are batch/runtime bounded.';
+
 INSERT INTO public.cron_tasks (
   name,
   description,
@@ -138,9 +239,9 @@ INSERT INTO public.cron_tasks (
   healthcheck_url
 ) VALUES (
   'canceled_org_version_cleanup',
-  'Soft-delete app versions for orgs canceled/deleted more than 90 days',
+  'Soft-delete app versions and purge audit logs for orgs canceled/deleted more than 90 days',
   'function',
-  'public.soft_delete_versions_for_long_canceled_orgs()',
+  'public.cleanup_long_canceled_org_data()',
   NULL,
   NULL,
   NULL,

--- a/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
+++ b/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
@@ -1,13 +1,43 @@
 -- Soft-delete app versions and purge audit_logs for orgs that have been
--- canceled (or Stripe-deleted) for more than 90 days past period end / cancel /
--- trial end. Also mark never-converted expired trials as canceled so they enter
+-- canceled (or Stripe-deleted) for more than 90 days past end of paid/trial
+-- access. Also mark never-converted expired trials as canceled so they enter
 -- the same path.
 --
 -- Timeout safety: version soft-delete is limited by p_batch_size; audit delete
--- uses ctid batches + max_runtime_ms (same pattern as cleanup_old_audit_logs).
--- Catch-up continues on later cron ticks — no edge/queue fan-out needed.
+-- uses ctid batches + max_runtime_ms with a per-batch statement_timeout equal
+-- to the remaining budget (plus lock_timeout). Catch-up continues on later
+-- cron ticks — no edge/queue fan-out needed.
+
+-- Shared eligibility: canceled/deleted and end-of-access was 90+ days ago.
+-- GREATEST ignores NULLs in PostgreSQL, so cancel-at-period-end (early
+-- canceled_at + later subscription_anchor_end) starts grace at period end.
+CREATE OR REPLACE FUNCTION public.long_canceled_org_ids()
+RETURNS SETOF uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT o.id
+  FROM public.stripe_info AS si
+  JOIN public.orgs AS o ON o.customer_id = si.customer_id
+  WHERE si.status IN ('canceled', 'deleted')
+    AND GREATEST(si.canceled_at, si.subscription_anchor_end, si.trial_at)
+      <= pg_catalog.now() - INTERVAL '90 days';
+$$;
+
+ALTER FUNCTION public.long_canceled_org_ids() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.long_canceled_org_ids() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.long_canceled_org_ids() FROM anon;
+REVOKE ALL ON FUNCTION public.long_canceled_org_ids() FROM authenticated;
+GRANT ALL ON FUNCTION public.long_canceled_org_ids() TO service_role;
+
+COMMENT ON FUNCTION public.long_canceled_org_ids() IS
+  'Org ids whose stripe_info is canceled/deleted and GREATEST(canceled_at, subscription_anchor_end, trial_at) is older than 90 days.';
 
 -- Expired free trials: mark canceled (NULL status never matched "<> succeeded").
+-- Only never-converted trials — do not rewrite already-canceled/deleted rows
+-- (avoids backdating canceled_at from an old trial_at).
 CREATE OR REPLACE FUNCTION public.process_free_trial_expired()
 RETURNS void
 LANGUAGE plpgsql
@@ -19,8 +49,8 @@ BEGIN
     is_good_plan = false,
     status = 'canceled',
     canceled_at = COALESCE(canceled_at, trial_at)
-  WHERE status IS DISTINCT FROM 'succeeded'
-    AND status IS DISTINCT FROM 'deleted'
+  WHERE (status IS NULL OR status NOT IN ('succeeded', 'deleted', 'canceled'))
+    AND trial_at IS NOT NULL
     AND trial_at < NOW();
 END;
 $$;
@@ -52,23 +82,12 @@ BEGIN
   -- Bypass channel promote guard for this internal cleanup (same gate seed uses).
   PERFORM set_config('capgo.seed_channel_targets', 'true', true);
 
-  -- Eligible when canceled/deleted and paid/trial access ended 90+ days ago.
-  -- canceled_at is period end for cancel-at-period-end; for past_due churn it is
-  -- set when Stripe finally ends the sub (after retries). Trials use trial_at.
   -- Single WITH: pick a version batch first, unlink only those targets, then soft-delete.
-  WITH eligible_orgs AS (
-    SELECT o.id AS org_id
-    FROM public.stripe_info AS si
-    JOIN public.orgs AS o ON o.customer_id = si.customer_id
-    WHERE si.status IN ('canceled', 'deleted')
-      AND COALESCE(si.canceled_at, si.subscription_anchor_end, si.trial_at)
-        <= pg_catalog.now() - INTERVAL '90 days'
-  ),
-  candidates AS (
-    SELECT av.id
+  WITH candidates AS (
+    SELECT av.id, av.app_id
     FROM public.app_versions AS av
-    JOIN eligible_orgs AS e ON e.org_id = av.owner_org
-    WHERE av.deleted = false
+    WHERE av.owner_org IN (SELECT public.long_canceled_org_ids())
+      AND av.deleted = false
       AND av.name NOT IN ('builtin', 'unknown')
     ORDER BY av.id
     LIMIT v_batch_size
@@ -85,11 +104,12 @@ BEGIN
         ELSE c.rollout_version
       END,
       updated_at = pg_catalog.now()
-    WHERE EXISTS (
-      SELECT 1
-      FROM candidates AS x
-      WHERE x.id = c.version OR x.id = c.rollout_version
-    )
+    WHERE c.app_id IN (SELECT DISTINCT x.app_id FROM candidates AS x)
+      AND EXISTS (
+        SELECT 1
+        FROM candidates AS x
+        WHERE x.id = c.version OR x.id = c.rollout_version
+      )
     RETURNING c.id
   ),
   soft_deleted AS (
@@ -122,7 +142,7 @@ REVOKE ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(intege
 GRANT ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) TO service_role;
 
 COMMENT ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) IS
-  'Soft-deletes app_versions for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Unlinks only channel targets pointing at deletion candidates. Bounded by p_batch_size.';
+  'Soft-deletes app_versions for orgs past the 90-day canceled grace window (see long_canceled_org_ids). Unlinks only channel targets pointing at deletion candidates. Bounded by p_batch_size.';
 
 -- Purge audit_logs for long-canceled orgs. Bounded by batch size + runtime budget
 -- so a large backlog cannot timeout the daily cron tick.
@@ -144,35 +164,43 @@ DECLARE
   v_batch_size integer := GREATEST(1, COALESCE(batch_size, 1000));
   v_max_runtime_ms integer := GREATEST(1000, COALESCE(max_runtime_ms, 60000));
   started_at timestamptz := pg_catalog.clock_timestamp();
+  remaining_ms bigint;
 BEGIN
-  PERFORM pg_catalog.set_config('statement_timeout', '0', true);
-
   LOOP
     batch_no := batch_no + 1;
     EXIT WHEN batch_no > v_max_batches;
-    EXIT WHEN (EXTRACT(EPOCH FROM (pg_catalog.clock_timestamp() - started_at)) * 1000) >= v_max_runtime_ms;
 
-    WITH eligible_orgs AS (
-      SELECT o.id AS org_id
-      FROM public.stripe_info AS si
-      JOIN public.orgs AS o ON o.customer_id = si.customer_id
-      WHERE si.status IN ('canceled', 'deleted')
-        AND COALESCE(si.canceled_at, si.subscription_anchor_end, si.trial_at)
-          <= pg_catalog.now() - INTERVAL '90 days'
-    )
-    DELETE FROM public.audit_logs AS al
-    WHERE al.ctid IN (
-      SELECT audit.ctid
-      FROM public.audit_logs AS audit
-      JOIN eligible_orgs AS e ON e.org_id = audit.org_id
-      ORDER BY audit.org_id, audit.created_at, audit.id
-      LIMIT v_batch_size
-    );
+    remaining_ms := v_max_runtime_ms
+      - (EXTRACT(EPOCH FROM (pg_catalog.clock_timestamp() - started_at)) * 1000)::bigint;
+    EXIT WHEN remaining_ms <= 0;
 
-    GET DIAGNOSTICS deleted_batch = ROW_COUNT;
+    -- Bound each batch to the remaining runtime budget so one slow delete
+    -- cannot overrun the cron tick / hold the scheduler lock.
+    PERFORM pg_catalog.set_config('statement_timeout', remaining_ms::text || 'ms', true);
+    PERFORM pg_catalog.set_config('lock_timeout', '5s', true);
+
+    BEGIN
+      DELETE FROM public.audit_logs AS al
+      WHERE al.ctid IN (
+        SELECT audit.ctid
+        FROM public.audit_logs AS audit
+        WHERE audit.org_id IN (SELECT public.long_canceled_org_ids())
+        ORDER BY audit.org_id, audit.created_at, audit.id
+        LIMIT v_batch_size
+      );
+
+      GET DIAGNOSTICS deleted_batch = ROW_COUNT;
+    EXCEPTION
+      WHEN query_canceled OR lock_not_available THEN
+        EXIT;
+    END;
+
     deleted_total := deleted_total + deleted_batch;
     EXIT WHEN deleted_batch = 0;
   END LOOP;
+
+  PERFORM pg_catalog.set_config('statement_timeout', '0', true);
+  PERFORM pg_catalog.set_config('lock_timeout', '0', true);
 
   IF deleted_total > 0 THEN
     RAISE NOTICE
@@ -196,7 +224,7 @@ REVOKE ALL ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer,
 GRANT ALL ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) TO service_role;
 
 COMMENT ON FUNCTION public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer) IS
-  'Deletes audit_logs for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Batched with a runtime budget to avoid cron timeouts.';
+  'Deletes audit_logs for orgs past the 90-day canceled grace window (see long_canceled_org_ids). Batched with a remaining-budget statement_timeout to avoid cron timeouts.';
 
 -- One cron entry: versions first (may write audit rows), then purge org audit logs.
 CREATE OR REPLACE FUNCTION public.cleanup_long_canceled_org_data()

--- a/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
+++ b/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
@@ -1,0 +1,163 @@
+-- Soft-delete app versions for orgs that have been canceled (or Stripe-deleted)
+-- for more than 90 days past period end / cancel / trial end.
+-- Also mark never-converted expired trials as canceled so they enter the same path.
+
+-- Expired free trials: mark canceled (NULL status never matched "<> succeeded").
+CREATE OR REPLACE FUNCTION public.process_free_trial_expired()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  UPDATE public.stripe_info
+  SET
+    is_good_plan = false,
+    status = 'canceled',
+    canceled_at = COALESCE(canceled_at, trial_at)
+  WHERE status IS DISTINCT FROM 'succeeded'
+    AND status IS DISTINCT FROM 'deleted'
+    AND trial_at < NOW();
+END;
+$$;
+
+ALTER FUNCTION public.process_free_trial_expired() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.process_free_trial_expired() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.process_free_trial_expired() FROM anon;
+REVOKE ALL ON FUNCTION public.process_free_trial_expired() FROM authenticated;
+GRANT ALL ON FUNCTION public.process_free_trial_expired() TO service_role;
+
+COMMENT ON FUNCTION public.process_free_trial_expired() IS
+  'Marks expired never-converted trials as canceled (is_good_plan=false, status=canceled, canceled_at=trial_at) so they share the canceled-org retention path.';
+
+-- Soft-delete versions for long-canceled orgs. Reuses on_version_update +
+-- delete_old_deleted_versions for storage cleanup and hard delete.
+CREATE OR REPLACE FUNCTION public.soft_delete_versions_for_long_canceled_orgs(
+  p_batch_size integer DEFAULT 5000
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_batch_size integer := GREATEST(1, COALESCE(p_batch_size, 5000));
+  unlinked_count bigint := 0;
+  deleted_count bigint := 0;
+BEGIN
+  -- Bypass channel promote guard for this internal cleanup (same gate seed uses).
+  PERFORM set_config('capgo.seed_channel_targets', 'true', true);
+
+  -- Eligible when canceled/deleted and paid/trial access ended 90+ days ago.
+  -- canceled_at is period end for cancel-at-period-end; for past_due churn it is
+  -- set when Stripe finally ends the sub (after retries). Trials use trial_at.
+  WITH eligible_orgs AS (
+    SELECT o.id AS org_id
+    FROM public.stripe_info AS si
+    JOIN public.orgs AS o ON o.customer_id = si.customer_id
+    WHERE si.status IN ('canceled', 'deleted')
+      AND COALESCE(si.canceled_at, si.subscription_anchor_end, si.trial_at)
+        <= pg_catalog.now() - INTERVAL '90 days'
+  ),
+  cleared AS (
+    UPDATE public.channels AS c
+    SET
+      version = NULL,
+      rollout_version = NULL,
+      updated_at = pg_catalog.now()
+    FROM public.apps AS a
+    JOIN eligible_orgs AS e ON e.org_id = a.owner_org
+    WHERE c.app_id = a.app_id
+      AND (c.version IS NOT NULL OR c.rollout_version IS NOT NULL)
+    RETURNING c.id
+  )
+  SELECT COUNT(*) INTO unlinked_count FROM cleared;
+
+  WITH eligible_orgs AS (
+    SELECT o.id AS org_id
+    FROM public.stripe_info AS si
+    JOIN public.orgs AS o ON o.customer_id = si.customer_id
+    WHERE si.status IN ('canceled', 'deleted')
+      AND COALESCE(si.canceled_at, si.subscription_anchor_end, si.trial_at)
+        <= pg_catalog.now() - INTERVAL '90 days'
+  ),
+  candidates AS (
+    SELECT av.id
+    FROM public.app_versions AS av
+    JOIN eligible_orgs AS e ON e.org_id = av.owner_org
+    WHERE av.deleted = false
+      AND av.name NOT IN ('builtin', 'unknown')
+    ORDER BY av.id
+    LIMIT v_batch_size
+  )
+  UPDATE public.app_versions AS av
+  SET deleted = true
+  FROM candidates
+  WHERE av.id = candidates.id;
+
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  IF unlinked_count > 0 OR deleted_count > 0 THEN
+    RAISE NOTICE
+      'soft_delete_versions_for_long_canceled_orgs: unlinked_channels=% soft_deleted_versions=%',
+      unlinked_count,
+      deleted_count;
+  END IF;
+
+  RETURN deleted_count;
+END;
+$$;
+
+ALTER FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) FROM anon;
+REVOKE ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) FROM authenticated;
+GRANT ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) TO service_role;
+
+COMMENT ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) IS
+  'Soft-deletes app_versions for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Unlinks channels first. Bounded by p_batch_size.';
+
+INSERT INTO public.cron_tasks (
+  name,
+  description,
+  task_type,
+  target,
+  batch_size,
+  payload,
+  second_interval,
+  minute_interval,
+  hour_interval,
+  run_at_hour,
+  run_at_minute,
+  run_at_second,
+  run_on_dow,
+  run_on_day,
+  enabled,
+  healthcheck_url
+) VALUES (
+  'canceled_org_version_cleanup',
+  'Soft-delete app versions for orgs canceled/deleted more than 90 days',
+  'function',
+  'public.soft_delete_versions_for_long_canceled_orgs()',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  3,
+  20,
+  0,
+  NULL,
+  NULL,
+  true,
+  NULL
+)
+ON CONFLICT (name) DO UPDATE
+SET
+  description = EXCLUDED.description,
+  task_type = EXCLUDED.task_type,
+  target = EXCLUDED.target,
+  run_at_hour = EXCLUDED.run_at_hour,
+  run_at_minute = EXCLUDED.run_at_minute,
+  run_at_second = EXCLUDED.run_at_second,
+  enabled = EXCLUDED.enabled,
+  updated_at = now();

--- a/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
+++ b/supabase/migrations/20260725150503_canceled_org_version_cleanup.sql
@@ -50,28 +50,7 @@ BEGIN
   -- Eligible when canceled/deleted and paid/trial access ended 90+ days ago.
   -- canceled_at is period end for cancel-at-period-end; for past_due churn it is
   -- set when Stripe finally ends the sub (after retries). Trials use trial_at.
-  WITH eligible_orgs AS (
-    SELECT o.id AS org_id
-    FROM public.stripe_info AS si
-    JOIN public.orgs AS o ON o.customer_id = si.customer_id
-    WHERE si.status IN ('canceled', 'deleted')
-      AND COALESCE(si.canceled_at, si.subscription_anchor_end, si.trial_at)
-        <= pg_catalog.now() - INTERVAL '90 days'
-  ),
-  cleared AS (
-    UPDATE public.channels AS c
-    SET
-      version = NULL,
-      rollout_version = NULL,
-      updated_at = pg_catalog.now()
-    FROM public.apps AS a
-    JOIN eligible_orgs AS e ON e.org_id = a.owner_org
-    WHERE c.app_id = a.app_id
-      AND (c.version IS NOT NULL OR c.rollout_version IS NOT NULL)
-    RETURNING c.id
-  )
-  SELECT COUNT(*) INTO unlinked_count FROM cleared;
-
+  -- Single WITH: pick a version batch first, unlink only those targets, then soft-delete.
   WITH eligible_orgs AS (
     SELECT o.id AS org_id
     FROM public.stripe_info AS si
@@ -88,13 +67,37 @@ BEGIN
       AND av.name NOT IN ('builtin', 'unknown')
     ORDER BY av.id
     LIMIT v_batch_size
+  ),
+  cleared AS (
+    UPDATE public.channels AS c
+    SET
+      version = CASE
+        WHEN EXISTS (SELECT 1 FROM candidates AS x WHERE x.id = c.version) THEN NULL
+        ELSE c.version
+      END,
+      rollout_version = CASE
+        WHEN EXISTS (SELECT 1 FROM candidates AS x WHERE x.id = c.rollout_version) THEN NULL
+        ELSE c.rollout_version
+      END,
+      updated_at = pg_catalog.now()
+    WHERE EXISTS (
+      SELECT 1
+      FROM candidates AS x
+      WHERE x.id = c.version OR x.id = c.rollout_version
+    )
+    RETURNING c.id
+  ),
+  soft_deleted AS (
+    UPDATE public.app_versions AS av
+    SET deleted = true
+    FROM candidates
+    WHERE av.id = candidates.id
+    RETURNING av.id
   )
-  UPDATE public.app_versions AS av
-  SET deleted = true
-  FROM candidates
-  WHERE av.id = candidates.id;
-
-  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  SELECT
+    (SELECT COUNT(*) FROM cleared),
+    (SELECT COUNT(*) FROM soft_deleted)
+  INTO unlinked_count, deleted_count;
 
   IF unlinked_count > 0 OR deleted_count > 0 THEN
     RAISE NOTICE
@@ -114,7 +117,7 @@ REVOKE ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(intege
 GRANT ALL ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) TO service_role;
 
 COMMENT ON FUNCTION public.soft_delete_versions_for_long_canceled_orgs(integer) IS
-  'Soft-deletes app_versions for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Unlinks channels first. Bounded by p_batch_size.';
+  'Soft-deletes app_versions for orgs canceled/deleted more than 90 days past COALESCE(canceled_at, subscription_anchor_end, trial_at). Unlinks only channel targets pointing at deletion candidates. Bounded by p_batch_size.';
 
 INSERT INTO public.cron_tasks (
   name,

--- a/supabase/tests/64_test_canceled_org_version_cleanup.sql
+++ b/supabase/tests/64_test_canceled_org_version_cleanup.sql
@@ -1,0 +1,280 @@
+BEGIN;
+
+SELECT plan(14);
+
+SELECT tests.authenticate_as_service_role();
+
+SELECT ok(
+  to_regprocedure('public.soft_delete_versions_for_long_canceled_orgs(integer)') IS NOT NULL,
+  'soft_delete_versions_for_long_canceled_orgs exists'
+);
+
+SELECT is(
+  has_function_privilege(
+    'anon',
+    'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+    'EXECUTE'
+  ),
+  false,
+  'anon cannot execute soft_delete_versions_for_long_canceled_orgs'
+);
+
+SELECT is(
+  has_function_privilege(
+    'authenticated',
+    'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+    'EXECUTE'
+  ),
+  false,
+  'authenticated cannot execute soft_delete_versions_for_long_canceled_orgs'
+);
+
+SELECT is(
+  has_function_privilege(
+    'service_role',
+    'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+    'EXECUTE'
+  ),
+  true,
+  'service_role can execute soft_delete_versions_for_long_canceled_orgs'
+);
+
+SELECT ok(
+  (
+    SELECT count(*)::int
+    FROM public.cron_tasks
+    WHERE name = 'canceled_org_version_cleanup'
+      AND enabled = true
+      AND task_type = 'function'::public.cron_task_type
+      AND target = 'public.soft_delete_versions_for_long_canceled_orgs()'
+      AND run_at_hour = 3
+      AND run_at_minute = 20
+  ) = 1,
+  'cron_tasks contains daily canceled_org_version_cleanup task'
+);
+
+-- Dedicated fixtures (unique customer/app ids for parallel safety)
+CREATE TEMP TABLE canceled_cleanup_ctx AS
+SELECT
+  'a0c1e2f3-1111-4aaa-8bbb-000000000001'::uuid AS long_canceled_org,
+  'a0c1e2f3-1111-4aaa-8bbb-000000000002'::uuid AS recent_canceled_org,
+  'a0c1e2f3-1111-4aaa-8bbb-000000000003'::uuid AS trial_org,
+  'a0c1e2f3-1111-4aaa-8bbb-000000000004'::uuid AS paying_org,
+  'cus_canceled_cleanup_long'::varchar AS long_customer,
+  'cus_canceled_cleanup_recent'::varchar AS recent_customer,
+  'cus_canceled_cleanup_trial'::varchar AS trial_customer,
+  'cus_canceled_cleanup_paying'::varchar AS paying_customer,
+  'com.test.canceled.cleanup.long'::varchar AS long_app,
+  'com.test.canceled.cleanup.recent'::varchar AS recent_app,
+  'com.test.canceled.cleanup.trial'::varchar AS trial_app,
+  'com.test.canceled.cleanup.paying'::varchar AS paying_app,
+  '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid AS user_id,
+  'prod_LQIregjtNduh4q'::varchar AS product_id;
+
+INSERT INTO public.stripe_info (
+  customer_id,
+  status,
+  product_id,
+  trial_at,
+  is_good_plan,
+  subscription_anchor_start,
+  subscription_anchor_end,
+  canceled_at
+)
+SELECT
+  long_customer,
+  'canceled'::public.stripe_status,
+  product_id,
+  now() - interval '200 days',
+  false,
+  now() - interval '200 days',
+  now() - interval '100 days',
+  now() - interval '100 days'
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  recent_customer,
+  'canceled'::public.stripe_status,
+  product_id,
+  now() - interval '40 days',
+  false,
+  now() - interval '40 days',
+  now() - interval '10 days',
+  now() - interval '10 days'
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  trial_customer,
+  NULL::public.stripe_status,
+  product_id,
+  now() - interval '1 day',
+  true,
+  now() - interval '16 days',
+  now() + interval '14 days',
+  NULL::timestamptz
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  paying_customer,
+  'succeeded'::public.stripe_status,
+  product_id,
+  now() - interval '200 days',
+  true,
+  now() - interval '20 days',
+  now() + interval '10 days',
+  NULL::timestamptz
+FROM canceled_cleanup_ctx;
+
+INSERT INTO public.orgs (id, created_by, name, management_email, customer_id)
+SELECT long_canceled_org, user_id, 'Long Canceled Cleanup Org', 'canceled-long@test.local', long_customer
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT recent_canceled_org, user_id, 'Recent Canceled Cleanup Org', 'canceled-recent@test.local', recent_customer
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT trial_org, user_id, 'Expired Trial Cleanup Org', 'canceled-trial@test.local', trial_customer
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT paying_org, user_id, 'Paying Cleanup Org', 'canceled-paying@test.local', paying_customer
+FROM canceled_cleanup_ctx;
+
+INSERT INTO public.apps (app_id, icon_url, owner_org, name, user_id)
+SELECT long_app, '', long_canceled_org, 'Long Canceled App', user_id FROM canceled_cleanup_ctx
+UNION ALL
+SELECT recent_app, '', recent_canceled_org, 'Recent Canceled App', user_id FROM canceled_cleanup_ctx
+UNION ALL
+SELECT trial_app, '', trial_org, 'Trial App', user_id FROM canceled_cleanup_ctx
+UNION ALL
+SELECT paying_app, '', paying_org, 'Paying App', user_id FROM canceled_cleanup_ctx;
+
+INSERT INTO public.app_versions (id, app_id, name, storage_provider, owner_org, user_id, deleted)
+SELECT 970101, long_app, '1.0.0', 'r2', long_canceled_org, user_id, false FROM canceled_cleanup_ctx
+UNION ALL
+SELECT 970102, long_app, '1.0.1-linked', 'r2', long_canceled_org, user_id, false FROM canceled_cleanup_ctx
+UNION ALL
+SELECT 970103, long_app, 'builtin', 'r2', long_canceled_org, user_id, false FROM canceled_cleanup_ctx
+UNION ALL
+SELECT 970201, recent_app, '1.0.0', 'r2', recent_canceled_org, user_id, false FROM canceled_cleanup_ctx
+UNION ALL
+SELECT 970301, trial_app, '1.0.0', 'r2', trial_org, user_id, false FROM canceled_cleanup_ctx
+UNION ALL
+SELECT 970401, paying_app, '1.0.0', 'r2', paying_org, user_id, false FROM canceled_cleanup_ctx;
+
+SELECT set_config('capgo.seed_channel_targets', 'true', true);
+
+INSERT INTO public.channels (
+  created_at, name, app_id, version, updated_at, public,
+  disable_auto_update_under_native, disable_auto_update, ios, android,
+  allow_device_self_set, allow_emulator, allow_device, allow_dev, allow_prod,
+  created_by, owner_org
+)
+SELECT
+  now(),
+  'production',
+  long_app,
+  970102,
+  now(),
+  true,
+  true,
+  'major'::public.disable_update,
+  false,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  user_id,
+  long_canceled_org
+FROM canceled_cleanup_ctx;
+
+-- Expired trial -> canceled
+SELECT public.process_free_trial_expired();
+
+SELECT is(
+  (
+    SELECT status::text
+    FROM public.stripe_info
+    WHERE customer_id = (SELECT trial_customer FROM canceled_cleanup_ctx)
+  ),
+  'canceled',
+  'process_free_trial_expired sets expired trial status to canceled'
+);
+
+SELECT is(
+  (
+    SELECT is_good_plan
+    FROM public.stripe_info
+    WHERE customer_id = (SELECT trial_customer FROM canceled_cleanup_ctx)
+  ),
+  false,
+  'process_free_trial_expired sets is_good_plan false for expired trial'
+);
+
+SELECT ok(
+  (
+    SELECT canceled_at = trial_at
+    FROM public.stripe_info
+    WHERE customer_id = (SELECT trial_customer FROM canceled_cleanup_ctx)
+  ),
+  'process_free_trial_expired sets canceled_at from trial_at'
+);
+
+SELECT is(
+  (
+    SELECT status::text
+    FROM public.stripe_info
+    WHERE customer_id = (SELECT paying_customer FROM canceled_cleanup_ctx)
+  ),
+  'succeeded',
+  'process_free_trial_expired leaves paying orgs unchanged'
+);
+
+-- Long-canceled cleanup
+SELECT public.soft_delete_versions_for_long_canceled_orgs();
+
+SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970101),
+  true,
+  'long-canceled org version is soft-deleted after 90 days'
+);
+
+SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970102),
+  true,
+  'channel-linked version is soft-deleted after channel unlink'
+);
+
+SELECT is(
+  (
+    SELECT version
+    FROM public.channels
+    WHERE app_id = (SELECT long_app FROM canceled_cleanup_ctx)
+  ),
+  NULL::bigint,
+  'channels are unlinked before soft-delete'
+);
+
+SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970103),
+  false,
+  'builtin versions are never soft-deleted'
+);
+
+SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970201),
+  false,
+  'recently canceled org versions are kept within 90 days'
+);
+
+SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970401),
+  false,
+  'paying org versions are never soft-deleted by canceled cleanup'
+);
+
+SELECT tests.clear_authentication();
+
+SELECT * FROM finish(); -- noqa: AM04
+
+ROLLBACK;

--- a/supabase/tests/64_test_canceled_org_version_cleanup.sql
+++ b/supabase/tests/64_test_canceled_org_version_cleanup.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(22);
+SELECT plan(21);
 
 SELECT tests.authenticate_as_service_role();
 

--- a/supabase/tests/64_test_canceled_org_version_cleanup.sql
+++ b/supabase/tests/64_test_canceled_org_version_cleanup.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(15);
+SELECT plan(16);
 
 SELECT tests.authenticate_as_service_role();
 
@@ -186,6 +186,26 @@ SELECT
   true,
   user_id,
   long_canceled_org
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  now(),
+  'builtin-channel',
+  long_app,
+  970103,
+  now(),
+  false,
+  true,
+  'major'::public.disable_update,
+  false,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  user_id,
+  long_canceled_org
 FROM canceled_cleanup_ctx;
 
 -- Expired trial -> canceled
@@ -250,9 +270,21 @@ SELECT is(
     SELECT version
     FROM public.channels
     WHERE app_id = (SELECT long_app FROM canceled_cleanup_ctx)
+      AND name = 'production'
   ),
   NULL::bigint,
-  'channels are unlinked before soft-delete'
+  'channels targeting deletion candidates are unlinked'
+);
+
+SELECT is(
+  (
+    SELECT version
+    FROM public.channels
+    WHERE app_id = (SELECT long_app FROM canceled_cleanup_ctx)
+      AND name = 'builtin-channel'
+  ),
+  970103::bigint,
+  'channels targeting builtin versions are preserved'
 );
 
 SELECT is(

--- a/supabase/tests/64_test_canceled_org_version_cleanup.sql
+++ b/supabase/tests/64_test_canceled_org_version_cleanup.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(14);
+SELECT plan(15);
 
 SELECT tests.authenticate_as_service_role();
 

--- a/supabase/tests/64_test_canceled_org_version_cleanup.sql
+++ b/supabase/tests/64_test_canceled_org_version_cleanup.sql
@@ -1,8 +1,13 @@
 BEGIN;
 
-SELECT plan(21);
+SELECT plan(25);
 
 SELECT tests.authenticate_as_service_role();
+
+SELECT ok(
+  to_regprocedure('public.long_canceled_org_ids()') IS NOT NULL,
+  'long_canceled_org_ids exists'
+);
 
 SELECT ok(
   to_regprocedure('public.soft_delete_versions_for_long_canceled_orgs(integer)') IS NOT NULL,
@@ -72,14 +77,17 @@ SELECT
   'a0c1e2f3-1111-4aaa-8bbb-000000000002'::uuid AS recent_canceled_org,
   'a0c1e2f3-1111-4aaa-8bbb-000000000003'::uuid AS trial_org,
   'a0c1e2f3-1111-4aaa-8bbb-000000000004'::uuid AS paying_org,
+  'a0c1e2f3-1111-4aaa-8bbb-000000000005'::uuid AS early_cancel_org,
   'cus_canceled_cleanup_long'::varchar AS long_customer,
   'cus_canceled_cleanup_recent'::varchar AS recent_customer,
   'cus_canceled_cleanup_trial'::varchar AS trial_customer,
   'cus_canceled_cleanup_paying'::varchar AS paying_customer,
+  'cus_canceled_cleanup_early'::varchar AS early_customer,
   'com.test.canceled.cleanup.long'::varchar AS long_app,
   'com.test.canceled.cleanup.recent'::varchar AS recent_app,
   'com.test.canceled.cleanup.trial'::varchar AS trial_app,
   'com.test.canceled.cleanup.paying'::varchar AS paying_app,
+  'com.test.canceled.cleanup.early'::varchar AS early_app,
   '6aa76066-55ef-4238-ade6-0b32334a4097'::uuid AS user_id,
   'prod_LQIregjtNduh4q'::varchar AS product_id;
 
@@ -135,6 +143,18 @@ SELECT
   now() - interval '20 days',
   now() + interval '10 days',
   NULL::timestamptz
+FROM canceled_cleanup_ctx
+UNION ALL
+-- Cancel clicked early, but paid access ended recently (grace from period end).
+SELECT
+  early_customer,
+  'canceled'::public.stripe_status,
+  product_id,
+  now() - interval '200 days',
+  false,
+  now() - interval '40 days',
+  now() - interval '10 days',
+  now() - interval '100 days'
 FROM canceled_cleanup_ctx;
 
 INSERT INTO public.orgs (id, created_by, name, management_email, customer_id)
@@ -148,6 +168,9 @@ SELECT trial_org, user_id, 'Expired Trial Cleanup Org', 'canceled-trial@test.loc
 FROM canceled_cleanup_ctx
 UNION ALL
 SELECT paying_org, user_id, 'Paying Cleanup Org', 'canceled-paying@test.local', paying_customer
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT early_cancel_org, user_id, 'Early Cancel Cleanup Org', 'canceled-early@test.local', early_customer
 FROM canceled_cleanup_ctx;
 
 INSERT INTO public.apps (app_id, icon_url, owner_org, name, user_id)
@@ -157,7 +180,9 @@ SELECT recent_app, '', recent_canceled_org, 'Recent Canceled App', user_id FROM 
 UNION ALL
 SELECT trial_app, '', trial_org, 'Trial App', user_id FROM canceled_cleanup_ctx
 UNION ALL
-SELECT paying_app, '', paying_org, 'Paying App', user_id FROM canceled_cleanup_ctx;
+SELECT paying_app, '', paying_org, 'Paying App', user_id FROM canceled_cleanup_ctx
+UNION ALL
+SELECT early_app, '', early_cancel_org, 'Early Cancel App', user_id FROM canceled_cleanup_ctx;
 
 INSERT INTO public.app_versions (id, app_id, name, storage_provider, owner_org, user_id, deleted)
 SELECT 970101, long_app, '1.0.0', 'r2', long_canceled_org, user_id, false FROM canceled_cleanup_ctx
@@ -170,7 +195,9 @@ SELECT 970201, recent_app, '1.0.0', 'r2', recent_canceled_org, user_id, false FR
 UNION ALL
 SELECT 970301, trial_app, '1.0.0', 'r2', trial_org, user_id, false FROM canceled_cleanup_ctx
 UNION ALL
-SELECT 970401, paying_app, '1.0.0', 'r2', paying_org, user_id, false FROM canceled_cleanup_ctx;
+SELECT 970401, paying_app, '1.0.0', 'r2', paying_org, user_id, false FROM canceled_cleanup_ctx
+UNION ALL
+SELECT 970501, early_app, '1.0.0', 'r2', early_cancel_org, user_id, false FROM canceled_cleanup_ctx;
 
 SELECT set_config('capgo.seed_channel_targets', 'true', true);
 
@@ -263,6 +290,18 @@ SELECT
   'UPDATE',
   user_id,
   paying_org,
+  '{}'::jsonb,
+  '{}'::jsonb,
+  ARRAY['canceled_org_cleanup']::text []
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  now() - interval '2 days',
+  'canceled_org_cleanup_test',
+  'audit-trial',
+  'UPDATE',
+  user_id,
+  trial_org,
   '{}'::jsonb,
   '{}'::jsonb,
   ARRAY['canceled_org_cleanup']::text []
@@ -360,9 +399,21 @@ SELECT is(
 );
 
 SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970301),
+  false,
+  'freshly expired trial org versions are kept for the 90-day grace window'
+);
+
+SELECT is(
   (SELECT deleted FROM public.app_versions WHERE id = 970401),
   false,
   'paying org versions are never soft-deleted by canceled cleanup'
+);
+
+SELECT is(
+  (SELECT deleted FROM public.app_versions WHERE id = 970501),
+  false,
+  'early cancel still inside period-end grace keeps versions'
 );
 
 SELECT is(
@@ -396,6 +447,17 @@ SELECT is(
   ),
   1,
   'audit logs for paying orgs are never purged by canceled cleanup'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.audit_logs
+    WHERE table_name = 'canceled_org_cleanup_test'
+      AND record_id = 'audit-trial'
+  ),
+  1,
+  'audit logs for freshly expired trial orgs are kept for the 90-day grace window'
 );
 
 SELECT tests.clear_authentication();

--- a/supabase/tests/64_test_canceled_org_version_cleanup.sql
+++ b/supabase/tests/64_test_canceled_org_version_cleanup.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(16);
+SELECT plan(22);
 
 SELECT tests.authenticate_as_service_role();
 
@@ -9,34 +9,46 @@ SELECT ok(
   'soft_delete_versions_for_long_canceled_orgs exists'
 );
 
+SELECT ok(
+  to_regprocedure(
+    'public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer)'
+  ) IS NOT NULL,
+  'cleanup_audit_logs_for_long_canceled_orgs exists'
+);
+
+SELECT ok(
+  to_regprocedure('public.cleanup_long_canceled_org_data()') IS NOT NULL,
+  'cleanup_long_canceled_org_data exists'
+);
+
 SELECT is(
   has_function_privilege(
     'anon',
-    'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+    'public.cleanup_long_canceled_org_data()',
     'EXECUTE'
   ),
   false,
-  'anon cannot execute soft_delete_versions_for_long_canceled_orgs'
+  'anon cannot execute cleanup_long_canceled_org_data'
 );
 
 SELECT is(
   has_function_privilege(
     'authenticated',
-    'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+    'public.cleanup_long_canceled_org_data()',
     'EXECUTE'
   ),
   false,
-  'authenticated cannot execute soft_delete_versions_for_long_canceled_orgs'
+  'authenticated cannot execute cleanup_long_canceled_org_data'
 );
 
 SELECT is(
   has_function_privilege(
     'service_role',
-    'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+    'public.cleanup_long_canceled_org_data()',
     'EXECUTE'
   ),
   true,
-  'service_role can execute soft_delete_versions_for_long_canceled_orgs'
+  'service_role can execute cleanup_long_canceled_org_data'
 );
 
 SELECT ok(
@@ -46,11 +58,11 @@ SELECT ok(
     WHERE name = 'canceled_org_version_cleanup'
       AND enabled = true
       AND task_type = 'function'::public.cron_task_type
-      AND target = 'public.soft_delete_versions_for_long_canceled_orgs()'
+      AND target = 'public.cleanup_long_canceled_org_data()'
       AND run_at_hour = 3
       AND run_at_minute = 20
   ) = 1,
-  'cron_tasks contains daily canceled_org_version_cleanup task'
+  'cron_tasks points canceled_org_version_cleanup at cleanup_long_canceled_org_data'
 );
 
 -- Dedicated fixtures (unique customer/app ids for parallel safety)
@@ -208,6 +220,54 @@ SELECT
   long_canceled_org
 FROM canceled_cleanup_ctx;
 
+-- Fresh audit rows (not age-expired) so only canceled-org cleanup removes them.
+INSERT INTO public.audit_logs (
+  created_at,
+  table_name,
+  record_id,
+  operation,
+  user_id,
+  org_id,
+  old_record,
+  new_record,
+  changed_fields
+)
+SELECT
+  now() - interval '2 days',
+  'canceled_org_cleanup_test',
+  'audit-long-canceled',
+  'UPDATE',
+  user_id,
+  long_canceled_org,
+  '{}'::jsonb,
+  '{}'::jsonb,
+  ARRAY['canceled_org_cleanup']::text []
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  now() - interval '2 days',
+  'canceled_org_cleanup_test',
+  'audit-recent-canceled',
+  'UPDATE',
+  user_id,
+  recent_canceled_org,
+  '{}'::jsonb,
+  '{}'::jsonb,
+  ARRAY['canceled_org_cleanup']::text []
+FROM canceled_cleanup_ctx
+UNION ALL
+SELECT
+  now() - interval '2 days',
+  'canceled_org_cleanup_test',
+  'audit-paying',
+  'UPDATE',
+  user_id,
+  paying_org,
+  '{}'::jsonb,
+  '{}'::jsonb,
+  ARRAY['canceled_org_cleanup']::text []
+FROM canceled_cleanup_ctx;
+
 -- Expired trial -> canceled
 SELECT public.process_free_trial_expired();
 
@@ -250,8 +310,8 @@ SELECT is(
   'process_free_trial_expired leaves paying orgs unchanged'
 );
 
--- Long-canceled cleanup
-SELECT public.soft_delete_versions_for_long_canceled_orgs();
+-- Full canceled-org cleanup (versions + audit logs)
+SELECT public.cleanup_long_canceled_org_data();
 
 SELECT is(
   (SELECT deleted FROM public.app_versions WHERE id = 970101),
@@ -303,6 +363,39 @@ SELECT is(
   (SELECT deleted FROM public.app_versions WHERE id = 970401),
   false,
   'paying org versions are never soft-deleted by canceled cleanup'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.audit_logs
+    WHERE table_name = 'canceled_org_cleanup_test'
+      AND record_id = 'audit-long-canceled'
+  ),
+  0,
+  'audit logs for long-canceled orgs are purged'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.audit_logs
+    WHERE table_name = 'canceled_org_cleanup_test'
+      AND record_id = 'audit-recent-canceled'
+  ),
+  1,
+  'audit logs for recently canceled orgs are kept within 90 days'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.audit_logs
+    WHERE table_name = 'canceled_org_cleanup_test'
+      AND record_id = 'audit-paying'
+  ),
+  1,
+  'audit logs for paying orgs are never purged by canceled cleanup'
 );
 
 SELECT tests.clear_authentication();

--- a/tests/security-definer-execute-hardening.test.ts
+++ b/tests/security-definer-execute-hardening.test.ts
@@ -28,6 +28,8 @@ const SERVICE_ONLY_PROCS = [
   'public.check_org_hashed_key_enforcement(uuid, public.apikeys)',
   'public.cleanup_onboarding_app_data_on_complete()',
   'public.delete_old_deleted_versions()',
+  'public.long_canceled_org_ids()',
+  'public.process_free_trial_expired()',
   'public.soft_delete_versions_for_long_canceled_orgs(integer)',
   'public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer)',
   'public.cleanup_long_canceled_org_data()',

--- a/tests/security-definer-execute-hardening.test.ts
+++ b/tests/security-definer-execute-hardening.test.ts
@@ -29,6 +29,8 @@ const SERVICE_ONLY_PROCS = [
   'public.cleanup_onboarding_app_data_on_complete()',
   'public.delete_old_deleted_versions()',
   'public.soft_delete_versions_for_long_canceled_orgs(integer)',
+  'public.cleanup_audit_logs_for_long_canceled_orgs(integer, integer, integer)',
+  'public.cleanup_long_canceled_org_data()',
   'public.enqueue_credit_usage_posthog_event()',
   'public.generate_org_user_stripe_info_on_org_create()',
   'public.get_apikey()',

--- a/tests/security-definer-execute-hardening.test.ts
+++ b/tests/security-definer-execute-hardening.test.ts
@@ -28,6 +28,7 @@ const SERVICE_ONLY_PROCS = [
   'public.check_org_hashed_key_enforcement(uuid, public.apikeys)',
   'public.cleanup_onboarding_app_data_on_complete()',
   'public.delete_old_deleted_versions()',
+  'public.soft_delete_versions_for_long_canceled_orgs(integer)',
   'public.enqueue_credit_usage_posthog_event()',
   'public.generate_org_user_stripe_info_on_org_create()',
   'public.get_apikey()',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Expired never-converted trials are now marked `canceled` (`status=canceled`, `canceled_at=trial_at`, `is_good_plan=false`), fixing the previous `NULL status <> 'succeeded'` miss.
- New daily cron `canceled_org_version_cleanup` soft-deletes `app_versions` for orgs in `canceled`/`deleted` whose access ended more than 90 days ago (`COALESCE(canceled_at, subscription_anchor_end, trial_at)`).
- Channel targets are unlinked first so channel-linked bundles are included; existing `on_version_update` + `delete_old_deleted_versions` finish R2/manifest cleanup and hard delete.
- Added pgTAP coverage and service-role execute hardening check.

## Motivation (AI generated)

Canceled customers (and trials that never convert) currently keep bundle data indefinitely. Retention should start after paid access ends (renewal/period end, or Stripe cancel after past-due retries), then wait 90 days before removing app versions.

## Business Impact (AI generated)

Reduces long-term storage cost for churned orgs and expired trials while giving a 90-day grace window after access ends in case they resubscribe.

## Test Plan (AI generated)

- [x] Migration applies on Tinbase
- [x] Manual SQL assertions: trial → canceled; long-canceled versions soft-deleted; recent/paying/builtin kept; channels unlinked
- [ ] CI `supabase test db` runs `64_test_canceled_org_version_cleanup.sql`
- [ ] Confirm cron row `canceled_org_version_cleanup` at 03:20 UTC
- [ ] Confirm soft-delete queues `on_version_update` cleanup for affected versions

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f98cb5cc-9b51-4d41-a818-e3e23fca9dba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f98cb5cc-9b51-4d41-a818-e3e23fca9dba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cleanup for data associated with organizations canceled or deleted for more than 90 days.
  * Expired free trials are now marked as canceled, with related billing status updated.
  * Cleanup runs daily, removing eligible audit records and safely soft-deleting outdated app versions while preserving active data.

* **Bug Fixes**
  * Channels linked to removed versions are automatically unlinked.

* **Tests**
  * Added coverage for trial cancellation, data retention rules, cleanup behavior, and access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->