### PR TITLE
fix(api): deliver plugin notification flush in-process

### DIFF
--- a/cloudflare_workers/api/index.ts
+++ b/cloudflare_workers/api/index.ts
@@ -210,6 +210,7 @@ app.route('/triggers', appTriggers)
 app.route('/private', appPrivate)
 
 appScheduled.post('/flush-plugin-notifications', async (c) => {
+  c.set('deliverPluginNotificationsInProcess', true)
   const result = await flushQueuedPluginNotifications(c)
   return c.json({ ...BRES, ...result })
 })

--- a/supabase/functions/_backend/triggers/plugin_notifications.ts
+++ b/supabase/functions/_backend/triggers/plugin_notifications.ts
@@ -29,7 +29,7 @@ function isValidPluginNotificationItem(item: unknown): item is PluginNotificatio
 }
 
 type PluginNotificationSendResult = boolean | { sent: false, lastSendAt: string }
-type PluginNotificationItemResult = { status: 'delivered' } | { status: 'failed' } | { lastSendAt: string, status: 'throttled' }
+export type PluginNotificationItemResult = { status: 'delivered' } | { status: 'failed' } | { lastSendAt: string, status: 'throttled' }
 
 function getPluginNotificationItemResult(result: PluginNotificationSendResult): PluginNotificationItemResult {
   if (result === true)
@@ -82,13 +82,18 @@ async function processPluginNotifications(c: Context, items: PluginNotificationQ
   return { processed, failed, throttled, results }
 }
 
-export const app = new Hono<MiddlewareKeyVariables>()
+export interface PluginNotificationDeliveryResult {
+  processed: number
+  failed: number
+  throttled: number
+  invalid: number
+  results: PluginNotificationItemResult[]
+}
 
-app.post('/', middlewareAPISecret, async (c) => {
-  const body = await parseBody<PluginNotificationBatchBody>(c)
-  const rawItems = Array.isArray(body.items) ? body.items : []
-  if (rawItems.length === 0)
-    return c.json({ ...BRES, processed: 0, failed: 0, throttled: 0, results: [] })
+export async function deliverQueuedPluginNotifications(
+  c: Context,
+  rawItems: PluginNotificationQueueItem[],
+): Promise<PluginNotificationDeliveryResult> {
   if (rawItems.length > MAX_PLUGIN_NOTIFICATION_BATCH)
     throw simpleError('too_many_items', 'Too many plugin notification items', { max: MAX_PLUGIN_NOTIFICATION_BATCH, count: rawItems.length })
 
@@ -98,11 +103,23 @@ app.post('/', middlewareAPISecret, async (c) => {
     cloudlog({ requestId: c.get('requestId'), message: 'Plugin notification batch contained invalid items', invalid })
   }
   if (items.length === 0)
-    return c.json({ ...BRES, processed: 0, failed: 0, throttled: 0, results: [], invalid })
+    return { processed: 0, failed: 0, throttled: 0, invalid, results: [] }
 
   const result = await processPluginNotifications(c, items)
+  return { ...result, invalid }
+}
+
+export const app = new Hono<MiddlewareKeyVariables>()
+
+app.post('/', middlewareAPISecret, async (c) => {
+  const body = await parseBody<PluginNotificationBatchBody>(c)
+  const rawItems = Array.isArray(body.items) ? body.items : []
+  if (rawItems.length === 0)
+    return c.json({ ...BRES, processed: 0, failed: 0, throttled: 0, results: [], invalid: 0 })
+
+  const result = await deliverQueuedPluginNotifications(c, rawItems)
   if (result.failed > 0) {
-    throw quickError(500, 'plugin_notification_batch_failed', 'Plugin notification batch failed', { ...result, invalid }, undefined, { alert: false })
+    throw quickError(500, 'plugin_notification_batch_failed', 'Plugin notification batch failed', result, undefined, { alert: false })
   }
-  return c.json({ ...BRES, ...result, invalid })
+  return c.json({ ...BRES, ...result })
 })

--- a/supabase/functions/_backend/triggers/plugin_notifications.ts
+++ b/supabase/functions/_backend/triggers/plugin_notifications.ts
@@ -119,7 +119,7 @@ app.post('/', middlewareAPISecret, async (c) => {
 
   const result = await deliverQueuedPluginNotifications(c, rawItems)
   if (result.failed > 0) {
-    throw quickError(500, 'plugin_notification_batch_failed', 'Plugin notification batch failed', result, undefined, { alert: false })
+    throw quickError(500, 'plugin_notification_batch_failed', 'Plugin notification batch failed', { ...result }, undefined, { alert: false })
   }
   return c.json({ ...BRES, ...result })
 })

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -59,6 +59,7 @@ export interface MiddlewareKeyVariables {
     skipSupabaseStatsFallback?: boolean
     skipSupabaseNotificationWrites?: boolean
     queuePluginNotifications?: boolean
+    deliverPluginNotificationsInProcess?: boolean
     skipChannelSelfPostgresFallback?: boolean
     requireReadReplica?: boolean
   }

--- a/supabase/functions/_backend/utils/plugin_notification_flush.ts
+++ b/supabase/functions/_backend/utils/plugin_notification_flush.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import type { PluginNotificationQueueItem } from './plugin_notification_queue.ts'
 import { parseCronExpression } from 'cron-schedule'
+import { deliverQueuedPluginNotifications } from '../triggers/plugin_notifications.ts'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
 import { parsePluginNotificationQueueItem, PLUGIN_NOTIFICATION_QUEUE_PREFIX, suppressPluginNotificationQueue } from './plugin_notification_queue.ts'
 import { getEnv } from './utils.ts'
@@ -55,6 +56,24 @@ function getPluginNotificationThrottleTtlSeconds(c: Context, item: PluginNotific
 }
 
 async function postPluginNotificationBatch(c: Context, items: PluginNotificationQueueItem[]): Promise<PluginNotificationTransferResult> {
+  // Cron flush runs on the API worker: deliver in-process to avoid brittle self-HTTP (prod 522s).
+  if (c.get('deliverPluginNotificationsInProcess')) {
+    const result = await deliverQueuedPluginNotifications(c, items)
+    if (result.failed > 0) {
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'Plugin notification in-process transfer failed',
+        failed: result.failed,
+        processed: result.processed,
+        throttled: result.throttled,
+        invalid: result.invalid,
+      })
+      return { accepted: false }
+    }
+    const throttledResult = result.results.find(entry => entry.status === 'throttled' && entry.lastSendAt)
+    return { accepted: true, throttledLastSendAt: throttledResult?.lastSendAt }
+  }
+
   const url = getPluginNotificationTriggerUrl(c)
   const apiSecret = getEnv(c, 'API_SECRET')
   if (!url || !apiSecret) {
@@ -78,7 +97,7 @@ async function postPluginNotificationBatch(c: Context, items: PluginNotification
   }
 
   const body = await response.text().catch(() => '')
-  cloudlogErr({ requestId: c.get('requestId'), message: 'Plugin notification trigger transfer failed', status: response.status, statusText: response.statusText, body })
+  cloudlogErr({ requestId: c.get('requestId'), message: 'Plugin notification trigger transfer failed', url, status: response.status, statusText: response.statusText, body })
   return { accepted: false }
 }
 

--- a/supabase/functions/_backend/utils/plugin_notification_flush.ts
+++ b/supabase/functions/_backend/utils/plugin_notification_flush.ts
@@ -70,7 +70,9 @@ async function postPluginNotificationBatch(c: Context, items: PluginNotification
       })
       return { accepted: false }
     }
-    const throttledResult = result.results.find(entry => entry.status === 'throttled' && entry.lastSendAt)
+    const throttledResult = result.results.find(
+      (entry): entry is { status: 'throttled', lastSendAt: string } => entry.status === 'throttled' && Boolean(entry.lastSendAt),
+    )
     return { accepted: true, throttledLastSendAt: throttledResult?.lastSendAt }
   }
 

