### PR TITLE
fix: Sonar bash [[ and CacheHelper constructor smells

### DIFF
--- a/cli-helper/scripts/sign-and-notarize.sh
+++ b/cli-helper/scripts/sign-and-notarize.sh
@@ -28,7 +28,7 @@ EXPECTED_TEAM_ID="UVTJ336J2D"
 # Bundle identifier baked into Info.plist; pinned in the designated requirement
 # (must match HELPER_BUNDLE_IDENTIFIER in macos-signing.ts).
 HELPER_IDENTIFIER="app.capgo.cli.helper"
-if [ "$CAPGO_APPLE_TEAM_ID" != "$EXPECTED_TEAM_ID" ]; then
+if [[ "$CAPGO_APPLE_TEAM_ID" != "$EXPECTED_TEAM_ID" ]]; then
   echo "CAPGO_APPLE_TEAM_ID ($CAPGO_APPLE_TEAM_ID) != $EXPECTED_TEAM_ID expected by the CLI verifier." >&2
   echo "Fix the APPLE_TEAM_ID secret or update macos-signing.ts; refusing to sign a helper users can't run." >&2
   exit 1
@@ -48,9 +48,9 @@ for arch in arm64 x64; do
     --wait --timeout 30m --output-format json) || true
   id=$(echo "$out" | jq -r '.id // empty')
   status=$(echo "$out" | jq -r '.status // empty')
-  if [ "$status" != "Accepted" ]; then
+  if [[ "$status" != "Accepted" ]]; then
     echo "Notarization failed for $app (status: ${status:-unknown})" >&2
-    if [ -n "$id" ]; then
+    if [[ -n "$id" ]]; then
       xcrun notarytool log "$id" \
         --key "$APPLE_KEY_PATH" --key-id "$APPLE_KEY_ID" --issuer "$APPLE_ISSUER_ID" >&2 || true
     fi

--- a/supabase/functions/_backend/plugin_runtime/utils/cache.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cache.ts
@@ -51,19 +51,13 @@ export type CacheKeyParams = Record<string, string>
 
 export class CacheHelper {
   private cache: Cache | null = null
-  private cachePromise: Promise<Cache | null>
+  private cachePromise: Promise<Cache | null> | null = null
 
-  constructor(private context: Context) {
-    this.cachePromise = resolveGlobalCache().then((cache) => {
-      this.cache = cache
-      return cache
-    })
-  }
+  constructor(private context: Context) {}
 
   private async ensureCache(): Promise<Cache | null> {
-    if (this.cache === null) {
-      await this.cachePromise
-    }
+    this.cachePromise ??= resolveGlobalCache()
+    this.cache = await this.cachePromise
     return this.cache
   }
 

--- a/supabase/functions/_backend/utils/cache.ts
+++ b/supabase/functions/_backend/utils/cache.ts
@@ -51,19 +51,13 @@ export type CacheKeyParams = Record<string, string>
 
 export class CacheHelper {
   private cache: Cache | null = null
-  private cachePromise: Promise<Cache | null>
+  private cachePromise: Promise<Cache | null> | null = null
 
-  constructor(private context: Context) {
-    this.cachePromise = resolveGlobalCache().then((cache) => {
-      this.cache = cache
-      return cache
-    })
-  }
+  constructor(private context: Context) {}
 
   private async ensureCache(): Promise<Cache | null> {
-    if (this.cache === null) {
-      await this.cachePromise
-    }
+    this.cachePromise ??= resolveGlobalCache()
+    this.cache = await this.cachePromise
     return this.cache
   }
 


### PR DESCRIPTION
## Summary (AI generated)

- Use `[[` instead of `[` in `cli-helper/scripts/sign-and-notarize.sh` conditionals.
- Move `CacheHelper` Cache API resolution out of the constructor into lazy `ensureCache()` in both backend and plugin_runtime cache helpers.

## Motivation (AI generated)

SonarQube flagged these as Major/Critical code smells: bash `[` tests and asynchronous work started inside constructors.

## Business Impact (AI generated)

No product behavior change expected. Improves maintainability and keeps CI/Sonar quality gates green.

## Test Plan (AI generated)

- [ ] Confirm `sign-and-notarize.sh` still fails fast on team-id mismatch and notarization failure paths.
- [ ] Smoke CacheHelper paths (`/updates` app status / rate limit) still resolve cache via lazy init.
- [ ] CI backend checks pass.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cache initialization to load only when needed and reuse the resolved cache across requests.
  * Streamlined notarization and team-ID validation checks without changing the observable workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->