### PR TITLE
fix(db): skip app_versions bookkeeping in audit_logs

### DIFF
--- a/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
+++ b/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
@@ -1,6 +1,8 @@
 -- Slim audit_logs: do not store internal app_versions upload/migrate bookkeeping.
 -- Capgo-EU evidence: r2_path/storage_provider/manifest pipeline updates were hundreds
 -- of MB of TOAST with no user-facing audit value. Soft-delete and real edits stay.
+-- Historical cleanup is intentionally NOT in this migration (avoids one-shot WAL/lock
+-- storm on audit_logs). Run bounded ops deletes separately if needed.
 
 CREATE OR REPLACE FUNCTION "public"."audit_log_trigger"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
@@ -24,15 +26,6 @@ DECLARE
   v_stats_refresh_fields constant text[] := ARRAY['stats_refresh_requested_at', 'stats_updated_at', 'updated_at'];
   v_background_counter_fields constant text[] := ARRAY['channel_device_count', 'manifest_bundle_count', 'updated_at'];
   v_fat_app_version_fields constant text[] := ARRAY['manifest', 'native_packages'];
-  -- Internal upload/migrate bookkeeping only. Real user intent fields
-  -- (comment, checksum, deleted, name, ...) must still produce audit rows.
-  v_app_version_bookkeeping_fields constant text[] := ARRAY[
-    'manifest',
-    'manifest_count',
-    'storage_provider',
-    'r2_path',
-    'updated_at'
-  ];
 BEGIN
   SELECT auth.uid() INTO v_actor_user_id;
 
@@ -72,6 +65,36 @@ BEGIN
   END IF;
 
   v_user_id := v_actor_user_id;
+
+  -- Skip internal app_versions upload/migrate bookkeeping before to_jsonb()
+  -- so multi-MB manifest/native_packages are never serialized for those UPDATEs.
+  IF TG_OP = 'UPDATE'
+    AND TG_TABLE_NAME = 'app_versions'
+    AND NEW.native_packages IS NOT DISTINCT FROM OLD.native_packages
+    AND NEW.comment IS NOT DISTINCT FROM OLD.comment
+    AND NEW.checksum IS NOT DISTINCT FROM OLD.checksum
+    AND NEW.deleted IS NOT DISTINCT FROM OLD.deleted
+    AND NEW.deleted_at IS NOT DISTINCT FROM OLD.deleted_at
+    AND NEW.name IS NOT DISTINCT FROM OLD.name
+    AND NEW.external_url IS NOT DISTINCT FROM OLD.external_url
+    AND NEW.min_update_version IS NOT DISTINCT FROM OLD.min_update_version
+    AND NEW.owner_org IS NOT DISTINCT FROM OLD.owner_org
+    AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
+    AND NEW.link IS NOT DISTINCT FROM OLD.link
+    AND NEW.key_id IS NOT DISTINCT FROM OLD.key_id
+    AND NEW.cli_version IS NOT DISTINCT FROM OLD.cli_version
+    AND NEW.created_by_apikey_rbac_id IS NOT DISTINCT FROM OLD.created_by_apikey_rbac_id
+    AND NEW.app_id IS NOT DISTINCT FROM OLD.app_id
+    AND NEW.session_key IS NOT DISTINCT FROM OLD.session_key
+    AND (
+      NEW.manifest IS DISTINCT FROM OLD.manifest
+      OR NEW.manifest_count IS DISTINCT FROM OLD.manifest_count
+      OR NEW.storage_provider IS DISTINCT FROM OLD.storage_provider
+      OR NEW.r2_path IS DISTINCT FROM OLD.r2_path
+      OR NEW.updated_at IS DISTINCT FROM OLD.updated_at
+    ) THEN
+    RETURN NEW;
+  END IF;
 
   IF TG_OP = 'DELETE' THEN
     v_old_record := pg_catalog.to_jsonb(OLD);
@@ -122,21 +145,6 @@ BEGIN
       v_new_record := v_new_record - v_fat_app_version_fields;
     END IF;
 
