### PR TITLE
fix(frontend): load plain API key before copying

### DIFF
--- a/src/pages/ApiKeys.vue
+++ b/src/pages/ApiKeys.vue
@@ -84,6 +84,7 @@ interface ApiKeyAppAccessOption {
 
 type ApiKeyRow = Database['public']['Tables']['apikeys']['Row'] & {
   global_permissions?: string[]
+  is_hashed_key?: boolean
 }
 
 const { t } = useI18n()
@@ -160,7 +161,9 @@ function hideString(str: string | null) {
 }
 
 // Check if a key is a hashed (secure) key
-function isHashedKey(key: Database['public']['Tables']['apikeys']['Row']) {
+function isHashedKey(key: ApiKeyRow) {
+  if (typeof key.is_hashed_key === 'boolean')
+    return key.is_hashed_key
   return key.key === null && key.key_hash !== null
 }
 
@@ -1558,22 +1561,38 @@ async function getUserFacingErrorMessage(error: unknown, fallbackMessage: string
   return fallbackMessage
 }
 
-async function copyKey(apikey: Database['public']['Tables']['apikeys']['Row']) {
+async function copyKey(apikey: ApiKeyRow) {
   // Cannot copy hashed keys - they are never stored in plain text
   if (isHashedKey(apikey)) {
     toast.error(t('cannot-copy-secure-key'))
     return
   }
 
+  // List endpoint omits the raw key; load it on demand for plain keys only.
+  let key = apikey.key
+  if (!key) {
+    const { data, error } = await supabase
+      .from('apikeys')
+      .select('key')
+      .eq('id', apikey.id)
+      .single()
+
+    if (error || !data?.key) {
+      toast.error(t('cannot-copy-key'))
+      return
+    }
+    key = data.key
+  }
+
   try {
-    await navigator.clipboard.writeText(apikey.key!)
+    await navigator.clipboard.writeText(key)
     toast.success(t('key-copied'))
   }
   catch (err) {
     console.error('Failed to copy: ', err)
     dialogStore.openDialog({
       title: t('cannot-copy-key'),
-      description: apikey.key!,
+      description: key,
       buttons: [
         {
           text: t('ok'),


### PR DESCRIPTION
## Summary (AI generated)

- Fixed the API keys page copy button writing `undefined` to the clipboard.
- The list endpoint omits the raw `key`, so copy now loads only the `key` column on demand for plain keys.
- Hashed keys are detected via `is_hashed_key` from the API response and stay non-copyable.

## Motivation (AI generated)

Non-hashed API keys are meant to be copyable from the console, but `/apikey` intentionally excludes the raw key. The UI still tried to copy `apikey.key`, which was always missing from the list payload.

## Business Impact (AI generated)

Restores copy-to-clipboard for plain API keys used in CLI/CI setup, without changing hashed-key behavior.

## Test Plan (AI generated)

- [ ] Create a non-hashed API key, click copy, verify the real key is on the clipboard.
- [ ] Create a secure/hashed API key and verify copy still shows the secure-key error toast.
- [ ] Confirm PR only changes `src/pages/ApiKeys.vue`.

Generated with AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-page UI fix that restores plain-key copy via an on-demand read; hashed keys remain non-copyable and behavior is unchanged for secure keys.
> 
> **Overview**
> Fixes **copy-to-clipboard** on the API keys page when the list payload omits the raw `key` (so copy no longer writes `undefined`).
> 
> **Copy flow:** For non-secure keys, `copyKey` now **fetches only the `key` column** from `apikeys` when it is missing on the row, then copies that value. Secure/hashed keys still show the existing cannot-copy toast.
> 
> **Hashed detection:** `ApiKeyRow` includes optional `is_hashed_key` from the API; `isHashedKey` prefers that flag and keeps the previous `key` / `key_hash` fallback for older responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85bb922f9423bfa8942ac4ce280b6dde77554b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key copying when key values are omitted from the initial list.
  * Added clearer handling for secure or hashed keys that cannot be copied.
  * Preserved compatibility with existing API key data formats.
  * Enhanced error feedback when copying an API key fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->