### PR TITLE
fix(frontend): require current password when changing password

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -933,6 +933,7 @@
   "stripe-subscriptions-past-due": "Stripe subscriptions past due",
   "current-bundle": "Current bundle",
   "current-password": "Current Password",
+  "current-password-required": "Please enter your current password to set a new one.",
   "current-version": "Current Version",
   "currently-live-on": "Currently live on {channels}",
   "custom": "Custom",

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -224,54 +224,55 @@ async function submit(form: { current_password: string, password: string, passwo
     return
   isLoading.value = true
 
-  const mfaOk = await ensureMfaIfNeeded()
-  if (!mfaOk) {
+  try {
+    const mfaOk = await ensureMfaIfNeeded()
+    if (!mfaOk)
+      return
+
+    // Auth may require the current password (security_update_password_require_current_password).
+    const { error: updateError } = await supabase.auth.updateUser({
+      password: form.password,
+      current_password: form.current_password,
+    })
+
+    if (updateError) {
+      // Auth error codes from GoTrue user update (do not match on message text —
+      // current_password_mismatch reuses the same message as current_password_required).
+      if (updateError.code === 'current_password_required' || updateError.code === 'reauthentication_needed') {
+        reportPasswordUpdateError(t('current-password-required'))
+        return
+      }
+      if (
+        updateError.code === 'current_password_mismatch'
+        || updateError.code === 'reauthentication_not_valid'
+        || updateError.code === 'invalid_credentials'
+      ) {
+        reportPasswordUpdateError(t('invalid-password'))
+        return
+      }
+      reportPasswordUpdateError(updateError.message || t('account-password-error'))
+      return
+    }
+
+    resetCaptcha()
+
+    if (!organizationStore.currentOrganization?.password_has_access) {
+      await organizationStore.fetchOrganizations()
+    }
+
+    // Best-effort: password already changed; do not treat other-session sign-out as failure.
+    const { error: signOutError } = await supabase.auth.signOut({ scope: 'others' })
+    if (signOutError)
+      console.error('Failed to sign out other sessions after password change', signOutError)
+
+    toast.success(t('changed-password-suc'))
+    form.password = ''
+    form.password_confirm = ''
+    form.current_password = ''
+  }
+  finally {
     isLoading.value = false
-    return
   }
-
-  // Auth may require the current password (security_update_password_require_current_password).
-  const { error: updateError } = await supabase.auth.updateUser({
-    password: form.password,
-    current_password: form.current_password,
-  })
-
-  isLoading.value = false
-  if (updateError) {
-    // Auth error codes from GoTrue user update (do not match on message text —
-    // current_password_mismatch reuses the same message as current_password_required).
-    if (updateError.code === 'current_password_required' || updateError.code === 'reauthentication_needed') {
-      reportPasswordUpdateError(t('current-password-required'))
-      return
-    }
-    if (
-      updateError.code === 'current_password_mismatch'
-      || updateError.code === 'reauthentication_not_valid'
-      || updateError.code === 'invalid_credentials'
-    ) {
-      reportPasswordUpdateError(t('invalid-password'))
-      return
-    }
-    reportPasswordUpdateError(updateError.message || t('account-password-error'))
-    return
-  }
-
-  resetCaptcha()
-
-  if (!organizationStore.currentOrganization?.password_has_access) {
-    await organizationStore.fetchOrganizations()
-  }
-
-  const { error: signOutError } = await supabase.auth.signOut({ scope: 'others' })
-  if (signOutError) {
-    reportPasswordUpdateError(signOutError.message)
-    return
-  }
-
-  toast.success(t('changed-password-suc'))
-  form.password = ''
-  form.password_confirm = ''
-  form.current_password = ''
 }
 </script>
 

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -21,7 +21,6 @@ const supabase = useSupabase()
 const organizationStore = useOrganizationStore()
 const mainStore = useMainStore()
 const mfaCode = ref('')
-const needsReauthentication = ref(false)
 const turnstileToken = ref('')
 const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
 const captchaComponent = ref<InstanceType<typeof VueTurnstile> | null>(null)
@@ -156,56 +155,26 @@ async function verifyPassword(form: { current_password: string }) {
   }
 }
 
-async function verifyCurrentPassword(currentPassword: string) {
-  const user = mainStore.user
-  if (!user?.email) {
-    setErrors('change-pass', [t('user-not-found')], {})
-    return false
-  }
-
-  const { error: signInError } = await supabase.auth.signInWithPassword({
-    email: user.email,
-    password: currentPassword,
-    options: turnstileToken.value
-      ? { captchaToken: turnstileToken.value }
-      : undefined,
-  })
-
-  if (signInError?.code === 'mfa_required') {
-    return await runMfaChallenge()
-  }
-
-  if (signInError) {
-    resetCaptcha()
-    if (signInError.message.includes('captcha')) {
-      toast.error(t('captcha-fail'))
-    }
-    else {
-      setErrors('change-pass', [t('invalid-password')], {})
-    }
-    return false
-  }
-
-  return true
-}
-
 async function runMfaChallenge() {
   const { data: mfaFactors, error: mfaError } = await supabase.auth.mfa.listFactors()
   if (mfaError) {
-    setErrors('forgot-password', [mfaError.message], {})
+    setErrors('change-pass', [mfaError.message], {})
+    toast.error(mfaError.message)
     console.error('Cannot get MFA factors', mfaError)
     return false
   }
   const factor = mfaFactors.all.find(factor => factor.status === 'verified')
   if (!factor) {
-    setErrors('forgot-password', ['Cannot find MFA factor'], {})
+    setErrors('change-pass', [t('alert-2fa-required')], {})
+    toast.error(t('alert-2fa-required'))
     console.error('Cannot find MFA factors', mfaError)
     return false
   }
 
   const { data: challenge, error: errorChallenge } = await supabase.auth.mfa.challenge({ factorId: factor.id })
   if (errorChallenge) {
-    setErrors('forgot-password', [errorChallenge.message], {})
+    setErrors('change-pass', [errorChallenge.message], {})
+    toast.error(errorChallenge.message)
     console.error('Cannot challenge MFA factor', errorChallenge)
     return false
   }
@@ -245,56 +214,66 @@ async function ensureMfaIfNeeded() {
   return true
 }
 
-async function submit(form: { current_password?: string, password: string, password_confirm: string }) {
+function reportPasswordUpdateError(message: string) {
+  setErrors('change-pass', [message], {})
+  toast.error(message)
+}
+
+async function submit(form: { current_password: string, password: string, password_confirm: string }) {
   if (isLoading.value)
     return
   isLoading.value = true
-
-  if (needsReauthentication.value) {
-    const currentPasswordValid = await verifyCurrentPassword(form.current_password ?? '')
-    if (!currentPasswordValid) {
-      isLoading.value = false
-      return
-    }
-  }
 
   const mfaOk = await ensureMfaIfNeeded()
   if (!mfaOk) {
     isLoading.value = false
     return
   }
-  const { error: updateError } = await supabase.auth.updateUser({ password: form.password })
+
+  // Auth may require the current password (security_update_password_require_current_password).
+  const { error: updateError } = await supabase.auth.updateUser({
+    password: form.password,
+    current_password: form.current_password,
+  })
 
   isLoading.value = false
   if (updateError) {
-    if (updateError.code === 'reauthentication_needed' || updateError.code === 'reauthentication_not_valid') {
-      needsReauthentication.value = true
-      isLoading.value = false
+    if (
+      updateError.code === 'current_password_required'
+      || updateError.code === 'reauthentication_needed'
+      || updateError.code === 'reauthentication_not_valid'
+      || updateError.message.toLowerCase().includes('current password')
+    ) {
+      reportPasswordUpdateError(t('current-password-required'))
       return
     }
-    setErrors('change-pass', [t('account-password-error')], {})
-  }
-  else {
-    needsReauthentication.value = false
-    resetCaptcha()
-
-    if (!organizationStore.currentOrganization?.password_has_access) {
-      await organizationStore.fetchOrganizations()
-    }
-
-    const { error: signOutError } = await supabase.auth.signOut({ scope: 'others' })
-    if (signOutError) {
-      setErrors('change-pass', [signOutError.message], {})
+    if (
+      updateError.code === 'invalid_credentials'
+      || updateError.message.toLowerCase().includes('invalid')
+    ) {
+      reportPasswordUpdateError(t('invalid-password'))
       return
     }
+    reportPasswordUpdateError(updateError.message || t('account-password-error'))
+    return
+  }
 
-    toast.success(t('changed-password-suc'))
+  resetCaptcha()
+
+  if (!organizationStore.currentOrganization?.password_has_access) {
+    await organizationStore.fetchOrganizations()
   }
-  if (!updateError) {
-    form.password = ''
-    form.password_confirm = ''
-    form.current_password = ''
+
+  const { error: signOutError } = await supabase.auth.signOut({ scope: 'others' })
+  if (signOutError) {
+    reportPasswordUpdateError(signOutError.message)
+    return
   }
+
+  toast.success(t('changed-password-suc'))
+  form.password = ''
+  form.password_confirm = ''
+  form.current_password = ''
 }
 </script>
 
@@ -401,7 +380,6 @@ async function submit(form: { current_password?: string, password: string, passw
           <section>
             <div class="mt-5 flex flex-col gap-4 sm:flex-row sm:flex-wrap">
               <FormKit
-                v-if="needsReauthentication"
                 type="password"
                 name="current_password"
                 :prefix-icon="iconPassword"

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -272,9 +272,10 @@ async function submit(form: { current_password: string, password: string, passwo
 
     if (updateError?.code === 'reauthentication_needed' || updateError?.code === 'reauthentication_not_valid') {
       const refreshed = await refreshSessionWithCurrentPassword(form.current_password)
-      if (!refreshed) {
+      if (!refreshed)
         return
-      }({ error: updateError } = await updatePasswordWithCurrent(form.password, form.current_password))
+      const retry = await updatePasswordWithCurrent(form.password, form.current_password)
+      updateError = retry.error
     }
 
     if (updateError) {

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -272,9 +272,9 @@ async function submit(form: { current_password: string, password: string, passwo
 
     if (updateError?.code === 'reauthentication_needed' || updateError?.code === 'reauthentication_not_valid') {
       const refreshed = await refreshSessionWithCurrentPassword(form.current_password)
-      if (!refreshed)
+      if (!refreshed) {
         return
-      ;({ error: updateError } = await updatePasswordWithCurrent(form.password, form.current_password))
+      }({ error: updateError } = await updatePasswordWithCurrent(form.password, form.current_password))
     }
 
     if (updateError) {

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -214,9 +214,47 @@ async function ensureMfaIfNeeded() {
   return true
 }
 
+// Refresh the session with the current password when GoTrue requires recent reauthentication.
+async function refreshSessionWithCurrentPassword(currentPassword: string) {
+  const user = mainStore.user
+  if (!user?.email) {
+    reportPasswordUpdateError(t('account-password-error'))
+    return false
+  }
+
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email: user.email,
+    password: currentPassword,
+    options: turnstileToken.value
+      ? { captchaToken: turnstileToken.value }
+      : undefined,
+  })
+
+  if (signInError?.code === 'mfa_required')
+    return await runMfaChallenge()
+
+  if (signInError) {
+    resetCaptcha()
+    if (signInError.message.includes('captcha'))
+      toast.error(t('captcha-fail'))
+    else
+      reportPasswordUpdateError(t('invalid-password'))
+    return false
+  }
+
+  return true
+}
+
 function reportPasswordUpdateError(message: string) {
   setErrors('change-pass', [message], {})
   toast.error(message)
+}
+
+async function updatePasswordWithCurrent(password: string, currentPassword: string) {
+  return supabase.auth.updateUser({
+    password,
+    current_password: currentPassword,
+  })
 }
 
 async function submit(form: { current_password: string, password: string, password_confirm: string }) {
@@ -229,22 +267,25 @@ async function submit(form: { current_password: string, password: string, passwo
     if (!mfaOk)
       return
 
-    // Auth may require the current password (security_update_password_require_current_password).
-    const { error: updateError } = await supabase.auth.updateUser({
-      password: form.password,
-      current_password: form.current_password,
-    })
+    // Auth may require current_password and/or a fresh session (reauthentication).
+    let { error: updateError } = await updatePasswordWithCurrent(form.password, form.current_password)
+
+    if (updateError?.code === 'reauthentication_needed' || updateError?.code === 'reauthentication_not_valid') {
+      const refreshed = await refreshSessionWithCurrentPassword(form.current_password)
+      if (!refreshed)
+        return
+      ;({ error: updateError } = await updatePasswordWithCurrent(form.password, form.current_password))
+    }
 
     if (updateError) {
       // Auth error codes from GoTrue user update (do not match on message text —
       // current_password_mismatch reuses the same message as current_password_required).
-      if (updateError.code === 'current_password_required' || updateError.code === 'reauthentication_needed') {
+      if (updateError.code === 'current_password_required') {
         reportPasswordUpdateError(t('current-password-required'))
         return
       }
       if (
         updateError.code === 'current_password_mismatch'
-        || updateError.code === 'reauthentication_not_valid'
         || updateError.code === 'invalid_credentials'
       ) {
         reportPasswordUpdateError(t('invalid-password'))

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -238,18 +238,16 @@ async function submit(form: { current_password: string, password: string, passwo
 
   isLoading.value = false
   if (updateError) {
-    if (
-      updateError.code === 'current_password_required'
-      || updateError.code === 'reauthentication_needed'
-      || updateError.code === 'reauthentication_not_valid'
-      || updateError.message.toLowerCase().includes('current password')
-    ) {
+    // Auth error codes from GoTrue user update (do not match on message text —
+    // current_password_mismatch reuses the same message as current_password_required).
+    if (updateError.code === 'current_password_required' || updateError.code === 'reauthentication_needed') {
       reportPasswordUpdateError(t('current-password-required'))
       return
     }
     if (
-      updateError.code === 'invalid_credentials'
-      || updateError.message.toLowerCase().includes('invalid')
+      updateError.code === 'current_password_mismatch'
+      || updateError.code === 'reauthentication_not_valid'
+      || updateError.code === 'invalid_credentials'
     ) {
       reportPasswordUpdateError(t('invalid-password'))
       return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Always show a **Current Password** field on Settings → Change Password
- Send `current_password` with `supabase.auth.updateUser()` so Auth accepts the change when `security_update_password_require_current_password` is enabled
- If Auth returns `reauthentication_needed`, refresh the session with the current password and retry
- Show toast + form errors for Auth failures instead of failing silently

## Motivation (AI generated)

A customer reported that after org 2FA / password policy forced a password update, `PUT /auth/v1/user` returned:

```json
{ "code": "current_password_required", "message": "Current password required when setting new password." }
```

The UI had no current-password input on first submit (it only appeared after a different reauth error), never sent `current_password`, and did not surface this API error clearly.

## Business Impact (AI generated)

Users locked by org password policy / 2FA can complete password updates again without digging through the network tab. Reduces support load and unlocks blocked org access.

## Visual changes (AI generated)

![Change password form with Current Password field and error toast](https://cursor.com/artifacts/c/art-dd1fb9f5-2d24-42bf-bc59-d238a0b6fbe6)

<!-- visual-diff:required -->

## Test Plan (AI generated)

- [ ] Open `/settings/account/change-password` and confirm Current Password is always visible
- [ ] Submit with only new password → form validation blocks empty current password
- [ ] Submit with wrong current password → toast/error shown
- [ ] Submit with correct current password (+ MFA if enabled) → password updates successfully
- [ ] With an old session + reauth required → session refreshes and password updates
- [ ] Org password-policy verify flow still works independently

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faef4-86d3-7014-8763-687cf66d5c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faef4-86d3-7014-8763-687cf66d5c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an English prompt message for requiring entry of the current password when changing to a new one.

* **Bug Fixes**
  * Improved the password-change flow to use current-password reauthentication outcomes and show clearer, field-specific error messages.
  * Updated MFA handling and “2FA required” messaging to better match the change-password experience.
  * Ensured the current-password input is consistently available during password changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->