-    -- Skip internal upload/migrate bookkeeping. Examples that must not audit:
-    -- - manifest[] write then null + manifest_count (dual-storage migrate)
-    -- - r2_path / storage_provider finalization from backend workers
-    -- - updated_at-only bumps
-    -- Keep soft-delete, comment, checksum, channel-facing edits, etc.
-    IF TG_OP = 'UPDATE'
-      AND NEW.native_packages IS NOT DISTINCT FROM OLD.native_packages
-      AND v_changed_fields IS NOT NULL
-      AND NOT EXISTS (
-        SELECT 1
-        FROM pg_catalog.unnest(v_changed_fields) AS changed_field(field_name)
-        WHERE changed_field.field_name <> ALL(v_app_version_bookkeeping_fields)
-      ) THEN
-      RETURN NEW;
-    END IF;
   END IF;
 
   CASE TG_TABLE_NAME
@@ -198,19 +206,3 @@ $$;
 
 
 ALTER FUNCTION "public"."audit_log_trigger"() OWNER TO "postgres";
-
-SET statement_timeout = '0';
-
--- Remove historical bookkeeping noise already written under the old rules.
--- Soft-deletes and user-facing field edits are kept.
-DELETE FROM public.audit_logs
-WHERE table_name = 'app_versions'
-  AND changed_fields IS NOT NULL
-  AND NOT EXISTS (
-    SELECT 1
-    FROM pg_catalog.unnest(changed_fields) AS changed_field(field_name)
-    WHERE changed_field.field_name <> ALL(
-      ARRAY['manifest', 'manifest_count', 'storage_provider', 'r2_path', 'updated_at']::text[]
-    )
-  );
-

--- a/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
+++ b/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
@@ -66,34 +66,31 @@ BEGIN
 
   v_user_id := v_actor_user_id;
 
