### PR TITLE
fix(frontend): keep bundle pagination page count correct after deletes

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -36,6 +36,8 @@ interface Props {
   addButtonTestId?: string
   search?: string
   total: number
+  /** Fixed page size used for last-page / next calculations. Prefer this over inferring from the current page length. */
+  offset?: number
   currentPage: number
   columns: TableColumn[]
   elementList: { [key: string]: any }[]
@@ -71,11 +73,18 @@ const pendingAdd = ref(false)
 // const sorts = ref<TableSort>({})
 // get columns from elementList
 
-const offset = computed(() => {
-  if (!props.elementList)
-    return 0
+// Page size must stay fixed across pages. Inferring it from the current page's
+// row count breaks last-page / next controls when the final page is short
+// (common after deletes).
+const pageSize = computed(() => {
+  if (props.offset && props.offset > 0)
+    return props.offset
+  if (!props.elementList || props.elementList.length === 0)
+    return 1
   return props.elementList.length
 })
+
+const totalPages = computed(() => Math.max(1, Math.ceil(props.total / pageSize.value)))
 
 const selectedRows = ref<boolean[]>(props.elementList.map(_ => false))
 const previousSelectedRow = ref<number | null>(null)
@@ -335,13 +344,15 @@ function tooltipIdFor(rowIndex: number, actionIndex: number): string {
 }
 
 const displayElemRange = computed(() => {
-  const begin = (props.currentPage - 1) * props.elementList.length
+  if (props.elementList.length === 0)
+    return '0-0'
+  const begin = (props.currentPage - 1) * pageSize.value
   const end = begin + props.elementList.length
   return `${begin}-${end}`
 })
 
 function canNext() {
-  return props.currentPage < Math.ceil(props.total / offset.value)
+  return props.currentPage < totalPages.value
 }
 function canPrev() {
   return props.currentPage > 1
@@ -356,7 +367,7 @@ async function next() {
 async function fastForward() {
   if (canNext()) {
     emit('fastForward')
-    emit('update:currentPage', Math.ceil(props.total / offset.value))
+    emit('update:currentPage', totalPages.value)
   }
 }
 async function prev() {

--- a/src/components/tables/AppTable.vue
+++ b/src/components/tables/AppTable.vue
@@ -15,6 +15,8 @@ const props = defineProps<{
   apps: (Database['public']['Tables']['apps']['Row'])[]
   deleteButton: boolean
   total?: number
+  /** Fixed page size for server-side pagination controls */
+  offset?: number
   currentPage?: number
   search?: string
   serverSidePagination?: boolean
@@ -308,6 +310,7 @@ const filteredApps = computed(() => {
         v-model:search="internalSearch"
         :show-add="!isMobile"
         :total="props.total ?? filteredApps.length"
+        :offset="props.offset"
         :element-list="filteredApps"
         :search-placeholder="t('search-by-name-or-app-id')"
         :is-loading="props.isLoading ?? false"

--- a/src/components/tables/BundleTable.vue
+++ b/src/components/tables/BundleTable.vue
@@ -18,6 +18,7 @@ import { formatBytes } from '~/services/conversion'
 import { formatDate } from '~/services/date'
 import { checkPermissions } from '~/services/permissions'
 import { useSupabase } from '~/services/supabase'
+import { refetchIfPageOutOfRange } from '~/services/tablePagination'
 import { useDialogV2Store } from '~/stores/dialogv2'
 
 const props = defineProps<{
@@ -248,14 +249,8 @@ async function getData() {
     if (!dataVersions)
       return
     total.value = count ?? 0
-    const maxPage = Math.max(1, Math.ceil(total.value / offset))
-    if (currentPage.value > maxPage) {
-      currentPage.value = maxPage
-      // Await the clamped-page refetch so isLoading stays true until fresh rows
-      // arrive (e.g. after deletes shrink the last page away).
-      await getData()
+    if (await refetchIfPageOutOfRange(currentPage, total.value, offset, getData))
       return
-    }
     const enhancedVersions = await enhanceVersionElems(dataVersions)
     await fetchChannelsForVersions(enhancedVersions)
     elements.value = enhancedVersions as any

--- a/src/components/tables/BundleTable.vue
+++ b/src/components/tables/BundleTable.vue
@@ -247,10 +247,17 @@ async function getData() {
     const { data: dataVersions, count } = await req
     if (!dataVersions)
       return
+    total.value = count ?? 0
+    const maxPage = Math.max(1, Math.ceil(total.value / offset))
+    if (currentPage.value > maxPage) {
+      currentPage.value = maxPage
+      // Re-fetch the clamped page so pagination stays aligned with the new total
+      // (e.g. after deletes shrink the last page away).
+      return getData()
+    }
     const enhancedVersions = await enhanceVersionElems(dataVersions)
     await fetchChannelsForVersions(enhancedVersions)
     elements.value = enhancedVersions as any
-    total.value = count ?? 0
   }
   catch (error) {
     console.error(error)
@@ -612,6 +619,7 @@ watch(props, async () => {
       <DataTable
         v-model:filters="filters" v-model:columns="columns" v-model:current-page="currentPage" v-model:search="search"
         :total="total"
+        :offset="offset"
         :show-add="!isMobile"
         :element-list="elements"
         filter-text="Filters"

--- a/src/components/tables/BundleTable.vue
+++ b/src/components/tables/BundleTable.vue
@@ -251,9 +251,10 @@ async function getData() {
     const maxPage = Math.max(1, Math.ceil(total.value / offset))
     if (currentPage.value > maxPage) {
       currentPage.value = maxPage
-      // Re-fetch the clamped page so pagination stays aligned with the new total
-      // (e.g. after deletes shrink the last page away).
-      return getData()
+      // Await the clamped-page refetch so isLoading stays true until fresh rows
+      // arrive (e.g. after deletes shrink the last page away).
+      await getData()
+      return
     }
     const enhancedVersions = await enhanceVersionElems(dataVersions)
     await fetchChannelsForVersions(enhancedVersions)

--- a/src/components/tables/ChannelHistoryTable.vue
+++ b/src/components/tables/ChannelHistoryTable.vue
@@ -423,6 +423,7 @@ watch([search, page], () => {
     :search="search"
     :search-placeholder="t('search-by-name')"
     :total="total"
+    :offset="pageSize"
     :current-page="page"
     :columns="columns"
     :element-list="historyEntries"

--- a/src/components/tables/ChannelTable.vue
+++ b/src/components/tables/ChannelTable.vue
@@ -133,10 +133,17 @@ async function getData() {
     const { data: dataVersions, count } = await req
     if (!dataVersions)
       return
+    total.value = count ?? 0
+    const maxPage = Math.max(1, Math.ceil(total.value / offset))
+    if (currentPage.value > maxPage) {
+      currentPage.value = maxPage
+      // Await the clamped-page refetch so isLoading stays true until fresh rows
+      // arrive (e.g. after deletes shrink the last page away).
+      await getData()
+      return
+    }
     elements.value.length = 0
     elements.value.push(...dataVersions as any)
-    // console.log('count', count)
-    total.value = count ?? 0
     if (count === 0) {
       showAddModal()
     }
@@ -166,16 +173,13 @@ async function getData() {
   isLoading.value = false
 }
 async function refreshData(keepCurrentPage = false) {
-  // console.log('refreshData')
   try {
-    const page = currentPage.value
     if (!keepCurrentPage)
       currentPage.value = 1
 
     elements.value.length = 0
+    // getData clamps currentPage when deletes leave it past the last page
     await getData()
-    if (keepCurrentPage)
-      currentPage.value = page
   }
   catch (error) {
     console.error(error)

--- a/src/components/tables/ChannelTable.vue
+++ b/src/components/tables/ChannelTable.vue
@@ -14,6 +14,7 @@ import IconTrash from '~icons/heroicons/trash'
 import { formatDate } from '~/services/date'
 import { checkPermissions } from '~/services/permissions'
 import { useSupabase } from '~/services/supabase'
+import { refetchIfPageOutOfRange } from '~/services/tablePagination'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
@@ -134,14 +135,8 @@ async function getData() {
     if (!dataVersions)
       return
     total.value = count ?? 0
-    const maxPage = Math.max(1, Math.ceil(total.value / offset))
-    if (currentPage.value > maxPage) {
-      currentPage.value = maxPage
-      // Await the clamped-page refetch so isLoading stays true until fresh rows
-      // arrive (e.g. after deletes shrink the last page away).
-      await getData()
+    if (await refetchIfPageOutOfRange(currentPage, total.value, offset, getData))
       return
-    }
     elements.value.length = 0
     elements.value.push(...dataVersions as any)
     if (count === 0) {

--- a/src/components/tables/ChannelTable.vue
+++ b/src/components/tables/ChannelTable.vue
@@ -380,7 +380,7 @@ watch(props, async () => {
   <div>
     <DataTable
       v-model:filters="filters" v-model:columns="columns" v-model:current-page="currentPage" v-model:search="search"
-      :total="total" :element-list="elements"
+      :total="total" :offset="offset" :element-list="elements"
       show-add
       filter-text="Filters"
       :is-loading="isLoading"

--- a/src/components/tables/DeviceTable.vue
+++ b/src/components/tables/DeviceTable.vue
@@ -409,7 +409,7 @@ async function ensureVersionNames(devices: Device[]) {
   <div>
     <DataTable
       v-model:filters="filters" v-model:columns="columns" v-model:current-page="currentPage" v-model:search="search"
-      :total="total" :element-list="elements"
+      :total="total" :offset="offset" :element-list="elements"
       filter-text="Filters"
       :show-add="showAddButton"
       :is-loading="isLoading"

--- a/src/components/tables/HistoryTable.vue
+++ b/src/components/tables/HistoryTable.vue
@@ -488,6 +488,7 @@ watch([() => props.channelId, () => props.bundleId, () => props.appId], () => {
     :search="search"
     :search-placeholder="t('search-by-name')"
     :total="total"
+    :offset="pageSize"
     :current-page="page"
     :columns="columns"
     :element-list="deployHistory"

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -214,6 +214,7 @@ displayStore.defaultBack = '/apps'
               :search="searchQuery"
               :apps="apps"
               :total="totalApps"
+              :offset="pageSize"
               :delete-button="!organizationStore.currentOrganizationFailed"
               :server-side-pagination="true"
               :is-loading="isTableLoading"

--- a/src/services/tablePagination.ts
+++ b/src/services/tablePagination.ts
@@ -1,0 +1,17 @@
+/**
+ * If the active page is past the last page for the new total, clamp it and refetch.
+ * Returns true when a refetch was started.
+ */
+export async function refetchIfPageOutOfRange(
+  currentPage: { value: number },
+  total: number,
+  pageSize: number,
+  refetch: () => Promise<void>,
+): Promise<boolean> {
+  const maxPage = Math.max(1, Math.ceil(total / pageSize))
+  if (currentPage.value <= maxPage)
+    return false
+  currentPage.value = maxPage
+  await refetch()
+  return true
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Fixed `DataTable` pagination so last-page / next controls use a fixed page size (`offset`) instead of the current page’s row count
- Passed `offset` from bundle and other server-side tables (channels, devices, history, apps, builds already passed it)
- Clamped the current page in `BundleTable` when deletes shrink the total below the active page

## Motivation (AI generated)

After deleting bundles, the last page often has fewer rows than the page size. `DataTable` previously treated that short page length as the page size, so “last page” and “next” calculated too many pages and produced empty/weird navigation.

## Business Impact (AI generated)

Improves console UX for customers managing large bundle lists so pagination stays trustworthy after cleanup/deletes.

## Test Plan (AI generated)

- [ ] Open an app with enough bundles for multiple pages
- [ ] Go to the last page and confirm the next/last controls are disabled when appropriate
- [ ] Delete one or more bundles (normal or unsafe) and confirm total/page controls update
- [ ] From a high page URL after deletes, confirm the table clamps to the new last page instead of showing empty results
- [ ] Smoke-check channels/devices tables still paginate correctly

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faea8-86c4-7b74-b492-57c9ebeae820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faea8-86c4-7b74-b492-57c9ebeae820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent fixed page-size and pagination offset support across application, channel, device, bundle, and history tables.
* **Improvements**
  * Enhanced pagination controls and the “showing X–Y” row range to match the effective page size.
* **Bug Fixes**
  * Added safeguards to keep the current page valid when total results change (for example, after deletions), preventing out-of-range navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->