### PR TITLE
fix(cli): refuse delta uploads over 10k files + docs

### DIFF
--- a/cli/skills/release-management/SKILL.md
+++ b/cli/skills/release-management/SKILL.md
@@ -71,7 +71,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
   - `--zip`
   - `--tus`
   - `--tus-chunk-size <tusChunkSize>`
-  - `--delta` (refuses when the bundle has more than 10,000 files; use `--no-delta` or reduce files)
+  - `--delta` (refuses over 10,000 files — delta tracks each file; use `--no-delta` for a full zip, or reduce build files)
   - `--delta-only`
   - `--no-delta`
   - `--encrypted-checksum <encryptedChecksum>`

--- a/cli/skills/release-management/SKILL.md
+++ b/cli/skills/release-management/SKILL.md
@@ -71,7 +71,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
   - `--zip`
   - `--tus`
   - `--tus-chunk-size <tusChunkSize>`
-  - `--delta`
+  - `--delta` (refuses when the bundle has more than 10,000 files; use `--no-delta` or reduce files)
   - `--delta-only`
   - `--no-delta`
   - `--encrypted-checksum <encryptedChecksum>`

--- a/cli/src/bundle/partial.ts
+++ b/cli/src/bundle/partial.ts
@@ -14,7 +14,7 @@ import { parse } from '@std/semver'
 import * as micromatch from 'micromatch'
 import * as tus from 'tus-js-client'
 import { encryptChecksum, encryptChecksumV3, encryptSource } from '../api/crypto'
