### PR TITLE
fix(rbac): scope organization invitation membership checks

### DIFF
--- a/supabase/functions/_backend/private/invite_existing_user_to_org.ts
+++ b/supabase/functions/_backend/private/invite_existing_user_to_org.ts
@@ -263,6 +263,9 @@ app.post('/', middlewareAuth, async (c) => {
     .select('id, is_invite, rbac_role_name')
     .eq('org_id', body.org_id)
     .eq('user_id', invitedUser.id)
+    // Legacy app/channel-scoped rows share (org_id, user_id); only the org-level row is the membership.
+    .is('app_id', null)
+    .is('channel_id', null)
     .maybeSingle()
 
   if (membershipError) {

--- a/supabase/migrations/20260730141406_scope_org_level_membership_lookups.sql
+++ b/supabase/migrations/20260730141406_scope_org_level_membership_lookups.sql
@@ -389,4 +389,95 @@ BEGIN
 END;
 $$;
 
+-- A scoped legacy row is not evidence that the caller has an organization
+-- invitation. Keep this as a separate guard so an old contaminated row cannot
+-- use the invite-acceptance exception in prevent_role_binding_priority_escalation.
+CREATE OR REPLACE FUNCTION public.prevent_scoped_invite_role_acceptance() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+BEGIN
+  IF public.is_internal_request_role(public.current_request_role()) THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.principal_type = public.rbac_principal_user()
+    AND NEW.principal_id = auth.uid()
+    AND NEW.scope_type = public.rbac_scope_org()
+    AND NEW.reason = 'Accepted invitation'
+    AND NEW.app_id IS NULL
+    AND NEW.bundle_id IS NULL
+    AND NEW.channel_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.org_users ou
+      JOIN public.roles r
+        ON r.name = ou.rbac_role_name
+        AND r.scope_type = public.rbac_scope_org()
+      WHERE ou.user_id = NEW.principal_id
+        AND ou.org_id = NEW.org_id
+        AND ou.is_invite IS TRUE
+        AND ou.app_id IS NULL
+        AND ou.channel_id IS NULL
+        AND r.id = NEW.role_id
+    )
+  THEN
+    PERFORM public.pg_log(
+      'deny: SCOPED_INVITE_ROLE_ACCEPTANCE',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', auth.uid())
+    );
+    RAISE EXCEPTION 'Admins cannot elevate privileges!';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.prevent_scoped_invite_role_acceptance() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.prevent_scoped_invite_role_acceptance() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.prevent_scoped_invite_role_acceptance() TO service_role;
+
+DROP TRIGGER IF EXISTS prevent_scoped_invite_role_acceptance ON public.role_bindings;
+CREATE TRIGGER prevent_scoped_invite_role_acceptance
+BEFORE INSERT ON public.role_bindings
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_scoped_invite_role_acceptance();
+
+-- Scope columns are part of a membership row's identity. External callers must
+-- not turn an app/channel row into an organization invitation after the fact.
+CREATE OR REPLACE FUNCTION public.prevent_org_user_scope_mutation() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+BEGIN
+  IF public.is_internal_request_role(public.current_request_role()) THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.app_id IS DISTINCT FROM OLD.app_id
+    OR NEW.channel_id IS DISTINCT FROM OLD.channel_id
+  THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_SCOPE_MOVE',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', auth.uid())
+    );
+    RAISE EXCEPTION 'Admins cannot move org membership scopes!';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.prevent_org_user_scope_mutation() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.prevent_org_user_scope_mutation() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.prevent_org_user_scope_mutation() TO service_role;
+
+DROP TRIGGER IF EXISTS prevent_org_user_scope_mutation ON public.org_users;
+CREATE TRIGGER prevent_org_user_scope_mutation
+BEFORE UPDATE OF app_id, channel_id ON public.org_users
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_org_user_scope_mutation();
+
+COMMENT ON FUNCTION public.prevent_scoped_invite_role_acceptance() IS 'Requires an org-level pending membership row before an authenticated user can insert an accepted org-role binding.';
+COMMENT ON FUNCTION public.prevent_org_user_scope_mutation() IS 'Prevents external callers from changing an org_users row between org, app, and channel scopes.';
 COMMENT ON FUNCTION "public"."accept_invitation_to_org"("org_id" "uuid") IS 'Accepts a pending org invite and creates the active RBAC binding. Kept for old clients.';

