### PR TITLE
feat(cli): write manifest rows directly via private API

### DIFF
--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -671,11 +671,14 @@ async function uploadBundleToCapgoCloud(apikey: string, supabase: SupabaseType, 
     if (options.verbose)
       log.info(`[Verbose] Cleaning up failed version from database...`)
 
-    // call delete version on path /delete_failed_version to delete the version
-    await deletedFailedVersion(supabase, appid, bundle)
-
-    if (options.verbose)
-      log.info(`[Verbose] Failed version cleaned up`)
+    try {
+      await deletedFailedVersion(supabase, appid, bundle)
+      if (options.verbose)
+        log.info(`[Verbose] Failed version cleaned up`)
+    }
+    catch (cleanupError) {
+      log.error(`Cleanup of the incomplete version failed (${formatError(cleanupError)}); delete bundle ${bundle} manually before retrying.`)
+    }
 
     throw errorUpload instanceof Error ? errorUpload : new Error(String(errorUpload))
   }
@@ -1580,7 +1583,12 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
       await persistVersionData(supabase, versionData, 'update')
     }
     catch (error) {
-      await deletedFailedVersion(supabase, appid, bundle)
+      try {
+        await deletedFailedVersion(supabase, appid, bundle)
+      }
+      catch (cleanupError) {
+        uploadFail(`Cannot upload bundle to S3 ${formatError(error)}. Cleanup of the incomplete version also failed (${formatError(cleanupError)}); delete bundle ${bundle} manually before retrying.`)
+      }
       uploadFail(`Cannot upload bundle to S3 ${formatError(error)}`)
     }
 
@@ -1655,7 +1663,12 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
         await setVersionManifest(supabase, appid, bundle, finalManifest)
       }
       catch (error) {
-        await deletedFailedVersion(supabase, appid, bundle)
+        try {
+          await deletedFailedVersion(supabase, appid, bundle)
+        }
+        catch (cleanupError) {
+          uploadFail(`Cannot set bundle manifest ${formatError(error)}. Cleanup of the incomplete version also failed (${formatError(cleanupError)}); delete bundle ${bundle} manually before retrying.`)
+        }
         uploadFail(`Cannot set bundle manifest ${formatError(error)}`)
       }
 

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -23,7 +23,7 @@ import { confirmWithRememberedChoice } from '../promptPreferences'
 import { showReplicationProgress } from '../replicationProgress'
 import { formatTable } from '../terminal-table'
 import { usesAlwaysDirectUpdate } from '../updaterConfig'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, isCompatible, isDeprecatedPluginVersion, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, isCompatible, isDeprecatedPluginVersion, regexSemver, resolveUserIdFromApiKey, sendEvent, setVersionManifest, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { maybePromptBuilderCta, shouldBlockIncompatibleUpload } from './builder-cta'
 import { checkIndexPosition, searchInDirectory } from './check'
@@ -1647,11 +1647,28 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
         log.info(`[Verbose] Delta upload error details: ${formatError(err)}`)
     }
 
+    if (finalManifest?.length) {
+      if (options.verbose)
+        log.info(`[Verbose] Writing ${finalManifest.length} manifest rows via set_manifest...`)
+
+      try {
+        await setVersionManifest(supabase, appid, bundle, finalManifest)
+      }
+      catch (error) {
+        await deletedFailedVersion(supabase, appid, bundle)
+        uploadFail(`Cannot set bundle manifest ${formatError(error)}`)
+      }
+
+      if (options.verbose)
+        log.info(`[Verbose] Manifest rows written (sizes filled by backend from R2)`)
+    }
+
+    // Keep jsonb null — legacy CLIs still upload via app_versions.manifest.
     versionData.storage_provider = 'r2'
-    versionData.manifest = finalManifest
+    versionData.manifest = null
 
     if (options.verbose)
-      log.info(`[Verbose] Updating version record with storage provider and manifest...`)
+      log.info(`[Verbose] Updating version record with storage provider...`)
 
     await persistVersionData(supabase, versionData, 'update')
 

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1503,6 +1503,39 @@ export async function deletedFailedVersion(supabase: SupabaseClient<Database>, a
   }
 }
 