-  -- Skip internal app_versions upload/migrate bookkeeping before to_jsonb()
-  -- so multi-MB manifest/native_packages are never serialized for those UPDATE operations.
-  IF TG_OP = 'UPDATE'
-    AND TG_TABLE_NAME = 'app_versions'
-    AND NEW.native_packages IS NOT DISTINCT FROM OLD.native_packages
-    AND NEW.comment IS NOT DISTINCT FROM OLD.comment
-    AND NEW.checksum IS NOT DISTINCT FROM OLD.checksum
-    AND NEW.deleted IS NOT DISTINCT FROM OLD.deleted
-    AND NEW.deleted_at IS NOT DISTINCT FROM OLD.deleted_at
-    AND NEW.name IS NOT DISTINCT FROM OLD.name
-    AND NEW.external_url IS NOT DISTINCT FROM OLD.external_url
-    AND NEW.min_update_version IS NOT DISTINCT FROM OLD.min_update_version
-    AND NEW.owner_org IS NOT DISTINCT FROM OLD.owner_org
-    AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
-    AND NEW.link IS NOT DISTINCT FROM OLD.link
-    AND NEW.key_id IS NOT DISTINCT FROM OLD.key_id
-    AND NEW.cli_version IS NOT DISTINCT FROM OLD.cli_version
-    AND NEW.created_by_apikey_rbac_id IS NOT DISTINCT FROM OLD.created_by_apikey_rbac_id
-    AND NEW.app_id IS NOT DISTINCT FROM OLD.app_id
-    AND NEW.session_key IS NOT DISTINCT FROM OLD.session_key
-    AND (
-      NEW.manifest IS DISTINCT FROM OLD.manifest
-      OR NEW.manifest_count IS DISTINCT FROM OLD.manifest_count
-      OR NEW.storage_provider IS DISTINCT FROM OLD.storage_provider
-      OR NEW.r2_path IS DISTINCT FROM OLD.r2_path
-      OR NEW.updated_at IS DISTINCT FROM OLD.updated_at
+  -- Skip internal app_versions upload/migrate bookkeeping before the generic
+  -- changed_fields walk. Compare via to_jsonb only (this trigger is shared across
+  -- tables; never touch NEW.column names that only exist on app_versions).
+  IF TG_OP = 'UPDATE' AND TG_TABLE_NAME = 'app_versions' THEN
+    v_old_record := pg_catalog.to_jsonb(OLD);
+    v_new_record := pg_catalog.to_jsonb(NEW);
+    IF (
+      v_old_record
+        - 'manifest'
+        - 'native_packages'
+        - 'updated_at'
+        - 'manifest_count'
+        - 'storage_provider'
+        - 'r2_path'
+    ) IS NOT DISTINCT FROM (
+      v_new_record
+        - 'manifest'
+        - 'native_packages'
+        - 'updated_at'
+        - 'manifest_count'
+        - 'storage_provider'
+        - 'r2_path'
     ) THEN
-    RETURN NEW;
+      RETURN NEW;
+    END IF;
   END IF;
 
   IF TG_OP = 'DELETE' THEN

--- a/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
+++ b/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
@@ -1,0 +1,216 @@
+-- Slim audit_logs: do not store internal app_versions upload/migrate bookkeeping.
+-- Capgo-EU evidence: r2_path/storage_provider/manifest pipeline updates were hundreds
+-- of MB of TOAST with no user-facing audit value. Soft-delete and real edits stay.
+
+CREATE OR REPLACE FUNCTION "public"."audit_log_trigger"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_old_record jsonb;
+  v_new_record jsonb;
+  v_changed_fields text[];
+  v_org_id uuid;
+  v_record_id text;
+  v_user_id uuid;
+  v_key text;
+  v_api_key_text text;
+  v_api_key public.apikeys%ROWTYPE;
+  v_actor_type text := 'system';
+  v_actor_user_id uuid;
+  v_actor_user_email text;
+  v_actor_apikey_id bigint;
+  v_actor_apikey_name text;
+  v_stats_refresh_fields constant text[] := ARRAY['stats_refresh_requested_at', 'stats_updated_at', 'updated_at'];
+  v_background_counter_fields constant text[] := ARRAY['channel_device_count', 'manifest_bundle_count', 'updated_at'];
+  v_fat_app_version_fields constant text[] := ARRAY['manifest', 'native_packages'];
+  -- Internal upload/migrate bookkeeping only. Real user intent fields
+  -- (comment, checksum, deleted, name, ...) must still produce audit rows.
+  v_app_version_bookkeeping_fields constant text[] := ARRAY[
+    'manifest',
+    'manifest_count',
+    'storage_provider',
+    'r2_path',
+    'updated_at'
+  ];
+BEGIN
+  SELECT auth.uid() INTO v_actor_user_id;
+
+  IF v_actor_user_id IS NOT NULL THEN
+    v_actor_type := 'user';
+  ELSE
+    SELECT public.get_apikey_header() INTO v_api_key_text;
+
+    IF v_api_key_text IS NOT NULL THEN
+      SELECT *
+      INTO v_api_key
+      FROM public.find_apikey_by_value(v_api_key_text)
+      LIMIT 1;
+
+      -- Attribute only valid, write-capable API keys; a read-only key present on
+      -- a request must not be recorded as the actor of a mutation.
+      IF v_api_key.id IS NOT NULL
+        AND NOT public.is_apikey_expired(v_api_key.expires_at)
+        AND (
+          public.is_allowed_capgkey(v_api_key_text, '{upload}'::text[])
+          OR public.is_allowed_capgkey(v_api_key_text, '{write}'::text[])
+          OR public.is_allowed_capgkey(v_api_key_text, '{all}'::text[])
+        ) THEN
+        v_actor_type := 'apikey';
+        v_actor_user_id := v_api_key.user_id;
+        v_actor_apikey_id := v_api_key.id;
+        v_actor_apikey_name := v_api_key.name;
+      END IF;
+    END IF;
+  END IF;
+
+  IF v_actor_user_id IS NOT NULL THEN
+    SELECT users.email
+    INTO v_actor_user_email
+    FROM public.users AS users
+    WHERE users.id = v_actor_user_id;
+  END IF;
+
+  v_user_id := v_actor_user_id;
+
+  IF TG_OP = 'DELETE' THEN
+    v_old_record := pg_catalog.to_jsonb(OLD);
+    v_new_record := NULL;
+  ELSIF TG_OP = 'INSERT' THEN
+    v_old_record := NULL;
+    v_new_record := pg_catalog.to_jsonb(NEW);
+  ELSE
+    v_old_record := pg_catalog.to_jsonb(OLD);
+    v_new_record := pg_catalog.to_jsonb(NEW);
+
+    FOR v_key IN SELECT pg_catalog.jsonb_object_keys(v_new_record)
+    LOOP
+      IF v_old_record->v_key IS DISTINCT FROM v_new_record->v_key THEN
+        v_changed_fields := pg_catalog.array_append(v_changed_fields, v_key);
+      END IF;
+    END LOOP;
+
+    IF TG_TABLE_NAME = ANY(ARRAY['apps', 'orgs'])
+      AND v_changed_fields && ARRAY['stats_refresh_requested_at', 'stats_updated_at']
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(v_changed_fields) AS changed_field(field_name)
+        WHERE changed_field.field_name <> ALL(v_stats_refresh_fields)
+      ) THEN
+      RETURN NEW;
+    END IF;
+
+    IF v_actor_type = 'system'
+      AND TG_TABLE_NAME = 'apps'
+      AND v_changed_fields && ARRAY['channel_device_count', 'manifest_bundle_count']
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(v_changed_fields) AS changed_field(field_name)
+        WHERE changed_field.field_name <> ALL(v_background_counter_fields)
+      ) THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  -- Never persist multi-MB array/json columns in audit TOAST.
+  -- Keep fat field names in changed_fields when co-occurring with real user edits.
+  IF TG_TABLE_NAME = 'app_versions' THEN
+    IF v_old_record IS NOT NULL THEN
+      v_old_record := v_old_record - v_fat_app_version_fields;
+    END IF;
+    IF v_new_record IS NOT NULL THEN
+      v_new_record := v_new_record - v_fat_app_version_fields;
+    END IF;
+
+    -- Skip internal upload/migrate bookkeeping. Examples that must not audit:
+    -- - manifest[] write then null + manifest_count (dual-storage migrate)
+    -- - r2_path / storage_provider finalization from backend workers
+    -- - updated_at-only bumps
+    -- Keep soft-delete, comment, checksum, channel-facing edits, etc.
+    IF TG_OP = 'UPDATE'
+      AND NEW.native_packages IS NOT DISTINCT FROM OLD.native_packages
+      AND v_changed_fields IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(v_changed_fields) AS changed_field(field_name)
+        WHERE changed_field.field_name <> ALL(v_app_version_bookkeeping_fields)
+      ) THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  CASE TG_TABLE_NAME
+    WHEN 'orgs' THEN
+      v_org_id := COALESCE(NEW.id, OLD.id);
+      v_record_id := COALESCE(NEW.id, OLD.id)::text;
+    WHEN 'apps' THEN
+      v_org_id := COALESCE(NEW.owner_org, OLD.owner_org);
+      v_record_id := COALESCE(NEW.app_id, OLD.app_id)::text;
+    WHEN 'channels' THEN
+      v_org_id := COALESCE(NEW.owner_org, OLD.owner_org);
+      v_record_id := COALESCE(NEW.id, OLD.id)::text;
+    WHEN 'app_versions' THEN
+      v_org_id := COALESCE(NEW.owner_org, OLD.owner_org);
+      v_record_id := COALESCE(NEW.id, OLD.id)::text;
+    WHEN 'org_users' THEN
+      v_org_id := COALESCE(NEW.org_id, OLD.org_id);
+      v_record_id := COALESCE(NEW.id, OLD.id)::text;
+    ELSE
+      v_org_id := NULL;
+      v_record_id := NULL;
+  END CASE;
+
+  IF v_org_id IS NOT NULL THEN
+    INSERT INTO public.audit_logs (
+      table_name,
+      record_id,
+      operation,
+      user_id,
+      org_id,
+      old_record,
+      new_record,
+      changed_fields,
+      actor_type,
+      actor_user_id,
+      actor_user_email,
+      actor_apikey_id,
+      actor_apikey_name
+    ) VALUES (
+      TG_TABLE_NAME,
+      v_record_id,
+      TG_OP,
+      v_user_id,
+      v_org_id,
+      v_old_record,
+      v_new_record,
+      v_changed_fields,
+      v_actor_type,
+      v_actor_user_id,
+      v_actor_user_email,
+      v_actor_apikey_id,
+      v_actor_apikey_name
+    );
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+
+ALTER FUNCTION "public"."audit_log_trigger"() OWNER TO "postgres";
+
+SET statement_timeout = '0';
+
+-- Remove historical bookkeeping noise already written under the old rules.
+-- Soft-deletes and user-facing field edits are kept.
+DELETE FROM public.audit_logs
+WHERE table_name = 'app_versions'
+  AND changed_fields IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.unnest(changed_fields) AS changed_field(field_name)
+    WHERE changed_field.field_name <> ALL(
+      ARRAY['manifest', 'manifest_count', 'storage_provider', 'r2_path', 'updated_at']::text[]
+    )
+  );
+

