### PR TITLE
fix(manifest): stop chr(0) advisory lock flooding Postgres 54000

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/manifest_encoding.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/manifest_encoding.ts
@@ -14,10 +14,16 @@ export function decodeManifestPathSegments(path: string): string | null {
 }
 
 function isSafeManifestPath(path: string): boolean {
-  if (!path || path.startsWith('/') || path.includes('\\'))
+  // Postgres text/varchar cannot store U+0000; reject before decode/persist.
+  if (!path || path.startsWith('/') || path.includes('\\') || path.includes('\0'))
     return false
 
   return path.split('/').every(segment => segment !== '' && segment !== '.' && segment !== '..')
+}
+
+/** True when a string is safe to store in Postgres text/varchar columns. */
+export function isPostgresSafeText(value: string): boolean {
+  return value.length > 0 && !value.includes('\0')
 }
 
 export function normalizeLegacyEncodedManifestFileName(fileName: string | null | undefined, s3Path: string | null | undefined): string | null {

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -313,8 +313,9 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
         try {
           await entryPg.query('BEGIN')
           // Serialize shared-hash cleanup across concurrent deleted versions.
+          // Do NOT use chr(0) as a separator — Postgres raises 54000 "null character not permitted".
           await entryPg.query(
-            `SELECT pg_advisory_xact_lock(hashtextextended($1 || chr(0) || $2, 0))`,
+            `SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))`,
             [entry.file_hash, entry.file_name],
           )
 

--- a/supabase/functions/_backend/utils/manifest_encoding.ts
+++ b/supabase/functions/_backend/utils/manifest_encoding.ts
@@ -14,10 +14,16 @@ export function decodeManifestPathSegments(path: string): string | null {
 }
 
 function isSafeManifestPath(path: string): boolean {
-  if (!path || path.startsWith('/') || path.includes('\\'))
+  // Postgres text/varchar cannot store U+0000; reject before decode/persist.
+  if (!path || path.startsWith('/') || path.includes('\\') || path.includes('\0'))
     return false
 
   return path.split('/').every(segment => segment !== '' && segment !== '.' && segment !== '..')
+}
+
+/** True when a string is safe to store in Postgres text/varchar columns. */
+export function isPostgresSafeText(value: string): boolean {
+  return value.length > 0 && !value.includes('\0')
 }
 
 export function normalizeLegacyEncodedManifestFileName(fileName: string | null | undefined, s3Path: string | null | undefined): string | null {

--- a/supabase/functions/_backend/utils/manifest_persist.ts
+++ b/supabase/functions/_backend/utils/manifest_persist.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import { cloudlog } from './logging.ts'
-import { normalizeLegacyEncodedManifestFileName } from './manifest_encoding.ts'
+import { isPostgresSafeText, normalizeLegacyEncodedManifestFileName } from './manifest_encoding.ts'
 import { closeClient, getPgClient } from './pg.ts'
 import { supabaseAdmin } from './supabase.ts'
 
@@ -33,6 +33,12 @@ export function buildTrustedManifestRows(
       // Never trust client-provided sizes; on_manifest_create fills these from R2.
       file_size: 0,
     }))
+    // Drop rows that would raise Postgres 54000 "null character not permitted".
+    .filter(entry =>
+      isPostgresSafeText(entry.file_name)
+      && isPostgresSafeText(entry.file_hash)
+      && isPostgresSafeText(entry.s3_path),
+    )
 }
 
 async function clearLegacyAppVersionManifest(c: Context, versionId: number) {

--- a/tests/manifest-path-encoding.unit.test.ts
+++ b/tests/manifest-path-encoding.unit.test.ts
@@ -55,6 +55,15 @@ describe('manifest path encoding', () => {
     )).toBe('assets/suite-marketing/images/social-media/sad_post_grey%402x.png')
   })
 