+export interface VersionManifestEntry {
+  file_name: string
+  s3_path: string
+  file_hash: string
+}
+
+/**
+ * Writes delta manifest rows through the backend (file_size stays 0 until R2 size lookup).
+ * Prefer this over writing app_versions.manifest jsonb — old CLIs still use that legacy path.
+ */
+export async function setVersionManifest(
+  supabase: SupabaseClient<Database>,
+  appId: string,
+  name: string,
+  manifest: VersionManifestEntry[],
+): Promise<void> {
+  const data = {
+    app_id: appId,
+    name,
+    manifest,
+  }
+  const pathSetManifest = 'private/set_manifest'
+  const res = await supabase.functions.invoke(pathSetManifest, { body: JSON.stringify(data) })
+
+  if (res.error) {
+    if (res.error instanceof FunctionsHttpError) {
+      const errorBody = await res.error.context.json().catch(() => ({}))
+      throw new Error(errorBody.error || errorBody.status || errorBody.message || JSON.stringify(errorBody))
+    }
+    throw new Error(res.error.message)
+  }
+}
+
 export async function updateOrCreateChannel(supabase: SupabaseClient<Database>, update: Database['public']['Tables']['channels']['Insert']) {
   // console.log('updateOrCreateChannel', update)
   if (!update.app_id || !update.name || !update.created_by) {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1475,31 +1475,15 @@ export async function deletedFailedVersion(supabase: SupabaseClient<Database>, a
     app_id: appId,
     name,
   }
-  try {
-    const pathFailed = 'private/delete_failed_version'
-    const res = await supabase.functions.invoke(pathFailed, { body: JSON.stringify(data), method: 'DELETE' })
+  const pathFailed = 'private/delete_failed_version'
+  const res = await supabase.functions.invoke(pathFailed, { body: JSON.stringify(data), method: 'DELETE' })
 
-    if (res.error) {
-      if (res.error instanceof FunctionsHttpError) {
-        const errorBody = await res.error.context.json()
-        log.error(`Cannot delete failed version: ${errorBody.status || JSON.stringify(errorBody)}`)
-      }
-      else {
-        log.error(`Cannot delete failed version: ${res.error.message}`)
-      }
-      return
+  if (res.error) {
+    if (res.error instanceof FunctionsHttpError) {
+      const errorBody = await res.error.context.json().catch(() => ({}))
+      throw new Error(errorBody.status || errorBody.message || JSON.stringify(errorBody))
     }
-
-    return res.data?.status
-  }
-  catch (error) {
-    if (error instanceof FunctionsHttpError) {
-      const errorBody = await error.context.json()
-      log.error(`Cannot delete failed version: ${errorBody.message || JSON.stringify(errorBody)}`)
-    }
-    else {
-      log.error(`Cannot delete failed version: ${formatError(error)}`)
-    }
+    throw new Error(res.error.message)
   }
 }
 

--- a/cloudflare_workers/api/index.ts
+++ b/cloudflare_workers/api/index.ts
@@ -22,6 +22,7 @@ import { app as log_as } from '../../supabase/functions/_backend/private/log_as.
 import { app as plans } from '../../supabase/functions/_backend/private/plans.ts'
 import { app as publicStats } from '../../supabase/functions/_backend/private/public_stats.ts'
 import { app as replay } from '../../supabase/functions/_backend/private/replay.ts'
+import { app as set_manifest } from '../../supabase/functions/_backend/private/set_manifest.ts'
 import { app as set_org_email } from '../../supabase/functions/_backend/private/set_org_email.ts'
 import { app as sso_check_domain } from '../../supabase/functions/_backend/private/sso/check-domain.ts'
 import { app as sso_check_enforcement } from '../../supabase/functions/_backend/private/sso/check-enforcement.ts'
@@ -135,6 +136,7 @@ appPrivate.route('/stripe_checkout', stripe_checkout)
 appPrivate.route('/stripe_portal', stripe_portal)
 appPrivate.route('/verify_email_otp', verify_email_otp)
 appPrivate.route('/delete_failed_version', deleted_failed_version)
+appPrivate.route('/set_manifest', set_manifest)
 appPrivate.route('/create_device', create_device)
 appPrivate.route('/latency', latency)
 appPrivate.route('/replay', replay)

--- a/supabase/functions/_backend/private/set_manifest.ts
+++ b/supabase/functions/_backend/private/set_manifest.ts
@@ -15,6 +15,12 @@ interface DataSetManifest {
   manifest?: ManifestPersistEntry[]
 }
 
+// Bundles of ~5k files are expected; keep headroom without allowing unbounded payloads.
+const MAX_MANIFEST_ENTRIES = 20_000
+const MAX_FILE_NAME_LENGTH = 2048
+const MAX_S3_PATH_LENGTH = 2048
+const MAX_FILE_HASH_LENGTH = 512
+
 export const app = new Hono<MiddlewareKeyVariables>()
 
 app.post('/', middlewareKey(), async (c) => {
@@ -36,6 +42,12 @@ app.post('/', middlewareKey(), async (c) => {
     return quickError(400, 'error_bundle_name_missing', 'Error bundle name missing', { body })
   if (!Array.isArray(body.manifest) || body.manifest.length === 0)
     return quickError(400, 'error_manifest_missing', 'Error manifest missing or empty', { body })
+  if (body.manifest.length > MAX_MANIFEST_ENTRIES) {
+    return quickError(400, 'error_manifest_too_large', 'Manifest has too many entries', {
+      max: MAX_MANIFEST_ENTRIES,
+      count: body.manifest.length,
+    })
+  }
 
   if (!(await checkPermission(c, 'app.upload_bundle', { appId: body.app_id })))
     return quickError(401, 'not_authorized', 'You can\'t access this app', { app_id: body.app_id })
@@ -63,6 +75,9 @@ app.post('/', middlewareKey(), async (c) => {
     !entry?.file_name
     || !entry?.file_hash
     || !entry?.s3_path
+    || entry.file_name.length > MAX_FILE_NAME_LENGTH
+    || entry.file_hash.length > MAX_FILE_HASH_LENGTH
+    || entry.s3_path.length > MAX_S3_PATH_LENGTH
     || !entry.s3_path.startsWith(s3PathPrefix),
   )
   if (invalidEntry) {

--- a/supabase/functions/_backend/private/set_manifest.ts
+++ b/supabase/functions/_backend/private/set_manifest.ts
@@ -15,8 +15,8 @@ interface DataSetManifest {
   manifest?: ManifestPersistEntry[]
 }
 
-// Bundles of ~5k files are expected; keep headroom without allowing unbounded payloads.
-const MAX_MANIFEST_ENTRIES = 20_000
+// Prod max is ~7.5k files per version; keep modest headroom without unbounded payloads.
+const MAX_MANIFEST_ENTRIES = 10_000
 const MAX_FILE_NAME_LENGTH = 2048
 const MAX_S3_PATH_LENGTH = 2048
 const MAX_FILE_HASH_LENGTH = 512

--- a/supabase/functions/_backend/private/set_manifest.ts
+++ b/supabase/functions/_backend/private/set_manifest.ts
@@ -1,0 +1,124 @@
+import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { ManifestPersistEntry } from '../utils/manifest_persist.ts'
+import type { Database } from '../utils/supabase.types.ts'
+import { Hono } from 'hono/tiny'
+import { BRES, parseBody, quickError, simpleError } from '../utils/hono.ts'
+import { middlewareKey } from '../utils/hono_middleware.ts'
+import { cloudlog } from '../utils/logging.ts'
+import { persistVersionManifestEntries } from '../utils/manifest_persist.ts'
+import { checkPermission } from '../utils/rbac.ts'
+import { supabaseAdmin, supabaseApikey } from '../utils/supabase.ts'
+
+interface DataSetManifest {
+  app_id: string
+  name: string
+  manifest?: ManifestPersistEntry[]
+}
+
+export const app = new Hono<MiddlewareKeyVariables>()
+
+app.post('/', middlewareKey(), async (c) => {
+  const body = await parseBody<DataSetManifest>(c)
+  cloudlog({
+    requestId: c.get('requestId'),
+    message: 'post set_manifest body',
+    app_id: body.app_id,
+    name: body.name,
+    manifest_entries: Array.isArray(body.manifest) ? body.manifest.length : 0,
+  })
+
+  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
+  const capgkey = c.get('capgkey') as string
+
+  if (!body.app_id)
+    return quickError(400, 'error_app_id_missing', 'Error app_id missing', { body })
+  if (!body.name)
+    return quickError(400, 'error_bundle_name_missing', 'Error bundle name missing', { body })
+  if (!Array.isArray(body.manifest) || body.manifest.length === 0)
+    return quickError(400, 'error_manifest_missing', 'Error manifest missing or empty', { body })
+
+  if (!(await checkPermission(c, 'app.upload_bundle', { appId: body.app_id })))
+    return quickError(401, 'not_authorized', 'You can\'t access this app', { app_id: body.app_id })
+
+  const { data: appRow, error: errorApp } = await supabaseApikey(c, capgkey)
+    .from('apps')
+    .select('app_id, owner_org')
+    .eq('app_id', body.app_id)
+    .single()
+  if (errorApp || !appRow)
+    return quickError(404, 'app_not_found', 'Error App not found', { errorApp })
+
+  const { data: version, error: errorVersion } = await supabaseApikey(c, capgkey)
+    .from('app_versions')
+    .select('id, app_id, name, storage_provider, deleted, owner_org')
+    .eq('name', body.name)
+    .eq('app_id', body.app_id)
+    .eq('deleted', false)
+    .single()
+  if (errorVersion || !version)
+    return quickError(404, 'error_version_not_found', 'Error Version not found', { errorVersion })
+
+  const s3PathPrefix = `orgs/${appRow.owner_org}/apps/${appRow.app_id}/`
+  const invalidEntry = body.manifest.find(entry =>
+    !entry?.file_name
+    || !entry?.file_hash
+    || !entry?.s3_path
+    || !entry.s3_path.startsWith(s3PathPrefix),
+  )
+  if (invalidEntry) {
+    return quickError(400, 'error_manifest_invalid', 'Manifest entries must include file_name, file_hash, and an s3_path under this app', {
+      app_id: body.app_id,
+      s3_path_prefix: s3PathPrefix,
+    })
+  }
+
+  // After storage_provider flips to r2, only idempotent retries are allowed.
+  if (version.storage_provider === 'r2') {
+    const { data: existingEntries, error: existingError } = await supabaseAdmin(c)
+      .from('manifest')
+      .select('id')
+      .eq('app_version_id', version.id)
+      .limit(1)
+    if (existingError)
+      throw simpleError('error_set_manifest', 'Failed to check existing manifest', { existingError })
+    if (!existingEntries?.length) {
+      return quickError(400, 'error_version_already_finalized', 'Version upload already finalized without a direct manifest write window', {
+        storage_provider: version.storage_provider,
+      })
+    }
+    return c.json({ ...BRES, inserted: 0, alreadyPresent: true })
+  }
+
+  if (version.storage_provider !== 'r2-direct') {
+    return quickError(400, 'error_version_not_uploadable', 'Version is not in an uploadable state', {
+      storage_provider: version.storage_provider,
+    })
+  }
+
+  try {
+    const result = await persistVersionManifestEntries(
+      c,
+      { id: version.id, app_id: version.app_id },
+      body.manifest,
+      { s3PathPrefix },
+    )
+
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'set_manifest done',
+      version_id: version.id,
+      inserted: result.inserted,
+      alreadyPresent: result.alreadyPresent,
+      apikeyId: apikey?.id,
+    })
+
+    return c.json({
+      ...BRES,
+      inserted: result.inserted,
+      alreadyPresent: result.alreadyPresent,
+    })
+  }
+  catch (error) {
+    throw simpleError('error_set_manifest', 'Failed to set manifest', { error })
+  }
+})

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -5,7 +5,7 @@ import { eq } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { normalizeLegacyEncodedManifestFileName } from '../utils/manifest_encoding.ts'
+import { persistVersionManifestEntries } from '../utils/manifest_persist.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { manifest } from '../utils/postgres_schema.ts'
 import { getPath, s3 } from '../utils/s3.ts'
@@ -190,7 +190,8 @@ async function ensureVersionManifest(
 }
 
 /**
- * Persists manifest rows and updates aggregate counters when a version includes a manifest payload.
+ * Legacy path: CLI wrote jsonb onto app_versions.manifest; migrate into public.manifest.
+ * New CLIs call /private/set_manifest directly and skip this jsonb hop.
  */
 async function handleManifest(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   cloudlog({ requestId: c.get('requestId'), message: 'manifest', manifest: record.manifest })
@@ -198,68 +199,17 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
   if (!Array.isArray(manifestEntries))
     return
 
-  // Check if entries exist
-  const { data: existingEntries } = await supabaseAdmin(c)
-    .from('manifest')
-    .select('id')
-    .eq('app_version_id', record.id)
-    .limit(1)
-
-  // Only create entries if none exist
-  if (!existingEntries?.length && manifestEntries.length > 0) {
-    const validEntries = manifestEntries
-      .filter(entry => entry.file_name && entry.file_hash && entry.s3_path)
-      .map(entry => ({
-        app_version_id: record.id,
-        file_name: normalizeLegacyEncodedManifestFileName(entry.file_name, entry.s3_path)!,
-        file_hash: entry.file_hash!,
-        s3_path: entry.s3_path!,
-        file_size: 0,
-      }))
-
-    if (validEntries.length > 0) {
-      const { error: insertError } = await supabaseAdmin(c)
-        .from('manifest')
-        .insert(validEntries)
-      if (insertError) {
-        cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest', error: insertError })
-      }
-      else {
-        // Update manifest_count on the version
-        const { error: countError } = await supabaseAdmin(c)
-          .from('app_versions')
-          .update({ manifest_count: validEntries.length })
-          .eq('id', record.id)
-        if (countError)
-          cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_count', error: countError })
-
-        // Increment manifest_bundle_count on the app using raw SQL
-        const pgClient = getPgClient(c, false)
-        try {
-          await pgClient.query(
-            `UPDATE apps
-             SET manifest_bundle_count = manifest_bundle_count + 1,
-                 updated_at = now()
-             WHERE app_id = $1`,
-            [record.app_id],
-          )
-        }
-        catch (error) {
-          cloudlog({ requestId: c.get('requestId'), message: 'error update manifest_bundle_count', error })
-        }
-        finally {
-          await closeClient(c, pgClient)
-        }
-      }
-    }
+  try {
+    await persistVersionManifestEntries(
+      c,
+      { id: record.id, app_id: record.app_id },
+      manifestEntries,
+      { clearAppVersionsManifest: true },
+    )
   }
-  // delete manifest in app_versions
-  const { error: deleteError } = await supabaseAdmin(c)
-    .from('app_versions')
-    .update({ manifest: null })
-    .eq('id', record.id)
-  if (deleteError)
-    cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
+  catch (error) {
+    cloudlog({ requestId: c.get('requestId'), message: 'error handleManifest', error, id: record.id })
+  }
 }
 
 /**

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -199,17 +199,17 @@ async function handleManifest(c: Context, record: Database['public']['Tables']['
   if (!Array.isArray(manifestEntries))
     return
 
-  try {
-    await persistVersionManifestEntries(
-      c,
-      { id: record.id, app_id: record.app_id },
-      manifestEntries,
-      { clearAppVersionsManifest: true },
-    )
-  }
-  catch (error) {
-    cloudlog({ requestId: c.get('requestId'), message: 'error handleManifest', error, id: record.id })
-  }
+  const ownerOrg = await resolveOwnerOrg(c, record)
+  const s3PathPrefix = ownerOrg && record.app_id
+    ? `orgs/${ownerOrg}/apps/${record.app_id}/`
+    : null
+
+  await persistVersionManifestEntries(
+    c,
+    { id: record.id, app_id: record.app_id },
+    manifestEntries,
+    { clearAppVersionsManifest: true, s3PathPrefix },
+  )
 }
 
 /**

--- a/supabase/functions/_backend/utils/manifest_persist.ts
+++ b/supabase/functions/_backend/utils/manifest_persist.ts
@@ -1,0 +1,143 @@
+import type { Context } from 'hono'
+import { cloudlog } from './logging.ts'
+import { normalizeLegacyEncodedManifestFileName } from './manifest_encoding.ts'
+import { closeClient, getPgClient } from './pg.ts'
+import { supabaseAdmin } from './supabase.ts'
+
+export interface ManifestPersistEntry {
+  file_name?: string | null
+  file_hash?: string | null
+  s3_path?: string | null
+  // Intentionally ignored — file sizes are set by on_manifest_create from R2.
+  file_size?: number | null
+}
+
+export interface PersistVersionManifestResult {
+  inserted: number
+  alreadyPresent: boolean
+}
+
+export function buildTrustedManifestRows(
+  appVersionId: number,
+  entries: ManifestPersistEntry[],
+  s3PathPrefix?: string | null,
+) {
+  return entries
+    .filter(entry => entry.file_name && entry.file_hash && entry.s3_path)
+    .filter(entry => !s3PathPrefix || entry.s3_path!.startsWith(s3PathPrefix))
+    .map(entry => ({
+      app_version_id: appVersionId,
+      file_name: normalizeLegacyEncodedManifestFileName(entry.file_name, entry.s3_path)!,
+      file_hash: entry.file_hash!,
+      s3_path: entry.s3_path!,
+      // Never trust client-provided sizes; on_manifest_create fills these from R2.
+      file_size: 0,
+    }))
+}
+
+/**
+ * Inserts manifest rows for a version when none exist yet.
+ * Always writes file_size=0; trusted sizes come from on_manifest_create via R2 HEAD.
+ */
+export async function persistVersionManifestEntries(
+  c: Context,
+  record: { id: number, app_id: string },
+  manifestEntries: ManifestPersistEntry[],
+  options: {
+    clearAppVersionsManifest?: boolean
+    s3PathPrefix?: string | null
+  } = {},
+): Promise<PersistVersionManifestResult> {
+  if (!Array.isArray(manifestEntries))
+    return { inserted: 0, alreadyPresent: false }
+
+  const { data: existingEntries, error: existingError } = await supabaseAdmin(c)
+    .from('manifest')
+    .select('id')
+    .eq('app_version_id', record.id)
+    .limit(1)
+
+  if (existingError) {
+    cloudlog({ requestId: c.get('requestId'), message: 'error check existing manifest', error: existingError, id: record.id })
+    throw existingError
+  }
+
+  if (existingEntries?.length) {
+    if (options.clearAppVersionsManifest) {
+      const { error: deleteError } = await supabaseAdmin(c)
+        .from('app_versions')
+        .update({ manifest: null })
+        .eq('id', record.id)
+      if (deleteError)
+        cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
+    }
+    return { inserted: 0, alreadyPresent: true }
+  }
+
+  const validEntries = buildTrustedManifestRows(record.id, manifestEntries, options.s3PathPrefix)
+  if (validEntries.length === 0) {
+    if (options.clearAppVersionsManifest) {
+      const { error: deleteError } = await supabaseAdmin(c)
+        .from('app_versions')
+        .update({ manifest: null })
+        .eq('id', record.id)
+      if (deleteError)
+        cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
+    }
+    return { inserted: 0, alreadyPresent: false }
+  }
+
+  const pgClient = getPgClient(c, false)
+  try {
+    await pgClient.query('BEGIN')
+    await pgClient.query(
+      `INSERT INTO public.manifest (app_version_id, file_name, s3_path, file_hash, file_size)
+       SELECT
+         $1::bigint,
+         entry.file_name,
+         entry.s3_path,
+         entry.file_hash,
+         0
+       FROM jsonb_to_recordset($2::jsonb) AS entry(
+         file_name text,
+         s3_path text,
+         file_hash text
+       )`,
+      [record.id, JSON.stringify(validEntries.map(({ file_name, s3_path, file_hash }) => ({ file_name, s3_path, file_hash })))],
+    )
+
+    await pgClient.query(
+      `UPDATE public.app_versions
+       SET manifest_count = $2,
+           updated_at = now()
+           ${options.clearAppVersionsManifest ? ', manifest = NULL' : ''}
+       WHERE id = $1`,
+      [record.id, validEntries.length],
+    )
+
+    await pgClient.query(
+      `UPDATE public.apps
+       SET manifest_bundle_count = manifest_bundle_count + 1,
+           updated_at = now()
+       WHERE app_id = $1`,
+      [record.app_id],
+    )
+
+    await pgClient.query('COMMIT')
+  }
+  catch (error) {
+    try {
+      await pgClient.query('ROLLBACK')
+    }
+    catch (rollbackError) {
+      cloudlog({ requestId: c.get('requestId'), message: 'error rollback manifest persist', error: rollbackError, id: record.id })
+    }
+    cloudlog({ requestId: c.get('requestId'), message: 'error insert manifest', error, id: record.id })
+    throw error
+  }
+  finally {
+    await closeClient(c, pgClient)
+  }
+
+  return { inserted: validEntries.length, alreadyPresent: false }
+}

--- a/supabase/functions/_backend/utils/manifest_persist.ts
+++ b/supabase/functions/_backend/utils/manifest_persist.ts
@@ -79,7 +79,8 @@ export async function persistVersionManifestEntries(
     return { inserted: 0, alreadyPresent: false }
   }
 
-  const pgClient = getPgClient(c, false)
+  const pgPool = getPgClient(c, false)
+  const pgClient = await pgPool.connect()
   try {
     await pgClient.query('BEGIN')
     // Serialize concurrent writers for this version (no unique constraint on manifest rows).
@@ -142,7 +143,8 @@ export async function persistVersionManifestEntries(
     throw error
   }
   finally {
-    await closeClient(c, pgClient)
+    pgClient.release()
+    await closeClient(c, pgPool)
   }
 
   return { inserted: validEntries.length, alreadyPresent: false }

--- a/supabase/functions/_backend/utils/manifest_persist.ts
+++ b/supabase/functions/_backend/utils/manifest_persist.ts
@@ -35,6 +35,15 @@ export function buildTrustedManifestRows(
     }))
 }
 
+async function clearLegacyAppVersionManifest(c: Context, versionId: number) {
+  const { error: deleteError } = await supabaseAdmin(c)
+    .from('app_versions')
+    .update({ manifest: null })
+    .eq('id', versionId)
+  if (deleteError)
+    cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
+}
+
 /**
  * Inserts manifest rows for a version when none exist yet.
  * Always writes file_size=0; trusted sizes come from on_manifest_create via R2 HEAD.
@@ -51,45 +60,42 @@ export async function persistVersionManifestEntries(
   if (!Array.isArray(manifestEntries))
     return { inserted: 0, alreadyPresent: false }
 
-  const { data: existingEntries, error: existingError } = await supabaseAdmin(c)
-    .from('manifest')
-    .select('id')
-    .eq('app_version_id', record.id)
-    .limit(1)
-
-  if (existingError) {
-    cloudlog({ requestId: c.get('requestId'), message: 'error check existing manifest', error: existingError, id: record.id })
-    throw existingError
-  }
-
-  if (existingEntries?.length) {
-    if (options.clearAppVersionsManifest) {
-      const { error: deleteError } = await supabaseAdmin(c)
-        .from('app_versions')
-        .update({ manifest: null })
-        .eq('id', record.id)
-      if (deleteError)
-        cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
-    }
-    return { inserted: 0, alreadyPresent: true }
-  }
-
   const validEntries = buildTrustedManifestRows(record.id, manifestEntries, options.s3PathPrefix)
+  const dropped = manifestEntries.length - validEntries.length
+  if (dropped > 0) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'manifest persist dropped invalid entries',
+      id: record.id,
+      dropped,
+      total: manifestEntries.length,
+      kept: validEntries.length,
+    })
+  }
+
   if (validEntries.length === 0) {
-    if (options.clearAppVersionsManifest) {
-      const { error: deleteError } = await supabaseAdmin(c)
-        .from('app_versions')
-        .update({ manifest: null })
-        .eq('id', record.id)
-      if (deleteError)
-        cloudlog({ requestId: c.get('requestId'), message: 'error delete manifest in app_versions', error: deleteError })
-    }
+    if (options.clearAppVersionsManifest)
+      await clearLegacyAppVersionManifest(c, record.id)
     return { inserted: 0, alreadyPresent: false }
   }
 
   const pgClient = getPgClient(c, false)
   try {
     await pgClient.query('BEGIN')
+    // Serialize concurrent writers for this version (no unique constraint on manifest rows).
+    await pgClient.query('SELECT pg_advisory_xact_lock($1)', [record.id])
+
+    const existing = await pgClient.query<{ id: number }>(
+      'SELECT id FROM public.manifest WHERE app_version_id = $1 LIMIT 1',
+      [record.id],
+    )
+    if (existing.rows.length > 0) {
+      await pgClient.query('COMMIT')
+      if (options.clearAppVersionsManifest)
+        await clearLegacyAppVersionManifest(c, record.id)
+      return { inserted: 0, alreadyPresent: true }
+    }
+
     await pgClient.query(
       `INSERT INTO public.manifest (app_version_id, file_name, s3_path, file_hash, file_size)
        SELECT

--- a/supabase/functions/private/index.ts
+++ b/supabase/functions/private/index.ts
@@ -23,6 +23,7 @@ import { app as publicStats } from '../_backend/private/public_stats.ts'
 import { app as replay } from '../_backend/private/replay.ts'
 import { app as role_bindings } from '../_backend/private/role_bindings.ts'
 import { app as roles } from '../_backend/private/roles.ts'
+import { app as set_manifest } from '../_backend/private/set_manifest.ts'
 import { app as set_org_email } from '../_backend/private/set_org_email.ts'
 import { app as sso_check_domain } from '../_backend/private/sso/check-domain.ts'
 import { app as sso_check_enforcement } from '../_backend/private/sso/check-enforcement.ts'
@@ -67,6 +68,7 @@ appGlobal.route('/stats', stats_priv)
 appGlobal.route('/stripe_checkout', stripe_checkout)
 appGlobal.route('/stripe_portal', stripe_portal)
 appGlobal.route('/upload_link', upload_link)
+appGlobal.route('/set_manifest', set_manifest)
 appGlobal.route('/delete_failed_version', deleted_failed_version)
 appGlobal.route('/set_org_email', set_org_email)
 appGlobal.route('/latency', latency)

--- a/tests/manifest-persist.unit.test.ts
+++ b/tests/manifest-persist.unit.test.ts
@@ -31,4 +31,33 @@ describe('buildTrustedManifestRows', () => {
       file_size: 0,
     }])
   })
+
+  it.concurrent('keeps all valid rows when s3PathPrefix is omitted', () => {
+    const rows = buildTrustedManifestRows(7, [
+      {
+        file_name: 'a.js',
+        s3_path: 'orgs/a/apps/com.a/delta/h_a.js',
+        file_hash: 'ha',
+      },
+      {
+        file_name: 'b.js',
+        s3_path: 'orgs/b/apps/com.b/delta/h_b.js',
+        file_hash: 'hb',
+      },
+    ])
+
+    expect(rows).toHaveLength(2)
+    expect(rows.every(row => row.file_size === 0)).toBe(true)
+  })
+
+  it.concurrent('normalizes legacy percent-encoded file names', () => {
+    const rows = buildTrustedManifestRows(9, [{
+      file_name: 'assets/img/sad_post_grey%402x.png',
+      s3_path: 'orgs/org/apps/com.app/delta/hash_assets/img/sad_post_grey%402x.png',
+      file_hash: 'imghash',
+    }])
+
+    expect(rows[0]?.file_name).toBe('assets/img/sad_post_grey@2x.png')
+    expect(rows[0]?.file_size).toBe(0)
+  })
 })

--- a/tests/manifest-persist.unit.test.ts
+++ b/tests/manifest-persist.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { buildTrustedManifestRows } from '../supabase/functions/_backend/utils/manifest_persist.ts'
+
+describe('buildTrustedManifestRows', () => {
+  it.concurrent('ignores client file_size and enforces s3 path prefix', () => {
+    const rows = buildTrustedManifestRows(42, [
+      {
+        file_name: 'index.html',
+        s3_path: 'orgs/org/apps/com.app/delta/h_index.html',
+        file_hash: 'abc',
+        file_size: 123456,
+      },
+      {
+        file_name: 'evil.js',
+        s3_path: 'orgs/other/apps/com.evil/delta/x_evil.js',
+        file_hash: 'evil',
+        file_size: 1,
+      },
+      {
+        file_name: '',
+        s3_path: 'orgs/org/apps/com.app/delta/bad',
+        file_hash: 'bad',
+      },
+    ], 'orgs/org/apps/com.app/')
+
+    expect(rows).toEqual([{
+      app_version_id: 42,
+      file_name: 'index.html',
+      s3_path: 'orgs/org/apps/com.app/delta/h_index.html',
+      file_hash: 'abc',
+      file_size: 0,
+    }])
+  })
+})

--- a/tests/set-manifest.test.ts
+++ b/tests/set-manifest.test.ts
@@ -81,7 +81,7 @@ describe('[POST] /private/set_manifest', () => {
     })
 
     expect(response.status).toBe(200)
-    const json = await response.json()
+    const json = await response.json() as { status: string, inserted: number, alreadyPresent: boolean }
     expect(json.status).toBe('ok')
     expect(json.inserted).toBe(2)
     expect(json.alreadyPresent).toBe(false)
@@ -116,7 +116,7 @@ describe('[POST] /private/set_manifest', () => {
       body: JSON.stringify(body),
     })
     expect(retry.status).toBe(200)
-    const retryJson = await retry.json()
+    const retryJson = await retry.json() as { inserted: number, alreadyPresent: boolean }
     expect(retryJson.alreadyPresent).toBe(true)
     expect(retryJson.inserted).toBe(0)
   })
@@ -206,7 +206,7 @@ describe('[POST] /private/set_manifest', () => {
     })
 
     expect(response.status).toBe(400)
-    const json = await response.json()
+    const json = await response.json() as { error: string }
     expect(json.error).toBe('error_version_already_finalized')
   })
 })

--- a/tests/set-manifest.test.ts
+++ b/tests/set-manifest.test.ts
@@ -180,7 +180,7 @@ describe('[POST] /private/set_manifest', () => {
 
   it('rejects finalized versions that have no manifest rows yet', async () => {
     const finalizedName = `${BUNDLE_NAME}-final`
-    await getSupabaseClient()
+    const { data: finalized } = await getSupabaseClient()
       .from('app_versions')
       .insert({
         app_id: APP_ID,
@@ -191,6 +191,8 @@ describe('[POST] /private/set_manifest', () => {
         storage_provider: 'r2',
         deleted: false,
       })
+      .select('owner_org')
+      .single()
 
     const response = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
       method: 'POST',
@@ -201,12 +203,62 @@ describe('[POST] /private/set_manifest', () => {
       body: JSON.stringify({
         app_id: APP_ID,
         name: finalizedName,
-        manifest: manifestEntries(ORG_ID),
+        manifest: manifestEntries(finalized!.owner_org),
       }),
     })
 
     expect(response.status).toBe(400)
     const json = await response.json() as { error: string }
     expect(json.error).toBe('error_version_already_finalized')
+  })
+
+  it('rejects missing versions and non-uploadable storage providers', async () => {
+    const missing = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify({
+        app_id: APP_ID,
+        name: `${BUNDLE_NAME}-does-not-exist`,
+        manifest: manifestEntries(ORG_ID),
+      }),
+    })
+    expect(missing.status).toBe(404)
+    const missingJson = await missing.json() as { error: string }
+    expect(missingJson.error).toBe('error_version_not_found')
+
+    const externalName = `${BUNDLE_NAME}-external`
+    const { data: external } = await getSupabaseClient()
+      .from('app_versions')
+      .insert({
+        app_id: APP_ID,
+        name: externalName,
+        checksum: randomUUID().replaceAll('-', ''),
+        owner_org: ORG_ID,
+        user_id: USER_ID,
+        storage_provider: 'external',
+        external_url: 'https://example.com/bundle.zip',
+        deleted: false,
+      })
+      .select('owner_org')
+      .single()
+
+    const response = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify({
+        app_id: APP_ID,
+        name: externalName,
+        manifest: manifestEntries(external!.owner_org),
+      }),
+    })
+    expect(response.status).toBe(400)
+    const json = await response.json() as { error: string }
+    expect(json.error).toBe('error_version_not_uploadable')
   })
 })

--- a/tests/set-manifest.test.ts
+++ b/tests/set-manifest.test.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  APIKEY_TEST_ALL,
+  executeSQL,
+  fetchTestRequest,
+  getEndpointUrl,
+  getSupabaseClient,
+  ORG_ID,
+  resetAndSeedAppData,
+  resetAppData,
+  USER_ID,
+} from './test-utils.ts'
+
+const id = randomUUID()
+const APP_ID = `com.demo.set-manifest.${id}`
+const BUNDLE_NAME = `1.0.0-set-manifest-${id.slice(0, 8)}`
+
+async function createUploadVersion(storageProvider: 'r2-direct' | 'r2' = 'r2-direct') {
+  const { data, error } = await getSupabaseClient()
+    .from('app_versions')
+    .insert({
+      app_id: APP_ID,
+      name: BUNDLE_NAME,
+      checksum: randomUUID().replaceAll('-', ''),
+      owner_org: ORG_ID,
+      user_id: USER_ID,
+      storage_provider: storageProvider,
+      deleted: false,
+    })
+    .select('id, owner_org')
+    .single()
+
+  if (error || !data)
+    throw new Error(`Failed to create version: ${error?.message}`)
+
+  return data
+}
+
+function manifestEntries(ownerOrg: string) {
+  const prefix = `orgs/${ownerOrg}/apps/${APP_ID}/delta`
+  return [
+    {
+      file_name: 'index.html',
+      s3_path: `${prefix}/hash1_index.html`,
+      file_hash: 'hash1',
+      file_size: 999999, // must be ignored by backend
+    },
+    {
+      file_name: 'main.js',
+      s3_path: `${prefix}/hash2_main.js`,
+      file_hash: 'hash2',
+    },
+  ]
+}
+
+describe('[POST] /private/set_manifest', () => {
+  beforeAll(async () => {
+    await resetAndSeedAppData(APP_ID)
+  })
+
+  afterAll(async () => {
+    await resetAppData(APP_ID)
+  })
+
+  it('writes manifest rows with file_size 0 and keeps legacy jsonb path unused', async () => {
+    const version = await createUploadVersion('r2-direct')
+    const body = {
+      app_id: APP_ID,
+      name: BUNDLE_NAME,
+      manifest: manifestEntries(version.owner_org),
+    }
+
+    const response = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify(body),
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.status).toBe('ok')
+    expect(json.inserted).toBe(2)
+    expect(json.alreadyPresent).toBe(false)
+
+    const { data: rows, error } = await getSupabaseClient()
+      .from('manifest')
+      .select('file_name, file_hash, s3_path, file_size')
+      .eq('app_version_id', version.id)
+      .order('file_name')
+
+    expect(error).toBeNull()
+    expect(rows).toHaveLength(2)
+    expect(rows?.every(row => row.file_size === 0)).toBe(true)
+    expect(rows?.map(row => row.file_name)).toEqual(['index.html', 'main.js'])
+
+    const { data: appVersion } = await getSupabaseClient()
+      .from('app_versions')
+      .select('manifest, manifest_count')
+      .eq('id', version.id)
+      .single()
+
+    expect(appVersion?.manifest).toBeNull()
+    expect(appVersion?.manifest_count).toBe(2)
+
+    // Idempotent retry
+    const retry = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify(body),
+    })
+    expect(retry.status).toBe(200)
+    const retryJson = await retry.json()
+    expect(retryJson.alreadyPresent).toBe(true)
+    expect(retryJson.inserted).toBe(0)
+  })
+
+  it('rejects paths outside the app prefix and keeps old jsonb upload compatible', async () => {
+    const otherBundle = `${BUNDLE_NAME}-legacy`
+    const { data: version, error } = await getSupabaseClient()
+      .from('app_versions')
+      .insert({
+        app_id: APP_ID,
+        name: otherBundle,
+        checksum: randomUUID().replaceAll('-', ''),
+        owner_org: ORG_ID,
+        user_id: USER_ID,
+        storage_provider: 'r2-direct',
+        deleted: false,
+      })
+      .select('id, owner_org')
+      .single()
+    expect(error).toBeNull()
+
+    const response = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify({
+        app_id: APP_ID,
+        name: otherBundle,
+        manifest: [{
+          file_name: 'evil.js',
+          s3_path: 'orgs/other-org/apps/com.evil/delta/x_evil.js',
+          file_hash: 'evil',
+        }],
+      }),
+    })
+    expect(response.status).toBe(400)
+
+    // Legacy CLI path: writing jsonb onto app_versions.manifest still works.
+    await executeSQL(
+      `UPDATE public.app_versions
+       SET storage_provider = 'r2',
+           manifest = ARRAY[
+             ROW('legacy.html', $2, 'legacyhash')::public.manifest_entry
+           ],
+           updated_at = now()
+       WHERE id = $1`,
+      [version!.id, `orgs/${version!.owner_org}/apps/${APP_ID}/delta/legacy_legacy.html`],
+    )
+
+    const { data: legacyVersion } = await getSupabaseClient()
+      .from('app_versions')
+      .select('manifest')
+      .eq('id', version!.id)
+      .single()
+
+    expect(Array.isArray(legacyVersion?.manifest)).toBe(true)
+    expect(legacyVersion?.manifest?.length).toBe(1)
+  })
+
+  it('rejects finalized versions that have no manifest rows yet', async () => {
+    const finalizedName = `${BUNDLE_NAME}-final`
+    await getSupabaseClient()
+      .from('app_versions')
+      .insert({
+        app_id: APP_ID,
+        name: finalizedName,
+        checksum: randomUUID().replaceAll('-', ''),
+        owner_org: ORG_ID,
+        user_id: USER_ID,
+        storage_provider: 'r2',
+        deleted: false,
+      })
+
+    const response = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify({
+        app_id: APP_ID,
+        name: finalizedName,
+        manifest: manifestEntries(ORG_ID),
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    const json = await response.json()
+    expect(json.error).toBe('error_version_already_finalized')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Add `POST /private/set_manifest` so the CLI can insert delta files into `public.manifest` directly (with `file_size = 0`)
- Update the Capgo CLI upload path to call that endpoint instead of writing a multi-MB `app_versions.manifest` jsonb payload
- Keep trusted file sizes on the backend via existing `on_manifest_create` R2 HEAD lookups
- Keep the legacy jsonb → `handleManifest` path working for older CLIs

## Motivation (AI generated)

Uploading manifests into `app_versions.manifest` and then migrating them in a trigger is wasteful and puts large payloads on `app_versions` / queue messages. The CLI already knows the final `{ file_name, s3_path, file_hash }` entries after TUS upload, so it can write them to the right table immediately. File sizes must stay server-side because clients cannot be trusted for billing/download-size accounting.

## Business Impact (AI generated)

Faster and cheaper delta uploads (less jsonb churn and smaller version-update payloads), while preserving billing integrity through backend size discovery. Old CLI versions remain supported, so customers are not forced to upgrade immediately.

## Test Plan (AI generated)

- [x] Unit tests for trusted row building (`tests/manifest-persist.unit.test.ts`) — ignores client `file_size`, enforces s3 path prefix
- [x] CLI lint/build/`test:mcp`/`test:bundle`
- [x] Full unit suite (`bun test:unit`)
- [ ] Integration: `tests/set-manifest.test.ts` (needs Supabase/edge functions in CI)
  - inserts rows with `file_size = 0`
  - rejects paths outside the app prefix
  - rejects finalized `r2` versions with no rows
  - leaves legacy jsonb writes intact
- [ ] Manual: upload with `--delta` on new CLI and confirm `manifest` rows appear without `app_versions.manifest` jsonb
- [ ] Manual: old CLI jsonb upload still migrates via `on_version_update`

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43979b6b-5a1c-4386-80bb-2e23a033d719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43979b6b-5a1c-4386-80bb-2e23a033d719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploads now reliably persist bundle manifests for partial and delta uploads.
  * Added manifest validation to ensure entries belong to the correct app/version and S3 prefix.
  * Manifest saving is now idempotent, avoiding duplicate entries on retries.
  * Finalized versions are protected from invalid manifest changes.

* **Bug Fixes**
  * Improved failure cleanup during upload so cleanup errors don’t hide the original failure.
  * Normalizes client-provided file sizes when storing manifest entries.

* **Tests**
  * Added unit and API tests for manifest filtering, normalization, validation, retry behavior, and finalized-version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->