--- a/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
+++ b/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
@@ -1,8 +1,8 @@
 -- Slim audit_logs: do not store internal app_versions upload/migrate bookkeeping.
 -- Capgo-EU evidence: r2_path/storage_provider/manifest pipeline updates were hundreds
 -- of MB of TOAST with no user-facing audit value. Soft-delete and real edits stay.
--- Historical cleanup is intentionally NOT in this migration (avoids one-shot WAL/lock
--- storm on audit_logs). Run bounded ops deletes separately if needed.
+-- Historical cleanup stays out of this migration to avoid a WAL/lock storm.
+-- Run bounded ops deletes separately if needed.
 
 CREATE OR REPLACE FUNCTION "public"."audit_log_trigger"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
@@ -75,7 +75,6 @@ BEGIN
     IF (
       v_old_record
         - 'manifest'
-        - 'native_packages'
         - 'updated_at'
         - 'manifest_count'
         - 'storage_provider'
@@ -83,7 +82,6 @@ BEGIN
     ) IS NOT DISTINCT FROM (
       v_new_record
         - 'manifest'
-        - 'native_packages'
         - 'updated_at'
         - 'manifest_count'
         - 'storage_provider'

--- a/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
+++ b/supabase/migrations/20260725163259_slim_audit_logs_skip_bookkeeping.sql
@@ -67,7 +67,7 @@ BEGIN
   v_user_id := v_actor_user_id;
 
   -- Skip internal app_versions upload/migrate bookkeeping before to_jsonb()
-  -- so multi-MB manifest/native_packages are never serialized for those UPDATEs.
+  -- so multi-MB manifest/native_packages are never serialized for those UPDATE operations.
   IF TG_OP = 'UPDATE'
     AND TG_TABLE_NAME = 'app_versions'
     AND NEW.native_packages IS NOT DISTINCT FROM OLD.native_packages

--- a/tests/cleanup_swap_memory.test.ts
+++ b/tests/cleanup_swap_memory.test.ts
@@ -184,7 +184,124 @@ describe('swap memory cleanup functions', () => {
     await executeSQL(`DELETE FROM public.apps WHERE app_id = $1`, [appId])
   })
 
-  it('null_migrated_app_version_manifests skips partially migrated arrays', async () => {
+  async function seedAuditAppVersion(appId: string, orgId: string) {
+    await executeSQL(
+      `INSERT INTO public.apps (app_id, name, icon_url, owner_org)
+       VALUES ($1, 'swap-audit-skip', '', $2::uuid)`,
+      [appId, orgId],
+    )
+    const versionRows = await executeSQL(
+      `INSERT INTO public.app_versions (app_id, name, owner_org, storage_provider, comment)
+       VALUES ($1, $2, $3::uuid, 'r2-direct', 'seed')
+       RETURNING id`,
+      [appId, `1.0.0-${randomUUID().slice(0, 8)}`, orgId],
+    )
+    return versionRows[0]?.id as number
+  }
+
+  async function clearVersionAudits(versionId: number) {
+    await executeSQL(
+      `DELETE FROM public.audit_logs
+       WHERE table_name = 'app_versions' AND record_id = $1`,
+      [String(versionId)],
+    )
+  }
+
+  it('audit_log_trigger skips dual-storage migrate finalize', async () => {
+    const appId = `com.swap.auditskip.${randomUUID().slice(0, 8)}`
+    const orgId = (await executeSQL(`SELECT id FROM public.orgs ORDER BY created_at LIMIT 1`))[0]?.id as string
+    const versionId = await seedAuditAppVersion(appId, orgId)
+
+    await executeSQL(
+      `UPDATE public.app_versions
+       SET manifest = ARRAY[ROW('a.js', 'apps/a.js', 'hash')::public.manifest_entry]
+       WHERE id = $1`,
+      [versionId],
+    )
+    await clearVersionAudits(versionId)
+
+    await executeSQL(
+      `INSERT INTO public.manifest (app_version_id, file_name, s3_path, file_hash)
+       VALUES ($1, 'a.js', 'apps/a.js', 'hash')`,
+      [versionId],
+    )
+    await executeSQL(
+      `UPDATE public.app_versions
+       SET manifest = NULL, manifest_count = 1, updated_at = now()
+       WHERE id = $1`,
+      [versionId],
+    )
+
+    const logs = await executeSQL(
+      `SELECT id FROM public.audit_logs
+       WHERE table_name = 'app_versions' AND record_id = $1 AND operation = 'UPDATE'`,
+      [String(versionId)],
+    )
+    expect(logs).toHaveLength(0)
+
+    await executeSQL(`DELETE FROM public.manifest WHERE app_version_id = $1`, [versionId])
+    await executeSQL(`DELETE FROM public.app_versions WHERE id = $1`, [versionId])
+    await executeSQL(`DELETE FROM public.apps WHERE app_id = $1`, [appId])
+  })
+
+  it('audit_log_trigger skips r2_path and storage_provider bookkeeping', async () => {
+    const appId = `com.swap.auditpath.${randomUUID().slice(0, 8)}`
+    const orgId = (await executeSQL(`SELECT id FROM public.orgs ORDER BY created_at LIMIT 1`))[0]?.id as string
+    const versionId = await seedAuditAppVersion(appId, orgId)
+    await clearVersionAudits(versionId)
+
+    await executeSQL(
+      `UPDATE public.app_versions
+       SET r2_path = 'apps/test/bundle.zip', updated_at = now()
+       WHERE id = $1`,
+      [versionId],
+    )
+    await executeSQL(
+      `UPDATE public.app_versions
+       SET storage_provider = 'r2', updated_at = now()
+       WHERE id = $1`,
+      [versionId],
+    )
+
+    const logs = await executeSQL(
+      `SELECT id, changed_fields FROM public.audit_logs
+       WHERE table_name = 'app_versions' AND record_id = $1 AND operation = 'UPDATE'`,
+      [String(versionId)],
+    )
+    expect(logs).toHaveLength(0)
+
+    await executeSQL(`DELETE FROM public.app_versions WHERE id = $1`, [versionId])
+    await executeSQL(`DELETE FROM public.apps WHERE app_id = $1`, [appId])
+  })
+
+  it('audit_log_trigger still records soft-delete', async () => {
+    const appId = `com.swap.auditdel.${randomUUID().slice(0, 8)}`
+    const orgId = (await executeSQL(`SELECT id FROM public.orgs ORDER BY created_at LIMIT 1`))[0]?.id as string
+    const versionId = await seedAuditAppVersion(appId, orgId)
+    await clearVersionAudits(versionId)
+
+    await executeSQL(
+      `UPDATE public.app_versions
+       SET deleted = true, deleted_at = now(), updated_at = now()
+       WHERE id = $1`,
+      [versionId],
+    )
+
+    const logs = await executeSQL(
+      `SELECT changed_fields FROM public.audit_logs
+       WHERE table_name = 'app_versions' AND record_id = $1 AND operation = 'UPDATE'
+       ORDER BY id DESC LIMIT 1`,
+      [String(versionId)],
+    )
+    expect(logs).toHaveLength(1)
+    expect(logs[0]?.changed_fields).toContain('deleted')
+
+    await executeSQL(`DELETE FROM public.audit_logs WHERE record_id = $1 AND table_name = 'app_versions'`, [String(versionId)])
+    await executeSQL(`DELETE FROM public.app_versions WHERE id = $1`, [versionId])
+    await executeSQL(`DELETE FROM public.apps WHERE app_id = $1`, [appId])
+  })
+
+  it('null_migrated_app_version_manifests skips partially migrated arrays, async () => {
     const appId = `com.swap.partialmanifest.${randomUUID().slice(0, 8)}`
     const orgRows = await executeSQL(
       `SELECT id FROM public.orgs ORDER BY created_at LIMIT 1`,

--- a/tests/cleanup_swap_memory.test.ts
+++ b/tests/cleanup_swap_memory.test.ts
@@ -301,7 +301,7 @@ describe('swap memory cleanup functions', () => {
     await executeSQL(`DELETE FROM public.apps WHERE app_id = $1`, [appId])
   })
 
-  it('null_migrated_app_version_manifests skips partially migrated arrays, async () => {
+  it('null_migrated_app_version_manifests skips partially migrated arrays', async () => {
     const appId = `com.swap.partialmanifest.${randomUUID().slice(0, 8)}`
     const orgRows = await executeSQL(
       `SELECT id FROM public.orgs ORDER BY created_at LIMIT 1`,


### PR DESCRIPTION
## Summary (AI generated)

- Expand `audit_log_trigger` so `app_versions` UPDATEs that only touch upload/migrate bookkeeping fields are not written to `audit_logs`
- Skipped fields: `manifest`, `manifest_count`, `storage_provider`, `r2_path`, `updated_at`
- Keep soft-delete and real user-facing edits (`comment`, `checksum`, `deleted`, etc.)
- One-shot DELETE of matching historical bookkeeping rows in the migration
- Add coverage in `tests/cleanup_swap_memory.test.ts`

## Motivation (AI generated)

Capgo-EU `audit_logs` toast was dominating Postgres `shared_buffers` (~63% / ~1.3 GB). Live breakdown showed most of the fat was internal pipeline noise (`r2_path`, `storage_provider`, dual-storage `manifest`/`manifest_count` updates), not console user actions. Storing that TOAST for ~800 active users is pure waste and thrash.

## Business Impact (AI generated)

Reduces primary DB memory/disk pressure without changing customer-visible audit for deletes and intentional version edits. Improves stability of Capgo-EU under current compute size.

## Test Plan (AI generated)

- [ ] Migration applies cleanly on local Supabase
- [ ] `bun run supabase:with-env -- bunx vitest run tests/cleanup_swap_memory.test.ts`
- [ ] Confirm soft-delete of a bundle still creates an audit row
- [ ] Confirm `r2_path` / `storage_provider` / dual-storage finalize UPDATEs do not create audit rows
- [ ] Confirm comment/checksum updates still create audit rows

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary audit-log writes by skipping low-value internal bookkeeping and background counter/stat refresh updates.
  * Slimmed stored audit payloads for app version records by omitting large “fat” fields while retaining meaningful change details.
  * Preserved audit logging for important user-facing changes, including soft-deletes.

* **Tests**
  * Added coverage for the new audit skip behaviors (specific internal updates) and ensured soft-deleted app versions continue to be logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->