--- a/supabase/migrations/20260730141406_scope_org_level_membership_lookups.sql
+++ b/supabase/migrations/20260730141406_scope_org_level_membership_lookups.sql
@@ -1,0 +1,392 @@
+-- Scope org-level membership lookups to org-level org_users rows.
+--
+-- public.org_users still carries legacy app-scoped and channel-scoped rows
+-- (app_id / channel_id set). The RBAC invite path treated every row for a
+-- (org_id, user_id) pair as the organization membership, which breaks orgs that
+-- still have those legacy rows:
+--   * accept_invitation_to_org picked an app/channel-scoped row, found no
+--     matching org-scope role, and returned ROLE_NOT_FOUND forever, so the
+--     invitee could never accept (surfaces as a stuck invitation).
+--   * accept_invitation_to_org and update_org_invite_role_rbac also wrote the
+--     org role name onto those scoped rows and cleared their is_invite flag.
+--   * invite_user_to_org_rbac reported ALREADY_INVITED for a user who only had
+--     an app-scoped row and no organization membership at all.
+--   * get_org_members_rbac listed those scoped rows as pending org invitations.
+--
+-- private/accept_invitation.ts already filters app_id/channel_id when it does
+-- the same work; this aligns the SQL paths with it.
+
+CREATE OR REPLACE FUNCTION "public"."accept_invitation_to_org"("org_id" "uuid") RETURNS character varying
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    SET "row_security" TO 'off'
+    AS $$
+DECLARE
+  invite public.org_users%ROWTYPE;
+  invite_user_id uuid;
+  invite_org_id uuid;
+  role_name text;
+  role_id uuid;
+BEGIN
+  SELECT public.org_users.*
+  INTO invite
+  FROM public.org_users
+  WHERE public.org_users.org_id = accept_invitation_to_org.org_id
+    AND public.org_users.user_id = auth.uid()
+    AND public.org_users.is_invite IS TRUE
+    AND public.org_users.app_id IS NULL
+    AND public.org_users.channel_id IS NULL
+  ORDER BY public.org_users.created_at DESC NULLS LAST,
+    public.org_users.id DESC
+  LIMIT 1;
+
+  IF invite.id IS NOT NULL THEN
+    IF invite.rbac_role_name IS NULL THEN
+      RETURN 'ROLE_NOT_FOUND';
+    END IF;
+    invite_user_id := invite.user_id;
+    invite_org_id := invite.org_id;
+    role_name := invite.rbac_role_name;
+  ELSE
+    SELECT rb.principal_id, rb.org_id, r.name
+    INTO invite_user_id, invite_org_id, role_name
+    FROM public.role_bindings rb
+    JOIN public.roles r
+      ON r.id = rb.role_id
+      AND r.scope_type = rb.scope_type
+    WHERE rb.principal_type = public.rbac_principal_user()
+      AND rb.principal_id = auth.uid()
+      AND rb.org_id = accept_invitation_to_org.org_id
+      AND rb.scope_type = public.rbac_scope_org()
+      AND rb.reason IN ('Pending invitation', 'Invited via invite_user_to_org_rbac')
+    ORDER BY rb.granted_at DESC NULLS LAST
+    LIMIT 1;
+
+    IF invite_user_id IS NULL THEN
+      RETURN 'NO_INVITE';
+    END IF;
+  END IF;
+
+  IF role_name IS NULL THEN
+    RETURN 'ROLE_NOT_FOUND';
+  END IF;
+
+  SELECT public.roles.id INTO role_id
+  FROM public.roles
+  WHERE public.roles.name = role_name
+    AND public.roles.scope_type = public.rbac_scope_org()
+    AND public.roles.is_assignable = true
+  LIMIT 1;
+
+  IF role_id IS NULL THEN
+    RETURN 'ROLE_NOT_FOUND';
+  END IF;
+
+  -- Keep is_invite true until after the accepted binding is inserted so the
+  -- privilege guards can verify this is a real invite acceptance.
+  IF invite.id IS NULL THEN
+    INSERT INTO public.org_users (user_id, org_id, rbac_role_name, is_invite)
+    VALUES (invite_user_id, invite_org_id, role_name, true);
+  END IF;
+
+  DELETE FROM public.role_bindings
+  WHERE public.role_bindings.principal_type = public.rbac_principal_user()
+    AND public.role_bindings.principal_id = invite_user_id
+    AND public.role_bindings.scope_type = public.rbac_scope_org()
+    AND public.role_bindings.org_id = invite_org_id;
+
+  INSERT INTO public.role_bindings (
+    principal_type,
+    principal_id,
+    role_id,
+    scope_type,
+    org_id,
+    app_id,
+    channel_id,
+    granted_by,
+    granted_at,
+    reason,
+    is_direct
+  ) VALUES (
+    public.rbac_principal_user(),
+    invite_user_id,
+    role_id,
+    public.rbac_scope_org(),
+    invite_org_id,
+    NULL,
+    NULL,
+    auth.uid(),
+    now(),
+    'Accepted invitation',
+    true
+  ) ON CONFLICT DO NOTHING;
+
+  UPDATE public.org_users
+  SET is_invite = false,
+      rbac_role_name = role_name,
+      updated_at = CURRENT_TIMESTAMP
+  WHERE public.org_users.user_id = invite_user_id
+    AND public.org_users.org_id = invite_org_id
+    AND public.org_users.is_invite IS TRUE
+    AND public.org_users.app_id IS NULL
+    AND public.org_users.channel_id IS NULL;
+
+  RETURN 'OK';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."invite_user_to_org_rbac"("email" character varying, "org_id" "uuid", "role_name" "text") RETURNS character varying
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  org record;
+  invited_user record;
+  current_record record;
+  current_tmp_user record;
+  role_id uuid;
+  role_priority integer;
+  caller_max_priority integer := 0;
+  api_key_text text;
+  api_key_row public.apikeys%ROWTYPE;
+  v_granted_by uuid;
+  v_principal_type text;
+  v_principal_id uuid;
+BEGIN
+  SELECT * INTO org FROM public.orgs WHERE public.orgs.id = invite_user_to_org_rbac.org_id;
+  IF org IS NULL THEN
+    RETURN 'NO_ORG';
+  END IF;
+
+  SELECT r.id, r.priority_rank INTO role_id, role_priority
+  FROM public.roles r
+  WHERE r.name = invite_user_to_org_rbac.role_name
+    AND r.scope_type = public.rbac_scope_org()
+    AND r.is_assignable = true
+  LIMIT 1;
+
+  IF role_id IS NULL THEN
+    RETURN 'ROLE_NOT_FOUND';
+  END IF;
+
+  SELECT public.get_apikey_header() INTO api_key_text;
+  IF api_key_text IS NOT NULL THEN
+    SELECT * INTO api_key_row FROM public.find_apikey_by_value(api_key_text) LIMIT 1;
+    v_granted_by := api_key_row.user_id;
+    v_principal_type := public.rbac_principal_apikey();
+    v_principal_id := api_key_row.rbac_id;
+  ELSE
+    v_granted_by := auth.uid();
+    v_principal_type := public.rbac_principal_user();
+    v_principal_id := auth.uid();
+  END IF;
+
+  IF invite_user_to_org_rbac.role_name = public.rbac_role_org_super_admin() THEN
+    IF NOT public.rbac_check_permission_direct(public.rbac_perm_org_update_user_roles(), auth.uid(), invite_user_to_org_rbac.org_id, NULL, NULL, api_key_text) THEN
+      RETURN 'NO_RIGHTS';
+    END IF;
+  ELSE
+    IF NOT public.rbac_check_permission_direct(public.rbac_perm_org_invite_user(), auth.uid(), invite_user_to_org_rbac.org_id, NULL, NULL, api_key_text) THEN
+      RETURN 'NO_RIGHTS';
+    END IF;
+  END IF;
+
+  IF v_principal_id IS NULL THEN
+    RETURN 'NO_RIGHTS';
+  END IF;
+
+  SELECT COALESCE(MAX(r.priority_rank), 0) INTO caller_max_priority
+  FROM public.role_bindings rb
+  JOIN public.roles r
+    ON r.id = rb.role_id
+    AND r.scope_type = rb.scope_type
+  WHERE rb.principal_type = v_principal_type
+    AND rb.principal_id = v_principal_id
+    AND rb.org_id = invite_user_to_org_rbac.org_id
+    AND (rb.expires_at IS NULL OR rb.expires_at > now());
+
+  IF caller_max_priority < role_priority THEN
+    RETURN 'NO_RIGHTS';
+  END IF;
+
+  SELECT public.users.id INTO invited_user FROM public.users WHERE public.users.email = invite_user_to_org_rbac.email;
+
+  IF invited_user IS NOT NULL THEN
+    SELECT public.org_users.id INTO current_record
+    FROM public.org_users
+    WHERE public.org_users.user_id = invited_user.id
+      AND public.org_users.org_id = invite_user_to_org_rbac.org_id
+      AND public.org_users.app_id IS NULL
+      AND public.org_users.channel_id IS NULL;
+
+    IF current_record IS NOT NULL THEN
+      RETURN 'ALREADY_INVITED';
+    ELSE
+      INSERT INTO public.org_users (user_id, org_id, rbac_role_name, is_invite)
+      VALUES (invited_user.id, invite_user_to_org_rbac.org_id, invite_user_to_org_rbac.role_name, true);
+
+      INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id,
+        granted_by, granted_at, expires_at, reason, is_direct
+      ) VALUES (
+        public.rbac_principal_user(), invited_user.id, role_id, public.rbac_scope_org(), invite_user_to_org_rbac.org_id,
+        COALESCE(v_granted_by, invited_user.id), now(), now() - INTERVAL '1 second', 'Pending invitation', true
+      ) ON CONFLICT DO NOTHING;
+
+      RETURN 'OK';
+    END IF;
+  ELSE
+    SELECT * INTO current_tmp_user
+    FROM public.tmp_users
+    WHERE public.tmp_users.email = invite_user_to_org_rbac.email
+      AND public.tmp_users.org_id = invite_user_to_org_rbac.org_id;
+
+    IF current_tmp_user IS NOT NULL THEN
+      IF current_tmp_user.cancelled_at IS NOT NULL THEN
+        IF current_tmp_user.cancelled_at > (CURRENT_TIMESTAMP - INTERVAL '3 hours') THEN
+          RETURN 'TOO_RECENT_INVITATION_CANCELATION';
+        ELSE
+          RETURN 'NO_EMAIL';
+        END IF;
+      ELSE
+        RETURN 'ALREADY_INVITED';
+      END IF;
+    ELSE
+      RETURN 'NO_EMAIL';
+    END IF;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."update_org_invite_role_rbac"("p_org_id" "uuid", "p_user_id" "uuid", "p_new_role_name" "text") RETURNS "text"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  role_id uuid;
+BEGIN
+  SELECT id INTO role_id
+  FROM public.roles r
+  WHERE r.name = p_new_role_name
+    AND r.scope_type = public.rbac_scope_org()
+    AND r.is_assignable = true
+  LIMIT 1;
+
+  IF role_id IS NULL THEN
+    RAISE EXCEPTION 'ROLE_NOT_FOUND';
+  END IF;
+
+  IF p_new_role_name = public.rbac_role_org_super_admin() THEN
+    IF NOT public.rbac_check_permission_request(public.rbac_perm_org_update_user_roles(), p_org_id, NULL::character varying, NULL::bigint) THEN
+      RAISE EXCEPTION 'NO_PERMISSION_TO_UPDATE_ROLES';
+    END IF;
+  ELSE
+    IF NOT public.rbac_check_permission_request(public.rbac_perm_org_invite_user(), p_org_id, NULL::character varying, NULL::bigint) THEN
+      RAISE EXCEPTION 'NO_PERMISSION_TO_UPDATE_ROLES';
+    END IF;
+  END IF;
+
+  UPDATE public.org_users
+  SET rbac_role_name = p_new_role_name,
+      updated_at = now()
+  WHERE org_id = p_org_id
+    AND user_id = p_user_id
+    AND is_invite IS TRUE
+    AND app_id IS NULL
+    AND channel_id IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'NO_INVITATION';
+  END IF;
+
+  RETURN 'OK';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."get_org_members_rbac"("p_org_id" "uuid") RETURNS TABLE("user_id" "uuid", "email" character varying, "image_url" character varying, "role_name" "text", "role_id" "uuid", "binding_id" "uuid", "granted_at" timestamp with time zone, "is_invite" boolean, "is_tmp" boolean, "org_user_id" bigint)
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  IF NOT public.rbac_check_permission_request(
+    public.rbac_perm_org_read_members(),
+    p_org_id,
+    NULL::character varying,
+    NULL::bigint
+  ) THEN
+    RAISE EXCEPTION 'NO_PERMISSION_TO_VIEW_MEMBERS';
+  END IF;
+
+  RETURN QUERY
+  WITH rbac_members AS (
+    SELECT
+      u.id AS user_id,
+      u.email,
+      u.image_url,
+      r.name AS role_name,
+      rb.role_id,
+      rb.id AS binding_id,
+      rb.granted_at,
+      false AS is_invite,
+      false AS is_tmp,
+      NULL::bigint AS org_user_id
+    FROM public.users u
+    INNER JOIN public.role_bindings rb ON rb.principal_id = u.id
+      AND rb.principal_type = public.rbac_principal_user()
+      AND rb.scope_type = public.rbac_scope_org()
+      AND rb.org_id = p_org_id
+      AND (rb.expires_at IS NULL OR rb.expires_at > now())
+    INNER JOIN public.roles r ON rb.role_id = r.id
+      AND r.scope_type = rb.scope_type
+    WHERE r.scope_type = public.rbac_scope_org()
+      AND r.name LIKE 'org_%'
+  ),
+  pending_user_invites AS (
+    SELECT
+      u.id AS user_id,
+      u.email,
+      u.image_url,
+      COALESCE(ou.rbac_role_name, public.rbac_role_org_member()) AS role_name,
+      NULL::uuid AS role_id,
+      NULL::uuid AS binding_id,
+      ou.created_at AS granted_at,
+      true AS is_invite,
+      false AS is_tmp,
+      ou.id AS org_user_id
+    FROM public.org_users ou
+    INNER JOIN public.users u ON u.id = ou.user_id
+    WHERE ou.org_id = p_org_id
+      AND ou.is_invite IS TRUE
+      AND ou.app_id IS NULL
+      AND ou.channel_id IS NULL
+  ),
+  tmp_invites AS (
+    SELECT
+      tmp.future_uuid AS user_id,
+      tmp.email,
+      ''::character varying AS image_url,
+      tmp.rbac_role_name AS role_name,
+      NULL::uuid AS role_id,
+      NULL::uuid AS binding_id,
+      GREATEST(tmp.updated_at, tmp.created_at) AS granted_at,
+      true AS is_invite,
+      true AS is_tmp,
+      NULL::bigint AS org_user_id
+    FROM public.tmp_users tmp
+    WHERE tmp.org_id = p_org_id
+      AND tmp.cancelled_at IS NULL
+      AND GREATEST(tmp.updated_at, tmp.created_at) > (CURRENT_TIMESTAMP - INTERVAL '7 days')
+  )
+  SELECT *
+  FROM (
+    SELECT * FROM rbac_members
+    UNION ALL
+    SELECT * FROM pending_user_invites
+    UNION ALL
+    SELECT * FROM tmp_invites
+  ) AS combined
+  ORDER BY is_tmp ASC, is_invite ASC, email ASC;
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."accept_invitation_to_org"("org_id" "uuid") IS 'Accepts a pending org invite and creates the active RBAC binding. Kept for old clients.';