-import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
+import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, deltaManifestTooLargeMessage, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
 
 // Check if file already exists on server (bypass cache and force storage lookup)
 async function fileExists(localConfig: any, filename: string): Promise<boolean> {
@@ -231,9 +231,9 @@ export async function uploadPartial(
     throw new Error(`Files with spaces in their names (${filesWithSpaces.map(f => f.file).join(', ')}). Please rename the files.`)
   }
 
-  if (manifest.length > MAX_MANIFEST_ENTRIES) {
-    throw new Error(`Delta uploads are limited to ${MAX_MANIFEST_ENTRIES.toLocaleString('en-US')} files per bundle (got ${manifest.length.toLocaleString('en-US')}). Use --no-delta for a full zip upload, or reduce the number of files in your web build output.`)
-  }
+  if (manifest.length > MAX_MANIFEST_ENTRIES)
+    throw new Error(deltaManifestTooLargeMessage(manifest.length))
+
 
   let uploadedFiles = 0
   const totalFiles = manifest.length

--- a/cli/src/bundle/partial.ts
+++ b/cli/src/bundle/partial.ts
@@ -14,7 +14,7 @@ import { parse } from '@std/semver'
 import * as micromatch from 'micromatch'
 import * as tus from 'tus-js-client'
 import { encryptChecksum, encryptChecksumV3, encryptSource } from '../api/crypto'
-import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
+import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
 
 // Check if file already exists on server (bypass cache and force storage lookup)
 async function fileExists(localConfig: any, filename: string): Promise<boolean> {
@@ -229,6 +229,10 @@ export async function uploadPartial(
 
   if (filesWithSpaces.length > 0) {
     throw new Error(`Files with spaces in their names (${filesWithSpaces.map(f => f.file).join(', ')}). Please rename the files.`)
+  }
+
+  if (manifest.length > MAX_MANIFEST_ENTRIES) {
+    throw new Error(`Delta uploads are limited to ${MAX_MANIFEST_ENTRIES.toLocaleString('en-US')} files per bundle (got ${manifest.length.toLocaleString('en-US')}). Use --no-delta for a full zip upload, or reduce the number of files in your web build output.`)
   }
 
   let uploadedFiles = 0

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -23,7 +23,7 @@ import { confirmWithRememberedChoice } from '../promptPreferences'
 import { showReplicationProgress } from '../replicationProgress'
 import { formatTable } from '../terminal-table'
 import { usesAlwaysDirectUpdate } from '../updaterConfig'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, isCompatible, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, regexSemver, resolveUserIdFromApiKey, sendEvent, setVersionManifest, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, deltaManifestTooLargeMessage, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, isCompatible, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, regexSemver, resolveUserIdFromApiKey, sendEvent, setVersionManifest, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { maybePromptBuilderCta, shouldBlockIncompatibleUpload } from './builder-cta'
 import { checkIndexPosition, searchInDirectory } from './check'
@@ -1511,9 +1511,9 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
     log.info(`[Verbose] Delta manifest prepared with ${manifest.length} files`)
 
   // Refuse before creating a version row or uploading files (matches set_manifest cap).
-  if (options.delta && manifest.length > MAX_MANIFEST_ENTRIES) {
-    uploadFail(`Delta uploads are limited to ${MAX_MANIFEST_ENTRIES.toLocaleString('en-US')} files per bundle (got ${manifest.length.toLocaleString('en-US')}). Use --no-delta for a full zip upload, or reduce the number of files in your web build output.`)
-  }
+  if (options.delta && manifest.length > MAX_MANIFEST_ENTRIES)
+    uploadFail(deltaManifestTooLargeMessage(manifest.length))
+
 
   if (options.verbose)
     log.info(`[Verbose] Creating version record in database...`)

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -23,7 +23,7 @@ import { confirmWithRememberedChoice } from '../promptPreferences'
 import { showReplicationProgress } from '../replicationProgress'
 import { formatTable } from '../terminal-table'
 import { usesAlwaysDirectUpdate } from '../updaterConfig'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, isCompatible, isDeprecatedPluginVersion, regexSemver, resolveUserIdFromApiKey, sendEvent, setVersionManifest, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, canPromptInteractively, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteChecksums, getRemoteFileConfig, hasCliPermission, isCompatible, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, regexSemver, resolveUserIdFromApiKey, sendEvent, setVersionManifest, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { maybePromptBuilderCta, shouldBlockIncompatibleUpload } from './builder-cta'
 import { checkIndexPosition, searchInDirectory } from './check'
@@ -1509,6 +1509,11 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
 
   if (options.verbose && options.delta)
     log.info(`[Verbose] Delta manifest prepared with ${manifest.length} files`)
+
+  // Refuse before creating a version row or uploading files (matches set_manifest cap).
+  if (options.delta && manifest.length > MAX_MANIFEST_ENTRIES) {
+    uploadFail(`Delta uploads are limited to ${MAX_MANIFEST_ENTRIES.toLocaleString('en-US')} files per bundle (got ${manifest.length.toLocaleString('en-US')}). Use --no-delta for a full zip upload, or reduce the number of files in your web build output.`)
+  }
 
   if (options.verbose)
     log.info(`[Verbose] Creating version record in database...`)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -260,7 +260,7 @@ Example: npx @capgo/cli@latest bundle upload com.example.app --path ./dist --cha
   .option('--tus-chunk-size <tusChunkSize>', `Chunk size in bytes for TUS resumable uploads (default: auto)`)
   .option('--partial', `[DEPRECATED] Use --delta instead. Upload incremental updates`)
   .option('--partial-only', `[DEPRECATED] Use --delta-only instead. Upload only incremental updates, skip full bundle`)
-  .option('--delta', `Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads`)
+  .option('--delta', `Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads. Capgo refuses delta uploads with more than 10,000 files; use --no-delta or reduce the build file count.`)
   .option('--delta-only', `Upload only delta updates without full bundle for maximum speed (useful for large apps)`)
   .option('--no-delta', `Disable delta updates even if instant updates are enabled`)
   .option('--encrypted-checksum <encryptedChecksum>', `An encrypted checksum (signature). Used only when uploading an external bundle.`)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -260,7 +260,7 @@ Example: npx @capgo/cli@latest bundle upload com.example.app --path ./dist --cha
   .option('--tus-chunk-size <tusChunkSize>', `Chunk size in bytes for TUS resumable uploads (default: auto)`)
   .option('--partial', `[DEPRECATED] Use --delta instead. Upload incremental updates`)
   .option('--partial-only', `[DEPRECATED] Use --delta-only instead. Upload only incremental updates, skip full bundle`)
-  .option('--delta', `Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads. Capgo refuses delta uploads with more than 10,000 files; use --no-delta or reduce the build file count.`)
+  .option('--delta', `Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads. Capgo refuses delta uploads over 10,000 files (delta tracks each file); use --no-delta for a full zip, or reduce files in your web build.`)
   .option('--delta-only', `Upload only delta updates without full bundle for maximum speed (useful for large apps)`)
   .option('--no-delta', `Disable delta updates even if instant updates are enabled`)
   .option('--encrypted-checksum <encryptedChecksum>', `An encrypted checksum (signature). Used only when uploading an external bundle.`)

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -55,6 +55,20 @@ export const TUS_UPLOAD_RETRY_DELAYS = [0, 1000, 3000, 5000, 10000]
 // Keep in sync with supabase/functions/_backend/private/set_manifest.ts
 export const MAX_MANIFEST_ENTRIES = 10_000
 
+/** User-facing error when a delta/manifest upload exceeds MAX_MANIFEST_ENTRIES. */
+export function deltaManifestTooLargeMessage(fileCount: number): string {
+  const max = MAX_MANIFEST_ENTRIES.toLocaleString('en-US')
+  const count = fileCount.toLocaleString('en-US')
+  return [
+    `Delta updates cannot upload this bundle: it has ${count} files, and Capgo allows at most ${max} files per delta (manifest) upload.`,
+    'Delta mode tracks and uploads each file individually so devices can download only what changed. Very large file counts are not supported on that path.',
+    'What you can do:',
+    `1. Upload a full zip instead: npx @capgo/cli@latest bundle upload --no-delta`,
+    '2. Or reduce files in your web build output (remove unused assets, avoid copying large trees into dist).',
+    'See https://capgo.app/docs/faq/#are-there-delta-update-file-path-limitations',
+  ].join('\n')
+}
+
 export const PACKNAME = 'package.json'
 
 export type ArrayElement<ArrayType extends readonly unknown[]>

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -52,6 +52,8 @@ export const ALERT_UPLOAD_SIZE_BYTES = 1024 * 1024 * 20 // 20MB
 export const MAX_UPLOAD_LENGTH_BYTES = 1024 * 1024 * 1024 // 1GB
 export const MAX_CHUNK_SIZE_BYTES = 1024 * 1024 * 99 // 99MB
 export const TUS_UPLOAD_RETRY_DELAYS = [0, 1000, 3000, 5000, 10000]
+// Keep in sync with supabase/functions/_backend/private/set_manifest.ts
+export const MAX_MANIFEST_ENTRIES = 10_000
 
 export const PACKNAME = 'package.json'
 

--- a/cli/webdocs/bundle.mdx
+++ b/cli/webdocs/bundle.mdx
@@ -69,7 +69,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **--tus-chunk-size** | <code>string</code> | Chunk size in bytes for TUS resumable uploads (default: auto) |
 | **--partial** | <code>boolean</code> | [DEPRECATED] Use --delta instead. Upload incremental updates |
 | **--partial-only** | <code>boolean</code> | [DEPRECATED] Use --delta-only instead. Upload only incremental updates, skip full bundle |
-| **--delta** | <code>boolean</code> | Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads. Capgo refuses delta uploads with more than 10,000 files; use --no-delta or reduce the build file count. |
+| **--delta** | <code>boolean</code> | Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads. Capgo refuses delta uploads over 10,000 files because delta mode tracks each file individually; use --no-delta for a full zip, or reduce files in your web build. |
 | **--delta-only** | <code>boolean</code> | Upload only delta updates without full bundle for maximum speed (useful for large apps) |
 | **--no-delta** | <code>boolean</code> | Disable delta updates even if instant updates are enabled |
 | **--encrypted-checksum** | <code>string</code> | An encrypted checksum (signature). Used only when uploading an external bundle. |

--- a/cli/webdocs/bundle.mdx
+++ b/cli/webdocs/bundle.mdx
@@ -69,7 +69,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **--tus-chunk-size** | <code>string</code> | Chunk size in bytes for TUS resumable uploads (default: auto) |
 | **--partial** | <code>boolean</code> | [DEPRECATED] Use --delta instead. Upload incremental updates |
 | **--partial-only** | <code>boolean</code> | [DEPRECATED] Use --delta-only instead. Upload only incremental updates, skip full bundle |
-| **--delta** | <code>boolean</code> | Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads |
+| **--delta** | <code>boolean</code> | Upload delta updates (only changed files) for instant, super-fast updates instead of big zip downloads. Capgo refuses delta uploads with more than 10,000 files; use --no-delta or reduce the build file count. |
 | **--delta-only** | <code>boolean</code> | Upload only delta updates without full bundle for maximum speed (useful for large apps) |
 | **--no-delta** | <code>boolean</code> | Disable delta updates even if instant updates are enabled |
 | **--encrypted-checksum** | <code>string</code> | An encrypted checksum (signature). Used only when uploading an external bundle. |

--- a/supabase/functions/_backend/private/set_manifest.ts
+++ b/supabase/functions/_backend/private/set_manifest.ts
@@ -43,7 +43,7 @@ app.post('/', middlewareKey(), async (c) => {
   if (!Array.isArray(body.manifest) || body.manifest.length === 0)
     return quickError(400, 'error_manifest_missing', 'Error manifest missing or empty', { body })
   if (body.manifest.length > MAX_MANIFEST_ENTRIES) {
-    return quickError(400, 'error_manifest_too_large', 'Manifest has too many entries', {
+    return quickError(400, 'error_manifest_too_large', `Delta manifests are limited to ${MAX_MANIFEST_ENTRIES} files (got ${body.manifest.length}). Use a full zip upload (--no-delta) or reduce files in the web build.`, {
       max: MAX_MANIFEST_ENTRIES,
       count: body.manifest.length,
     })

--- a/tests/set-manifest.test.ts
+++ b/tests/set-manifest.test.ts
@@ -212,6 +212,48 @@ describe('[POST] /private/set_manifest', () => {
     expect(json.error).toBe('error_version_already_finalized')
   })
 
+  it('rejects manifests larger than 10,000 entries', async () => {
+    const oversizedName = `${BUNDLE_NAME}-too-large`
+    const { data: version, error } = await getSupabaseClient()
+      .from('app_versions')
+      .insert({
+        app_id: APP_ID,
+        name: oversizedName,
+        checksum: randomUUID().replaceAll('-', ''),
+        owner_org: ORG_ID,
+        user_id: USER_ID,
+        storage_provider: 'r2-direct',
+        deleted: false,
+      })
+      .select('owner_org')
+      .single()
+    expect(error).toBeNull()
+
+    const prefix = `orgs/${version!.owner_org}/apps/${APP_ID}/delta`
+    const oversized = Array.from({ length: 10_001 }, (_, i) => ({
+      file_name: `f${i}.js`,
+      s3_path: `${prefix}/h${i}_f${i}.js`,
+      file_hash: `h${i}`,
+    }))
+
+    const response = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': APIKEY_TEST_ALL,
+      },
+      body: JSON.stringify({
+        app_id: APP_ID,
+        name: oversizedName,
+        manifest: oversized,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    const json = await response.json() as { error: string, max?: number, count?: number }
+    expect(json.error).toBe('error_manifest_too_large')
+  })
+
   it('rejects missing versions and non-uploadable storage providers', async () => {
     const missing = await fetchTestRequest(getEndpointUrl('/private/set_manifest'), {
       method: 'POST',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- CLI refuses delta uploads when the prepared manifest has more than **10,000** files (before creating a version row or uploading)
- Same guard in `uploadPartial` as defense in depth
- Shared `MAX_MANIFEST_ENTRIES` constant in the CLI (kept in sync with `set_manifest`)
- Backend test coverage for `error_manifest_too_large`
- Documented in CLI `--delta` help, `cli/webdocs/bundle.mdx`, and release-management skill

## Motivation (AI generated)

Backend `set_manifest` already rejects oversized manifests. Without a CLI pre-check, users can spend time uploading thousands of delta files and then fail at finalize. Matching the cap client-side gives an immediate, actionable error (`--no-delta` or fewer files).

## Business Impact (AI generated)

Fewer failed/incomplete delta uploads and clearer guidance for large asset trees, while keeping the production-safe 10k ceiling already enforced by the API.

## Test Plan (AI generated)

- [x] CLI check after `prepareBundlePartialFiles` and again in `uploadPartial`
- [x] Integration test asserts `error_manifest_too_large` for 10,001 entries
- [ ] CI green on this PR
- [ ] Manual: bundle with >10k files + `--delta` exits before upload
- [ ] Manual: same bundle with `--no-delta` still uploads as zip

## Landing FAQ / docs PR (AI generated)

Website PR is **blocked** here: `cursor[bot]` has no push access to `Cap-go/website`. Ready-to-apply edits for a separate landing PR:

**`apps/docs/src/content/docs/docs/faq.mdx`** (Delta limitations list):

```md
- **File count:** Delta uploads are limited to **10,000 files** per bundle version. The CLI refuses the upload before sending files when the limit is exceeded. Use a full bundle upload (`npx @capgo/cli@latest bundle upload --no-delta`) or reduce the number of files in your web build output.
```

**`apps/docs/src/content/docs/docs/live-updates/differentials.mdx`** (Delta update limitations):

```md
- **File count:** Capgo accepts at most **10,000 files** in a Delta (manifest) upload. The CLI checks this before upload and exits with an error if your build folder has more files. Prefer a full zip upload with `--no-delta`, or trim unused assets from your web build.
```

Suggested website branch name: `cursor/delta-manifest-file-limit-faq-d719`.

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43979b6b-5a1c-4386-80bb-2e23a033d719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43979b6b-5a1c-4386-80bb-2e23a033d719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