--- a/tests/plugin-notification-flush.unit.test.ts
+++ b/tests/plugin-notification-flush.unit.test.ts
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { flushQueuedPluginNotifications } from '../supabase/functions/_backend/utils/plugin_notification_flush.ts'
 import { PLUGIN_NOTIFICATION_QUEUE_PREFIX } from '../supabase/functions/_backend/utils/plugin_notification_queue.ts'
 
+const deliverMock = vi.hoisted(() => vi.fn())
+vi.mock('../supabase/functions/_backend/triggers/plugin_notifications.ts', () => ({
+  deliverQueuedPluginNotifications: (...args: unknown[]) => deliverMock(...args),
+}))
+
 const originalApiSecret = process.env.API_SECRET
 const originalCloudflareFunctionUrl = process.env.CLOUDFLARE_FUNCTION_URL
 
@@ -33,6 +38,18 @@ function createStore(seed: Record<string, string>) {
   }
 }
 
+
+function createContext(env: Record<string, unknown>, inProcess = false) {
+  return {
+    env,
+    get: (key: string) => {
+      if (key === 'deliverPluginNotificationsInProcess')
+        return inProcess
+      return 'request-id'
+    },
+  } as any
+}
+
 function queueItem(eventName: string) {
   return JSON.stringify({
     type: 'org',
@@ -48,6 +65,7 @@ function queueItem(eventName: string) {
 
 describe('plugin notification flush', () => {
   afterEach(() => {
+    deliverMock.mockReset()
     vi.unstubAllGlobals()
     if (originalApiSecret === undefined)
       delete process.env.API_SECRET
@@ -60,10 +78,7 @@ describe('plugin notification flush', () => {
   })
 
   it('fails when the KV queue binding is missing', async () => {
-    await expect(flushQueuedPluginNotifications({
-      env: {},
-      get: () => 'request-id',
-    } as any)).rejects.toThrow('Plugin notification KV queue missing')
+    await expect(flushQueuedPluginNotifications(createContext({}))).rejects.toThrow('Plugin notification KV queue missing')
   })
 
   it('deletes delivered queue items and keeps failed items for retry', async () => {
@@ -83,12 +98,9 @@ describe('plugin notification flush', () => {
     process.env.API_SECRET = 'secret'
     process.env.CLOUDFLARE_FUNCTION_URL = 'https://api.capgo.test'
 
-    const result = await flushQueuedPluginNotifications({
-      env: {
-        PLUGIN_NOTIFICATION_QUEUE: store,
-      },
-      get: () => 'request-id',
-    } as any)
+    const result = await flushQueuedPluginNotifications(createContext({
+      PLUGIN_NOTIFICATION_QUEUE: store,
+    }))
 
     expect(result).toMatchObject({ scanned: 2, transferred: 1, deleted: 1, failed: 1 })
     expect(store.values.has(successKey)).toBe(false)
@@ -113,17 +125,60 @@ describe('plugin notification flush', () => {
     process.env.API_SECRET = 'secret'
     process.env.CLOUDFLARE_FUNCTION_URL = 'https://api.capgo.test'
 
-    const result = await flushQueuedPluginNotifications({
-      env: {
-        PLUGIN_NOTIFICATION_QUEUE: store,
-      },
-      get: () => 'request-id',
-    } as any)
+    const result = await flushQueuedPluginNotifications(createContext({
+      PLUGIN_NOTIFICATION_QUEUE: store,
+    }))
 
     expect(result).toMatchObject({ scanned: 1, transferred: 1, deleted: 1, failed: 0 })
     expect(store.values.has(throttledKey)).toBe(false)
     const throttlePut = store.puts.find(({ key }) => key.startsWith('plugin:notif:throttle:v1:'))
     expect(throttlePut?.options?.expirationTtl).toBeGreaterThanOrEqual(60)
     expect(Array.from(store.values.keys()).filter(key => key.startsWith('plugin:notif:processing:v1:'))).toEqual([])
+  })
+
+  it('delivers in-process when the scheduled flush flag is set', async () => {
+    const successKey = `${PLUGIN_NOTIFICATION_QUEUE_PREFIX}org:org-1:success:hash`
+    const store = createStore({
+      [successKey]: queueItem('success'),
+    })
+    deliverMock.mockResolvedValue({
+      processed: 1,
+      failed: 0,
+      throttled: 0,
+      invalid: 0,
+      results: [{ status: 'delivered' }],
+    })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await flushQueuedPluginNotifications(createContext({
+      PLUGIN_NOTIFICATION_QUEUE: store,
+    }, true))
+
+    expect(result).toMatchObject({ scanned: 1, transferred: 1, deleted: 1, failed: 0 })
+    expect(store.values.has(successKey)).toBe(false)
+    expect(deliverMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('logs the trigger URL when HTTP transfer fails', async () => {
+    const failedKey = `${PLUGIN_NOTIFICATION_QUEUE_PREFIX}org:org-1:failed:hash`
+    const store = createStore({
+      [failedKey]: queueItem('failed'),
+    })
+    const fetchMock = vi.fn(async () => new Response('error code: 522', { status: 522, statusText: '' }))
+    vi.stubGlobal('fetch', fetchMock)
+    process.env.API_SECRET = 'secret'
+    process.env.CLOUDFLARE_FUNCTION_URL = 'https://broken.example'
+
+    const result = await flushQueuedPluginNotifications(createContext({
+      PLUGIN_NOTIFICATION_QUEUE: store,
+    }))
+
+    expect(result).toMatchObject({ scanned: 1, transferred: 0, deleted: 0, failed: 1 })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://broken.example/triggers/plugin_notifications',
+      expect.objectContaining({ method: 'POST' }),
+    )
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Cron plugin-notification flush on `capgo_api-prod` now delivers queued items **in-process** instead of HTTP self-calls through `CLOUDFLARE_FUNCTION_URL`
- That path was failing with Cloudflare **522** (`error code: 522`), so every minute flushed 100 items as failed and never drained the KV queue
- HTTP transfer failures now log the target `url` for faster diagnosis if the fallback path is used
- Unit tests cover in-process delivery and the HTTP URL failure path

## Motivation (AI generated)

Production scheduled flush was throwing `flush-plugin-notifications had 100 failed transfers`. Observability showed ~138k `Plugin notification trigger transfer failed` events in 24h, almost all `status: 522`, while `api.capgo.app/triggers/plugin_notifications` itself was healthy. The flush was leaving the worker over a misconfigured/unreachable external URL.

## Business Impact (AI generated)

Restores delivery of plugin-originated org/member email notifications that were stuck in the KV queue, and stops noisy cron exception spam from the flush job.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/plugin-notification-flush.unit.test.ts tests/plugin-notifications-trigger.unit.test.ts`
- [ ] After deploy: confirm cron no longer throws `had N failed transfers`
- [ ] After deploy: confirm `Plugin notification trigger transfer failed` with 522 stops for the scheduled flush
- [ ] After deploy: confirm queued plugin notifications drain / emails resume

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

