### PR TITLE
fix(supabase): replace deprecated [inbucket] with [local_smtp]

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2.0.0
         with:
-          version: 2.98.2
+          version: 2.109.1
       - name: Prepare Supabase
         run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -351,7 +351,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2 # v2.0.0
         with:
-          version: 2.84.2
+          version: 2.109.1
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates
       - name: Stop this job's Supabase stack
@@ -465,7 +465,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.84.2
+          version: 2.109.1
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates
       - name: Stop this job's Supabase stack
@@ -549,7 +549,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.84.2
+          version: 2.109.1
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates
       - name: Stop this job's Supabase stack
@@ -662,7 +662,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2 # v2.0.0
         with:
-          version: 2.84.2
+          version: 2.109.1
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates
       - name: Stop this job's Supabase stack
@@ -802,7 +802,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2 # v2.0.0
         with:
-          version: 2.84.2
+          version: 2.109.1
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates
       - id: start_playwright_services
@@ -1226,7 +1226,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2 # v2.0.0
         with:
-          version: 2.84.2
+          version: 2.109.1
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates
       - name: Stop this job's Supabase stack

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.84.2
+          version: 2.109.1
 
       - name: Link Supabase templates
         run: ln -sfn supabase/templates templates

--- a/scripts/supabase-worktree.ts
+++ b/scripts/supabase-worktree.ts
@@ -91,7 +91,7 @@ function rewriteConfigToml(raw: string, cfg: ReturnType<typeof getSupabaseWorktr
     db: ports.db,
     'db.pooler': ports.dbPooler,
     studio: ports.studio,
-    inbucket: ports.inbucket,
+    local_smtp: ports.inbucket,
     analytics: ports.analytics,
   }
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -70,7 +70,7 @@ openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
-[inbucket]
+[local_smtp]
 enabled = false
 # Port to use for the email testing server web interface.
 port = 54324


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Renamed the Supabase local email testing config section from `[inbucket]` to `[local_smtp]` in `supabase/config.toml`
- Updated the worktree config rewriter to rewrite the `local_smtp` port section so worktree-isolated ports keep working
- Bumped GitHub Actions Supabase CLI pins from `2.84.2` / `2.98.2` to `2.109.1` so CI and deploy jobs can parse `[local_smtp]` (matches `package.json`)

## Motivation (AI generated)

The Supabase CLI emits a deprecation warning when `config.toml` still uses `[inbucket]`:
`WARN: config section [inbucket] is deprecated. Please use [local_smtp] instead.`

Updating to the new preferred key removes the warning. Older CLI pins in CI reject `[local_smtp]`, so those must be upgraded together.

## Business Impact (AI generated)

No user-facing product change. Improves local developer experience by clearing a noisy Supabase CLI warning during `supabase start` / worktree setups, and keeps CI compatible with the new config key.

## Test Plan (AI generated)

- [ ] Confirm `supabase/config.toml` contains `[local_smtp]` and no longer contains `[inbucket]`
- [ ] Run `bun run supabase:start` and verify the `[inbucket]` deprecation warning is gone
- [ ] Confirm worktree port rewriting still updates the email testing server `port` under `[local_smtp]`
- [ ] Confirm CI backend/Cloudflare/Playwright jobs that start Supabase succeed with CLI `2.109.1`

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54d0cfa7-5c81-40c0-817c-fcdb48a092b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54d0cfa7-5c81-40c0-817c-fcdb48a092b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Supabase CLI used by deployment, testing, and visual comparison workflows.
* **Bug Fixes**
  * Corrected local email testing configuration so port settings are applied to the appropriate service.
  * Renamed the local email testing configuration section to align with current Supabase settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->