### PR TITLE
feat(api): query devices by custom_id

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -1042,10 +1042,23 @@ function buildReadDevicesCFUpdatedAtGtCondition(updatedAtGt: string | undefined)
   return `updated_at > toDateTime('${safeUpdatedAtGt}')`
 }
 
+function buildReadDevicesCFCustomIdsCondition(customIds: string[] | undefined) {
+  if (!customIds?.length)
+    return ''
+
+  if (customIds.length === 1)
+    return `custom_id = '${escapeSqlString(customIds[0])}'`
+
+  const customIdsList = customIds.map(id => `'${escapeSqlString(id)}'`).join(', ')
+  return `custom_id IN (${customIdsList})`
+}
+
 function buildReadDevicesCFOuterConditions(params: ReadDevicesParams, devicesOrder: DevicesOrderCF | null) {
   const conditions = [
     buildReadDevicesCFCursorCondition(params.cursor, devicesOrder),
     buildReadDevicesCFUpdatedAtGtCondition(params.updated_at_gt),
+    // Match the latest aggregated custom_id, not historical event rows.
+    buildReadDevicesCFCustomIdsCondition(params.customIds),
   ]
   return conditions.filter(Boolean)
 }

--- a/supabase/functions/_backend/plugin_runtime/utils/types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/types.ts
@@ -131,6 +131,8 @@ export interface ReadDevicesParams {
   app_id: string
   version_name?: string | undefined
   deviceIds?: string[]
+  /** Exact custom_id match filter (case-sensitive, already trimmed by callers) */
+  customIds?: string[]
   installSources?: string[]
   search?: string
   order?: Order[]

--- a/supabase/functions/_backend/public/device/get.ts
+++ b/supabase/functions/_backend/public/device/get.ts
@@ -11,6 +11,8 @@ import { fetchLimit, isValidAppId } from '../../utils/utils.ts'
 interface GetDevice {
   app_id: string
   device_id?: string
+  /** Exact custom_id match (trimmed). Returns the paginated list shape. */
+  custom_id?: string
   customIdMode?: boolean
   /** Cursor for pagination - pass nextCursor from previous response */
   cursor?: string
@@ -88,6 +90,21 @@ function parseDevicesOrder(order: string | undefined) {
   if (order !== 'asc' && order !== 'desc')
     throw simpleError('invalid_order', 'order must be asc or desc', { order })
   return [{ key: 'updated_at', sortable: order as 'asc' | 'desc' }]
+}
+
+function parseCustomIdFilter(customId: string | undefined): string | undefined {
+  if (customId == null)
+    return undefined
+  if (typeof customId !== 'string')
+    throw simpleError('invalid_custom_id', 'custom_id must be a string', { custom_id: customId })
+
+  const trimmed = customId.trim()
+  if (!trimmed)
+    throw simpleError('invalid_custom_id', 'custom_id must not be empty', { custom_id: customId })
+  if (trimmed.length > 36)
+    throw simpleError('invalid_custom_id', 'custom_id must be at most 36 characters', { custom_id: customId })
+
+  return trimmed
 }
 
 export function filterDeviceKeys(devices: DeviceRes[]) {
@@ -170,6 +187,7 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
     return c.json(dataDevice)
   }
   else {
+    const customIdFilter = parseCustomIdFilter(body.custom_id)
     const updatedAtGt = parseUpdatedAtFilter(body.updated_at)
     const order = parseDevicesOrder(body.order)
     const limit = body.limit == null ? fetchLimit : Number(body.limit)
@@ -179,6 +197,7 @@ export async function get(c: Context, body: GetDevice, apikey: Database['public'
 
     const res = await readDevices(c, {
       app_id: body.app_id,
+      customIds: customIdFilter ? [customIdFilter] : undefined,
       cursor: body.cursor,
       limit,
       updated_at_gt: updatedAtGt,

--- a/supabase/functions/_backend/public/device/get.ts
+++ b/supabase/functions/_backend/public/device/get.ts
@@ -12,7 +12,7 @@ interface GetDevice {
   app_id: string
   device_id?: string
   /** Exact custom_id match (trimmed). Returns the paginated list shape. */
-  custom_id?: string
+  custom_id?: string | null
   customIdMode?: boolean
   /** Cursor for pagination - pass nextCursor from previous response */
   cursor?: string
@@ -92,8 +92,9 @@ function parseDevicesOrder(order: string | undefined) {
   return [{ key: 'updated_at', sortable: order as 'asc' | 'desc' }]
 }
 
-function parseCustomIdFilter(customId: string | undefined): string | undefined {
-  if (customId == null)
+export function parseCustomIdFilter(customId: string | null | undefined): string | undefined {
+  // Only omit when the query/body field is absent. Explicit null must fail validation.
+  if (customId === undefined)
     return undefined
   if (typeof customId !== 'string')
     throw simpleError('invalid_custom_id', 'custom_id must be a string', { custom_id: customId })

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1042,10 +1042,23 @@ function buildReadDevicesCFUpdatedAtGtCondition(updatedAtGt: string | undefined)
   return `updated_at > toDateTime('${safeUpdatedAtGt}')`
 }
 
+function buildReadDevicesCFCustomIdsCondition(customIds: string[] | undefined) {
+  if (!customIds?.length)
+    return ''
+
+  if (customIds.length === 1)
+    return `custom_id = '${escapeSqlString(customIds[0])}'`
+
+  const customIdsList = customIds.map(id => `'${escapeSqlString(id)}'`).join(', ')
+  return `custom_id IN (${customIdsList})`
+}
+
 function buildReadDevicesCFOuterConditions(params: ReadDevicesParams, devicesOrder: DevicesOrderCF | null) {
   const conditions = [
     buildReadDevicesCFCursorCondition(params.cursor, devicesOrder),
     buildReadDevicesCFUpdatedAtGtCondition(params.updated_at_gt),
+    // Match the latest aggregated custom_id, not historical event rows.
+    buildReadDevicesCFCustomIdsCondition(params.customIds),
   ]
   return conditions.filter(Boolean)
 }

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1512,6 +1512,14 @@ export async function readDevicesSB(c: Context, params: ReadDevicesParams, custo
       query = query.in('device_id', params.deviceIds)
   }
 
+  if (params.customIds?.length) {
+    cloudlog({ requestId: c.get('requestId'), message: 'customIds', customIds: params.customIds })
+    if (params.customIds.length === 1)
+      query = query.eq('custom_id', params.customIds[0])
+    else
+      query = query.in('custom_id', params.customIds)
+  }
+
   if (params.search) {
     cloudlog({ requestId: c.get('requestId'), message: 'search', search: params.search })
     const searchPattern = buildIlikeContainsPattern(params.search)

--- a/supabase/functions/_backend/utils/types.ts
+++ b/supabase/functions/_backend/utils/types.ts
@@ -131,6 +131,8 @@ export interface ReadDevicesParams {
   app_id: string
   version_name?: string | undefined
   deviceIds?: string[]
+  /** Exact custom_id match filter (case-sensitive, already trimmed by callers) */
+  customIds?: string[]
   installSources?: string[]
   search?: string
   order?: Order[]

--- a/supabase/migrations/20260729161824_devices_custom_id_lookup_index.sql
+++ b/supabase/migrations/20260729161824_devices_custom_id_lookup_index.sql
@@ -1,0 +1,5 @@
+-- Support exact lookups / filters by custom_id on the public device API.
+-- Most devices keep the empty-string default, so index only non-empty values.
+CREATE INDEX IF NOT EXISTS idx_devices_app_id_custom_id
+ON public.devices USING btree (app_id, custom_id)
+WHERE custom_id <> '';

--- a/tests/device-update-format.unit.test.ts
+++ b/tests/device-update-format.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Database } from '../src/types/supabase.types'
 import { describe, expect, it } from 'vitest'
 import { useDeviceUpdateFormat } from '../src/composables/useDeviceUpdateFormat'
-import { filterDeviceKeys } from '../supabase/functions/_backend/public/device/get.ts'
+import { filterDeviceKeys, parseCustomIdFilter } from '../supabase/functions/_backend/public/device/get.ts'
 
 type DeviceRow = Database['public']['Tables']['devices']['Row']
 
@@ -90,5 +90,19 @@ describe('device update format helpers', () => {
       device_id: '31de6a5e-80a9-4348-9af1-31e1e9562583',
       install_source: 'app_store',
     })
+  })
+})
+
+describe('parseCustomIdFilter', () => {
+  it.concurrent('treats undefined as omitted', () => {
+    expect(parseCustomIdFilter(undefined)).toBeUndefined()
+  })
+
+  it.concurrent('rejects null custom_id', () => {
+    expect(() => parseCustomIdFilter(null)).toThrowError(/custom_id must be a string|invalid_custom_id/)
+  })
+
+  it.concurrent('trims and returns a valid custom_id', () => {
+    expect(parseCustomIdFilter('  user-123  ')).toBe('user-123')
   })
 })

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -198,6 +198,7 @@ describe('[GET] /device custom_id filter', () => {
     expect(response.status).toBe(400)
     expect(data.error).toBe('invalid_custom_id')
   })
+
 })
 
 

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -86,6 +86,7 @@ describe('[GET] /device custom_id filter', () => {
         custom_id: customId,
         is_prod: true,
         is_emulator: false,
+        updated_at: new Date().toISOString(),
       },
       {
         app_id: APPNAME_DEVICE,
@@ -98,6 +99,7 @@ describe('[GET] /device custom_id filter', () => {
         custom_id: `other-${customId}`,
         is_prod: true,
         is_emulator: false,
+        updated_at: new Date().toISOString(),
       },
     ])
     expect(insertError).toBeNull()
@@ -135,6 +137,7 @@ describe('[GET] /device custom_id filter', () => {
       custom_id: customId,
       is_prod: true,
       is_emulator: false,
+      updated_at: new Date().toISOString(),
     })
     expect(insertError).toBeNull()
 

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -67,6 +67,136 @@ describe.concurrent('[GET] /device operations', () => {
   })
 })
 
+describe('[GET] /device custom_id filter', () => {
+  it('returns devices matching an exact custom_id', async () => {
+    const supabase = getSupabaseClient()
+    const customId = `custom-${randomUUID().slice(0, 8)}`
+    const matchingDeviceId = randomUUID().toLowerCase()
+    const otherDeviceId = randomUUID().toLowerCase()
+
+    const { error: insertError } = await supabase.from('devices').upsert([
+      {
+        app_id: APPNAME_DEVICE,
+        device_id: matchingDeviceId,
+        platform: 'ios',
+        plugin_version: '6.0.0',
+        os_version: '17.0',
+        version_build: '1.0.0',
+        version_name: '1.0.0',
+        custom_id: customId,
+        is_prod: true,
+        is_emulator: false,
+      },
+      {
+        app_id: APPNAME_DEVICE,
+        device_id: otherDeviceId,
+        platform: 'android',
+        plugin_version: '6.0.0',
+        os_version: '14',
+        version_build: '1.0.0',
+        version_name: '1.0.0',
+        custom_id: `other-${customId}`,
+        is_prod: true,
+        is_emulator: false,
+      },
+    ])
+    expect(insertError).toBeNull()
+
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      custom_id: customId,
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ data: { device_id: string, custom_id: string }[], error?: string }>()
+    expect(response.status).toBe(200)
+    expect(data.error).toBeUndefined()
+    expect(data.data.length).toBeGreaterThanOrEqual(1)
+    expect(data.data.every(device => device.custom_id === customId)).toBe(true)
+    expect(data.data.some(device => device.device_id === matchingDeviceId)).toBe(true)
+    expect(data.data.some(device => device.device_id === otherDeviceId)).toBe(false)
+  })
+
+  it('trims custom_id before matching', async () => {
+    const supabase = getSupabaseClient()
+    const customId = `trim-${randomUUID().slice(0, 8)}`
+    const deviceId = randomUUID().toLowerCase()
+
+    const { error: insertError } = await supabase.from('devices').upsert({
+      app_id: APPNAME_DEVICE,
+      device_id: deviceId,
+      platform: 'ios',
+      plugin_version: '6.0.0',
+      os_version: '17.0',
+      version_build: '1.0.0',
+      version_name: '1.0.0',
+      custom_id: customId,
+      is_prod: true,
+      is_emulator: false,
+    })
+    expect(insertError).toBeNull()
+
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      custom_id: `  ${customId}  `,
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ data: { device_id: string, custom_id: string }[], error?: string }>()
+    expect(response.status).toBe(200)
+    expect(data.error).toBeUndefined()
+    expect(data.data.some(device => device.device_id === deviceId && device.custom_id === customId)).toBe(true)
+  })
+
+  it('returns an empty list when custom_id has no matches', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      custom_id: `missing-${randomUUID().slice(0, 8)}`,
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ data: unknown[], hasMore: boolean, error?: string }>()
+    expect(response.status).toBe(200)
+    expect(data.error).toBeUndefined()
+    expect(data.data).toEqual([])
+    expect(data.hasMore).toBe(false)
+  })
+
+  it('rejects empty custom_id', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      custom_id: '   ',
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ error?: string }>()
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('invalid_custom_id')
+  })
+
+  it('rejects custom_id longer than 36 characters', async () => {
+    const params = new URLSearchParams({
+      app_id: APPNAME_DEVICE,
+      custom_id: 'a'.repeat(37),
+    })
+    const response = await fetch(`${BASE_URL}/device?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    })
+    const data = await response.json<{ error?: string }>()
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('invalid_custom_id')
+  })
+})
+
 
 describe('[GET] /device updated_at filter and order', () => {
   it('filters devices by updated_at greater than ISO date', async () => {

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -263,6 +263,15 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
           limit: 10,
         }, true),
       },
+      {
+        name: 'buildReadDevicesCFQuery.customIds',
+        query: buildReadDevicesCFQuery({
+          app_id: SAMPLE_APP_ID,
+          customIds: ['user-123'],
+          order: [{ key: 'updated_at', sortable: 'desc' }],
+          limit: 10,
+        }, false),
+      },
     ]
 
     await captureCall('readDeviceUsageCF', () => readDeviceUsageCF(context, SAMPLE_APP_ID, SAMPLE_START, SAMPLE_END))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Add exact `custom_id` filter to public `GET /device` so API-key clients can look up devices set via `CapacitorUpdater.setCustomId({ customId })`
- Wire the filter through Postgres (`readDevicesSB`) and Analytics Engine (`readDevicesCF`, matching the latest aggregated custom_id)
- Add partial index `idx_devices_app_id_custom_id` on `(app_id, custom_id) WHERE custom_id <> ''` for lookup performance
- Cover success, trim, empty/missing, and length validation in `tests/device.test.ts`

## Motivation (AI generated)

Customers set `customId` from the plugin and need a public API way to find those devices without knowing Capgo's internal `device_id`. Existing `customIdMode` only filters devices that *have* a custom id; it does not look up by value.

## Business Impact (AI generated)

Unblocks support and backend workflows that correlate Capgo devices with customer user IDs / external identifiers, reducing friction for teams integrating Capgo into their own ops tooling.

## Test Plan (AI generated)

- [x] `GET /device?app_id=APP&custom_id=MY_ID` returns matching devices in the paginated list shape
- [x] Whitespace around `custom_id` is trimmed before matching
- [x] Empty / >36-char `custom_id` returns `400 invalid_custom_id`
- [x] Unknown `custom_id` returns empty `data` list (not 404)
- [x] `device_id` single-get path still works and ignores invalid list-only params
- [x] Migration applies cleanly (`idx_devices_app_id_custom_id`)
- [x] CI `Run tests` green on PR

### Example

```bash
curl -G 'https://api.capgo.app/device' \
  -H "authorization: YOUR_API_KEY" \
  --data-urlencode 'app_id=com.example.app' \
  --data-urlencode 'custom_id=user-123'
```

Response shape matches the device list endpoint (`{ data, nextCursor, hasMore }`). Use `limit=1&order=desc` to get the most recently updated match.

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faea9-a46a-7f82-9e7a-b029b6022bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faea9-a46a-7f82-9e7a-b029b6022bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