--- a/tests/accept-invitation-scoped-membership.test.ts
+++ b/tests/accept-invitation-scoped-membership.test.ts
@@ -262,4 +262,155 @@ describe('org invite path ignores app-scoped org_users rows', () => {
     )
     expect(members.rows).toEqual([])
   })
+
+  it('does not accept an app-scoped invite row as proof for an org-role elevation', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    const groupId = randomUUID()
+
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, public.rbac_role_org_admin(), false)
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+    await query(
+      `
+        INSERT INTO public.groups (id, org_id, name, created_by)
+        VALUES ($1::uuid, $2::uuid, $3, $4::uuid)
+      `,
+      [groupId, orgId, `Scoped invite guard ${groupId}`, USER_ID],
+    )
+    await query(
+      `
+        INSERT INTO public.role_bindings (
+          principal_type, principal_id, role_id, scope_type, org_id,
+          granted_by, granted_at, reason, is_direct
+        )
+        SELECT
+          public.rbac_principal_group(), $1::uuid, roles.id, public.rbac_scope_org(), $2::uuid,
+          $3::uuid, now(), 'Test group admin binding', true
+        FROM public.roles
+        WHERE roles.name = public.rbac_role_org_admin()
+          AND roles.scope_type = public.rbac_scope_org()
+      `,
+      [groupId, orgId, USER_ID],
+    )
+    await query(
+      `
+        INSERT INTO public.group_members (group_id, user_id, added_by)
+        VALUES ($1::uuid, $2::uuid, $3::uuid)
+      `,
+      [groupId, USER_ID_NONMEMBER, USER_ID],
+    )
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, app_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, $3, public.rbac_role_org_super_admin(), true)
+      `,
+      [orgId, USER_ID_NONMEMBER, appId],
+    )
+
+    await withAuthClaim(USER_ID_NONMEMBER)
+
+    let thrown: unknown
+    try {
+      await query(
+        `
+          INSERT INTO public.role_bindings (
+            principal_type, principal_id, role_id, scope_type, org_id,
+            granted_by, granted_at, reason, is_direct
+          )
+          SELECT
+            public.rbac_principal_user(), $1::uuid, roles.id, public.rbac_scope_org(), $2::uuid,
+            $1::uuid, now(), 'Accepted invitation', true
+          FROM public.roles
+          WHERE roles.name = public.rbac_role_org_super_admin()
+            AND roles.scope_type = public.rbac_scope_org()
+        `,
+        [USER_ID_NONMEMBER, orgId],
+      )
+    }
+    catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeTruthy()
+    expect((thrown as Error).message).toContain('Admins cannot elevate privileges!')
+  })
+
+  it('does not allow an app-scoped row to be converted into an org invitation', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    const groupId = randomUUID()
+
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, public.rbac_role_org_admin(), false)
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+    await query(
+      `
+        INSERT INTO public.groups (id, org_id, name, created_by)
+        VALUES ($1::uuid, $2::uuid, $3, $4::uuid)
+      `,
+      [groupId, orgId, `Scoped invite conversion ${groupId}`, USER_ID],
+    )
+    await query(
+      `
+        INSERT INTO public.role_bindings (
+          principal_type, principal_id, role_id, scope_type, org_id,
+          granted_by, granted_at, reason, is_direct
+        )
+        SELECT
+          public.rbac_principal_group(), $1::uuid, roles.id, public.rbac_scope_org(), $2::uuid,
+          $3::uuid, now(), 'Test group admin binding', true
+        FROM public.roles
+        WHERE roles.name = public.rbac_role_org_admin()
+          AND roles.scope_type = public.rbac_scope_org()
+      `,
+      [groupId, orgId, USER_ID],
+    )
+    await query(
+      `
+        INSERT INTO public.group_members (group_id, user_id, added_by)
+        VALUES ($1::uuid, $2::uuid, $3::uuid)
+      `,
+      [groupId, USER_ID_NONMEMBER, USER_ID],
+    )
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, app_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, $3, public.rbac_role_org_super_admin(), true)
+      `,
+      [orgId, USER_ID_NONMEMBER, appId],
+    )
+
+    await withAuthClaim(USER_ID_NONMEMBER)
+
+    let thrown: unknown
+    try {
+      await query(
+        `
+          UPDATE public.org_users
+          SET app_id = NULL
+          WHERE org_id = $1::uuid
+            AND user_id = $2::uuid
+            AND app_id = $3
+        `,
+        [orgId, USER_ID_NONMEMBER, appId],
+      )
+    }
+    catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeTruthy()
+    expect((thrown as Error).message).toContain('Admins cannot move org membership scopes!')
+  })
 })

