### PR TITLE
fix(dashboard): read Native Observe stats from Analytics Engine

### DIFF
--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -318,6 +318,20 @@ function percentileCont(sorted: number[], q: number): number | null {
   return sorted[lower]! * (1 - weight) + sorted[upper]! * weight
 }
 
+// Cap duration samples kept for percentiles so one busy app cannot pin unbounded arrays.
+const MAX_DURATION_SAMPLES = 10_000
+
+function pushDurationSample(target: number[], value: number) {
+  if (target.length < MAX_DURATION_SAMPLES) {
+    target.push(value)
+    return
+  }
+  // Reservoir sample so later days still influence percentiles.
+  const index = Math.floor(Math.random() * (target.length + 1))
+  if (index < target.length)
+    target[index] = value
+}
+
 function metricFromDurations(durations: number[]): Pick<NativeObserveMetricRow, 'p50_ms' | 'p90_ms' | 'p99_ms'> {
   const sorted = [...durations].sort((a, b) => a - b)
   return {
@@ -390,23 +404,23 @@ function foldNativeObserveSamples(state: NativeObserveAggregateState, samples: N
     if (sample.action === 'app_launch_timeout')
       state.launchTimeoutCount += 1
     if (sample.action === launchReadyAction && sample.duration_ms !== null)
-      state.launchDurations.push(sample.duration_ms)
+      pushDurationSample(state.launchDurations, sample.duration_ms)
     if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
-      state.webviewDurations.push(sample.duration_ms)
+      pushDurationSample(state.webviewDurations, sample.duration_ms)
 
     const dailyKey = `${sample.day}\0${sample.action}`
     const daily = state.dailyMap.get(dailyKey) ?? { events: 0, devices: new Set<string>(), durations: [] }
     daily.events += 1
     daily.devices.add(sample.device_id)
     if (sample.duration_ms !== null)
-      daily.durations.push(sample.duration_ms)
+      pushDurationSample(daily.durations, sample.duration_ms)
     state.dailyMap.set(dailyKey, daily)
 
     const action = state.actionMap.get(sample.action) ?? { events: 0, devices: new Set<string>(), durations: [] }
     action.events += 1
     action.devices.add(sample.device_id)
     if (sample.duration_ms !== null)
-      action.durations.push(sample.duration_ms)
+      pushDurationSample(action.durations, sample.duration_ms)
     state.actionMap.set(sample.action, action)
 
     const version = state.versionMap.get(sample.version_name) ?? {
@@ -424,9 +438,9 @@ function foldNativeObserveSamples(state: NativeObserveAggregateState, samples: N
       version.issueDevices.add(sample.device_id)
     }
     if (sample.action === launchReadyAction && sample.duration_ms !== null)
-      version.launchDurations.push(sample.duration_ms)
+      pushDurationSample(version.launchDurations, sample.duration_ms)
     if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
-      version.webviewDurations.push(sample.duration_ms)
+      pushDurationSample(version.webviewDurations, sample.duration_ms)
     state.versionMap.set(sample.version_name, version)
   }
 }
@@ -649,6 +663,8 @@ async function readReleaseMarkers(
   }
 }
 
+const MAX_NATIVE_OBSERVE_EVENTS = 100_000
+
 async function foldNativeObserveTimingEventsCFChunked(
   c: Context<MiddlewareKeyVariables>,
   appId: string,
@@ -660,7 +676,7 @@ async function foldNativeObserveTimingEventsCFChunked(
   let cursor = start.utc().startOf('day')
   const end = endExclusive.utc()
 
-  while (cursor.isBefore(end)) {
+  while (cursor.isBefore(end) && state.events < MAX_NATIVE_OBSERVE_EVENTS) {
     const next = cursor.add(1, 'day')
     const chunkEnd = next.isBefore(end) ? next : end
     const chunk = await readUpdateDeliveryTimingEventsCF(c, {
@@ -668,6 +684,7 @@ async function foldNativeObserveTimingEventsCFChunked(
       end_date: chunkEnd.toISOString(),
       actions: [...nativeObserveActions],
       app_ids: [appId],
+      limit: Math.min(50_000, MAX_NATIVE_OBSERVE_EVENTS - state.events),
     })
     foldNativeObserveSamples(state, toNativeObserveEventSamples(chunk))
     cursor = next
@@ -789,13 +806,11 @@ async function readNativeObservePluginStatsSB(c: Context<MiddlewareKeyVariables>
 }
 
 async function readNativeObservePluginStatsCF(c: Context<MiddlewareKeyVariables>, appId: string) {
-  const rows = await readNativeObservePluginVersionsCF(c, appId)
-  // Sum every version before slicing top 12 so shares match Postgres window total.
-  const totalDevices = rows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
-  return buildNativeObservePluginResponse(rows.slice(0, 12).map(row => ({
+  const { rows, total_devices } = await readNativeObservePluginVersionsCF(c, appId)
+  return buildNativeObservePluginResponse(rows.map(row => ({
     plugin_version: row.plugin_version,
     devices: row.devices,
-    total_devices: totalDevices,
+    total_devices,
   })))
 }
 

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -322,14 +322,9 @@ function percentileCont(sorted: number[], q: number): number | null {
 const MAX_DURATION_SAMPLES = 10_000
 
 function pushDurationSample(target: number[], value: number) {
-  if (target.length < MAX_DURATION_SAMPLES) {
+  // Keep the first N samples only (deterministic; matches a stable Postgres-like refresh).
+  if (target.length < MAX_DURATION_SAMPLES)
     target.push(value)
-    return
-  }
-  // Reservoir sample so later days still influence percentiles.
-  const index = Math.floor(Math.random() * (target.length + 1))
-  if (index < target.length)
-    target[index] = value
 }
 
 function metricFromDurations(durations: number[]): Pick<NativeObserveMetricRow, 'p50_ms' | 'p90_ms' | 'p99_ms'> {
@@ -680,7 +675,7 @@ async function foldNativeObserveTimingEventsCFChunked(
   endExclusive: Dayjs,
   state: NativeObserveAggregateState,
 ) {
-  // Build UTC day windows, then fetch with bounded concurrency and fold as batches complete.
+  // Build UTC day windows newest-first so an event cap truncates older days, not recent ones.
   const windows: Array<{ start: string, end: string }> = []
   let cursor = start.utc().startOf('day')
   const end = endExclusive.utc()
@@ -690,6 +685,7 @@ async function foldNativeObserveTimingEventsCFChunked(
     windows.push({ start: cursor.toISOString(), end: chunkEnd.toISOString() })
     cursor = next
   }
+  windows.reverse()
 
   for (let i = 0; i < windows.length && state.events < MAX_NATIVE_OBSERVE_EVENTS; i += NATIVE_OBSERVE_CHUNK_CONCURRENCY) {
     const batch = windows.slice(i, i + NATIVE_OBSERVE_CHUNK_CONCURRENCY)

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -388,55 +388,67 @@ function createNativeObserveAggregateState(): NativeObserveAggregateState {
   }
 }
 
+type NativeObserveMetricBucket = { events: number, devices: Set<string>, durations: number[] }
+function bumpMetricBucket(
+  map: Map<string, NativeObserveMetricBucket>,
+  key: string,
+  deviceId: string,
+  durationMs: number | null,
+) {
+  const bucket = map.get(key) ?? { events: 0, devices: new Set<string>(), durations: [] }
+  bucket.events += 1
+  bucket.devices.add(deviceId)
+  if (durationMs !== null)
+    pushDurationSample(bucket.durations, durationMs)
+  map.set(key, bucket)
+}
+
+function pushTimedActionDuration(action: string, durationMs: number | null, launch: number[], webview: number[]) {
+  if (durationMs === null)
+    return
+  if (action === launchReadyAction)
+    pushDurationSample(launch, durationMs)
+  else if (action === webviewPageLoadedAction)
+    pushDurationSample(webview, durationMs)
+}
+
+function foldOverviewCounters(state: NativeObserveAggregateState, sample: NativeObserveEventSample) {
+  state.events += 1
+  state.allDevices.add(sample.device_id)
+  if (issueActionSet.has(sample.action)) {
+    state.issueCount += 1
+    state.issueDevices.add(sample.device_id)
+  }
+  if (sample.action === 'app_launch_timeout')
+    state.launchTimeoutCount += 1
+  pushTimedActionDuration(sample.action, sample.duration_ms, state.launchDurations, state.webviewDurations)
+}
+
+function foldVersionBucket(state: NativeObserveAggregateState, sample: NativeObserveEventSample) {
+  const version = state.versionMap.get(sample.version_name) ?? {
+    devices: new Set<string>(),
+    issueDevices: new Set<string>(),
+    events: 0,
+    issueCount: 0,
+    launchDurations: [],
+    webviewDurations: [],
+  }
+  version.events += 1
+  version.devices.add(sample.device_id)
+  if (issueActionSet.has(sample.action)) {
+    version.issueCount += 1
+    version.issueDevices.add(sample.device_id)
+  }
+  pushTimedActionDuration(sample.action, sample.duration_ms, version.launchDurations, version.webviewDurations)
+  state.versionMap.set(sample.version_name, version)
+}
+
 function foldNativeObserveSamples(state: NativeObserveAggregateState, samples: NativeObserveEventSample[]) {
   for (const sample of samples) {
-    state.events += 1
-    state.allDevices.add(sample.device_id)
-    if (issueActionSet.has(sample.action)) {
-      state.issueCount += 1
-      state.issueDevices.add(sample.device_id)
-    }
-    if (sample.action === 'app_launch_timeout')
-      state.launchTimeoutCount += 1
-    if (sample.action === launchReadyAction && sample.duration_ms !== null)
-      pushDurationSample(state.launchDurations, sample.duration_ms)
-    if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
-      pushDurationSample(state.webviewDurations, sample.duration_ms)
-
-    const dailyKey = `${sample.day}\0${sample.action}`
-    const daily = state.dailyMap.get(dailyKey) ?? { events: 0, devices: new Set<string>(), durations: [] }
-    daily.events += 1
-    daily.devices.add(sample.device_id)
-    if (sample.duration_ms !== null)
-      pushDurationSample(daily.durations, sample.duration_ms)
-    state.dailyMap.set(dailyKey, daily)
-
-    const action = state.actionMap.get(sample.action) ?? { events: 0, devices: new Set<string>(), durations: [] }
-    action.events += 1
-    action.devices.add(sample.device_id)
-    if (sample.duration_ms !== null)
-      pushDurationSample(action.durations, sample.duration_ms)
-    state.actionMap.set(sample.action, action)
-
-    const version = state.versionMap.get(sample.version_name) ?? {
-      devices: new Set<string>(),
-      issueDevices: new Set<string>(),
-      events: 0,
-      issueCount: 0,
-      launchDurations: [],
-      webviewDurations: [],
-    }
-    version.events += 1
-    version.devices.add(sample.device_id)
-    if (issueActionSet.has(sample.action)) {
-      version.issueCount += 1
-      version.issueDevices.add(sample.device_id)
-    }
-    if (sample.action === launchReadyAction && sample.duration_ms !== null)
-      pushDurationSample(version.launchDurations, sample.duration_ms)
-    if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
-      pushDurationSample(version.webviewDurations, sample.duration_ms)
-    state.versionMap.set(sample.version_name, version)
+    foldOverviewCounters(state, sample)
+    bumpMetricBucket(state.dailyMap, `${sample.day}\0${sample.action}`, sample.device_id, sample.duration_ms)
+    bumpMetricBucket(state.actionMap, sample.action, sample.device_id, sample.duration_ms)
+    foldVersionBucket(state, sample)
   }
 }
 

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -1,8 +1,11 @@
 import type { Context } from 'hono'
+import type { Dayjs } from 'dayjs'
+import type { UpdateDeliveryTimingEventCF } from '../utils/cloudflare.ts'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import { Hono } from 'hono/tiny'
+import { readNativeObservePluginVersionsCF, readUpdateDeliveryTimingEventsCF } from '../utils/cloudflare.ts'
 import { parseBody, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog } from '../utils/logging.ts'
@@ -63,6 +66,14 @@ interface NativeObserveReleaseMarker {
   version_name: string
   channel_name: string
   deployed_at: string
+}
+
+interface NativeObserveEventSample {
+  day: string
+  action: string
+  version_name: string
+  device_id: string
+  duration_ms: number | null
 }
 
 type NativeObserveNumericValue = number | string | null | undefined
@@ -276,6 +287,198 @@ function setMetric(series: Array<number | null>, index: number, value: NativeObs
     series[index] = metric
 }
 
+function parseMetaDurationMs(metadata: Record<string, string> | null | undefined): number | null {
+  if (!metadata)
+    return null
+  for (const key of ['duration_ms', 'duration'] as const) {
+    const raw = metadata[key]
+    if (typeof raw !== 'string' || raw.length === 0 || raw.length > 15)
+      continue
+    if (!/^\d+(?:\.\d+)?$/.test(raw))
+      continue
+    const value = Number(raw)
+    if (!Number.isFinite(value))
+      continue
+    return value
+  }
+  return null
+}
+
+function percentileCont(sorted: number[], q: number): number | null {
+  if (!sorted.length)
+    return null
+  if (sorted.length === 1)
+    return sorted[0]!
+  const index = (sorted.length - 1) * q
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+  if (lower === upper)
+    return sorted[lower]!
+  const weight = index - lower
+  return sorted[lower]! * (1 - weight) + sorted[upper]! * weight
+}
+
+function metricFromDurations(durations: number[]): Pick<NativeObserveMetricRow, 'p50_ms' | 'p90_ms' | 'p99_ms'> {
+  const sorted = [...durations].sort((a, b) => a - b)
+  return {
+    p50_ms: percentileCont(sorted, 0.5),
+    p90_ms: percentileCont(sorted, 0.9),
+    p99_ms: percentileCont(sorted, 0.99),
+  }
+}
+
+function toNativeObserveEventSamples(events: UpdateDeliveryTimingEventCF[]): NativeObserveEventSample[] {
+  const samples: NativeObserveEventSample[] = []
+  for (const event of events) {
+    const createdAtMs = Date.parse(event.created_at)
+    if (!Number.isFinite(createdAtMs))
+      continue
+    samples.push({
+      day: new Date(createdAtMs).toISOString().slice(0, 10),
+      action: event.action,
+      version_name: event.version_name || 'unknown',
+      device_id: event.device_id,
+      duration_ms: parseMetaDurationMs(event.metadata),
+    })
+  }
+  return samples
+}
+
+function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]): {
+  dailyRows: NativeObserveMetricRow[]
+  actionRows: NativeObserveMetricRow[]
+  versionRows: NativeObserveVersionRow[]
+  overviewRow: NativeObserveOverviewRow
+} {
+  const dailyMap = new Map<string, { events: number, devices: Set<string>, durations: number[] }>()
+  const actionMap = new Map<string, { events: number, devices: Set<string>, durations: number[] }>()
+  const versionMap = new Map<string, {
+    devices: Set<string>
+    issueDevices: Set<string>
+    events: number
+    issueCount: number
+    launchDurations: number[]
+    webviewDurations: number[]
+  }>()
+
+  const allDevices = new Set<string>()
+  const issueDevices = new Set<string>()
+  let issueCount = 0
+  let launchTimeoutCount = 0
+  const launchDurations: number[] = []
+  const webviewDurations: number[] = []
+
+  for (const sample of samples) {
+    allDevices.add(sample.device_id)
+    if (issueActionSet.has(sample.action)) {
+      issueCount += 1
+      issueDevices.add(sample.device_id)
+    }
+    if (sample.action === 'app_launch_timeout')
+      launchTimeoutCount += 1
+    if (sample.action === launchReadyAction && sample.duration_ms !== null)
+      launchDurations.push(sample.duration_ms)
+    if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
+      webviewDurations.push(sample.duration_ms)
+
+    const dailyKey = `${sample.day}\0${sample.action}`
+    const daily = dailyMap.get(dailyKey) ?? { events: 0, devices: new Set<string>(), durations: [] }
+    daily.events += 1
+    daily.devices.add(sample.device_id)
+    if (sample.duration_ms !== null)
+      daily.durations.push(sample.duration_ms)
+    dailyMap.set(dailyKey, daily)
+
+    const action = actionMap.get(sample.action) ?? { events: 0, devices: new Set<string>(), durations: [] }
+    action.events += 1
+    action.devices.add(sample.device_id)
+    if (sample.duration_ms !== null)
+      action.durations.push(sample.duration_ms)
+    actionMap.set(sample.action, action)
+
+    const version = versionMap.get(sample.version_name) ?? {
+      devices: new Set<string>(),
+      issueDevices: new Set<string>(),
+      events: 0,
+      issueCount: 0,
+      launchDurations: [],
+      webviewDurations: [],
+    }
+    version.events += 1
+    version.devices.add(sample.device_id)
+    if (issueActionSet.has(sample.action)) {
+      version.issueCount += 1
+      version.issueDevices.add(sample.device_id)
+    }
+    if (sample.action === launchReadyAction && sample.duration_ms !== null)
+      version.launchDurations.push(sample.duration_ms)
+    if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
+      version.webviewDurations.push(sample.duration_ms)
+    versionMap.set(sample.version_name, version)
+  }
+
+  const dailyRows: NativeObserveMetricRow[] = [...dailyMap.entries()]
+    .map(([key, value]) => {
+      const [day, action] = key.split('\0')
+      return {
+        day,
+        action: action!,
+        events: value.events,
+        devices: value.devices.size,
+        ...metricFromDurations(value.durations),
+      }
+    })
+    .sort((a, b) => {
+      const dayCmp = (a.day ?? '').localeCompare(b.day ?? '')
+      return dayCmp !== 0 ? dayCmp : a.action.localeCompare(b.action)
+    })
+
+  const actionRows: NativeObserveMetricRow[] = [...actionMap.entries()]
+    .map(([action, value]) => ({
+      action,
+      events: value.events,
+      devices: value.devices.size,
+      ...metricFromDurations(value.durations),
+    }))
+    .sort((a, b) => {
+      const eventCmp = toCount(b.events) - toCount(a.events)
+      return eventCmp !== 0 ? eventCmp : a.action.localeCompare(b.action)
+    })
+
+  const versionRows: NativeObserveVersionRow[] = [...versionMap.entries()]
+    .map(([version_name, value]) => ({
+      version_name,
+      events: value.events,
+      devices: value.devices.size,
+      issue_count: value.issueCount,
+      affected_devices: value.issueDevices.size,
+      launch_p90_ms: percentileCont([...value.launchDurations].sort((a, b) => a - b), 0.9),
+      webview_load_p90_ms: percentileCont([...value.webviewDurations].sort((a, b) => a - b), 0.9),
+    }))
+    .sort((a, b) => {
+      const eventCmp = toCount(b.events) - toCount(a.events)
+      return eventCmp !== 0 ? eventCmp : a.version_name.localeCompare(b.version_name)
+    })
+    .slice(0, 12)
+
+  return {
+    dailyRows,
+    actionRows,
+    versionRows,
+    overviewRow: {
+      events: samples.length,
+      devices: allDevices.size,
+      issue_count: issueCount,
+      affected_devices: issueDevices.size,
+      launch_timeout_count: launchTimeoutCount,
+      launch_p50_ms: percentileCont([...launchDurations].sort((a, b) => a - b), 0.5),
+      launch_p90_ms: percentileCont([...launchDurations].sort((a, b) => a - b), 0.9),
+      webview_load_p50_ms: percentileCont([...webviewDurations].sort((a, b) => a - b), 0.5),
+      webview_load_p90_ms: percentileCont([...webviewDurations].sort((a, b) => a - b), 0.9),
+    },
+  }
+}
+
 function buildNativeObserveResponse(input: BuildNativeObserveResponseInput) {
   const labelIndex = new Map(input.labels.map((label, index) => [label, index]))
   const totalEvents = createSeries(input.labels.length)
@@ -396,11 +599,64 @@ function buildNativeObservePluginResponse(pluginVersionRows: NativeObservePlugin
   }
 }
 
-async function readNativeObserveStats(c: Context<MiddlewareKeyVariables>, appId: string, days: NativeObservePeriodDays) {
-  const endExclusive = dayjs().utc().add(1, 'day').startOf('day')
-  const start = endExclusive.subtract(days, 'day')
-  const endInclusive = endExclusive.subtract(1, 'millisecond')
-  const labels = generateDateLabels(start.toDate(), endExclusive.subtract(1, 'day').toDate())
+async function readReleaseMarkers(
+  c: Context<MiddlewareKeyVariables>,
+  appId: string,
+  start: Dayjs,
+  endExclusive: Dayjs,
+) {
+  const db = getPgClient(c, true)
+  try {
+    const result = await db.query<NativeObserveReleaseMarker>(
+      releaseMarkersQuery,
+      [appId, start.toISOString(), endExclusive.toISOString()],
+    )
+    return result.rows
+  }
+  catch (error) {
+    logPgError(c, 'readNativeObserveReleaseMarkers', error)
+    throw error
+  }
+  finally {
+    await closeClient(c, db)
+  }
+}
+
+async function readNativeObserveTimingEventsCFChunked(
+  c: Context<MiddlewareKeyVariables>,
+  appId: string,
+  start: Dayjs,
+  endExclusive: Dayjs,
+) {
+  const events: UpdateDeliveryTimingEventCF[] = []
+  let cursor = start.utc().startOf('day')
+  const end = endExclusive.utc()
+
+  while (cursor.isBefore(end)) {
+    const next = cursor.add(1, 'day')
+    const chunkEnd = next.isBefore(end) ? next : end
+    const chunk = await readUpdateDeliveryTimingEventsCF(c, {
+      start_date: cursor.toISOString(),
+      end_date: chunkEnd.toISOString(),
+      actions: [...nativeObserveActions],
+      app_ids: [appId],
+    })
+    events.push(...chunk)
+    cursor = next
+  }
+
+  return events
+}
+
+async function readNativeObserveStatsSB(
+  c: Context<MiddlewareKeyVariables>,
+  appId: string,
+  days: NativeObservePeriodDays,
+  labels: string[],
+  start: Dayjs,
+  endExclusive: Dayjs,
+  endInclusive: Dayjs,
+) {
   const params = [appId, start.toISOString(), endExclusive.toISOString(), nativeObserveActions]
   const paramsWithIssues = [...params, issueActions]
   const db = getPgClient(c, true)
@@ -425,7 +681,7 @@ async function readNativeObserveStats(c: Context<MiddlewareKeyVariables>, appId:
     })
   }
   catch (error) {
-    logPgError(c, 'readNativeObserveStats', error)
+    logPgError(c, 'readNativeObserveStatsSB', error)
     throw error
   }
   finally {
@@ -433,7 +689,64 @@ async function readNativeObserveStats(c: Context<MiddlewareKeyVariables>, appId:
   }
 }
 
-async function readNativeObservePluginStats(c: Context<MiddlewareKeyVariables>, appId: string) {
+async function readNativeObserveStatsCF(
+  c: Context<MiddlewareKeyVariables>,
+  appId: string,
+  days: NativeObservePeriodDays,
+  labels: string[],
+  start: Dayjs,
+  endExclusive: Dayjs,
+  endInclusive: Dayjs,
+) {
+  const events = await readNativeObserveTimingEventsCFChunked(c, appId, start, endExclusive)
+  const samples = toNativeObserveEventSamples(events)
+  const aggregates = aggregateNativeObserveSamples(samples)
+  const releaseMarkers = await readReleaseMarkers(c, appId, start, endExclusive)
+
+  return buildNativeObserveResponse({
+    labels,
+    days,
+    start: start.toISOString(),
+    end: endInclusive.toISOString(),
+    dailyRows: aggregates.dailyRows,
+    actionRows: aggregates.actionRows,
+    versionRows: aggregates.versionRows,
+    overviewRow: aggregates.overviewRow,
+    releaseMarkers,
+  })
+}
+
+async function readNativeObserveStats(c: Context<MiddlewareKeyVariables>, appId: string, days: NativeObservePeriodDays) {
+  const endExclusive = dayjs().utc().add(1, 'day').startOf('day')
+  const start = endExclusive.subtract(days, 'day')
+  const endInclusive = endExclusive.subtract(1, 'millisecond')
+  const labels = generateDateLabels(start.toDate(), endExclusive.subtract(1, 'day').toDate())
+
+  // Same dual-path pattern as private/stats and update_delivery_stats.
+  if (c.env.APP_LOG) {
+    return readNativeObserveStatsCF(
+      c,
+      appId,
+      days,
+      labels,
+      start,
+      endExclusive,
+      endInclusive,
+    )
+  }
+
+  return readNativeObserveStatsSB(
+    c,
+    appId,
+    days,
+    labels,
+    start,
+    endExclusive,
+    endInclusive,
+  )
+}
+
+async function readNativeObservePluginStatsSB(c: Context<MiddlewareKeyVariables>, appId: string) {
   const db = getPgClient(c, true)
 
   try {
@@ -441,12 +754,28 @@ async function readNativeObservePluginStats(c: Context<MiddlewareKeyVariables>, 
     return buildNativeObservePluginResponse(pluginVersionResult.rows)
   }
   catch (error) {
-    logPgError(c, 'readNativeObservePluginStats', error)
+    logPgError(c, 'readNativeObservePluginStatsSB', error)
     throw error
   }
   finally {
     await closeClient(c, db)
   }
+}
+
+async function readNativeObservePluginStatsCF(c: Context<MiddlewareKeyVariables>, appId: string) {
+  const rows = await readNativeObservePluginVersionsCF(c, appId)
+  const totalDevices = rows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
+  return buildNativeObservePluginResponse(rows.map(row => ({
+    plugin_version: row.plugin_version,
+    devices: row.devices,
+    total_devices: totalDevices,
+  })))
+}
+
+async function readNativeObservePluginStats(c: Context<MiddlewareKeyVariables>, appId: string) {
+  if (c.env.DEVICE_INFO)
+    return readNativeObservePluginStatsCF(c, appId)
+  return readNativeObservePluginStatsSB(c, appId)
 }
 
 export const app = new Hono<MiddlewareKeyVariables>()
@@ -484,9 +813,13 @@ app.post('/', middlewareAuth, async (c) => {
 })
 
 export const nativeObserveStatsTestUtils = {
+  aggregateNativeObserveSamples,
   buildNativeObservePluginResponse,
   buildNativeObserveResponse,
   generateDateLabels,
   normalizeNativeObservePeriodDays,
   normalizeNativeObserveView,
+  parseMetaDurationMs,
+  percentileCont,
+  toNativeObserveEventSamples,
 }

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -480,20 +480,27 @@ function finalizeNativeObserveAggregate(state: NativeObserveAggregateState): {
     })
 
   const versionRows: NativeObserveVersionRow[] = [...state.versionMap.entries()]
-    .map(([version_name, value]) => ({
-      version_name,
-      events: value.events,
-      devices: value.devices.size,
-      issue_count: value.issueCount,
-      affected_devices: value.issueDevices.size,
-      launch_p90_ms: percentileCont([...value.launchDurations].sort((a, b) => a - b), 0.9),
-      webview_load_p90_ms: percentileCont([...value.webviewDurations].sort((a, b) => a - b), 0.9),
-    }))
+    .map(([version_name, value]) => {
+      const launchMetrics = metricFromDurations(value.launchDurations)
+      const webviewMetrics = metricFromDurations(value.webviewDurations)
+      return {
+        version_name,
+        events: value.events,
+        devices: value.devices.size,
+        issue_count: value.issueCount,
+        affected_devices: value.issueDevices.size,
+        launch_p90_ms: launchMetrics.p90_ms,
+        webview_load_p90_ms: webviewMetrics.p90_ms,
+      }
+    })
     .sort((a, b) => {
       const eventCmp = toCount(b.events) - toCount(a.events)
       return eventCmp !== 0 ? eventCmp : a.version_name.localeCompare(b.version_name)
     })
     .slice(0, 12)
+
+  const launchSorted = [...state.launchDurations].sort((a, b) => a - b)
+  const webviewSorted = [...state.webviewDurations].sort((a, b) => a - b)
 
   return {
     dailyRows,
@@ -505,10 +512,10 @@ function finalizeNativeObserveAggregate(state: NativeObserveAggregateState): {
       issue_count: state.issueCount,
       affected_devices: state.issueDevices.size,
       launch_timeout_count: state.launchTimeoutCount,
-      launch_p50_ms: percentileCont([...state.launchDurations].sort((a, b) => a - b), 0.5),
-      launch_p90_ms: percentileCont([...state.launchDurations].sort((a, b) => a - b), 0.9),
-      webview_load_p50_ms: percentileCont([...state.webviewDurations].sort((a, b) => a - b), 0.5),
-      webview_load_p90_ms: percentileCont([...state.webviewDurations].sort((a, b) => a - b), 0.9),
+      launch_p50_ms: percentileCont(launchSorted, 0.5),
+      launch_p90_ms: percentileCont(launchSorted, 0.9),
+      webview_load_p50_ms: percentileCont(webviewSorted, 0.5),
+      webview_load_p90_ms: percentileCont(webviewSorted, 0.9),
     },
   }
 }
@@ -664,6 +671,7 @@ async function readReleaseMarkers(
 }
 
 const MAX_NATIVE_OBSERVE_EVENTS = 100_000
+const NATIVE_OBSERVE_CHUNK_CONCURRENCY = 4
 
 async function foldNativeObserveTimingEventsCFChunked(
   c: Context<MiddlewareKeyVariables>,
@@ -672,22 +680,33 @@ async function foldNativeObserveTimingEventsCFChunked(
   endExclusive: Dayjs,
   state: NativeObserveAggregateState,
 ) {
-  // Fold each UTC day chunk immediately so we never hold 30x50k rows in memory.
+  // Build UTC day windows, then fetch with bounded concurrency and fold as batches complete.
+  const windows: Array<{ start: string, end: string }> = []
   let cursor = start.utc().startOf('day')
   const end = endExclusive.utc()
-
-  while (cursor.isBefore(end) && state.events < MAX_NATIVE_OBSERVE_EVENTS) {
+  while (cursor.isBefore(end)) {
     const next = cursor.add(1, 'day')
     const chunkEnd = next.isBefore(end) ? next : end
-    const chunk = await readUpdateDeliveryTimingEventsCF(c, {
-      start_date: cursor.toISOString(),
-      end_date: chunkEnd.toISOString(),
+    windows.push({ start: cursor.toISOString(), end: chunkEnd.toISOString() })
+    cursor = next
+  }
+
+  for (let i = 0; i < windows.length && state.events < MAX_NATIVE_OBSERVE_EVENTS; i += NATIVE_OBSERVE_CHUNK_CONCURRENCY) {
+    const batch = windows.slice(i, i + NATIVE_OBSERVE_CHUNK_CONCURRENCY)
+    const remaining = MAX_NATIVE_OBSERVE_EVENTS - state.events
+    const perChunkLimit = Math.max(1, Math.min(50_000, Math.ceil(remaining / batch.length)))
+    const chunks = await Promise.all(batch.map(window => readUpdateDeliveryTimingEventsCF(c, {
+      start_date: window.start,
+      end_date: window.end,
       actions: [...nativeObserveActions],
       app_ids: [appId],
-      limit: Math.min(50_000, MAX_NATIVE_OBSERVE_EVENTS - state.events),
-    })
-    foldNativeObserveSamples(state, toNativeObserveEventSamples(chunk))
-    cursor = next
+      limit: perChunkLimit,
+    })))
+    for (const chunk of chunks) {
+      if (state.events >= MAX_NATIVE_OBSERVE_EVENTS)
+        break
+      foldNativeObserveSamples(state, toNativeObserveEventSamples(chunk))
+    }
   }
 }
 

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -344,59 +344,72 @@ function toNativeObserveEventSamples(events: UpdateDeliveryTimingEventCF[]): Nat
   return samples
 }
 
-function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]): {
-  dailyRows: NativeObserveMetricRow[]
-  actionRows: NativeObserveMetricRow[]
-  versionRows: NativeObserveVersionRow[]
-  overviewRow: NativeObserveOverviewRow
-} {
-  const dailyMap = new Map<string, { events: number, devices: Set<string>, durations: number[] }>()
-  const actionMap = new Map<string, { events: number, devices: Set<string>, durations: number[] }>()
-  const versionMap = new Map<string, {
+interface NativeObserveAggregateState {
+  dailyMap: Map<string, { events: number, devices: Set<string>, durations: number[] }>
+  actionMap: Map<string, { events: number, devices: Set<string>, durations: number[] }>
+  versionMap: Map<string, {
     devices: Set<string>
     issueDevices: Set<string>
     events: number
     issueCount: number
     launchDurations: number[]
     webviewDurations: number[]
-  }>()
+  }>
+  allDevices: Set<string>
+  issueDevices: Set<string>
+  issueCount: number
+  launchTimeoutCount: number
+  launchDurations: number[]
+  webviewDurations: number[]
+  events: number
+}
 
-  const allDevices = new Set<string>()
-  const issueDevices = new Set<string>()
-  let issueCount = 0
-  let launchTimeoutCount = 0
-  const launchDurations: number[] = []
-  const webviewDurations: number[] = []
+function createNativeObserveAggregateState(): NativeObserveAggregateState {
+  return {
+    dailyMap: new Map(),
+    actionMap: new Map(),
+    versionMap: new Map(),
+    allDevices: new Set(),
+    issueDevices: new Set(),
+    issueCount: 0,
+    launchTimeoutCount: 0,
+    launchDurations: [],
+    webviewDurations: [],
+    events: 0,
+  }
+}
 
+function foldNativeObserveSamples(state: NativeObserveAggregateState, samples: NativeObserveEventSample[]) {
   for (const sample of samples) {
-    allDevices.add(sample.device_id)
+    state.events += 1
+    state.allDevices.add(sample.device_id)
     if (issueActionSet.has(sample.action)) {
-      issueCount += 1
-      issueDevices.add(sample.device_id)
+      state.issueCount += 1
+      state.issueDevices.add(sample.device_id)
     }
     if (sample.action === 'app_launch_timeout')
-      launchTimeoutCount += 1
+      state.launchTimeoutCount += 1
     if (sample.action === launchReadyAction && sample.duration_ms !== null)
-      launchDurations.push(sample.duration_ms)
+      state.launchDurations.push(sample.duration_ms)
     if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
-      webviewDurations.push(sample.duration_ms)
+      state.webviewDurations.push(sample.duration_ms)
 
     const dailyKey = `${sample.day}\0${sample.action}`
-    const daily = dailyMap.get(dailyKey) ?? { events: 0, devices: new Set<string>(), durations: [] }
+    const daily = state.dailyMap.get(dailyKey) ?? { events: 0, devices: new Set<string>(), durations: [] }
     daily.events += 1
     daily.devices.add(sample.device_id)
     if (sample.duration_ms !== null)
       daily.durations.push(sample.duration_ms)
-    dailyMap.set(dailyKey, daily)
+    state.dailyMap.set(dailyKey, daily)
 
-    const action = actionMap.get(sample.action) ?? { events: 0, devices: new Set<string>(), durations: [] }
+    const action = state.actionMap.get(sample.action) ?? { events: 0, devices: new Set<string>(), durations: [] }
     action.events += 1
     action.devices.add(sample.device_id)
     if (sample.duration_ms !== null)
       action.durations.push(sample.duration_ms)
-    actionMap.set(sample.action, action)
+    state.actionMap.set(sample.action, action)
 
-    const version = versionMap.get(sample.version_name) ?? {
+    const version = state.versionMap.get(sample.version_name) ?? {
       devices: new Set<string>(),
       issueDevices: new Set<string>(),
       events: 0,
@@ -414,10 +427,17 @@ function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]): {
       version.launchDurations.push(sample.duration_ms)
     if (sample.action === webviewPageLoadedAction && sample.duration_ms !== null)
       version.webviewDurations.push(sample.duration_ms)
-    versionMap.set(sample.version_name, version)
+    state.versionMap.set(sample.version_name, version)
   }
+}
 
-  const dailyRows: NativeObserveMetricRow[] = [...dailyMap.entries()]
+function finalizeNativeObserveAggregate(state: NativeObserveAggregateState): {
+  dailyRows: NativeObserveMetricRow[]
+  actionRows: NativeObserveMetricRow[]
+  versionRows: NativeObserveVersionRow[]
+  overviewRow: NativeObserveOverviewRow
+} {
+  const dailyRows: NativeObserveMetricRow[] = [...state.dailyMap.entries()]
     .map(([key, value]) => {
       const [day, action] = key.split('\0')
       return {
@@ -433,7 +453,7 @@ function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]): {
       return dayCmp !== 0 ? dayCmp : a.action.localeCompare(b.action)
     })
 
-  const actionRows: NativeObserveMetricRow[] = [...actionMap.entries()]
+  const actionRows: NativeObserveMetricRow[] = [...state.actionMap.entries()]
     .map(([action, value]) => ({
       action,
       events: value.events,
@@ -445,7 +465,7 @@ function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]): {
       return eventCmp !== 0 ? eventCmp : a.action.localeCompare(b.action)
     })
 
-  const versionRows: NativeObserveVersionRow[] = [...versionMap.entries()]
+  const versionRows: NativeObserveVersionRow[] = [...state.versionMap.entries()]
     .map(([version_name, value]) => ({
       version_name,
       events: value.events,
@@ -466,18 +486,25 @@ function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]): {
     actionRows,
     versionRows,
     overviewRow: {
-      events: samples.length,
-      devices: allDevices.size,
-      issue_count: issueCount,
-      affected_devices: issueDevices.size,
-      launch_timeout_count: launchTimeoutCount,
-      launch_p50_ms: percentileCont([...launchDurations].sort((a, b) => a - b), 0.5),
-      launch_p90_ms: percentileCont([...launchDurations].sort((a, b) => a - b), 0.9),
-      webview_load_p50_ms: percentileCont([...webviewDurations].sort((a, b) => a - b), 0.5),
-      webview_load_p90_ms: percentileCont([...webviewDurations].sort((a, b) => a - b), 0.9),
+      events: state.events,
+      devices: state.allDevices.size,
+      issue_count: state.issueCount,
+      affected_devices: state.issueDevices.size,
+      launch_timeout_count: state.launchTimeoutCount,
+      launch_p50_ms: percentileCont([...state.launchDurations].sort((a, b) => a - b), 0.5),
+      launch_p90_ms: percentileCont([...state.launchDurations].sort((a, b) => a - b), 0.9),
+      webview_load_p50_ms: percentileCont([...state.webviewDurations].sort((a, b) => a - b), 0.5),
+      webview_load_p90_ms: percentileCont([...state.webviewDurations].sort((a, b) => a - b), 0.9),
     },
   }
 }
+
+function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]) {
+  const state = createNativeObserveAggregateState()
+  foldNativeObserveSamples(state, samples)
+  return finalizeNativeObserveAggregate(state)
+}
+
 
 function buildNativeObserveResponse(input: BuildNativeObserveResponseInput) {
   const labelIndex = new Map(input.labels.map((label, index) => [label, index]))
@@ -622,13 +649,14 @@ async function readReleaseMarkers(
   }
 }
 
-async function readNativeObserveTimingEventsCFChunked(
+async function foldNativeObserveTimingEventsCFChunked(
   c: Context<MiddlewareKeyVariables>,
   appId: string,
   start: Dayjs,
   endExclusive: Dayjs,
+  state: NativeObserveAggregateState,
 ) {
-  const events: UpdateDeliveryTimingEventCF[] = []
+  // Fold each UTC day chunk immediately so we never hold 30x50k rows in memory.
   let cursor = start.utc().startOf('day')
   const end = endExclusive.utc()
 
@@ -641,11 +669,9 @@ async function readNativeObserveTimingEventsCFChunked(
       actions: [...nativeObserveActions],
       app_ids: [appId],
     })
-    events.push(...chunk)
+    foldNativeObserveSamples(state, toNativeObserveEventSamples(chunk))
     cursor = next
   }
-
-  return events
 }
 
 async function readNativeObserveStatsSB(
@@ -698,9 +724,9 @@ async function readNativeObserveStatsCF(
   endExclusive: Dayjs,
   endInclusive: Dayjs,
 ) {
-  const events = await readNativeObserveTimingEventsCFChunked(c, appId, start, endExclusive)
-  const samples = toNativeObserveEventSamples(events)
-  const aggregates = aggregateNativeObserveSamples(samples)
+  const state = createNativeObserveAggregateState()
+  await foldNativeObserveTimingEventsCFChunked(c, appId, start, endExclusive, state)
+  const aggregates = finalizeNativeObserveAggregate(state)
   const releaseMarkers = await readReleaseMarkers(c, appId, start, endExclusive)
 
   return buildNativeObserveResponse({

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -764,8 +764,9 @@ async function readNativeObservePluginStatsSB(c: Context<MiddlewareKeyVariables>
 
 async function readNativeObservePluginStatsCF(c: Context<MiddlewareKeyVariables>, appId: string) {
   const rows = await readNativeObservePluginVersionsCF(c, appId)
+  // Sum every version before slicing top 12 so shares match Postgres window total.
   const totalDevices = rows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
-  return buildNativeObservePluginResponse(rows.map(row => ({
+  return buildNativeObservePluginResponse(rows.slice(0, 12).map(row => ({
     plugin_version: row.plugin_version,
     devices: row.devices,
     total_devices: totalDevices,

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1327,6 +1327,56 @@ export async function readUpdateDeliveryTimingEventsCF(
   }
 }
 
+
+export interface NativeObservePluginVersionCF {
+  plugin_version: string
+  devices: number
+}
+
+export function buildNativeObservePluginVersionsCFQuery(appId: string, limit = 12): string {
+  const safeLimit = normalizeAnalyticsLimit(limit, 12)
+  return `SELECT
+  if(plugin_version = '', 'unknown', plugin_version) AS plugin_version,
+  count() AS devices
+FROM (
+  SELECT
+    blob1 AS device_id,
+    argMax(blob3, timestamp) AS plugin_version,
+    argMax(double2, timestamp) AS is_prod,
+    argMax(double3, timestamp) AS is_emulator
+  FROM device_info
+  WHERE index1 = '${escapeSqlString(appId)}'
+  GROUP BY blob1
+)
+WHERE is_prod = 1 AND is_emulator != 1
+GROUP BY plugin_version
+ORDER BY devices DESC, plugin_version ASC
+LIMIT ${safeLimit}`
+}
+
+export async function readNativeObservePluginVersionsCF(
+  c: Context,
+  appId: string,
+  limit = 12,
+): Promise<NativeObservePluginVersionCF[]> {
+  if (!c.env.DEVICE_INFO)
+    return []
+
+  const query = buildNativeObservePluginVersionsCFQuery(appId, limit)
+  cloudlog({ requestId: c.get('requestId'), message: 'readNativeObservePluginVersionsCF query', query })
+  try {
+    const rows = await runQueryToCFA<{ plugin_version: string, devices: number }>(c, query)
+    return rows.map(row => ({
+      plugin_version: row.plugin_version || 'unknown',
+      devices: Number(row.devices) || 0,
+    }))
+  }
+  catch (e) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading native observe plugin versions', error: serializeError(e), query })
+    throw e
+  }
+}
+
 function buildStatsInsightsActionFilter(actions?: string[]) {
   if (!actions?.length)
     return ''

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1333,8 +1333,9 @@ export interface NativeObservePluginVersionCF {
   devices: number
 }
 
-export function buildNativeObservePluginVersionsCFQuery(appId: string, limit = 12): string {
-  const safeLimit = normalizeAnalyticsLimit(limit, 12)
+export function buildNativeObservePluginVersionsCFQuery(appId: string): string {
+  // No LIMIT here: callers need the full version set to compute total_devices
+  // (same as Postgres window sum), then slice the top N in JS.
   return `SELECT
   if(plugin_version = '', 'unknown', plugin_version) AS plugin_version,
   count() AS devices
@@ -1350,19 +1351,17 @@ FROM (
 )
 WHERE is_prod = 1 AND is_emulator != 1
 GROUP BY plugin_version
-ORDER BY devices DESC, plugin_version ASC
-LIMIT ${safeLimit}`
+ORDER BY devices DESC, plugin_version ASC`
 }
 
 export async function readNativeObservePluginVersionsCF(
   c: Context,
   appId: string,
-  limit = 12,
 ): Promise<NativeObservePluginVersionCF[]> {
   if (!c.env.DEVICE_INFO)
     return []
 
-  const query = buildNativeObservePluginVersionsCFQuery(appId, limit)
+  const query = buildNativeObservePluginVersionsCFQuery(appId)
   cloudlog({ requestId: c.get('requestId'), message: 'readNativeObservePluginVersionsCF query', query })
   try {
     const rows = await runQueryToCFA<{ plugin_version: string, devices: number }>(c, query)

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1333,45 +1333,66 @@ export interface NativeObservePluginVersionCF {
   devices: number
 }
 
-export function buildNativeObservePluginVersionsCFQuery(appId: string): string {
-  // No LIMIT here: callers need the full version set to compute total_devices
-  // (same as Postgres window sum), then slice the top N in JS.
+function nativeObservePluginDevicesSubquery(appId: string): string {
   return `SELECT
-  if(plugin_version = '', 'unknown', plugin_version) AS plugin_version,
-  count() AS devices
-FROM (
-  SELECT
     blob1 AS device_id,
     argMax(blob3, timestamp) AS plugin_version,
     argMax(double2, timestamp) AS is_prod,
     argMax(double3, timestamp) AS is_emulator
   FROM device_info
   WHERE index1 = '${escapeSqlString(appId)}'
-  GROUP BY blob1
+  GROUP BY blob1`
+}
+
+export function buildNativeObservePluginVersionsCFQuery(appId: string, limit = 12): string {
+  const safeLimit = normalizeAnalyticsLimit(limit, 12)
+  return `SELECT
+  if(plugin_version = '', 'unknown', plugin_version) AS plugin_version,
+  count() AS devices
+FROM (
+  ${nativeObservePluginDevicesSubquery(appId)}
 )
 WHERE is_prod = 1 AND is_emulator != 1
 GROUP BY plugin_version
-ORDER BY devices DESC, plugin_version ASC`
+ORDER BY devices DESC, plugin_version ASC
+LIMIT ${safeLimit}`
+}
+
+export function buildNativeObservePluginTotalDevicesCFQuery(appId: string): string {
+  return `SELECT
+  count() AS total_devices
+FROM (
+  ${nativeObservePluginDevicesSubquery(appId)}
+)
+WHERE is_prod = 1 AND is_emulator != 1`
 }
 
 export async function readNativeObservePluginVersionsCF(
   c: Context,
   appId: string,
-): Promise<NativeObservePluginVersionCF[]> {
+  limit = 12,
+): Promise<{ rows: NativeObservePluginVersionCF[], total_devices: number }> {
   if (!c.env.DEVICE_INFO)
-    return []
+    return { rows: [], total_devices: 0 }
 
-  const query = buildNativeObservePluginVersionsCFQuery(appId)
-  cloudlog({ requestId: c.get('requestId'), message: 'readNativeObservePluginVersionsCF query', query })
+  const versionsQuery = buildNativeObservePluginVersionsCFQuery(appId, limit)
+  const totalQuery = buildNativeObservePluginTotalDevicesCFQuery(appId)
+  cloudlog({ requestId: c.get('requestId'), message: 'readNativeObservePluginVersionsCF query', versionsQuery, totalQuery })
   try {
-    const rows = await runQueryToCFA<{ plugin_version: string, devices: number }>(c, query)
-    return rows.map(row => ({
-      plugin_version: row.plugin_version || 'unknown',
-      devices: Number(row.devices) || 0,
-    }))
+    const [rows, totalRows] = await Promise.all([
+      runQueryToCFA<{ plugin_version: string, devices: number }>(c, versionsQuery),
+      runQueryToCFA<{ total_devices: number }>(c, totalQuery),
+    ])
+    return {
+      rows: rows.map(row => ({
+        plugin_version: row.plugin_version || 'unknown',
+        devices: Number(row.devices) || 0,
+      })),
+      total_devices: Number(totalRows[0]?.total_devices) || 0,
+    }
   }
   catch (e) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading native observe plugin versions', error: serializeError(e), query })
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading native observe plugin versions', error: serializeError(e), versionsQuery, totalQuery })
     throw e
   }
 }

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -230,7 +230,7 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
       },
       {
         name: 'buildNativeObservePluginVersionsCFQuery.default',
-        query: buildNativeObservePluginVersionsCFQuery(SAMPLE_APP_ID, 12),
+        query: buildNativeObservePluginVersionsCFQuery(SAMPLE_APP_ID),
       },
 
       {

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import {
   buildReadDevicesCFQuery,
+  buildNativeObservePluginTotalDevicesCFQuery,
   buildNativeObservePluginVersionsCFQuery,
   buildUpdateDeliveryTimingEventsCFQuery,
   countDevicesCF,
@@ -230,13 +231,18 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
       },
       {
         name: 'buildNativeObservePluginVersionsCFQuery.default',
-        query: buildNativeObservePluginVersionsCFQuery(SAMPLE_APP_ID),
+        query: buildNativeObservePluginVersionsCFQuery(SAMPLE_APP_ID, 12),
       },
 
       {
         name: 'buildReadDevicesCFQuery.default',
         query: buildReadDevicesCFQuery({ app_id: SAMPLE_APP_ID, limit: 10 }, false),
       },
+      {
+        name: 'buildNativeObservePluginTotalDevicesCFQuery.default',
+        query: buildNativeObservePluginTotalDevicesCFQuery(SAMPLE_APP_ID),
+      },
+
       {
         name: 'buildReadDevicesCFQuery.installSources',
         query: buildReadDevicesCFQuery({

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import {
   buildReadDevicesCFQuery,
+  buildNativeObservePluginVersionsCFQuery,
   buildUpdateDeliveryTimingEventsCFQuery,
   countDevicesCF,
   countInstallSourcesCF,
@@ -227,6 +228,11 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
           limit: 10,
         }),
       },
+      {
+        name: 'buildNativeObservePluginVersionsCFQuery.default',
+        query: buildNativeObservePluginVersionsCFQuery(SAMPLE_APP_ID, 12),
+      },
+
       {
         name: 'buildReadDevicesCFQuery.default',
         query: buildReadDevicesCFQuery({ app_id: SAMPLE_APP_ID, limit: 10 }, false),

--- a/tests/native-observe-stats.unit.test.ts
+++ b/tests/native-observe-stats.unit.test.ts
@@ -83,4 +83,102 @@ describe('native observe stats helpers', () => {
       ],
     })
   })
+
+  it.concurrent('parses duration metadata strings', () => {
+    expect(nativeObserveStatsTestUtils.parseMetaDurationMs({ duration_ms: '1250.5' })).toBe(1250.5)
+    expect(nativeObserveStatsTestUtils.parseMetaDurationMs({ duration: '900' })).toBe(900)
+    expect(nativeObserveStatsTestUtils.parseMetaDurationMs({ duration_ms: 'nope' })).toBeNull()
+    expect(nativeObserveStatsTestUtils.parseMetaDurationMs(null)).toBeNull()
+  })
+
+  it('aggregates CF observe samples into daily/action/version/overview rows', () => {
+    const aggregates = nativeObserveStatsTestUtils.aggregateNativeObserveSamples([
+      {
+        day: '2026-07-01',
+        action: 'app_launch_ready',
+        version_name: '1.2.3',
+        device_id: 'd1',
+        duration_ms: 400,
+      },
+      {
+        day: '2026-07-01',
+        action: 'app_launch_ready',
+        version_name: '1.2.3',
+        device_id: 'd2',
+        duration_ms: 800,
+      },
+      {
+        day: '2026-07-01',
+        action: 'webview_page_loaded',
+        version_name: '1.2.3',
+        device_id: 'd1',
+        duration_ms: 1200,
+      },
+      {
+        day: '2026-07-02',
+        action: 'app_crash',
+        version_name: '1.2.3',
+        device_id: 'd3',
+        duration_ms: null,
+      },
+      {
+        day: '2026-07-02',
+        action: 'app_launch_timeout',
+        version_name: '1.2.4',
+        device_id: 'd3',
+        duration_ms: null,
+      },
+    ])
+
+    expect(aggregates.overviewRow).toMatchObject({
+      events: 5,
+      devices: 3,
+      issue_count: 2,
+      affected_devices: 1,
+      launch_timeout_count: 1,
+    })
+    expect(aggregates.overviewRow.launch_p50_ms).toBe(600)
+    expect(aggregates.overviewRow.webview_load_p90_ms).toBe(1200)
+
+    expect(aggregates.dailyRows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ day: '2026-07-01', action: 'app_launch_ready', events: 2, devices: 2 }),
+      expect.objectContaining({ day: '2026-07-02', action: 'app_crash', events: 1, devices: 1, p50_ms: null }),
+    ]))
+
+    expect(aggregates.actionRows[0]).toMatchObject({ action: 'app_launch_ready', events: 2, devices: 2 })
+    expect(aggregates.versionRows).toEqual([
+      expect.objectContaining({ version_name: '1.2.3', events: 4, devices: 3, issue_count: 1, affected_devices: 1 }),
+      expect.objectContaining({ version_name: '1.2.4', events: 1, devices: 1, issue_count: 1, affected_devices: 1 }),
+    ])
+  })
+
+  it('maps CF timing events into observe samples', () => {
+    expect(nativeObserveStatsTestUtils.toNativeObserveEventSamples([
+      {
+        app_id: 'com.demo.app',
+        device_id: 'd1',
+        action: 'app_launch_ready',
+        version_name: '1.0.0',
+        metadata: { duration_ms: '450' },
+        created_at: '2026-07-02T10:00:00.000Z',
+      },
+      {
+        app_id: 'com.demo.app',
+        device_id: 'd2',
+        action: 'app_crash',
+        version_name: '',
+        metadata: null,
+        created_at: 'not-a-date',
+      },
+    ])).toEqual([
+      {
+        day: '2026-07-02',
+        action: 'app_launch_ready',
+        version_name: '1.0.0',
+        device_id: 'd1',
+        duration_ms: 450,
+      },
+    ])
+  })
+
 })

--- a/tests/native-observe-stats.unit.test.ts
+++ b/tests/native-observe-stats.unit.test.ts
@@ -26,7 +26,7 @@ describe('native observe stats helpers', () => {
     )).toEqual(['2026-07-01', '2026-07-02', '2026-07-03'])
   })
 
-  it('builds daily timing, issue, action, and version aggregates', () => {
+  it.concurrent('builds daily timing, issue, action, and version aggregates', () => {
     const response = nativeObserveStatsTestUtils.buildNativeObserveResponse({
       labels: ['2026-07-01', '2026-07-02'],
       days: 7,
@@ -72,7 +72,7 @@ describe('native observe stats helpers', () => {
     expect(response.releaseMarkers).toHaveLength(1)
   })
 
-  it('builds plugin version aggregates without global statistics', () => {
+  it.concurrent('builds plugin version aggregates without global statistics', () => {
     expect(nativeObserveStatsTestUtils.buildNativeObservePluginResponse([
       { plugin_version: '7.0.0', devices: 3, total_devices: 4 },
       { plugin_version: '6.9.0', devices: 1, total_devices: 4 },
@@ -91,7 +91,7 @@ describe('native observe stats helpers', () => {
     expect(nativeObserveStatsTestUtils.parseMetaDurationMs(null)).toBeNull()
   })
 
-  it('aggregates CF observe samples into daily/action/version/overview rows', () => {
+  it.concurrent('aggregates CF observe samples into daily/action/version/overview rows', () => {
     const aggregates = nativeObserveStatsTestUtils.aggregateNativeObserveSamples([
       {
         day: '2026-07-01',
@@ -152,7 +152,7 @@ describe('native observe stats helpers', () => {
     ])
   })
 
-  it('maps CF timing events into observe samples', () => {
+  it.concurrent('maps CF timing events into observe samples', () => {
     expect(nativeObserveStatsTestUtils.toNativeObserveEventSamples([
       {
         app_id: 'com.demo.app',


### PR DESCRIPTION
## Summary (AI generated)

- Wire `POST /private/native_observe_stats` to the same dual path as other private stats: `APP_LOG` for global Observe metrics, `DEVICE_INFO` for plugin versions, Postgres only when those bindings are absent.
- Reuse day-chunked `readUpdateDeliveryTimingEventsCF` for Observe actions, aggregate durations/issues in JS, and keep release markers on Postgres `deploy_history`.
- Add CF plugin-version query + unit coverage and register the AE SQL fixture.

## Motivation (AI generated)

Production plugin stats land in Cloudflare Analytics Engine when `APP_LOG`/`DEVICE_INFO` are set. Observe still queried Postgres `public.stats` / `public.devices`, so the console chart stayed empty after the delivery-latency fix (#2770).

## Business Impact (AI generated)

Native Observe becomes usable in production again, so customers can see launch/webview latency and crash signals without waiting on Postgres-backed stats that no longer receive this traffic.

## Test Plan (AI generated)

- [ ] Unit tests: `bunx vitest run tests/native-observe-stats.unit.test.ts tests/analytics-engine-sql.unit.test.ts`
- [ ] Local without `APP_LOG`: Observe still returns Postgres-backed data
- [ ] Prod/staging with `APP_LOG`: global Observe charts populate from AE
- [ ] Prod/staging with `DEVICE_INFO`: plugins tab shows plugin_version breakdown
- [ ] Release markers still appear from `deploy_history`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native Observe statistics now include daily, action, version, and overview metrics.
  * Added duration percentiles (p50, p90, p99), issue counts, device counts, and timeout metrics.
  * Added reporting for native Observe plugin versions with associated device counts.
* **Bug Fixes**
  * Improved handling of missing or invalid duration metadata and normalized event timing for consistent reporting.
  * More efficient stats processing for large event volumes.
* **Tests**
  * Expanded unit coverage for duration parsing, CF-to-metrics aggregation, and plugin-version reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->