### PR TITLE
fix(admin): compute plan rates against paying orgs

### DIFF
--- a/scripts/backfill_org_conversion_rate_trend.ts
+++ b/scripts/backfill_org_conversion_rate_trend.ts
@@ -1,9 +1,12 @@
 /*
  * Backfill the admin org and plan conversion rate trend metrics.
  *
- * The historical paying counts in public.global_stats are Stripe-backed
- * snapshots written by the admin stats cron. The raw org count was not stored,
- * so this script reconstructs that denominator from public.orgs.created_at.
+ * org_conversion_rate = paying / orgs * 100
+ *   The raw org count was not stored historically, so this script reconstructs
+ *   that denominator from public.orgs.created_at.
+ *
+ * plan_*_conversion_rate = plan_count / paying * 100
+ *   Plan mix among paying orgs (same as the daily admin core shard / LogSnag).
  *
  * Dry run, defaulting to the last 30 UTC calendar days:
  *   bun run stripe:backfill-org-conversion-rate
@@ -95,18 +98,19 @@ export function calculateOrgConversionRate(paying: number | string | null | unde
   return Number(((payingCount * 100) / orgCount).toFixed(1))
 }
 
-function calculatePlanConversionRates(row: GlobalStatsRow, orgs: number): PlanConversionRates {
+function calculatePlanConversionRates(row: GlobalStatsRow, paying: number): PlanConversionRates {
+  // Plan mix among paying orgs — same denominator as the daily admin core shard.
   const total = toMetricNumber(row.plan_solo)
     + toMetricNumber(row.plan_maker)
     + toMetricNumber(row.plan_team)
     + toMetricNumber(row.plan_enterprise)
 
   return {
-    solo: calculateOrgConversionRate(row.plan_solo, orgs),
-    maker: calculateOrgConversionRate(row.plan_maker, orgs),
-    team: calculateOrgConversionRate(row.plan_team, orgs),
-    enterprise: calculateOrgConversionRate(row.plan_enterprise, orgs),
-    total: calculateOrgConversionRate(total, orgs),
+    solo: calculateOrgConversionRate(row.plan_solo, paying),
+    maker: calculateOrgConversionRate(row.plan_maker, paying),
+    team: calculateOrgConversionRate(row.plan_team, paying),
+    enterprise: calculateOrgConversionRate(row.plan_enterprise, paying),
+    total: calculateOrgConversionRate(total, paying),
   }
 }
 
@@ -159,7 +163,7 @@ export function buildOrgConversionRateBackfillRows(rows: GlobalStatsRow[], orgRo
     const currentRate = toMetricNumber(row.org_conversion_rate)
     const nextRate = calculateOrgConversionRate(paying, orgs)
     const currentPlanRates = getCurrentPlanConversionRates(row)
-    const nextPlanRates = calculatePlanConversionRates(row, orgs)
+    const nextPlanRates = calculatePlanConversionRates(row, paying)
     return {
       date_id: row.date_id,
       orgs,

--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -285,7 +285,7 @@ const planConversionSeries = computed(() => {
 
   return [
     {
-      label: 'All Paid Plans (%)',
+      label: 'All Paid Plans (% of paying)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.plan_total_conversion_rate || 0,
@@ -293,7 +293,7 @@ const planConversionSeries = computed(() => {
       color: '#3b82f6', // blue
     },
     {
-      label: 'Solo Conversion (%)',
+      label: 'Solo (% of paying)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.plan_solo_conversion_rate || 0,
@@ -301,7 +301,7 @@ const planConversionSeries = computed(() => {
       color: '#8b5cf6', // purple
     },
     {
-      label: 'Maker Conversion (%)',
+      label: 'Maker (% of paying)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.plan_maker_conversion_rate || 0,
@@ -309,7 +309,7 @@ const planConversionSeries = computed(() => {
       color: '#ec4899', // pink
     },
     {
-      label: 'Team Conversion (%)',
+      label: 'Team (% of paying)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.plan_team_conversion_rate || 0,
@@ -317,7 +317,7 @@ const planConversionSeries = computed(() => {
       color: '#10b981', // green
     },
     {
-      label: 'Enterprise Conversion (%)',
+      label: 'Enterprise (% of paying)',
       data: globalStatsTrendData.value.map(item => ({
         date: item.date,
         value: item.plan_enterprise_conversion_rate || 0,
@@ -1128,7 +1128,7 @@ displayStore.defaultBack = '/dashboard'
 
           <div class="grid grid-cols-1 gap-6">
             <ChartCard
-              title="Paid Plan Conversion Rate"
+              title="Paid Plan Mix (of paying)"
               :is-loading="isLoadingGlobalStatsTrend"
               :has-data="planConversionSeries.length > 0"
             >

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -562,13 +562,14 @@ function getPaidPlanTotal(plans: PlanTotal) {
   return (plans.Solo ?? 0) + (plans.Maker ?? 0) + (plans.Team ?? 0) + (plans.Enterprise ?? 0)
 }
 
-function getPlanConversionRates(plans: PlanTotal, totalOrgs: number): PlanConversionRates {
+function getPlanConversionRates(plans: PlanTotal, payingCount: number): PlanConversionRates {
+  // Plan mix among paying orgs (not all orgs/users). Matches LogSnag insight cards.
   return {
-    solo: calculateConversionRate(plans.Solo, totalOrgs),
-    maker: calculateConversionRate(plans.Maker, totalOrgs),
-    team: calculateConversionRate(plans.Team, totalOrgs),
-    enterprise: calculateConversionRate(plans.Enterprise, totalOrgs),
-    total: calculateConversionRate(getPaidPlanTotal(plans), totalOrgs),
+    solo: calculateConversionRate(plans.Solo, payingCount),
+    maker: calculateConversionRate(plans.Maker, payingCount),
+    team: calculateConversionRate(plans.Team, payingCount),
+    enterprise: calculateConversionRate(plans.Enterprise, payingCount),
+    total: calculateConversionRate(getPaidPlanTotal(plans), payingCount),
   }
 }
 
@@ -2638,7 +2639,8 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
   } = coreSnapshot
   const not_paying = users - customers.total - plans.Trial
   const org_conversion_rate = calculateConversionRate(payingOrgsForConversion, orgs)
-  const planConversionRates = getPlanConversionRates(plans, orgs)
+  // Plan upgrade/mix rates use paying orgs as denominator (not total users/orgs).
+  const planConversionRates = getPlanConversionRates(plans, customers.total)
 
   await updateGlobalStatsSnapshot(c, finalizedAppBuildOnboardingWindow.prevDayDateId, {
     apps_created: finalizedAppBuildOnboardingMetrics.apps_created,
@@ -2778,7 +2780,6 @@ async function runUsageDemoAppsGlobalStatsShard(c: Context, window: DailyWindow)
   await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage demo apps shard', { demo_apps_created: demoAppsCreated }, { demoAppsCreated })
 }
 
-
 function getTrailing12mStart(nextDayStart: Date): Date {
   const year = nextDayStart.getUTCFullYear() - 1
   const month = nextDayStart.getUTCMonth()
@@ -2805,11 +2806,14 @@ async function getUpgradeRate12m(c: Context, nextDayStart: Date): Promise<number
   const trailing12mStartIso = getTrailing12mStart(nextDayStart).toISOString()
 
   try {
+    // Paying denominator matches getBillingSnapshotCounts (plans join + lifecycle filters),
+    // not all orgs/users.
     const result = await drizzleClient.execute(sql`
       SELECT
         (
-          SELECT COUNT(*)::int
+          SELECT COUNT(DISTINCT si.customer_id)::int
           FROM public.stripe_info si
+          INNER JOIN public.plans p ON p.stripe_id = si.product_id
           WHERE si.is_good_plan = true
             AND si.created_at < ${snapshotEndIso}::timestamptz
             AND (
@@ -3323,6 +3327,8 @@ export const logsnagInsightsTestUtils = {
   calculateChurnRevenue,
   calculateConversionRate,
   calculateNrr,
+  getPlanConversionRates,
+  getPaidPlanTotal,
   getUpgradeRate12m,
   getTrailing12mStart,
   countUniqueCustomers,

--- a/supabase/migrations/20260727052012_fix_plan_conversion_paying_denominator.sql
+++ b/supabase/migrations/20260727052012_fix_plan_conversion_paying_denominator.sql
@@ -1,0 +1,21 @@
+-- Plan conversion rates are a mix among paying orgs (plan_x / paying),
+-- not a conversion against all orgs/users. Keep org_conversion_rate as
+-- paying / orgs. Align upgrade_rate_12m comment with the paying denominator.
+
+COMMENT ON COLUMN public.global_stats.plan_solo_conversion_rate
+  IS 'Percentage of paying organizations on the Solo plan (plan_solo / paying * 100)';
+
+COMMENT ON COLUMN public.global_stats.plan_maker_conversion_rate
+  IS 'Percentage of paying organizations on the Maker plan (plan_maker / paying * 100)';
+
+COMMENT ON COLUMN public.global_stats.plan_team_conversion_rate
+  IS 'Percentage of paying organizations on the Team plan (plan_team / paying * 100)';
+
+COMMENT ON COLUMN public.global_stats.plan_enterprise_conversion_rate
+  IS 'Percentage of paying organizations on the Enterprise plan (plan_enterprise / paying * 100)';
+
+COMMENT ON COLUMN public.global_stats.plan_total_conversion_rate
+  IS 'Percentage of paying organizations on any paid plan ((plan_solo + plan_maker + plan_team + plan_enterprise) / paying * 100)';
+
+COMMENT ON COLUMN public.global_stats.upgrade_rate_12m
+  IS 'Trailing 12-month paying-to-larger-plan upgrade events as a percentage of paying organizations (upgrade events in-window / paying * 100).';

--- a/tests/admin-stripe-backfill-scripts.unit.test.ts
+++ b/tests/admin-stripe-backfill-scripts.unit.test.ts
@@ -95,12 +95,13 @@ describe('admin Stripe backfill scripts', () => {
           total: 0,
         },
         current_rate: 0,
+        // Plan rates use paying denominator: 10/25, 15/25, 25/25
         next_plan_rates: {
           enterprise: 0,
-          maker: 5,
-          solo: 7.5,
+          maker: 40,
+          solo: 60,
           team: 0,
-          total: 12.5,
+          total: 100,
         },
         next_rate: 12.5,
         changed: true,
@@ -119,13 +120,13 @@ describe('admin Stripe backfill scripts', () => {
         current_rate: 25,
         next_plan_rates: {
           enterprise: 0,
-          maker: 10,
-          solo: 15,
+          maker: 40,
+          solo: 60,
           team: 0,
-          total: 25,
+          total: 100,
         },
         next_rate: 25,
-        changed: false,
+        changed: true,
       },
     ])
   })
@@ -161,12 +162,13 @@ describe('admin Stripe backfill scripts', () => {
           total: 19.5,
         },
         current_rate: 20,
+        // Plan rates use paying: 10/40=25, 30/40=75, 40/40=100
         next_plan_rates: {
           enterprise: 0,
-          maker: 5,
-          solo: 15,
+          maker: 25,
+          solo: 75,
           team: 0,
-          total: 20,
+          total: 100,
         },
         next_rate: 20,
         changed: true,

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -51,10 +51,24 @@ describe('logsnag revenue metric helpers', () => {
     )).toBe(1)
   })
 
-
   it.concurrent('clamps trailing 12-month start for leap-day ends', () => {
     const start = logsnagInsightsTestUtils.getTrailing12mStart(new Date('2024-02-29T00:00:00.000Z'))
     expect(start.toISOString()).toBe('2023-02-28T00:00:00.000Z')
+  })
+
+  it.concurrent('computes plan conversion rates against paying orgs, not all users/orgs', () => {
+    const rates = logsnagInsightsTestUtils.getPlanConversionRates(
+      { Solo: 15, Maker: 10, Team: 0, Enterprise: 0, Trial: 50 },
+      25,
+    )
+    expect(rates).toEqual({
+      solo: 60,
+      maker: 40,
+      team: 0,
+      enterprise: 0,
+      total: 100,
+    })
+    expect(logsnagInsightsTestUtils.calculateConversionRate(15, 200)).toBe(7.5)
   })
 
   it.concurrent('builds UTC calendar-day bounds', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Daily admin `plan_*_conversion_rate` metrics now use **paying** orgs as the denominator instead of all orgs/users
- Org conversion rate stays `paying / orgs`
- Align `upgrade_rate_12m` paying count with billing snapshot filters (`plans` join + distinct customers)
- Update backfill script, admin chart labels, and DB column comments

## Motivation (AI generated)

The daily admin plan mix / upgrade-related rates were calculated against the full org/user base, which made plan shares look artificially low compared to paying customers. LogSnag cards already showed plan mix over paying; stored `global_stats` and the revenue chart did not.

## Business Impact (AI generated)

Admin revenue dashboards now show accurate paid-plan mix and upgrade-rate denominators against paying organizations, so plan distribution and upgrade health are not diluted by free/trial volume.

## Test Plan (AI generated)

- [x] Unit tests: `tests/admin-stripe-backfill-scripts.unit.test.ts`
- [x] Unit tests: `tests/logsnag-insights-revenue.unit.test.ts` (new paying-denominator assertion)
- [x] Unit tests: `tests/backfill-upgrade-rate-12m.unit.test.ts`
- [ ] After merge: run `bun run stripe:backfill-org-conversion-rate --apply --all` to repair historical `plan_*_conversion_rate` rows
- [ ] After merge: optionally re-run `bun run stripe:backfill-upgrade-rate-12m --apply --all` if historical upgrade rates still look off

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa200-27e2-7d2a-8751-a657f9514080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa200-27e2-7d2a-8751-a657f9514080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

