### PR TITLE
fix(plugin): Cache API timeout + /updates connect/owner timing

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/cache.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cache.ts
@@ -95,10 +95,10 @@ export class CacheHelper {
   }
 
   private async matchJsonUnbound<T>(key: Request): Promise<T | null> {
-    const cache = await this.ensureCache()
-    if (!cache)
-      return null
     try {
+      const cache = await this.ensureCache()
+      if (!cache)
+        return null
       const cachedResponse = await cache.match(key)
       if (!cachedResponse)
         return null

--- a/supabase/functions/_backend/plugin_runtime/utils/cache.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cache.ts
@@ -4,7 +4,28 @@ import { cloudlogErr, serializeError } from './logging.ts'
 
 const CACHE_METHOD = 'GET'
 
+/** Hot-path Cache API reads must not block /updates P999 when CF Cache stalls. */
+export const CACHE_MATCH_TIMEOUT_MS = 20
+
 type CacheLike = Cache & { default?: Cache, open?: (cacheName: string) => Promise<Cache> }
+
+const TIMEOUT = Symbol('cache-timeout')
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof TIMEOUT> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT), timeoutMs)
+      }),
+    ])
+  }
+  finally {
+    if (timer !== undefined)
+      clearTimeout(timer)
+  }
+}
 
 async function resolveGlobalCache(): Promise<Cache | null> {
   if (typeof caches === 'undefined')
@@ -60,7 +81,20 @@ export class CacheHelper {
     return new Request(url.toString(), { method: CACHE_METHOD })
   }
 
-  async matchJson<T>(key: Request): Promise<T | null> {
+  /**
+   * Read JSON from Cache API. On timeout or error, fail open with null so hot
+   * paths (app status, manifest rows) continue via DB/cold logic instead of
+   * hanging the worker wall clock.
+   */
+  async matchJson<T>(key: Request, options?: { timeoutMs?: number }): Promise<T | null> {
+    const timeoutMs = options?.timeoutMs ?? CACHE_MATCH_TIMEOUT_MS
+    const result = await withTimeout(this.matchJsonUnbound<T>(key), timeoutMs)
+    if (result === TIMEOUT)
+      return null
+    return result
+  }
+
+  private async matchJsonUnbound<T>(key: Request): Promise<T | null> {
     const cache = await this.ensureCache()
     if (!cache)
       return null

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -769,9 +769,10 @@ export async function update(c: Context, body: AppInfos) {
     if (providerBlockedResponse)
       return providerBlockedResponse
   }
-  const startConnect = performance.now()
+  const startPgClient = performance.now()
   const pgClient = await getPgClient(c, true)
-  const connectMs = Math.round(performance.now() - startConnect)
+  // Hyperdrive: includes await client.connect(). Pool: construction only (lazy connect later).
+  const pgClientMs = Math.round(performance.now() - startPgClient)
   const pathTiming: UpdatePathTiming = {}
   try {
     const startLag = performance.now()
@@ -790,7 +791,7 @@ export async function update(c: Context, body: AppInfos) {
         outcome: 'total',
         totalMs,
         appStatusMs,
-        connectMs,
+        pgClientMs,
         ownerMs: pathTiming.ownerMs ?? 0,
         replicationLagMs,
         databaseSource: c.get('databaseSource') ?? c.res.headers.get('X-Database-Source') ?? null,

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -273,11 +273,16 @@ async function getStoredChannelSelfOverride(c: Context, appId: string, deviceId:
   return getChannelSelfOverride(c as Context<MiddlewareKeyVariables>, appId, deviceId)
 }
 
+export interface UpdatePathTiming {
+  ownerMs?: number
+}
+
 export async function updateWithPG(
   c: Context,
   body: AppInfos,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
   appStatus?: Awaited<ReturnType<typeof getAppStatus>>,
+  pathTiming?: UpdatePathTiming,
 ) {
   const {
     version_name,
@@ -316,7 +321,10 @@ export async function updateWithPG(
       return providerBlockedResponse
   }
 
+  const startOwner = performance.now()
   const appOwner = await getAppOwnerPostgres(c, app_id, drizzleClient, PLAN_LIMIT)
+  if (pathTiming)
+    pathTiming.ownerMs = Math.round(performance.now() - startOwner)
   // if version_build is not semver, then make it semver
   const device = makeDevice(body, appOwner?.allow_device_custom_id)
   if (!appOwner) {
@@ -761,7 +769,10 @@ export async function update(c: Context, body: AppInfos) {
     if (providerBlockedResponse)
       return providerBlockedResponse
   }
+  const startConnect = performance.now()
   const pgClient = await getPgClient(c, true)
+  const connectMs = Math.round(performance.now() - startConnect)
+  const pathTiming: UpdatePathTiming = {}
   try {
     const startLag = performance.now()
     await setReplicationLagHeader(c, pgClient)
@@ -769,7 +780,7 @@ export async function update(c: Context, body: AppInfos) {
 
     const drizzlePg = getDrizzleClient(pgClient, { logger: false })
     // Use the active DB client only when needed
-    const response = await updateWithPG(c, body, drizzlePg, appStatus)
+    const response = await updateWithPG(c, body, drizzlePg, appStatus, pathTiming)
     const totalMs = Math.round(performance.now() - startUpdate)
     if (totalMs >= 100) {
       cloudlog({
@@ -779,7 +790,10 @@ export async function update(c: Context, body: AppInfos) {
         outcome: 'total',
         totalMs,
         appStatusMs,
+        connectMs,
+        ownerMs: pathTiming.ownerMs ?? 0,
         replicationLagMs,
+        databaseSource: c.get('databaseSource') ?? c.res.headers.get('X-Database-Source') ?? null,
         app_id: body.app_id,
       })
     }

--- a/supabase/functions/_backend/utils/cache.ts
+++ b/supabase/functions/_backend/utils/cache.ts
@@ -95,10 +95,10 @@ export class CacheHelper {
   }
 
   private async matchJsonUnbound<T>(key: Request): Promise<T | null> {
-    const cache = await this.ensureCache()
-    if (!cache)
-      return null
     try {
+      const cache = await this.ensureCache()
+      if (!cache)
+        return null
       const cachedResponse = await cache.match(key)
       if (!cachedResponse)
         return null

--- a/supabase/functions/_backend/utils/cache.ts
+++ b/supabase/functions/_backend/utils/cache.ts
@@ -4,7 +4,28 @@ import { cloudlogErr, serializeError } from './logging.ts'
 
 const CACHE_METHOD = 'GET'
 
+/** Hot-path Cache API reads must not block /updates P999 when CF Cache stalls. */
+export const CACHE_MATCH_TIMEOUT_MS = 20
+
 type CacheLike = Cache & { default?: Cache, open?: (cacheName: string) => Promise<Cache> }
+
+const TIMEOUT = Symbol('cache-timeout')
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof TIMEOUT> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT), timeoutMs)
+      }),
+    ])
+  }
+  finally {
+    if (timer !== undefined)
+      clearTimeout(timer)
+  }
+}
 
 async function resolveGlobalCache(): Promise<Cache | null> {
   if (typeof caches === 'undefined')
@@ -60,7 +81,20 @@ export class CacheHelper {
     return new Request(url.toString(), { method: CACHE_METHOD })
   }
 
-  async matchJson<T>(key: Request): Promise<T | null> {
+  /**
+   * Read JSON from Cache API. On timeout or error, fail open with null so hot
+   * paths (app status, manifest rows) continue via DB/cold logic instead of
+   * hanging the worker wall clock.
+   */
+  async matchJson<T>(key: Request, options?: { timeoutMs?: number }): Promise<T | null> {
+    const timeoutMs = options?.timeoutMs ?? CACHE_MATCH_TIMEOUT_MS
+    const result = await withTimeout(this.matchJsonUnbound<T>(key), timeoutMs)
+    if (result === TIMEOUT)
+      return null
+    return result
+  }
+
+  private async matchJsonUnbound<T>(key: Request): Promise<T | null> {
     const cache = await this.ensureCache()
     if (!cache)
       return null

--- a/tests/cache-match-timeout.unit.test.ts
+++ b/tests/cache-match-timeout.unit.test.ts
@@ -65,4 +65,14 @@ describe('CacheHelper.matchJson timeout', () => {
     await vi.advanceTimersByTimeAsync(16)
     await expect(pending).resolves.toBeNull()
   })
+
+  it('fails open with null when caches.open rejects', async () => {
+    vi.stubGlobal('caches', {
+      open: vi.fn().mockRejectedValue(new Error('cache open failed')),
+    })
+
+    const helper = new CacheHelper(makeContext())
+    const key = helper.buildRequest('/.app-status-v3', { app_id: 'com.test.app' })
+    await expect(helper.matchJson(key)).resolves.toBeNull()
+  })
 })

--- a/tests/cache-match-timeout.unit.test.ts
+++ b/tests/cache-match-timeout.unit.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CACHE_MATCH_TIMEOUT_MS, CacheHelper } from '../supabase/functions/_backend/plugin_runtime/utils/cache.ts'
+
+function makeContext() {
+  return {
+    req: { url: 'https://api.capgo.test/updates' },
+    get: (key: string) => key === 'requestId' ? 'req-cache-timeout' : undefined,
+  } as any
+}
+
+function stubCaches(api: { match: ReturnType<typeof vi.fn>, put?: ReturnType<typeof vi.fn>, delete?: ReturnType<typeof vi.fn> }) {
+  const cache = {
+    match: api.match,
+    put: api.put ?? vi.fn(),
+    delete: api.delete ?? vi.fn(),
+  }
+  vi.stubGlobal('caches', {
+    default: cache,
+    open: vi.fn().mockResolvedValue(cache),
+  })
+}
+
+describe('CacheHelper.matchJson timeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns cached JSON when Cache API is fast', async () => {
+    stubCaches({
+      match: vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ status: 'cloud' }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    })
+
+    const helper = new CacheHelper(makeContext())
+    const key = helper.buildRequest('/.app-status-v3', { app_id: 'com.test.app' })
+    await expect(helper.matchJson<{ status: string }>(key)).resolves.toEqual({ status: 'cloud' })
+  })
+
+  it('fails open with null when Cache API stalls past timeout', async () => {
+    vi.useFakeTimers()
+    stubCaches({
+      match: vi.fn().mockImplementation(() => new Promise(() => {})),
+    })
+
+    const helper = new CacheHelper(makeContext())
+    const key = helper.buildRequest('/.app-status-v3', { app_id: 'com.test.app' })
+    const pending = helper.matchJson(key, { timeoutMs: CACHE_MATCH_TIMEOUT_MS })
+    await vi.advanceTimersByTimeAsync(CACHE_MATCH_TIMEOUT_MS + 1)
+    await expect(pending).resolves.toBeNull()
+  })
+
+  it('fails open with null when ensureCache open stalls', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('caches', {
+      open: vi.fn().mockImplementation(() => new Promise(() => {})),
+    })
+
+    const helper = new CacheHelper(makeContext())
+    const key = helper.buildRequest('/.app-status-v3', { app_id: 'com.test.app' })
+    const pending = helper.matchJson(key, { timeoutMs: 15 })
+    await vi.advanceTimersByTimeAsync(16)
+    await expect(pending).resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Cap hot-path Cache API `matchJson` at **20ms** and fail open (`null`) so stalled/rejecting CF Cache cannot own `/updates` P999 (`getAppStatus`, deferred manifest rows).
- Log `pgClientMs`, `ownerMs`, and `databaseSource` on slow `plugin_path_timing` totals to split Hyperdrive client init/connect vs owner query vs residual wait.
- Unit tests: fast hit, match stall, open stall, open reject.

## Motivation (AI generated)

Prod CF logs (2026-07-30): `/updates` wall p999 **912ms** vs cpu p999 **40ms**. Slow totals show `appStatusMs` p999 **2564ms** with **~7k** events `appStatusMs ≥ 100`; residual after cache med (~4ms) was unsplit (`getPgClient` + `getAppOwner` not timed).

## Business Impact (AI generated)

Reduces rare multi-second Cache API stalls for plugin update checks, and gives production proof for the next Hyperdrive/SQL RTT fix without guessing.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/cache-match-timeout.unit.test.ts`
- [x] CI green (reran flaky CF shards)
- [ ] After deploy: confirm `plugin_path_timing` totals include `pgClientMs`/`ownerMs`; `appStatusMs` p999 no longer multi-second spikes

Generated with AI