### PR TITLE
feat(aliproxy): stale-while-revalidate cache under client timeout

### DIFF
--- a/aliproxy/index.js
+++ b/aliproxy/index.js
@@ -3,22 +3,25 @@
 // Proxies updater.capgo.com.cn with stale-while-revalidate cache.
 // After an upstream timeout/error, serve cached JSON/files until a
 // revalidate succeeds.
+//
+// Important: FC freezes the instance after the HTTP response is returned, so
+// revalidation must finish inside this request (within CLIENT_BUDGET_MS). Do
+// not wait for a full upstream timeout and then answer — Capgo clients already
+// abandon around 3s.
 const { Buffer } = require('node:buffer')
 const crypto = require('node:crypto')
 const https = require('node:https')
 
 const TARGET_HOST = 'updater.capgo.com.cn'
-// Capgo plugin/edge often abandons around 3s (CF snippet TIMEOUT_MS=3000).
-// Never wait for a full upstream timeout and *then* answer — that response is
-// already lost. With a cache: answer within CLIENT_BUDGET_MS. Without cache:
-// allow a longer upstream wait for clients that raised responseTimeout.
 const CLIENT_BUDGET_MS = 2500
 const FETCH_TIMEOUT_MS = 15000
-const MAX_CACHE_BYTES = 20 * 1024 * 1024
+const MAX_ENTRY_BYTES = 2 * 1024 * 1024
+const MAX_TOTAL_CACHE_BYTES = 20 * 1024 * 1024
 const MAX_MEMORY_ENTRIES = 200
 
 /** @type {Map<string, CacheEntry>} */
 const memoryCache = new Map()
+let memoryCacheBytes = 0
 let upstreamDegraded = false
 
 /**
@@ -28,6 +31,7 @@ let upstreamDegraded = false
  *   body: string,
  *   isBase64Encoded: boolean,
  *   cachedAt: number,
+ *   byteLength: number,
  * }} CacheEntry
  */
 
