### PR TITLE
fix: types

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -3698,6 +3698,14 @@ export type Database = {
         Returns: undefined
       }
       audit_logs_allowed_orgs: { Args: never; Returns: string[] }
+      billing_period_completed_cycle: {
+        Args: { p_anchor_start: string; p_as_of?: string }
+        Returns: {
+          cycle_end: string
+          cycle_start: string
+          is_anniversary: boolean
+        }[]
+      }
       calculate_credit_cost: {
         Args: {
           p_metric: Database["public"]["Enums"]["credit_metric_type"]
@@ -4195,6 +4203,10 @@ export type Database = {
           total_build_time_unit: number
           total_builds: number
         }[]
+      }
+      get_org_credits_used_in_period: {
+        Args: { p_end: string; p_org_id: string; p_start: string }
+        Returns: number
       }
       get_org_members:
         | {

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -3698,6 +3698,14 @@ export type Database = {
         Returns: undefined
       }
       audit_logs_allowed_orgs: { Args: never; Returns: string[] }
+      billing_period_completed_cycle: {
+        Args: { p_anchor_start: string; p_as_of?: string }
+        Returns: {
+          cycle_end: string
+          cycle_start: string
+          is_anniversary: boolean
+        }[]
+      }
       calculate_credit_cost: {
         Args: {
           p_metric: Database["public"]["Enums"]["credit_metric_type"]
@@ -4195,6 +4203,10 @@ export type Database = {
           total_build_time_unit: number
           total_builds: number
         }[]
+      }
+      get_org_credits_used_in_period: {
+        Args: { p_end: string; p_org_id: string; p_start: string }
+        Returns: number
       }
       get_org_members:
         | {


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

## Test plan

<!-- Include the steps to test your PR -->
<!-- Any PR that requires a complex setup to test MUST include this -->

## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->
<!-- Please include this if CLI/frontend behaviour has changed, can be skipped for backend changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated type-only changes; no logic or schema migrations in the PR.
> 
> **Overview**
> Regenerates **Supabase TypeScript definitions** in `src/types/supabase.types.ts` and `supabase/functions/_backend/utils/supabase.types.ts` so the client matches new database RPCs.
> 
> Adds typings for **`billing_period_completed_cycle`** (anchor start + optional as-of → completed cycle windows with `cycle_start`, `cycle_end`, and `is_anniversary`) and **`get_org_credits_used_in_period`** (org + date range → total credits used as a number). No runtime or call-site changes are in this diff—only the generated `Database["public"]["Functions"]` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aecc429ee2b921445432e8d40d54ce36e2899ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for billing-cycle calculations, including cycle start and end dates and anniversary indicators.
  * Added support for retrieving credit usage totals within a specified billing period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->