### PR TITLE
fix(queue): drop version-queue special-case 30 retries

### DIFF
--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -278,6 +278,8 @@ type ManifestCleanupEntry = {
 /**
  * Trash unreferenced R2 objects first (exist → move to deleted-after-7-days/,
  * missing → ok), then delete that DB row. Never drop DB tracking before R2 is handled.
+ * Per-file work is committed, so a timeout mid-pass is safe to retry. Leftover rows
+ * after the normal retry budget are reclaimed by sweep_deleted_version_manifests.
  * Incomplete work throws so the queue retries; already-trashed paths are idempotent.
  */
 async function deleteManifest(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -26,7 +26,6 @@ const QUEUE_HTTP_TIMEOUT_MS = 15_000
 const VERSION_QUEUE_HTTP_TIMEOUT_MS = 300_000 // large deleted manifests: trash then DB delete
 const HEALTHCHECK_HTTP_TIMEOUT_MS = 8_000
 export const MAX_QUEUE_READS = 5
-const VERSION_QUEUE_MAX_READS = 30 // deleted manifests can need many partial trash/delete passes
 const DISCORD_IGNORED_ERROR_CODES = new Set(['version_not_found', 'no_channel'])
 
 export const messageSchema = z.object({
@@ -281,9 +280,10 @@ function getQueueHttpTimeoutMs(functionName: string): number {
   return QUEUE_HTTP_TIMEOUT_MS
 }
 
-function getQueueMaxReads(queueName: string): number {
-  if (isVersionQueueFunction(queueName))
-    return VERSION_QUEUE_MAX_READS
+function getQueueMaxReads(_queueName: string): number {
+  // Same budget for every queue. Large deleted-manifest cleanup already commits
+  // per file; leftover rows are reclaimed by sweep_deleted_version_manifests.
+  // Do not burn retries as a fake "progress" budget.
   return MAX_QUEUE_READS
 }
 

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -159,8 +159,8 @@ describe('queue_consumer legacy message compatibility', () => {
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('cron_email')).toBe(120)
     expect(__queueConsumerTestUtils__.getQueueVisibilityTimeout('on_version_update')).toBe(900)
     expect(__queueConsumerTestUtils__.getQueueHttpTimeoutMs('on_version_update')).toBe(300_000)
-    expect(__queueConsumerTestUtils__.getQueueMaxReads('on_version_update')).toBe(30)
-    expect(__queueConsumerTestUtils__.getQueueMaxReads('on_manifest_create')).toBe(5)
+    expect(__queueConsumerTestUtils__.getQueueMaxReads('on_version_update')).toBe(MAX_QUEUE_READS)
+    expect(__queueConsumerTestUtils__.getQueueMaxReads('on_manifest_create')).toBe(MAX_QUEUE_READS)
     expect(__queueConsumerTestUtils__.getQueueHttpTimeoutMs('cron_email')).toBe(15_000)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('on_manifest_create')).toBe(false)
     expect(__queueConsumerTestUtils__.shouldRunQueueSyncInBackground('cron_email')).toBe(true)
@@ -237,8 +237,8 @@ describe('queue_consumer legacy message compatibility', () => {
     )).toBe('continue')
   })
 
-  it.concurrent('uses the version queue retry budget for Discord failure alerts', () => {
-    const versionRetryBudget = __queueConsumerTestUtils__.getQueueMaxReads('on_version_update')
+  it.concurrent('uses the shared queue retry budget for Discord failure alerts', () => {
+    const retryBudget = __queueConsumerTestUtils__.getQueueMaxReads('on_version_update')
     const midRetry = {
       cf_id: 'cf-version-mid',
       error_code: 'manifest_cleanup_incomplete',
@@ -246,7 +246,7 @@ describe('queue_consumer legacy message compatibility', () => {
       function_type: 'supabase',
       msg_id: 2,
       payload_size: 10,
-      read_count: MAX_QUEUE_READS,
+      read_count: MAX_QUEUE_READS - 1,
       status: 500,
       status_text: 'Internal Server Error',
     }
@@ -254,12 +254,12 @@ describe('queue_consumer legacy message compatibility', () => {
       ...midRetry,
       cf_id: 'cf-version-done',
       msg_id: 3,
-      read_count: versionRetryBudget,
+      read_count: retryBudget,
     }
 
-    expect(versionRetryBudget).toBe(30)
-    expect(__queueConsumerTestUtils__.getActionableQueueFailures([midRetry], versionRetryBudget)).toEqual([])
-    expect(__queueConsumerTestUtils__.getActionableQueueFailures([exhausted], versionRetryBudget)).toEqual([exhausted])
+    expect(retryBudget).toBe(MAX_QUEUE_READS)
+    expect(__queueConsumerTestUtils__.getActionableQueueFailures([midRetry], retryBudget)).toEqual([])
+    expect(__queueConsumerTestUtils__.getActionableQueueFailures([exhausted], retryBudget)).toEqual([exhausted])
   })
 
   it.concurrent('alerts Discord after retry budget is exhausted', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Remove `VERSION_QUEUE_MAX_READS = 30` from the queue consumer
- Version queues (`on_version_update`, etc.) now use the shared `MAX_QUEUE_READS = 5` budget like every other queue
- Clarify that deleted-manifest cleanup commits per file and leftovers are reclaimed by `sweep_deleted_version_manifests`

## Motivation (AI generated)

#2724 raised version-queue retries to 30 with the claim that large deleted manifests need many “partial trash/delete passes.” That was the wrong model: cleanup already commits per file inside the pass, incomplete/timeout work should not burn a 30-retry failure budget, and the sweeper already re-touches stuck soft-deleted versions. The inflated budget also masked stuck messages from `/queue_health` (`stuck_high_read_ct` > 5 while the consumer still considered them “in budget”).

## Business Impact (AI generated)

Fails bad version-update work sooner (Discord + archive after 5 reads), keeps monitoring aligned with real retry policy, and avoids hiding backlog behind an oversized retry allowance.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/queue-consumer-message-shape.unit.test.ts`
- [ ] Confirm `/queue_health` no longer treats `read_ct` 6–29 on `on_version_update` as healthy while consumer still retries
- [ ] After deploy, watch Discord alerts for exhausted version-queue failures and sweeper reclaim of leftover manifests

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59a5a52e-f296-4b08-a481-9fbfde23388e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59a5a52e-f296-4b08-a481-9fbfde23388e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized queue retry limits across processing flows.
  * Updated failure handling and alerts to trigger only after the shared retry budget is exhausted.
  * Improved queue metadata to reflect the applicable retry limit.

* **Documentation**
  * Clarified that manifest cleanup can safely resume after a timeout, with remaining work handled by a later cleanup pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->