@@ -37,6 +41,10 @@ function isDegraded() {
 
 function setDegraded(value) {
   upstreamDegraded = value
+}
+
+function entryByteLength(entry) {
+  return entry.byteLength ?? Buffer.byteLength(entry.body, entry.isBase64Encoded ? 'base64' : 'utf8')
 }
 
 /**
@@ -52,22 +60,38 @@ function getCache(key) {
   return mem
 }
 
+function trimMemoryCache() {
+  while (
+    memoryCache.size > MAX_MEMORY_ENTRIES
+    || memoryCacheBytes > MAX_TOTAL_CACHE_BYTES
+  ) {
+    const oldest = memoryCache.keys().next().value
+    if (oldest === undefined)
+      break
+    const oldestEntry = memoryCache.get(oldest)
+    if (oldestEntry)
+      memoryCacheBytes -= entryByteLength(oldestEntry)
+    memoryCache.delete(oldest)
+  }
+}
+
 /**
  * @param {string} key
  * @param {CacheEntry} entry
  */
 function setCache(key, entry) {
-  const bodyBytes = Buffer.byteLength(entry.body, entry.isBase64Encoded ? 'base64' : 'utf8')
-  if (bodyBytes > MAX_CACHE_BYTES) {
-    console.log('[CACHE] skip oversized entry', { key: key.slice(0, 120), bodyBytes })
+  if (entry.byteLength > MAX_ENTRY_BYTES) {
+    console.log('[CACHE] skip oversized entry', { key: key.slice(0, 120), bodyBytes: entry.byteLength })
     return
   }
 
+  const previous = memoryCache.get(key)
+  if (previous)
+    memoryCacheBytes -= entryByteLength(previous)
+
   memoryCache.set(key, entry)
-  while (memoryCache.size > MAX_MEMORY_ENTRIES) {
-    const oldest = memoryCache.keys().next().value
-    memoryCache.delete(oldest)
-  }
+  memoryCacheBytes += entry.byteLength
+  trimMemoryCache()
 }
 
 /**
@@ -85,13 +109,13 @@ function makeCacheKey(method, reqPath, bodyBuffer) {
 /**
  * @param {Record<string, string | string[] | undefined>} headers
  */
-function sanitizeCachedHeaders(headers) {
-  // Keep content-encoding: body is stored as upstream wire bytes (base64 when binary/compressed).
+function sanitizeResponseHeaders(headers) {
   const skip = new Set([
     'connection',
     'keep-alive',
     'transfer-encoding',
     'content-length',
+    'set-cookie',
   ])
   /** @type {Record<string, string | string[] | undefined>} */
   const out = {}
@@ -111,7 +135,7 @@ function respondFromCache(entry, cacheState) {
   return {
     statusCode: entry.statusCode,
     headers: {
-      ...sanitizeCachedHeaders(entry.headers),
+      ...sanitizeResponseHeaders(entry.headers),
       'x-aliproxy-cache': cacheState,
       'x-aliproxy-cached-at': String(entry.cachedAt),
     },
@@ -127,10 +151,22 @@ function respondFromCache(entry, cacheState) {
  */
 function fetchUpstream(options, bodyBuffer, timeoutMs) {
   return new Promise((resolve) => {
+    let settled = false
+    const fail = (err, timeout = false) => {
+      if (settled)
+        return
+      settled = true
+      resolve({ ok: false, error: err, timeout })
+    }
+
     const req = https.request({ ...options, timeout: timeoutMs }, (res) => {
       const chunks = []
       res.on('data', d => chunks.push(d))
+      res.on('error', err => fail(err, false))
       res.on('end', () => {
+        if (settled)
+          return
+        settled = true
         resolve({
           ok: true,
           statusCode: res.statusCode || 502,
@@ -139,14 +175,6 @@ function fetchUpstream(options, bodyBuffer, timeoutMs) {
         })
       })
     })
-
-    let settled = false
-    const fail = (err, timeout = false) => {
-      if (settled)
-        return
-      settled = true
-      resolve({ ok: false, error: err, timeout })
-    }
 
     req.on('timeout', () => {
       req.destroy()
@@ -160,6 +188,10 @@ function fetchUpstream(options, bodyBuffer, timeoutMs) {
   })
 }
 
+function isUpstreamUsable(result) {
+  return result.ok && result.statusCode < 500
+}
+
 /**
  * @param {{ statusCode: number, headers: any, body: Buffer }} upstream
  */
@@ -169,16 +201,17 @@ function buildProxyResponse(upstream) {
   const isTextResponse = !isCompressed && /^(?:text\/|application\/(?:json|javascript|xml))/.test(
     upstream.headers['content-type'] || '',
   )
+  const body = isTextResponse ? upstream.body.toString('utf8') : upstream.body.toString('base64')
+  const isBase64Encoded = !isTextResponse
 
   return {
     statusCode: upstream.statusCode,
     headers: {
-      ...upstream.headers,
-      'access-control-allow-origin': '*',
+      ...sanitizeResponseHeaders(upstream.headers),
       'x-aliproxy-cache': 'MISS',
     },
-    body: isTextResponse ? upstream.body.toString('utf8') : upstream.body.toString('base64'),
-    isBase64Encoded: !isTextResponse,
+    body,
+    isBase64Encoded,
   }
 }
 
@@ -193,10 +226,11 @@ function maybeCacheResponse(key, response, upstreamHeaders) {
 
   setCache(key, {
     statusCode: response.statusCode,
-    headers: upstreamHeaders,
+    headers: sanitizeResponseHeaders(upstreamHeaders),
     body: response.body,
     isBase64Encoded: response.isBase64Encoded,
     cachedAt: Date.now(),
+    byteLength: Buffer.byteLength(response.body, response.isBase64Encoded ? 'base64' : 'utf8'),
   })
 }
 
@@ -240,23 +274,14 @@ function buildUpstreamRequest(requestData) {
   }
 }
 
-function cacheSuccessfulUpstream(cacheKey, result) {
+function storeFreshUpstream(cacheKey, result) {
   const response = buildProxyResponse(result)
   maybeCacheResponse(cacheKey, response, result.headers)
   setDegraded(false)
   return response
 }
 
-function startBackgroundRevalidate(options, bodyBuffer, cacheKey) {
-  fetchUpstream(options, bodyBuffer, FETCH_TIMEOUT_MS).then((result) => {
-    if (!result.ok)
-      return
-    cacheSuccessfulUpstream(cacheKey, result)
-    console.log('[CACHE] background revalidate succeeded, leaving degraded mode')
-  }).catch(() => {})
-}
-
-function upstreamErrorResponse(message) {
+function upstreamErrorResponse() {
   return {
     statusCode: 502,
     headers: {
@@ -264,7 +289,7 @@ function upstreamErrorResponse(message) {
       'x-aliproxy-cache': 'MISS',
       'x-aliproxy-degraded': '1',
     },
-    body: `upstream error: ${message}`,
+    body: 'upstream error',
   }
 }
 
@@ -284,20 +309,13 @@ async function handleRequest(event) {
     hasCache: !!cached,
   })
 
-  // Degraded + cache: answer STALE immediately, revalidate in background.
-  if (degraded && cached) {
-    startBackgroundRevalidate(options, bodyBuffer, cacheKey)
-    console.log('[DEBUG] Serving STALE immediately while revalidating')
-    return respondFromCache(cached, 'STALE')
-  }
-
-  // Have cache: only wait within client budget, then fall back to stale.
-  // No cache: allow longer wait for clients with raised responseTimeout.
+  // With cache (healthy or degraded): revalidate in-request within client budget,
+  // then fall back to stale. Never depend on work after the response is sent.
   const waitMs = cached ? CLIENT_BUDGET_MS : FETCH_TIMEOUT_MS
   const result = await fetchUpstream(options, bodyBuffer, waitMs)
 
-  if (result.ok) {
-    const response = cacheSuccessfulUpstream(cacheKey, result)
+  if (isUpstreamUsable(result)) {
+    const response = storeFreshUpstream(cacheKey, result)
     console.log('[DEBUG] Response:', {
       statusCode: response.statusCode,
       contentType: result.headers['content-type'],
@@ -307,16 +325,18 @@ async function handleRequest(event) {
     return response
   }
 
-  console.error('[ERROR] Request failed:', result.error.message, { timeout: result.timeout })
+  const failureReason = result.ok
+    ? `upstream status ${result.statusCode}`
+    : result.error.message
+  console.error('[ERROR] Request failed:', failureReason, { timeout: !result.ok && result.timeout })
   setDegraded(true)
 
   if (cached) {
-    startBackgroundRevalidate(options, bodyBuffer, cacheKey)
-    console.log('[DEBUG] Serving STALE after upstream failure within client budget')
+    console.log('[DEBUG] Serving STALE within client budget')
     return respondFromCache(cached, 'STALE')
   }
 
-  return upstreamErrorResponse(result.error.message)
+  return upstreamErrorResponse()
 }
 
 exports.handler = function (event, _context, callback) {
@@ -327,7 +347,7 @@ exports.handler = function (event, _context, callback) {
       callback(null, {
         statusCode: 500,
         headers: { 'content-type': 'text/plain' },
-        body: `internal error: ${err.message}`,
+        body: 'internal error',
       })
     })
 }

--- a/aliproxy/index.js
+++ b/aliproxy/index.js
@@ -5,9 +5,7 @@
 // revalidate succeeds.
 const { Buffer } = require('node:buffer')
 const crypto = require('node:crypto')
-const fs = require('node:fs')
 const https = require('node:https')
-const path = require('node:path')
 
 const TARGET_HOST = 'updater.capgo.com.cn'
 // Capgo plugin/edge often abandons around 3s (CF snippet TIMEOUT_MS=3000).
@@ -18,11 +16,10 @@ const CLIENT_BUDGET_MS = 2500
 const FETCH_TIMEOUT_MS = 15000
 const MAX_CACHE_BYTES = 20 * 1024 * 1024
 const MAX_MEMORY_ENTRIES = 200
-const CACHE_DIR = '/tmp/aliproxy-cache'
-const DEGRADED_FLAG = path.join(CACHE_DIR, '.degraded')
 
 /** @type {Map<string, CacheEntry>} */
 const memoryCache = new Map()
+let upstreamDegraded = false
 
 /**
  * @typedef {{
@@ -34,40 +31,12 @@ const memoryCache = new Map()
  * }} CacheEntry
  */
 
-function ensureCacheDir() {
-  try {
-    fs.mkdirSync(CACHE_DIR, { recursive: true })
-  }
-  catch (err) {
-    console.error('[CACHE] mkdir failed:', err.message)
-  }
-}
-
 function isDegraded() {
-  try {
-    return fs.existsSync(DEGRADED_FLAG)
-  }
-  catch {
-    return false
-  }
+  return upstreamDegraded
 }
 
 function setDegraded(value) {
-  ensureCacheDir()
-  try {
-    if (value)
-      fs.writeFileSync(DEGRADED_FLAG, String(Date.now()))
-    else if (fs.existsSync(DEGRADED_FLAG))
-      fs.unlinkSync(DEGRADED_FLAG)
-  }
-  catch (err) {
-    console.error('[CACHE] degraded flag error:', err.message)
-  }
-}
-
-function cacheFilePath(key) {
-  const hash = crypto.createHash('sha256').update(key).digest('hex')
-  return path.join(CACHE_DIR, `${hash}.json`)
+  upstreamDegraded = value
 }
 
 /**
@@ -76,26 +45,11 @@ function cacheFilePath(key) {
  */
 function getCache(key) {
   const mem = memoryCache.get(key)
-  if (mem) {
-    // refresh LRU order
-    memoryCache.delete(key)
-    memoryCache.set(key, mem)
-    return mem
-  }
-
-  try {
-    const file = cacheFilePath(key)
-    if (!fs.existsSync(file))
-      return null
-    const entry = JSON.parse(fs.readFileSync(file, 'utf8'))
-    memoryCache.set(key, entry)
-    trimMemoryCache()
-    return entry
-  }
-  catch (err) {
-    console.error('[CACHE] read failed:', err.message)
+  if (!mem)
     return null
-  }
+  memoryCache.delete(key)
+  memoryCache.set(key, mem)
+  return mem
 }
 
 /**
@@ -110,18 +64,6 @@ function setCache(key, entry) {
   }
 
   memoryCache.set(key, entry)
-  trimMemoryCache()
-
-  ensureCacheDir()
-  try {
-    fs.writeFileSync(cacheFilePath(key), JSON.stringify(entry))
-  }
-  catch (err) {
-    console.error('[CACHE] write failed:', err.message)
-  }
-}
-
-function trimMemoryCache() {
   while (memoryCache.size > MAX_MEMORY_ENTRIES) {
     const oldest = memoryCache.keys().next().value
     memoryCache.delete(oldest)
@@ -134,7 +76,7 @@ function trimMemoryCache() {
  * @param {Buffer | null} bodyBuffer
  */
 function makeCacheKey(method, reqPath, bodyBuffer) {
-  const bodyHash = bodyBuffer && bodyBuffer.length
+  const bodyHash = bodyBuffer?.length
     ? crypto.createHash('sha256').update(bodyBuffer).digest('hex')
     : ''
   return `${method.toUpperCase()} ${reqPath} ${bodyHash}`
@@ -154,9 +96,8 @@ function sanitizeCachedHeaders(headers) {
   /** @type {Record<string, string | string[] | undefined>} */
   const out = {}
   for (const [k, v] of Object.entries(headers || {})) {
-    if (skip.has(k.toLowerCase()))
-      continue
-    out[k] = v
+    if (!skip.has(k.toLowerCase()))
+      out[k] = v
   }
   out['access-control-allow-origin'] = '*'
   return out
@@ -183,7 +124,6 @@ function respondFromCache(entry, cacheState) {
  * @param {import('https').RequestOptions} options
  * @param {Buffer | null} bodyBuffer
  * @param {number} timeoutMs
- * @returns {Promise<{ ok: true, statusCode: number, headers: any, body: Buffer } | { ok: false, error: Error, timeout: boolean }>}
  */
 function fetchUpstream(options, bodyBuffer, timeoutMs) {
   return new Promise((resolve) => {
@@ -243,7 +183,6 @@ function buildProxyResponse(upstream) {
 }
 
 /**
- * Cache successful JSON + file responses (2xx).
  * @param {string} key
  * @param {ReturnType<typeof buildProxyResponse>} response
  * @param {any} upstreamHeaders
@@ -261,124 +200,134 @@ function maybeCacheResponse(key, response, upstreamHeaders) {
   })
 }
 
+function parseRequestData(event) {
+  if (Buffer.isBuffer(event))
+    return JSON.parse(event.toString('utf8'))
+  if (typeof event === 'string')
+    return JSON.parse(event)
+  return event
+}
+
+function buildUpstreamRequest(requestData) {
+  const method = requestData.requestContext?.http?.method || requestData.httpMethod || 'POST'
+  const reqPath = requestData.rawPath || requestData.path || '/'
+  const headers = requestData.headers || {}
+  const bodyString = requestData.body || ''
+
+  const proxyHeaders = { ...headers, host: TARGET_HOST }
+  if (!proxyHeaders['user-agent'])
+    proxyHeaders['user-agent'] = 'CapgoAlibabaProxy/1.0'
+
+  let bodyBuffer = null
+  if (bodyString) {
+    bodyBuffer = requestData.isBase64Encoded
+      ? Buffer.from(bodyString, 'base64')
+      : Buffer.from(bodyString, 'utf8')
+    proxyHeaders['content-length'] = bodyBuffer.length
+  }
+
+  return {
+    method,
+    reqPath,
+    bodyBuffer,
+    options: {
+      hostname: TARGET_HOST,
+      port: 443,
+      path: reqPath,
+      method,
+      headers: proxyHeaders,
+    },
+  }
+}
+
+function cacheSuccessfulUpstream(cacheKey, result) {
+  const response = buildProxyResponse(result)
+  maybeCacheResponse(cacheKey, response, result.headers)
+  setDegraded(false)
+  return response
+}
+
+function startBackgroundRevalidate(options, bodyBuffer, cacheKey) {
+  fetchUpstream(options, bodyBuffer, FETCH_TIMEOUT_MS).then((result) => {
+    if (!result.ok)
+      return
+    cacheSuccessfulUpstream(cacheKey, result)
+    console.log('[CACHE] background revalidate succeeded, leaving degraded mode')
+  }).catch(() => {})
+}
+
+function upstreamErrorResponse(message) {
+  return {
+    statusCode: 502,
+    headers: {
+      'content-type': 'text/plain',
+      'x-aliproxy-cache': 'MISS',
+      'x-aliproxy-degraded': '1',
+    },
+    body: `upstream error: ${message}`,
+  }
+}
+
+async function handleRequest(event) {
+  const requestData = parseRequestData(event)
+  const { method, reqPath, bodyBuffer, options } = buildUpstreamRequest(requestData)
+  const cacheKey = makeCacheKey(method, reqPath, bodyBuffer)
+  const cached = getCache(cacheKey)
+  const degraded = isDegraded()
+
+  console.log('[DEBUG] Proxying request:', {
+    url: `https://${TARGET_HOST}${reqPath}`,
+    method,
+    hasBody: !!bodyBuffer,
+    bodySize: bodyBuffer ? bodyBuffer.length : 0,
+    degraded,
+    hasCache: !!cached,
+  })
+
+  // Degraded + cache: answer STALE immediately, revalidate in background.
+  if (degraded && cached) {
+    startBackgroundRevalidate(options, bodyBuffer, cacheKey)
+    console.log('[DEBUG] Serving STALE immediately while revalidating')
+    return respondFromCache(cached, 'STALE')
+  }
+
+  // Have cache: only wait within client budget, then fall back to stale.
+  // No cache: allow longer wait for clients with raised responseTimeout.
+  const waitMs = cached ? CLIENT_BUDGET_MS : FETCH_TIMEOUT_MS
+  const result = await fetchUpstream(options, bodyBuffer, waitMs)
+
+  if (result.ok) {
+    const response = cacheSuccessfulUpstream(cacheKey, result)
+    console.log('[DEBUG] Response:', {
+      statusCode: response.statusCode,
+      contentType: result.headers['content-type'],
+      bodySize: result.body.length,
+      cache: 'MISS',
+    })
+    return response
+  }
+
+  console.error('[ERROR] Request failed:', result.error.message, { timeout: result.timeout })
+  setDegraded(true)
+
+  if (cached) {
+    startBackgroundRevalidate(options, bodyBuffer, cacheKey)
+    console.log('[DEBUG] Serving STALE after upstream failure within client budget')
+    return respondFromCache(cached, 'STALE')
+  }
+
+  return upstreamErrorResponse(result.error.message)
+}
+
 exports.handler = function (event, _context, callback) {
-  const done = (err, result) => callback(err, result)
-
-  ;(async () => {
-    try {
-      ensureCacheDir()
-
-      let requestData
-      if (Buffer.isBuffer(event))
-        requestData = JSON.parse(event.toString('utf8'))
-      else if (typeof event === 'string')
-        requestData = JSON.parse(event)
-      else
-        requestData = event
-
-      const method = requestData.requestContext?.http?.method || requestData.httpMethod || 'POST'
-      const reqPath = requestData.rawPath || requestData.path || '/'
-      const headers = requestData.headers || {}
-      const bodyString = requestData.body || ''
-
-      const proxyHeaders = { ...headers }
-      proxyHeaders.host = TARGET_HOST
-      if (!proxyHeaders['user-agent'])
-        proxyHeaders['user-agent'] = 'CapgoAlibabaProxy/1.0'
-
-      let bodyBuffer = null
-      if (bodyString) {
-        bodyBuffer = requestData.isBase64Encoded
-          ? Buffer.from(bodyString, 'base64')
-          : Buffer.from(bodyString, 'utf8')
-        proxyHeaders['content-length'] = bodyBuffer.length
-      }
-
-      const cacheKey = makeCacheKey(method, reqPath, bodyBuffer)
-      const cached = getCache(cacheKey)
-      const degraded = isDegraded()
-
-      const options = {
-        hostname: TARGET_HOST,
-        port: 443,
-        path: reqPath,
-        method,
-        headers: proxyHeaders,
-      }
-
-      console.log('[DEBUG] Proxying request:', {
-        url: `https://${TARGET_HOST}${reqPath}`,
-        method,
-        hasBody: !!bodyBuffer,
-        bodySize: bodyBuffer ? bodyBuffer.length : 0,
-        degraded,
-        hasCache: !!cached,
-      })
-
-      const startBackgroundRevalidate = () => {
-        fetchUpstream(options, bodyBuffer, FETCH_TIMEOUT_MS).then((result) => {
-          if (!result.ok)
-            return
-          const response = buildProxyResponse(result)
-          maybeCacheResponse(cacheKey, response, result.headers)
-          setDegraded(false)
-          console.log('[CACHE] background revalidate succeeded, leaving degraded mode')
-        }).catch(() => {})
-      }
-
-      // Degraded + cache: answer STALE immediately, revalidate in background.
-      if (degraded && cached) {
-        startBackgroundRevalidate()
-        console.log('[DEBUG] Serving STALE immediately while revalidating')
-        return done(null, respondFromCache(cached, 'STALE'))
-      }
-
-      // Have cache: only wait within client budget, then fall back to stale.
-      // No cache: allow longer wait for clients with raised responseTimeout.
-      const waitMs = cached ? CLIENT_BUDGET_MS : FETCH_TIMEOUT_MS
-      const result = await fetchUpstream(options, bodyBuffer, waitMs)
-
-      if (result.ok) {
-        const response = buildProxyResponse(result)
-        maybeCacheResponse(cacheKey, response, result.headers)
-        if (degraded)
-          setDegraded(false)
-        console.log('[DEBUG] Response:', {
-          statusCode: response.statusCode,
-          contentType: result.headers['content-type'],
-          bodySize: result.body.length,
-          cache: 'MISS',
-        })
-        return done(null, response)
-      }
-
-      console.error('[ERROR] Request failed:', result.error.message, { timeout: result.timeout })
-      setDegraded(true)
-
-      if (cached) {
-        // Still within CLIENT_BUDGET_MS — useful for this request.
-        startBackgroundRevalidate()
-        console.log('[DEBUG] Serving STALE after upstream failure within client budget')
-        return done(null, respondFromCache(cached, 'STALE'))
-      }
-
-      return done(null, {
-        statusCode: 502,
-        headers: {
-          'content-type': 'text/plain',
-          'x-aliproxy-cache': 'MISS',
-          'x-aliproxy-degraded': '1',
-        },
-        body: `upstream error: ${result.error.message}`,
-      })
-    }
-    catch (err) {
+  handleRequest(event)
+    .then(result => callback(null, result))
+    .catch((err) => {
       console.error('[ERROR] Handler exception:', err)
-      return done(null, {
+      callback(null, {
         statusCode: 500,
         headers: { 'content-type': 'text/plain' },
         body: `internal error: ${err.message}`,
       })
-    }
-  })()
+    })
 }

--- a/aliproxy/index.js
+++ b/aliproxy/index.js
@@ -1,128 +1,384 @@
 // index.js
 // Alibaba FC HTTP Trigger with Event Function
+// Proxies updater.capgo.com.cn with stale-while-revalidate cache.
+// After an upstream timeout/error, serve cached JSON/files until a
+// revalidate succeeds.
 const { Buffer } = require('node:buffer')
+const crypto = require('node:crypto')
+const fs = require('node:fs')
 const https = require('node:https')
+const path = require('node:path')
 
 const TARGET_HOST = 'updater.capgo.com.cn'
+// Capgo plugin/edge often abandons around 3s (CF snippet TIMEOUT_MS=3000).
+// Never wait for a full upstream timeout and *then* answer — that response is
+// already lost. With a cache: answer within CLIENT_BUDGET_MS. Without cache:
+// allow a longer upstream wait for clients that raised responseTimeout.
+const CLIENT_BUDGET_MS = 2500
+const FETCH_TIMEOUT_MS = 15000
+const MAX_CACHE_BYTES = 20 * 1024 * 1024
+const MAX_MEMORY_ENTRIES = 200
+const CACHE_DIR = '/tmp/aliproxy-cache'
+const DEGRADED_FLAG = path.join(CACHE_DIR, '.degraded')
 
-exports.handler = function (event, _context, callback) {
+/** @type {Map<string, CacheEntry>} */
+const memoryCache = new Map()
+
+/**
+ * @typedef {{
+ *   statusCode: number,
+ *   headers: Record<string, string | string[] | undefined>,
+ *   body: string,
+ *   isBase64Encoded: boolean,
+ *   cachedAt: number,
+ * }} CacheEntry
+ */
+
+function ensureCacheDir() {
   try {
-    // Alibaba FC passes the HTTP request as a Buffer containing JSON
-    let requestData
+    fs.mkdirSync(CACHE_DIR, { recursive: true })
+  }
+  catch (err) {
+    console.error('[CACHE] mkdir failed:', err.message)
+  }
+}
 
-    if (Buffer.isBuffer(event)) {
-      const eventString = event.toString('utf8')
-      requestData = JSON.parse(eventString)
-    }
-    else if (typeof event === 'string') {
-      requestData = JSON.parse(event)
-    }
-    else {
-      requestData = event
-    }
+function isDegraded() {
+  try {
+    return fs.existsSync(DEGRADED_FLAG)
+  }
+  catch {
+    return false
+  }
+}
 
-    console.log('[DEBUG] Parsed request data:', {
-      version: requestData.version,
-      rawPath: requestData.rawPath,
-      hasHeaders: !!requestData.headers,
-      hasBody: !!requestData.body,
-      method: requestData.requestContext?.http?.method,
-    })
+function setDegraded(value) {
+  ensureCacheDir()
+  try {
+    if (value)
+      fs.writeFileSync(DEGRADED_FLAG, String(Date.now()))
+    else if (fs.existsSync(DEGRADED_FLAG))
+      fs.unlinkSync(DEGRADED_FLAG)
+  }
+  catch (err) {
+    console.error('[CACHE] degraded flag error:', err.message)
+  }
+}
 
-    // Extract request information
-    const method = requestData.requestContext?.http?.method || requestData.httpMethod || 'POST'
-    const path = requestData.rawPath || requestData.path || '/'
-    const headers = requestData.headers || {}
-    const bodyString = requestData.body || ''
+function cacheFilePath(key) {
+  const hash = crypto.createHash('sha256').update(key).digest('hex')
+  return path.join(CACHE_DIR, `${hash}.json`)
+}
 
-    // Prepare proxy headers
-    const proxyHeaders = { ...headers }
-    proxyHeaders.host = TARGET_HOST
+/**
+ * @param {string} key
+ * @returns {CacheEntry | null}
+ */
+function getCache(key) {
+  const mem = memoryCache.get(key)
+  if (mem) {
+    // refresh LRU order
+    memoryCache.delete(key)
+    memoryCache.set(key, mem)
+    return mem
+  }
 
-    if (!proxyHeaders['user-agent']) {
-      proxyHeaders['user-agent'] = 'CapgoAlibabaProxy/1.0'
-    }
+  try {
+    const file = cacheFilePath(key)
+    if (!fs.existsSync(file))
+      return null
+    const entry = JSON.parse(fs.readFileSync(file, 'utf8'))
+    memoryCache.set(key, entry)
+    trimMemoryCache()
+    return entry
+  }
+  catch (err) {
+    console.error('[CACHE] read failed:', err.message)
+    return null
+  }
+}
 
-    // Prepare body buffer
-    let bodyBuffer = null
-    if (bodyString) {
-      bodyBuffer = requestData.isBase64Encoded
-        ? Buffer.from(bodyString, 'base64')
-        : Buffer.from(bodyString, 'utf8')
-      proxyHeaders['content-length'] = bodyBuffer.length
-    }
+/**
+ * @param {string} key
+ * @param {CacheEntry} entry
+ */
+function setCache(key, entry) {
+  const bodyBytes = Buffer.byteLength(entry.body, entry.isBase64Encoded ? 'base64' : 'utf8')
+  if (bodyBytes > MAX_CACHE_BYTES) {
+    console.log('[CACHE] skip oversized entry', { key: key.slice(0, 120), bodyBytes })
+    return
+  }
 
-    const options = {
-      hostname: TARGET_HOST,
-      port: 443,
-      path,
-      method,
-      headers: proxyHeaders,
-      timeout: 15000,
-    }
+  memoryCache.set(key, entry)
+  trimMemoryCache()
 
-    console.log('[DEBUG] Proxying request:', {
-      url: `https://${TARGET_HOST}${path}`,
-      method,
-      hasBody: !!bodyBuffer,
-      bodySize: bodyBuffer ? bodyBuffer.length : 0,
-    })
+  ensureCacheDir()
+  try {
+    fs.writeFileSync(cacheFilePath(key), JSON.stringify(entry))
+  }
+  catch (err) {
+    console.error('[CACHE] write failed:', err.message)
+  }
+}
 
-    const req = https.request(options, (res) => {
+function trimMemoryCache() {
+  while (memoryCache.size > MAX_MEMORY_ENTRIES) {
+    const oldest = memoryCache.keys().next().value
+    memoryCache.delete(oldest)
+  }
+}
+
+/**
+ * @param {string} method
+ * @param {string} reqPath
+ * @param {Buffer | null} bodyBuffer
+ */
+function makeCacheKey(method, reqPath, bodyBuffer) {
+  const bodyHash = bodyBuffer && bodyBuffer.length
+    ? crypto.createHash('sha256').update(bodyBuffer).digest('hex')
+    : ''
+  return `${method.toUpperCase()} ${reqPath} ${bodyHash}`
+}
+
+/**
+ * @param {Record<string, string | string[] | undefined>} headers
+ */
+function sanitizeCachedHeaders(headers) {
+  // Keep content-encoding: body is stored as upstream wire bytes (base64 when binary/compressed).
+  const skip = new Set([
+    'connection',
+    'keep-alive',
+    'transfer-encoding',
+    'content-length',
+  ])
+  /** @type {Record<string, string | string[] | undefined>} */
+  const out = {}
+  for (const [k, v] of Object.entries(headers || {})) {
+    if (skip.has(k.toLowerCase()))
+      continue
+    out[k] = v
+  }
+  out['access-control-allow-origin'] = '*'
+  return out
+}
+
+/**
+ * @param {CacheEntry} entry
+ * @param {'HIT' | 'STALE'} cacheState
+ */
+function respondFromCache(entry, cacheState) {
+  return {
+    statusCode: entry.statusCode,
+    headers: {
+      ...sanitizeCachedHeaders(entry.headers),
+      'x-aliproxy-cache': cacheState,
+      'x-aliproxy-cached-at': String(entry.cachedAt),
+    },
+    body: entry.body,
+    isBase64Encoded: entry.isBase64Encoded,
+  }
+}
+
+/**
+ * @param {import('https').RequestOptions} options
+ * @param {Buffer | null} bodyBuffer
+ * @param {number} timeoutMs
+ * @returns {Promise<{ ok: true, statusCode: number, headers: any, body: Buffer } | { ok: false, error: Error, timeout: boolean }>}
+ */
+function fetchUpstream(options, bodyBuffer, timeoutMs) {
+  return new Promise((resolve) => {
+    const req = https.request({ ...options, timeout: timeoutMs }, (res) => {
       const chunks = []
       res.on('data', d => chunks.push(d))
       res.on('end', () => {
-        const buf = Buffer.concat(chunks)
-
-        // Always return as base64 if compressed or binary
-        const encoding = res.headers['content-encoding']
-        const isCompressed = encoding === 'gzip' || encoding === 'deflate' || encoding === 'br' || encoding === 'zstd'
-        const isTextResponse = !isCompressed && /^(?:text\/|application\/(?:json|javascript|xml))/.test(
-          res.headers['content-type'] || '',
-        )
-
-        const responseBody = isTextResponse ? buf.toString('utf8') : buf.toString('base64')
-
-        console.log('[DEBUG] Response:', {
-          statusCode: res.statusCode,
-          contentType: res.headers['content-type'],
-          contentEncoding: encoding,
-          isCompressed,
-          bodySize: buf.length,
-        })
-
-        callback(null, {
+        resolve({
+          ok: true,
           statusCode: res.statusCode || 502,
-          headers: {
-            ...res.headers,
-            'access-control-allow-origin': '*',
-          },
-          body: responseBody,
-          isBase64Encoded: !isTextResponse,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
         })
       })
     })
 
-    req.on('error', (err) => {
-      console.error('[ERROR] Request failed:', err)
-      callback(null, {
-        statusCode: 502,
-        headers: { 'content-type': 'text/plain' },
-        body: `upstream error: ${err.message}`,
-      })
-    })
-
-    if (bodyBuffer) {
-      req.write(bodyBuffer)
+    let settled = false
+    const fail = (err, timeout = false) => {
+      if (settled)
+        return
+      settled = true
+      resolve({ ok: false, error: err, timeout })
     }
-    req.end()
-  }
-  catch (err) {
-    console.error('[ERROR] Handler exception:', err)
-    callback(null, {
-      statusCode: 500,
-      headers: { 'content-type': 'text/plain' },
-      body: `internal error: ${err.message}`,
+
+    req.on('timeout', () => {
+      req.destroy()
+      fail(new Error(`upstream timeout after ${timeoutMs}ms`), true)
     })
+    req.on('error', err => fail(err, false))
+
+    if (bodyBuffer)
+      req.write(bodyBuffer)
+    req.end()
+  })
+}
+
+/**
+ * @param {{ statusCode: number, headers: any, body: Buffer }} upstream
+ */
+function buildProxyResponse(upstream) {
+  const encoding = upstream.headers['content-encoding']
+  const isCompressed = encoding === 'gzip' || encoding === 'deflate' || encoding === 'br' || encoding === 'zstd'
+  const isTextResponse = !isCompressed && /^(?:text\/|application\/(?:json|javascript|xml))/.test(
+    upstream.headers['content-type'] || '',
+  )
+
+  return {
+    statusCode: upstream.statusCode,
+    headers: {
+      ...upstream.headers,
+      'access-control-allow-origin': '*',
+      'x-aliproxy-cache': 'MISS',
+    },
+    body: isTextResponse ? upstream.body.toString('utf8') : upstream.body.toString('base64'),
+    isBase64Encoded: !isTextResponse,
   }
+}
+
+/**
+ * Cache successful JSON + file responses (2xx).
+ * @param {string} key
+ * @param {ReturnType<typeof buildProxyResponse>} response
+ * @param {any} upstreamHeaders
+ */
+function maybeCacheResponse(key, response, upstreamHeaders) {
+  if (response.statusCode < 200 || response.statusCode >= 300)
+    return
+
+  setCache(key, {
+    statusCode: response.statusCode,
+    headers: upstreamHeaders,
+    body: response.body,
+    isBase64Encoded: response.isBase64Encoded,
+    cachedAt: Date.now(),
+  })
+}
+
+exports.handler = function (event, _context, callback) {
+  const done = (err, result) => callback(err, result)
+
+  ;(async () => {
+    try {
+      ensureCacheDir()
+
+      let requestData
+      if (Buffer.isBuffer(event))
+        requestData = JSON.parse(event.toString('utf8'))
+      else if (typeof event === 'string')
+        requestData = JSON.parse(event)
+      else
+        requestData = event
+
+      const method = requestData.requestContext?.http?.method || requestData.httpMethod || 'POST'
+      const reqPath = requestData.rawPath || requestData.path || '/'
+      const headers = requestData.headers || {}
+      const bodyString = requestData.body || ''
+
+      const proxyHeaders = { ...headers }
+      proxyHeaders.host = TARGET_HOST
+      if (!proxyHeaders['user-agent'])
+        proxyHeaders['user-agent'] = 'CapgoAlibabaProxy/1.0'
+
+      let bodyBuffer = null
+      if (bodyString) {
+        bodyBuffer = requestData.isBase64Encoded
+          ? Buffer.from(bodyString, 'base64')
+          : Buffer.from(bodyString, 'utf8')
+        proxyHeaders['content-length'] = bodyBuffer.length
+      }
+
+      const cacheKey = makeCacheKey(method, reqPath, bodyBuffer)
+      const cached = getCache(cacheKey)
+      const degraded = isDegraded()
+
+      const options = {
+        hostname: TARGET_HOST,
+        port: 443,
+        path: reqPath,
+        method,
+        headers: proxyHeaders,
+      }
+
+      console.log('[DEBUG] Proxying request:', {
+        url: `https://${TARGET_HOST}${reqPath}`,
+        method,
+        hasBody: !!bodyBuffer,
+        bodySize: bodyBuffer ? bodyBuffer.length : 0,
+        degraded,
+        hasCache: !!cached,
+      })
+
+      const startBackgroundRevalidate = () => {
+        fetchUpstream(options, bodyBuffer, FETCH_TIMEOUT_MS).then((result) => {
+          if (!result.ok)
+            return
+          const response = buildProxyResponse(result)
+          maybeCacheResponse(cacheKey, response, result.headers)
+          setDegraded(false)
+          console.log('[CACHE] background revalidate succeeded, leaving degraded mode')
+        }).catch(() => {})
+      }
+
+      // Degraded + cache: answer STALE immediately, revalidate in background.
+      if (degraded && cached) {
+        startBackgroundRevalidate()
+        console.log('[DEBUG] Serving STALE immediately while revalidating')
+        return done(null, respondFromCache(cached, 'STALE'))
+      }
+
+      // Have cache: only wait within client budget, then fall back to stale.
+      // No cache: allow longer wait for clients with raised responseTimeout.
+      const waitMs = cached ? CLIENT_BUDGET_MS : FETCH_TIMEOUT_MS
+      const result = await fetchUpstream(options, bodyBuffer, waitMs)
+
+      if (result.ok) {
+        const response = buildProxyResponse(result)
+        maybeCacheResponse(cacheKey, response, result.headers)
+        if (degraded)
+          setDegraded(false)
+        console.log('[DEBUG] Response:', {
+          statusCode: response.statusCode,
+          contentType: result.headers['content-type'],
+          bodySize: result.body.length,
+          cache: 'MISS',
+        })
+        return done(null, response)
+      }
+
+      console.error('[ERROR] Request failed:', result.error.message, { timeout: result.timeout })
+      setDegraded(true)
+
+      if (cached) {
+        // Still within CLIENT_BUDGET_MS — useful for this request.
+        startBackgroundRevalidate()
+        console.log('[DEBUG] Serving STALE after upstream failure within client budget')
+        return done(null, respondFromCache(cached, 'STALE'))
+      }
+
+      return done(null, {
+        statusCode: 502,
+        headers: {
+          'content-type': 'text/plain',
+          'x-aliproxy-cache': 'MISS',
+          'x-aliproxy-degraded': '1',
+        },
+        body: `upstream error: ${result.error.message}`,
+      })
+    }
+    catch (err) {
+      console.error('[ERROR] Handler exception:', err)
+      return done(null, {
+        statusCode: 500,
+        headers: { 'content-type': 'text/plain' },
+        body: `internal error: ${err.message}`,
+      })
+    }
+  })()
 }


### PR DESCRIPTION
## Summary (AI generated)

- Add in-memory + `/tmp` caching for Alibaba FC China proxy (`aliproxy`) for JSON and file responses
- On upstream timeout/error, enter degraded mode and serve stale cache
- While degraded, return stale **immediately** and revalidate in background — never wait for a timeout then answer (plugin/edge ~3s budget already abandoned the request)
- With a cache hit on the healthy path, only wait up to `CLIENT_BUDGET_MS` (2.5s) before falling back to stale

## Motivation (AI generated)

China updater uptime suffers when the connection to origin drops. The previous proxy returned 502 with no fallback. A wait-then-stale pattern is useless because Capgo clients already time out around 3 seconds.

## Business Impact (AI generated)

Better update availability for mainland China users during origin blips, reducing failed update checks without changing the public plugin API.

## Test Plan (AI generated)

- [ ] Deploy updated `aliproxy` to Alibaba FC (manual)
- [ ] Successful `/updates` and file GET populate cache (`x-aliproxy-cache: MISS`)
- [ ] Force upstream timeout → response is stale within ~2.5s (`x-aliproxy-cache: STALE`)
- [ ] Subsequent requests while degraded return stale immediately
- [ ] After upstream recovers, degraded flag clears and fresh responses resume

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for updater responses to improve availability and response times.
  * Supports serving previously cached content when the upstream service is unavailable.
  * Added stale-while-revalidate behavior to refresh cached content in the background.
  * Added cache status and timestamp headers to responses.

* **Bug Fixes**
  * Improved timeout and upstream error handling.
  * Returns a clear degraded response when neither the upstream service nor cached content is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->