### PR TITLE
fix(api): allow upload keys to clean up failed versions

### DIFF
--- a/supabase/functions/_backend/private/delete_failed_version.ts
+++ b/supabase/functions/_backend/private/delete_failed_version.ts
@@ -5,7 +5,7 @@ import { middlewareKey } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { checkPermission } from '../utils/rbac.ts'
 import { s3 } from '../utils/s3.ts'
-import { supabaseApikey } from '../utils/supabase.ts'
+import { supabaseAdmin, supabaseApikey } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 
 interface DataUpload {
@@ -29,7 +29,7 @@ app.delete('/', middlewareKey(), async (c) => {
     })
   }
   // Auth context is already set by middlewareKey
-  if (!(await checkPermission(c, 'bundle.delete', { appId: body.app_id }))) {
+  if (!(await checkPermission(c, 'app.upload_bundle', { appId: body.app_id }))) {
     return quickError(401, 'not_authorized', 'You can\'t access this app', { app_id: body.app_id })
   }
 
@@ -68,8 +68,8 @@ app.delete('/', middlewareKey(), async (c) => {
     }
   }
 
-  // delete the version
-  const { error: errorDelete } = await supabaseApikey(c, capgkey)
+  // Hard delete after upload-flow checks; upload keys lack bundle.delete RLS
+  const { error: errorDelete } = await supabaseAdmin(c)
     .from('app_versions')
     .delete()
     .eq('id', version.id)

--- a/tests/private-error-cases.test.ts
+++ b/tests/private-error-cases.test.ts
@@ -330,21 +330,7 @@ describe('[POST] /private/download_link - Error Cases', () => {
   })
 })
 
-describe('[POST] /private/delete_failed_version - Error Cases', () => {
-  it('should return 500 when user not found', async () => {
-    const response = await fetch(getEndpointUrl('/private/delete_failed_version'), {
-      method: 'DELETE',
-      headers,
-      body: JSON.stringify({
-        app_id: 'nonexistent.app',
-        name: '1.0.0',
-      }),
-    })
-    expect(response.status).toBe(401)
-    const data = await response.json() as { error: string }
-    expect(data.error).toBe('not_authorized')
-  })
-
+describe('[DELETE] /private/delete_failed_version', () => {
   it('should return 401 when user cannot access app', async () => {
     const response = await fetch(getEndpointUrl('/private/delete_failed_version'), {
       method: 'DELETE',
@@ -359,7 +345,7 @@ describe('[POST] /private/delete_failed_version - Error Cases', () => {
     expect(data.error).toBe('not_authorized')
   })
 
-  it('should return 500 when app_id or bundle name missing', async () => {
+  it('should return 400 when bundle name missing', async () => {
     const response = await fetch(getEndpointUrl('/private/delete_failed_version'), {
       method: 'DELETE',
       headers,
@@ -371,6 +357,80 @@ describe('[POST] /private/delete_failed_version - Error Cases', () => {
     expect(response.status).toBe(400)
     const data = await response.json() as { error: string }
     expect(data.error).toBe('error_bundle_name_missing')
+  })
+
+  it('allows app_uploader keys to clean up incomplete r2-direct versions', async () => {
+    const bundleName = `1.0.0-failed-upload-${id.slice(0, 8)}`
+    const createdApikey = await createDirectApiKeyWithBindings({
+      userId: USER_ID,
+      key: randomUUID(),
+      name: `delete-failed-uploader-${id}`,
+      orgId: ORG_ID,
+      roleName: 'apikey_org_reader',
+      appId: APPNAME,
+      appRoleName: 'app_uploader',
+    })
+    if (!createdApikey.key)
+      throw new Error('Expected plain API key from createDirectApiKeyWithBindings')
+
+    try {
+      const { data: version, error: versionError } = await getSupabaseClient()
+        .from('app_versions')
+        .insert({
+          app_id: APPNAME,
+          name: bundleName,
+          checksum: '',
+          owner_org: ORG_ID,
+          user_id: USER_ID,
+          storage_provider: 'r2-direct',
+          deleted: false,
+        })
+        .select('id')
+        .single()
+      if (versionError || !version)
+        throw new Error(`Failed to create incomplete version: ${versionError?.message}`)
+
+      const response = await fetch(getEndpointUrl('/private/delete_failed_version'), {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': createdApikey.key,
+        },
+        body: JSON.stringify({
+          app_id: APPNAME,
+          name: bundleName,
+        }),
+      })
+      expect(response.status).toBe(200)
+      const data = await response.json() as { status: string }
+      expect(data.status).toBe('ok')
+
+      const { data: remaining, error: remainingError } = await getSupabaseClient()
+        .from('app_versions')
+        .select('id')
+        .eq('id', version.id)
+        .maybeSingle()
+      expect(remainingError).toBeNull()
+      expect(remaining).toBeNull()
+
+      const denied = await fetch(getEndpointUrl('/private/delete_failed_version'), {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': createdApikey.key,
+        },
+        body: JSON.stringify({
+          app_id: 'com.demoadmin.app',
+          name: '1.0.0',
+        }),
+      })
+      expect(denied.status).toBe(401)
+      const deniedData = await denied.json() as { error: string }
+      expect(deniedData.error).toBe('not_authorized')
+    }
+    finally {
+      await getSupabaseClient().from('apikeys').delete().eq('id', createdApikey.id).throwOnError()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary (AI generated)

- `DELETE /private/delete_failed_version` now authorizes with `app.upload_bundle` (same as `set_manifest` / CLI upload cleanup) instead of `bundle.delete`
- After upload-flow safety checks, delete incomplete `r2-direct` versions via `supabaseAdmin` so upload keys are not blocked by `bundle.delete` RLS
- Added a test proving an `app_uploader` key can clean up a failed incomplete version and is still denied for apps it cannot access

## Motivation (AI generated)

Production logs for `private` showed many `401 not_authorized` / `"You can't access this app"` on `DELETE /private/delete_failed_version` across different `app_id`s. The CLI calls this endpoint after failed uploads with upload API keys that typically only have `app.upload_bundle`, not `bundle.delete`.

## Business Impact (AI generated)

Failed upload cleanup works again for normal uploader keys, reducing orphaned incomplete versions and noisy 401s on a hot private path used by CI/CD upload flows.

## Test Plan (AI generated)

- [x] `bun run supabase:with-env -- bunx vitest run tests/private-error-cases.test.ts` (38 passed)
- [ ] Confirm uploader-key cleanup succeeds for incomplete `r2-direct` versions
- [ ] Confirm unauthorized app access still returns `401 not_authorized`
- [ ] Confirm missing bundle name still returns `400 error_bundle_name_missing`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

