### PR TITLE
fix(dashboard): read delivery latency from AE double1

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2337,7 +2337,7 @@
   "update-delivery-latency": "Time to deliver an update",
   "update-delivery-latency-help": "Device-side download delivery latency percentiles from download start to download complete.",
   "update-delivery-no-data": "No delivery latency data yet",
-  "update-delivery-no-data-help": "Percentiles appear when devices report download timing via stats metadata, or when download start and complete events can be paired.",
+  "update-delivery-no-data-help": "Percentiles appear when devices report download duration (duration_ms) on download_complete, or when download start and complete events can be paired. Update @capgo/capacitor-updater if timing metadata is missing.",
   "update-delivery-no-data-help-platform": "Platform percentiles use download duration metadata only. Values appear when devices report duration_ms (or duration) on download complete events.",
   "update-delivery-fetch-error": "Could not load delivery latency",
   "update-delivery-fetch-error-help": "The request failed. Retry to refresh this chart.",

--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -197,17 +197,24 @@ export function trackVersionUsageCF(c: Context, version_name: string, app_id: st
   return Promise.resolve()
 }
 
-function parseStatsDurationMs(metadata?: StatsMetadata): number | null {
+const MAX_STATS_DURATION_MS = 7_200_000
+
+function parseStatsDurationMs(metadata?: StatsMetadata | Record<string, unknown> | null): number | null {
   if (!metadata)
     return null
   for (const key of ['duration_ms', 'duration'] as const) {
     const raw = metadata[key]
+    if (typeof raw === 'number') {
+      if (Number.isFinite(raw) && raw >= 0 && raw <= MAX_STATS_DURATION_MS)
+        return raw
+      continue
+    }
     if (typeof raw !== 'string' || raw.length === 0 || raw.length > 15)
       continue
-    if (!/^\d+(\.\d+)?$/.test(raw))
+    if (!/^\d+(?:\.\d+)?$/.test(raw))
       continue
     const value = Number(raw)
-    if (!Number.isFinite(value) || value < 0 || value > 7_200_000)
+    if (!Number.isFinite(value) || value < 0 || value > MAX_STATS_DURATION_MS)
       continue
     return value
   }

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -5,7 +5,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import { Hono } from 'hono/tiny'
-import { readNativeObservePluginVersionsCF, readUpdateDeliveryTimingEventsCF } from '../utils/cloudflare.ts'
+import { parseStatsDurationMs, readNativeObservePluginVersionsCF, readUpdateDeliveryTimingEventsCF, resolveUpdateDeliveryTimingDurationMs } from '../utils/cloudflare.ts'
 import { parseBody, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog } from '../utils/logging.ts'
@@ -288,20 +288,7 @@ function setMetric(series: Array<number | null>, index: number, value: NativeObs
 }
 
 function parseMetaDurationMs(metadata: Record<string, string> | null | undefined): number | null {
-  if (!metadata)
-    return null
-  for (const key of ['duration_ms', 'duration'] as const) {
-    const raw = metadata[key]
-    if (typeof raw !== 'string' || raw.length === 0 || raw.length > 15)
-      continue
-    if (!/^\d+(?:\.\d+)?$/.test(raw))
-      continue
-    const value = Number(raw)
-    if (!Number.isFinite(value))
-      continue
-    return value
-  }
-  return null
+  return parseStatsDurationMs(metadata)
 }
 
 function percentileCont(sorted: number[], q: number): number | null {
@@ -342,15 +329,12 @@ function toNativeObserveEventSamples(events: UpdateDeliveryTimingEventCF[]): Nat
     const createdAtMs = Date.parse(event.created_at)
     if (!Number.isFinite(createdAtMs))
       continue
-    const durationFromDouble = typeof event.duration_ms === 'number' && Number.isFinite(event.duration_ms) && event.duration_ms > 0
-      ? event.duration_ms
-      : null
     samples.push({
       day: new Date(createdAtMs).toISOString().slice(0, 10),
       action: event.action,
       version_name: event.version_name || 'unknown',
       device_id: event.device_id,
-      duration_ms: durationFromDouble ?? parseMetaDurationMs(event.metadata),
+      duration_ms: resolveUpdateDeliveryTimingDurationMs(event),
     })
   }
   return samples

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -342,12 +342,15 @@ function toNativeObserveEventSamples(events: UpdateDeliveryTimingEventCF[]): Nat
     const createdAtMs = Date.parse(event.created_at)
     if (!Number.isFinite(createdAtMs))
       continue
+    const durationFromDouble = typeof event.duration_ms === 'number' && Number.isFinite(event.duration_ms) && event.duration_ms > 0
+      ? event.duration_ms
+      : null
     samples.push({
       day: new Date(createdAtMs).toISOString().slice(0, 10),
       action: event.action,
       version_name: event.version_name || 'unknown',
       device_id: event.device_id,
-      duration_ms: parseMetaDurationMs(event.metadata),
+      duration_ms: durationFromDouble ?? parseMetaDurationMs(event.metadata),
     })
   }
   return samples

--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -255,21 +255,32 @@ function toMetric(value: NumericValue, decimals = 0) {
   return Math.round(numeric * factor) / factor
 }
 
-function parseMetaDurationMs(metadata: Record<string, string> | null | undefined): number | null {
+function parseMetaDurationMs(metadata: Record<string, unknown> | null | undefined): number | null {
   if (!metadata)
     return null
   for (const key of ['duration_ms', 'duration'] as const) {
     const raw = metadata[key]
+    if (typeof raw === 'number') {
+      if (Number.isFinite(raw) && raw >= 0 && raw <= maxDeliveryMs)
+        return raw
+      continue
+    }
     if (typeof raw !== 'string' || raw.length === 0 || raw.length > 15)
       continue
     if (!/^\d+(?:\.\d+)?$/.test(raw))
       continue
     const value = Number(raw)
-    if (!Number.isFinite(value))
+    if (!Number.isFinite(value) || value < 0 || value > maxDeliveryMs)
       continue
     return value
   }
   return null
+}
+
+function resolveEventDurationMs(event: UpdateDeliveryTimingEventCF): number | null {
+  if (typeof event.duration_ms === 'number' && Number.isFinite(event.duration_ms) && event.duration_ms > 0 && event.duration_ms <= maxDeliveryMs)
+    return event.duration_ms
+  return parseMetaDurationMs(event.metadata)
 }
 
 function percentileCont(sorted: number[], q: number): number | null {
@@ -327,7 +338,7 @@ function buildDeliveriesFromEvents(
     if (!Number.isFinite(endMs) || endMs < options.periodStartMs)
       continue
 
-    let durationMs = parseMetaDurationMs(event.metadata)
+    let durationMs = resolveEventDurationMs(event)
     if (!isValidDuration(durationMs) && options.allowPairing) {
       const key = `${event.app_id}\0${event.device_id}\0${event.version_name || 'unknown'}`
       const starts = startsByKey.get(key)
@@ -634,6 +645,19 @@ async function readUpdateDeliveryStatsCF(
   })
   const { dailyRows, overviewRow } = aggregateDeliverySamples(samples)
 
+  if (overviewRow.samples === 0) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'update_delivery_stats CF produced zero samples',
+      scope,
+      event_count: events.length,
+      app_count: appIds?.length ?? null,
+      allow_pairing: allowPairing,
+      start: start.toISOString(),
+      end: endExclusive.toISOString(),
+    })
+  }
+
   return buildUpdateDeliveryResponse({
     labels,
     days,
@@ -679,7 +703,9 @@ async function readUpdateDeliveryStats(
         endExclusive,
         endInclusive,
       )
-      await cache.putJson(cacheKey, cfResponse, UPDATE_DELIVERY_STATS_CACHE_TTL_SECONDS)
+      // Avoid caching empty windows — AE ingest lag or sparse orgs should retry next load.
+      if (cfResponse.overview.samples > 0)
+        await cache.putJson(cacheKey, cfResponse, UPDATE_DELIVERY_STATS_CACHE_TTL_SECONDS)
       return cfResponse
     }
     catch (error) {
@@ -702,7 +728,8 @@ async function readUpdateDeliveryStats(
     endExclusive,
     endInclusive,
   )
-  await cache.putJson(cacheKey, pgResponse, UPDATE_DELIVERY_STATS_CACHE_TTL_SECONDS)
+  if (pgResponse.overview.samples > 0)
+    await cache.putJson(cacheKey, pgResponse, UPDATE_DELIVERY_STATS_CACHE_TTL_SECONDS)
   return pgResponse
 }
 
@@ -769,6 +796,7 @@ export const updateDeliveryStatsTestUtils = {
   normalizePeriodDays,
   normalizeScope,
   parseMetaDurationMs,
+  resolveEventDurationMs,
   percentileCont,
   toMetric,
 }

--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import { Hono } from 'hono/tiny'
 import { CacheHelper } from '../utils/cache.ts'
-import { readUpdateDeliveryTimingEventsCF } from '../utils/cloudflare.ts'
+import { parseStatsDurationMs, readUpdateDeliveryTimingEventsCF, resolveUpdateDeliveryTimingDurationMs } from '../utils/cloudflare.ts'
 import { parseBody, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
@@ -256,31 +256,11 @@ function toMetric(value: NumericValue, decimals = 0) {
 }
 
 function parseMetaDurationMs(metadata: Record<string, unknown> | null | undefined): number | null {
-  if (!metadata)
-    return null
-  for (const key of ['duration_ms', 'duration'] as const) {
-    const raw = metadata[key]
-    if (typeof raw === 'number') {
-      if (Number.isFinite(raw) && raw >= 0 && raw <= maxDeliveryMs)
-        return raw
-      continue
-    }
-    if (typeof raw !== 'string' || raw.length === 0 || raw.length > 15)
-      continue
-    if (!/^\d+(?:\.\d+)?$/.test(raw))
-      continue
-    const value = Number(raw)
-    if (!Number.isFinite(value) || value < 0 || value > maxDeliveryMs)
-      continue
-    return value
-  }
-  return null
+  return parseStatsDurationMs(metadata)
 }
 
 function resolveEventDurationMs(event: UpdateDeliveryTimingEventCF): number | null {
-  if (typeof event.duration_ms === 'number' && Number.isFinite(event.duration_ms) && event.duration_ms > 0 && event.duration_ms <= maxDeliveryMs)
-    return event.duration_ms
-  return parseMetaDurationMs(event.metadata)
+  return resolveUpdateDeliveryTimingDurationMs(event)
 }
 
 function percentileCont(sorted: number[], q: number): number | null {

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1308,6 +1308,8 @@ export interface UpdateDeliveryTimingEventCF {
   action: string
   version_name: string
   metadata: StatsMetadata | null
+  /** Duration from Analytics Engine double1 when plugins report timing. */
+  duration_ms: number | null
   created_at: string
 }
 
@@ -1337,6 +1339,7 @@ export function buildUpdateDeliveryTimingEventsCFQuery(params: ReadUpdateDeliver
   blob2 AS action,
   blob3 AS version_name,
   blob4 AS metadata,
+  double1 AS duration_ms,
   timestamp AS created_at
 FROM app_log
 WHERE
@@ -1344,7 +1347,6 @@ WHERE
   AND timestamp < toDateTime('${formatDateCF(params.end_date)}')
   AND blob2 IN (${actionsList})
   ${appFilter}
-GROUP BY app_id, device_id, action, version_name, metadata, created_at
 ORDER BY created_at ASC
 LIMIT ${limit}`
 }
@@ -1372,16 +1374,21 @@ export async function readUpdateDeliveryTimingEventsCF(
       action: string
       version_name: string
       metadata: string | null
+      duration_ms: number | string | null
       created_at: string
     }>(c, query)
-    return rows.map(row => ({
-      app_id: row.app_id,
-      device_id: row.device_id,
-      action: row.action,
-      version_name: row.version_name || 'unknown',
-      metadata: parseStatsMetadata(row.metadata),
-      created_at: row.created_at,
-    }))
+    return rows.map(row => {
+      const rawDuration = Number(row.duration_ms)
+      return {
+        app_id: row.app_id,
+        device_id: row.device_id,
+        action: row.action,
+        version_name: row.version_name || 'unknown',
+        metadata: parseStatsMetadata(row.metadata),
+        duration_ms: Number.isFinite(rawDuration) && rawDuration > 0 ? rawDuration : null,
+        created_at: row.created_at,
+      }
+    })
   }
   catch (e) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading update delivery timing events', error: serializeError(e), query })

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -197,17 +197,24 @@ export function trackVersionUsageCF(c: Context, version_name: string, app_id: st
   return Promise.resolve()
 }
 
-function parseStatsDurationMs(metadata?: StatsMetadata): number | null {
+const MAX_STATS_DURATION_MS = 7_200_000
+
+export function parseStatsDurationMs(metadata?: StatsMetadata | Record<string, unknown> | null): number | null {
   if (!metadata)
     return null
   for (const key of ['duration_ms', 'duration'] as const) {
     const raw = metadata[key]
+    if (typeof raw === 'number') {
+      if (Number.isFinite(raw) && raw >= 0 && raw <= MAX_STATS_DURATION_MS)
+        return raw
+      continue
+    }
     if (typeof raw !== 'string' || raw.length === 0 || raw.length > 15)
       continue
-    if (!/^\d+(\.\d+)?$/.test(raw))
+    if (!/^\d+(?:\.\d+)?$/.test(raw))
       continue
     const value = Number(raw)
-    if (!Number.isFinite(value) || value < 0 || value > 7_200_000)
+    if (!Number.isFinite(value) || value < 0 || value > MAX_STATS_DURATION_MS)
       continue
     return value
   }
@@ -1312,6 +1319,14 @@ export interface UpdateDeliveryTimingEventCF {
   duration_ms: number | null
   created_at: string
 }
+
+/** Prefer AE double1, then stats metadata duration fields. */
+export function resolveUpdateDeliveryTimingDurationMs(event: UpdateDeliveryTimingEventCF): number | null {
+  if (typeof event.duration_ms === 'number' && Number.isFinite(event.duration_ms) && event.duration_ms > 0 && event.duration_ms <= MAX_STATS_DURATION_MS)
+    return event.duration_ms
+  return parseStatsDurationMs(event.metadata)
+}
+
 
 export interface ReadUpdateDeliveryTimingEventsCFParams {
   start_date: string

--- a/tests/native-observe-stats.unit.test.ts
+++ b/tests/native-observe-stats.unit.test.ts
@@ -160,6 +160,7 @@ describe('native observe stats helpers', () => {
         action: 'app_launch_ready',
         version_name: '1.0.0',
         metadata: { duration_ms: '450' },
+        duration_ms: null,
         created_at: '2026-07-02T10:00:00.000Z',
       },
       {
@@ -168,6 +169,7 @@ describe('native observe stats helpers', () => {
         action: 'app_crash',
         version_name: '',
         metadata: null,
+        duration_ms: null,
         created_at: 'not-a-date',
       },
     ])).toEqual([

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -76,6 +76,8 @@ describe('update delivery stats helpers', () => {
 
   it.concurrent('parses duration metadata strings', () => {
     expect(updateDeliveryStatsTestUtils.parseMetaDurationMs({ duration_ms: '1250.5' })).toBe(1250.5)
+    expect(updateDeliveryStatsTestUtils.parseMetaDurationMs({ duration_ms: 800 })).toBe(800)
+    expect(updateDeliveryStatsTestUtils.parseMetaDurationMs({ duration_ms: '0' })).toBe(0)
     expect(updateDeliveryStatsTestUtils.parseMetaDurationMs({ duration: '900' })).toBe(900)
     expect(updateDeliveryStatsTestUtils.parseMetaDurationMs({ duration_ms: '0' })).toBe(0)
     expect(updateDeliveryStatsTestUtils.parseMetaDurationMs({ duration_ms: 'nope' })).toBeNull()
@@ -91,6 +93,7 @@ describe('update delivery stats helpers', () => {
         action: 'download_0',
         version_name: '1.2.3',
         metadata: null,
+        duration_ms: null,
         created_at: '2026-07-02T10:00:00.000Z',
       },
       {
@@ -99,6 +102,7 @@ describe('update delivery stats helpers', () => {
         action: 'download_complete',
         version_name: '1.2.3',
         metadata: null,
+        duration_ms: null,
         created_at: '2026-07-02T10:00:01.500Z',
       },
       {
@@ -107,6 +111,7 @@ describe('update delivery stats helpers', () => {
         action: 'download_complete',
         version_name: '1.2.3',
         metadata: { duration_ms: '2200' },
+        duration_ms: null,
         created_at: '2026-07-02T11:00:00.000Z',
       },
     ], { periodStartMs, allowPairing: true })
@@ -136,6 +141,7 @@ describe('update delivery stats helpers', () => {
         action: 'download_0',
         version_name: '1.2.3',
         metadata: null,
+        duration_ms: null,
         created_at: '2026-07-02T10:00:00.000Z',
       },
       {
@@ -144,6 +150,7 @@ describe('update delivery stats helpers', () => {
         action: 'download_complete',
         version_name: '1.2.3',
         metadata: null,
+        duration_ms: null,
         created_at: '2026-07-02T10:00:01.500Z',
       },
       {
@@ -152,6 +159,7 @@ describe('update delivery stats helpers', () => {
         action: 'download_complete',
         version_name: '1.2.3',
         metadata: { duration_ms: '2200' },
+        duration_ms: null,
         created_at: '2026-07-02T11:00:00.000Z',
       },
     ], { periodStartMs, allowPairing: false })
@@ -163,6 +171,37 @@ describe('update delivery stats helpers', () => {
         device_id: 'device-2',
         duration_ms: 2200,
       },
+    ])
+  })
+
+
+  it.concurrent('uses Analytics Engine double1 when metadata is empty', () => {
+    expect(updateDeliveryStatsTestUtils.resolveEventDurationMs({
+      app_id: 'a',
+      device_id: 'd',
+      action: 'download_complete',
+      version_name: '1.0.0',
+      metadata: null,
+      duration_ms: 1200,
+      created_at: '2026-07-01T00:00:00.000Z',
+    })).toBe(1200)
+  })
+
+  it('builds samples from double1 without pairing', () => {
+    const periodStartMs = Date.parse('2026-07-02T00:00:00.000Z')
+    const samples = updateDeliveryStatsTestUtils.buildDeliveriesFromEvents([
+      {
+        app_id: 'com.demo.app',
+        device_id: 'device-9',
+        action: 'download_complete',
+        version_name: '1.2.3',
+        metadata: null,
+        duration_ms: 900,
+        created_at: '2026-07-02T12:00:00.000Z',
+      },
+    ], { periodStartMs, allowPairing: false })
+    expect(samples).toEqual([
+      { day: '2026-07-02', app_id: 'com.demo.app', device_id: 'device-9', duration_ms: 900 },
     ])
   })
 


### PR DESCRIPTION
## Summary (AI generated)

- Read update-delivery duration from Analytics Engine `double1` (written by `/stats` when plugins report timing), not metadata alone.
- Drop `GROUP BY` on the timing-events AE query so rows are not collapsed incorrectly.
- Prefer `event.duration_ms` when building delivery samples and native-observe samples.
- Do not cache empty latency responses (avoids sticky “No delivery latency data yet” for ~5 minutes).
- Clarify empty-state help copy for `duration_ms` / updater requirement.

UI tab chrome / Notifications beta / email-vs-stats tab work from earlier drafts is **out of scope** — already shipped in #2786.

## Motivation (AI generated)

#2778 wired the CF read path, but prod still showed empty latency because the query never selected `double1`, used a harmful `GROUP BY`, and cached zero-sample responses. #2786 fixed dashboard tab UI only; this PR is the remaining data-path fix.

## Business Impact (AI generated)

After API worker deploy, orgs whose devices already report download duration can see p50/p75/p95/p99 on the dashboard instead of a permanent empty state.

## Test Plan (AI generated)

- [ ] `bunx vitest run tests/update-delivery-stats.unit.test.ts tests/native-observe-stats.unit.test.ts tests/analytics-engine-sql.unit.test.ts`
- [ ] After API deploy: org with devices reporting `duration_ms` / AE `double1` shows percentiles on Delivery tab
- [ ] Empty orgs still show empty state; refreshing after first real samples is not stuck on a cached empty payload

Generated with AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the analytics read path and cache behavior for delivery latency; incorrect duration parsing or caching could show wrong percentiles or delay populated charts, but scope is observability only—not auth or billing.
> 
> **Overview**
> Fixes **update delivery latency** on the dashboard by reading download duration from Analytics Engine **`double1`** (written when `/stats` reports timing), not only from event metadata.
> 
> The timing-events query now **selects `double1`**, drops a **`GROUP BY` that collapsed rows**, and **`resolveUpdateDeliveryTimingDurationMs`** prefers AE duration then metadata (including **numeric** `duration_ms` / `duration`). **`parseStatsDurationMs`** is shared across delivery stats and native observe instead of duplicated parsers.
> 
> **Caching** no longer stores responses with **zero samples** (CF or Postgres), so empty windows from ingest lag are not stuck for the cache TTL. A **cloudlog** fires when CF returns events but zero delivery samples. Empty-state copy now mentions **`duration_ms` on `download_complete`** and updating **`@capgo/capacitor-updater`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de0d58e69bf9fbe16b2f85ac6a522d03af3d1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivery timing now supports duration data provided as numbers or numeric text.
  * Delivery latency percentiles can be calculated from reported download duration or paired start and completion events.
  * Analytics-based timing data is now used when available, with fallback handling for metadata.

* **Bug Fixes**
  * Improved handling of missing or invalid timing data.
  * Empty delivery statistics are no longer cached, improving subsequent reporting accuracy.
  * Updated guidance explains when percentiles become available and recommends updating the updater when timing metadata is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->