--- a/tests/accept-invitation-scoped-membership.test.ts
+++ b/tests/accept-invitation-scoped-membership.test.ts
@@ -1,0 +1,265 @@
+import type { PoolClient } from 'pg'
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { POSTGRES_URL, USER_EMAIL_NONMEMBER, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
+
+// public.org_users still carries legacy app-scoped rows (app_id set). Those rows share
+// (org_id, user_id) with the organization membership row, so every org-level lookup in the
+// invite path has to filter them out.
+describe('org invite path ignores app-scoped org_users rows', () => {
+  let pool: Pool
+  let client: PoolClient
+
+  const query = (text: string, params?: Array<string | number | null>) => client.query(text, params)
+
+  const withAuthClaim = async (userId: string) => {
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.sub', userId])
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'authenticated'])
+    await query(`SELECT set_config($1, $2, true)`, [
+      'request.jwt.claims',
+      JSON.stringify({ sub: userId, role: 'authenticated', aud: 'authenticated' }),
+    ])
+    await query('SET LOCAL ROLE authenticated')
+  }
+
+  const withServiceRole = async () => {
+    await query('RESET ROLE')
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.sub', ''])
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'service_role'])
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claims', JSON.stringify({ role: 'service_role' })])
+    await query('SET LOCAL ROLE service_role')
+  }
+
+  beforeAll(() => {
+    pool = new Pool({
+      connectionString: POSTGRES_URL,
+      // Keep one connection so SET LOCAL ROLE and JWT claims stay on the same session.
+      max: 1,
+    })
+  })
+
+  beforeEach(async () => {
+    client = await pool.connect()
+    await client.query('BEGIN')
+  })
+
+  afterEach(async () => {
+    if (!client)
+      return
+    try {
+      await query('ROLLBACK')
+    }
+    finally {
+      client.release()
+    }
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  // Org owned by USER_ID, who ends up with the org_super_admin binding.
+  const createOrgOwnedByUser = async (ownerId: string) => {
+    const orgId = randomUUID()
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.orgs (id, name, management_email, created_by)
+        VALUES ($1::uuid, $2, $3, $4::uuid)
+      `,
+      [orgId, `Scoped invite org ${orgId}`, `scoped-invite-${orgId}@capgo.app`, ownerId],
+    )
+    await query(
+      `
+        INSERT INTO public.role_bindings (
+          principal_type, principal_id, role_id, scope_type, org_id,
+          granted_by, granted_at, reason, is_direct
+        )
+        SELECT
+          public.rbac_principal_user(), $1::uuid, roles.id, public.rbac_scope_org(), $2::uuid,
+          $1::uuid, now(), 'Test owner binding', true
+        FROM public.roles
+        WHERE roles.name = public.rbac_role_org_super_admin()
+          AND roles.scope_type = public.rbac_scope_org()
+        ON CONFLICT DO NOTHING
+      `,
+      [ownerId, orgId],
+    )
+    return orgId
+  }
+
+  const createApp = async (orgId: string, ownerId: string) => {
+    const appId = `scoped.invite.${orgId.slice(0, 8)}`
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.apps (app_id, name, icon_url, owner_org, user_id)
+        VALUES ($1, $2, '', $3::uuid, $4::uuid)
+      `,
+      [appId, 'Scoped invite app', orgId, ownerId],
+    )
+    return appId
+  }
+
+  // Legacy leftover: a row for the same (org_id, user_id) that is scoped to a single app.
+  const createAppScopedRow = async (orgId: string, appId: string, userId: string) => {
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, app_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, $3, 'app_developer', true)
+      `,
+      [orgId, userId, appId],
+    )
+  }
+
+  const createPendingOrgInvite = async (orgId: string, inviteeId: string, roleName: string) => {
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, $3, true)
+      `,
+      [orgId, inviteeId, roleName],
+    )
+    await query(
+      `
+        INSERT INTO public.role_bindings (
+          principal_type, principal_id, role_id, scope_type, org_id,
+          granted_by, granted_at, expires_at, reason, is_direct
+        )
+        SELECT
+          public.rbac_principal_user(), $1::uuid, roles.id, public.rbac_scope_org(), $2::uuid,
+          $3::uuid, now(), now() - INTERVAL '1 second', 'Pending invitation', true
+        FROM public.roles
+        WHERE roles.name = $4
+          AND roles.scope_type = public.rbac_scope_org()
+      `,
+      [inviteeId, orgId, USER_ID, roleName],
+    )
+  }
+
+  it('accepts an org invitation even when an app-scoped row exists', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    await createPendingOrgInvite(orgId, USER_ID_NONMEMBER, 'org_admin')
+    await createAppScopedRow(orgId, appId, USER_ID_NONMEMBER)
+
+    await withAuthClaim(USER_ID_NONMEMBER)
+    const result = await query(`SELECT public.accept_invitation_to_org($1::uuid) AS status`, [orgId])
+    expect(result.rows[0]?.status).toBe('OK')
+
+    await withServiceRole()
+    const membership = await query(
+      `
+        SELECT rbac_role_name, is_invite
+        FROM public.org_users
+        WHERE org_id = $1::uuid
+          AND user_id = $2::uuid
+          AND app_id IS NULL
+          AND channel_id IS NULL
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+    expect(membership.rows).toEqual([{ rbac_role_name: 'org_admin', is_invite: false }])
+  })
+
+  it('leaves the app-scoped row untouched when accepting an org invitation', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    await createPendingOrgInvite(orgId, USER_ID_NONMEMBER, 'org_admin')
+    await createAppScopedRow(orgId, appId, USER_ID_NONMEMBER)
+
+    await withAuthClaim(USER_ID_NONMEMBER)
+    const accepted = await query(`SELECT public.accept_invitation_to_org($1::uuid) AS status`, [orgId])
+    expect(accepted.rows[0]?.status).toBe('OK')
+
+    await withServiceRole()
+    const appRow = await query(
+      `
+        SELECT rbac_role_name, is_invite
+        FROM public.org_users
+        WHERE org_id = $1::uuid
+          AND user_id = $2::uuid
+          AND app_id = $3
+      `,
+      [orgId, USER_ID_NONMEMBER, appId],
+    )
+    expect(appRow.rows).toEqual([{ rbac_role_name: 'app_developer', is_invite: true }])
+  })
+
+  it('invites a user who only has an app-scoped row', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    await createAppScopedRow(orgId, appId, USER_ID_NONMEMBER)
+
+    await withAuthClaim(USER_ID)
+    const result = await query(
+      `SELECT public.invite_user_to_org_rbac($1, $2::uuid, $3) AS status`,
+      [USER_EMAIL_NONMEMBER, orgId, 'org_admin'],
+    )
+    expect(result.rows[0]?.status).toBe('OK')
+
+    await withServiceRole()
+    const invite = await query(
+      `
+        SELECT rbac_role_name, is_invite
+        FROM public.org_users
+        WHERE org_id = $1::uuid
+          AND user_id = $2::uuid
+          AND app_id IS NULL
+          AND channel_id IS NULL
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+    expect(invite.rows).toEqual([{ rbac_role_name: 'org_admin', is_invite: true }])
+  })
+
+  it('retargets only the org-level pending row when the invite role changes', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    await createPendingOrgInvite(orgId, USER_ID_NONMEMBER, 'org_member')
+    await createAppScopedRow(orgId, appId, USER_ID_NONMEMBER)
+
+    await withAuthClaim(USER_ID)
+    const result = await query(
+      `SELECT public.update_org_invite_role_rbac($1::uuid, $2::uuid, $3) AS status`,
+      [orgId, USER_ID_NONMEMBER, 'org_admin'],
+    )
+    expect(result.rows[0]?.status).toBe('OK')
+
+    await withServiceRole()
+    const rows = await query(
+      `
+        SELECT app_id, rbac_role_name
+        FROM public.org_users
+        WHERE org_id = $1::uuid
+          AND user_id = $2::uuid
+        ORDER BY app_id NULLS FIRST
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+    expect(rows.rows).toEqual([
+      { app_id: null, rbac_role_name: 'org_admin' },
+      { app_id: appId, rbac_role_name: 'app_developer' },
+    ])
+  })
+
+  it('does not list app-scoped rows as pending org invitations', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    const appId = await createApp(orgId, USER_ID)
+    await createAppScopedRow(orgId, appId, USER_ID_NONMEMBER)
+
+    await withAuthClaim(USER_ID)
+    const members = await query(
+      `
+        SELECT user_id, role_name, is_invite
+        FROM public.get_org_members_rbac($1::uuid)
+        WHERE is_invite IS TRUE
+      `,
+      [orgId],
+    )
+    expect(members.rows).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- scope organization membership and invitation lookups to `org_users` rows where both `app_id` and `channel_id` are null
- preserve legacy app/channel-scoped rows when accepting an organization invitation or changing its role
- require a real org-level pending membership before the `Accepted invitation` RBAC guard exception can create an org role binding
- prevent external callers from changing an existing `org_users` row between organization, app, and channel scopes
- add regression coverage for acceptance, invite creation, role changes, member listing, direct RBAC elevation, and scope conversion

## Root cause

Legacy app/channel-scoped `org_users` rows share the same `(org_id, user_id)` pair as organization membership rows. Several invite paths treated any such row as the organization membership. In addition to stuck or incorrect invitation behavior, the RBAC invite-acceptance exception could treat a contaminated scoped row as proof for an org-level accepted role binding.

## Impact

Organization invitations now operate only on organization-level membership rows. Existing scoped access rows remain untouched, and scoped legacy rows can no longer be used to bypass the RBAC rank guard or be converted into organization invitations by authenticated callers.

## Validation

- `bun run supabase:db:reset`
- 33 targeted RBAC, invitation, and security-hardening tests
- `bun run typecheck`
- `bun run lint:backend`
- ESLint on `tests/accept-invitation-scoped-membership.test.ts`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization invitation and membership handling when legacy app- or channel-scoped records exist.
  * Organization invitations now accept, update, and list only organization-level memberships.
  * Prevented scoped memberships from being incorrectly used for organization-level access or converted into organization invitations.
  * Preserved existing app- and channel-level membership records during organization invitation changes.

* **Tests**
  * Added coverage for invitation acceptance, role updates, member listings, access elevation, and scope protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->