+  it.concurrent('does not decode legacy %00 into a Postgres-illegal null character', () => {
+    // Keep the encoded form rather than decoding to U+0000 (PG text rejects that).
+    expect(normalizeLegacyEncodedManifestFileName(
+      'assets/bad%00.js',
+      'orgs/org-id/apps/com.test.app/delta/hash_assets/bad%00.js',
+    )).toBe('assets/bad%00.js')
+  })
+
+
   it.concurrent('checks legacy percent, decoded, and upload-location encoded storage keys', () => {
     expect(getManifestStorageCandidateKeys(
       'orgs/org-id/apps/com.test.app/delta/hash_assets/suite-marketing/images/social-media/sad_post_grey%402x.png',

--- a/tests/manifest-persist.unit.test.ts
+++ b/tests/manifest-persist.unit.test.ts
@@ -60,4 +60,44 @@ describe('buildTrustedManifestRows', () => {
     expect(rows[0]?.file_name).toBe('assets/img/sad_post_grey@2x.png')
     expect(rows[0]?.file_size).toBe(0)
   })
+
+  it.concurrent('keeps legacy %00 encoded names but drops raw null bytes', () => {
+    const rows = buildTrustedManifestRows(11, [
+      {
+        file_name: 'ok.js',
+        s3_path: 'orgs/org/apps/com.app/delta/h_ok.js',
+        file_hash: 'okhash',
+      },
+      {
+        // Decode would yield U+0000 — keep the encoded form (Postgres-safe).
+        file_name: 'bad%00.js',
+        s3_path: 'orgs/org/apps/com.app/delta/h_bad%00.js',
+        file_hash: 'badhash',
+      },
+      {
+        file_name: 'raw\0null.js',
+        s3_path: 'orgs/org/apps/com.app/delta/h_raw.js',
+        file_hash: 'rawhash',
+      },
+    ], 'orgs/org/apps/com.app/')
+
+    expect(rows).toEqual([
+      {
+        app_version_id: 11,
+        file_name: 'ok.js',
+        s3_path: 'orgs/org/apps/com.app/delta/h_ok.js',
+        file_hash: 'okhash',
+        file_size: 0,
+      },
+      {
+        app_version_id: 11,
+        file_name: 'bad%00.js',
+        s3_path: 'orgs/org/apps/com.app/delta/h_bad%00.js',
+        file_hash: 'badhash',
+        file_size: 0,
+      },
+    ])
+  })
 })
+
+

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -191,6 +191,10 @@ describe('on_version_update deleted version cleanup', () => {
     expect(callOrder.indexOf('r2_trash')).toBeGreaterThan(callOrder.indexOf('lock'))
     expect(callOrder.indexOf('db_delete_row:1000')).toBeGreaterThan(callOrder.indexOf('r2_trash'))
     expect(pgQuery).toHaveBeenCalledWith(expect.stringContaining('WITH prev AS'), expect.any(Array))
+    // Postgres rejects chr(0) with 54000 "null character not permitted".
+    const lockSql = pgQuery.mock.calls.find(([sql]) => typeof sql === 'string' && sql.includes('pg_advisory_xact_lock'))?.[0] as string
+    expect(lockSql).toContain('hashtext($1::text), hashtext($2::text)')
+    expect(lockSql).not.toContain('chr(0)')
   })
 
   it('does not delete DB rows when R2 trash fails', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Deleted-version cleanup used `hashtextextended($1 || chr(0) || $2)` for an advisory lock
- Postgres rejects `chr(0)` with **54000 `null character not permitted`** — every deleted version with manifest rows flooded PG logs / retries
- Switch to `pg_advisory_xact_lock(hashtext($1), hashtext($2))`
- Harden legacy manifest filename normalize/persist so `%00` is not decoded into U+0000, and raw null bytes are dropped before insert

## Motivation (AI generated)

Production Postgres logs showed bursts of identical `54000 null character not permitted` at the same timestamp. Root cause is not old-CLI upload itself: it is the deleted-manifest cleanup path from #2724 calling `chr(0)`. Separately, legacy percent-decoding could theoretically introduce U+0000 into `file_name` on persist; that is now rejected/kept encoded.

## Business Impact (AI generated)

Stops cleanup-job error floods and queue retry storms when soft-deleted versions still have `manifest` rows. Keeps old CLI jsonb → `public.manifest` migration working, and prevents illegal text from reaching Postgres.

## Test Plan (AI generated)

- [x] Unit: cleanup lock SQL uses `hashtext` pair and not `chr(0)`
- [x] Unit: `%00` stays encoded; raw `\0` rows are dropped
- [x] `vitest` for cleanup / persist / encoding suites
- [ ] CI green
- [ ] After deploy: confirm 54000 flood stops on deleted-version cleanup

## Old CLI (AI generated)

Yes — old CLI still works: it writes `app_versions.manifest`, `on_version_update` → `handleManifest` → `persistVersionManifestEntries`. The 54000 flood was from **delete cleanup**, not from that upload path.

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43979b6b-5a1c-4386-80bb-2e23a033d719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43979b6b-5a1c-4386-80bb-2e23a033d719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid null characters from entering manifest paths and persisted metadata.
  * Preserved safely encoded `%00` values while filtering raw null bytes.
  * Improved cleanup locking to avoid database errors during concurrent version deletions.

* **Tests**
  * Added coverage for null-byte handling, manifest persistence, and cleanup lock queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->