### PR TITLE
fix(api): JWT notifications auth + builtin kill-switch revert

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -494,6 +494,8 @@ export async function updateWithPG(
     }
     // TODO: check why this event is send with wrong version_name
     await sendStatsAndDevice(c, device, [{ action: 'noNew', versionName: version.name }])
+    if (version.name === 'builtin')
+      return updateError200(c, 'already_on_builtin', 'Already on builtin')
     return updateError200(c, 'no_new_version_available', 'No new version available')
   }
 
@@ -665,12 +667,9 @@ export async function updateWithPG(
     }
   }
   if (version.name === 'builtin' && greaterOrEqual(parse(plugin_version), parse('6.2.0'))) {
-    // Already on builtin: up-to-date signal (error + kind). Plugin treats this as no-op.
-    if (body.version_name === 'builtin') {
-      return updateError200(c, 'already_on_builtin', 'Already on builtin')
-    }
     // Channel kill-switch / revert: success payload with version builtin and NO error/kind,
     // so the plugin reaches its builtin reset path (_reset / setNextBundle).
+    // (Already-on-builtin is handled above via version_name === version.name.)
     await sendStatsAndDevice(c, device, [{ action: 'get', versionName: 'builtin' }])
     return c.json({ version: 'builtin' }, 200)
   }

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -494,8 +494,6 @@ export async function updateWithPG(
     }
     // TODO: check why this event is send with wrong version_name
     await sendStatsAndDevice(c, device, [{ action: 'noNew', versionName: version.name }])
-    if (version.name === 'builtin')
-      return updateError200(c, 'already_on_builtin', 'Already on builtin')
     return updateError200(c, 'no_new_version_available', 'No new version available')
   }
 
@@ -667,9 +665,13 @@ export async function updateWithPG(
     }
   }
   if (version.name === 'builtin' && greaterOrEqual(parse(plugin_version), parse('6.2.0'))) {
-    // Channel kill-switch / revert: success payload with version builtin and NO error/kind,
-    // so the plugin reaches its builtin reset path (_reset / setNextBundle).
-    // (Already-on-builtin is handled above via version_name === version.name.)
+    // plugin_parser rewrites version_name "builtin" -> version_build, so we cannot
+    // compare version_name === "builtin" here. Store binary => names match build;
+    // OTA bundle => version_name is the live bundle and differs from version_build.
+    if (version_name === version_build) {
+      return updateError200(c, 'already_on_builtin', 'Already on builtin')
+    }
+    // Kill-switch: tell plugin to reset to the store binary (no error/kind).
     await sendStatsAndDevice(c, device, [{ action: 'get', versionName: 'builtin' }])
     return c.json({ version: 'builtin' }, 200)
   }

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -665,14 +665,14 @@ export async function updateWithPG(
     }
   }
   if (version.name === 'builtin' && greaterOrEqual(parse(plugin_version), parse('6.2.0'))) {
-    if (body.version_name === 'builtin' && version.name === 'builtin') {
+    // Already on builtin: up-to-date signal (error + kind). Plugin treats this as no-op.
+    if (body.version_name === 'builtin') {
       return updateError200(c, 'already_on_builtin', 'Already on builtin')
     }
-    else {
-      return updateError200(c, 'already_on_builtin', 'Already on builtin', {
-        version: 'builtin',
-      })
-    }
+    // Channel kill-switch / revert: success payload with version builtin and NO error/kind,
+    // so the plugin reaches its builtin reset path (_reset / setNextBundle).
+    await sendStatsAndDevice(c, device, [{ action: 'get', versionName: 'builtin' }])
+    return c.json({ version: 'builtin' }, 200)
   }
   else if (version.name === 'builtin' && !greaterOrEqual(parse(plugin_version), parse('6.2.0'))) {
     return updateError200(c, 'revert_to_builtin_plugin_version_too_old', 'revert_to_builtin used, but plugin version is too old')

--- a/supabase/functions/_backend/public/notifications/index.ts
+++ b/supabase/functions/_backend/public/notifications/index.ts
@@ -4,7 +4,7 @@ import type { NativeNotificationEvent, NativeNotificationPlatform, NativeNotific
 import type { Permission } from '../../utils/rbac.ts'
 import { sql } from 'drizzle-orm'
 import { BRES, createHono, parseBody, quickError, simpleError, simpleRateLimit, useCors } from '../../utils/hono.ts'
-import { middlewareKey } from '../../utils/hono_middleware.ts'
+import { middlewareAuth } from '../../utils/hono_middleware.ts'
 import {
   createNotificationEventProof,
   createNotificationIdentityProof,
@@ -682,7 +682,7 @@ app.post('/sync', async (c) => {
   })
 })
 
-app.post('/recipients/proof', middlewareKey(), async (c) => {
+app.post('/recipients/proof', middlewareAuth(), async (c) => {
   const body = await parseBody<RecipientProofBody>(c)
   const appId = assertString(body.appId, 'appId', 128)
   const externalId = assertString(body.externalId, 'externalId', 512)
@@ -690,7 +690,7 @@ app.post('/recipients/proof', middlewareKey(), async (c) => {
   return c.json({ identityProof: await createNotificationIdentityProof(c, appId, externalId) })
 })
 
-app.post('/recipients/lookup', middlewareKey(), async (c) => {
+app.post('/recipients/lookup', middlewareAuth(), async (c) => {
   const body = await parseBody<{ appId: string, externalId?: string, recipientKey?: string, limit?: number }>(c)
   const appId = assertString(body.appId, 'appId', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
@@ -701,18 +701,18 @@ app.post('/recipients/lookup', middlewareKey(), async (c) => {
   return c.json({ recipientKey, devices: devices.map(publicDevice), count: devices.length })
 })
 
-app.get('/settings', middlewareKey(), async (c) => {
+app.get('/settings', middlewareAuth(), async (c) => {
   const appId = assertString(c.req.query('app_id'), 'app_id', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
   return c.json(await getNotificationSettings(c, appId))
 })
 
-app.put('/settings', middlewareKey(), async (c) => {
+app.put('/settings', middlewareAuth(), async (c) => {
   const body = await parseBody<SettingsBody>(c)
   return c.json(await upsertNotificationSettings(c, body))
 })
 
-app.post('/badge', middlewareKey(), async (c) => {
+app.post('/badge', middlewareAuth(), async (c) => {
   const body = await parseBody<BadgeBody>(c)
   const appId = assertString(body.appId, 'appId', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
@@ -740,7 +740,7 @@ app.post('/badge', middlewareKey(), async (c) => {
   return c.json({ ...BRES, campaignId, queued, queuedBuckets: plan.buckets.length, targeted: null, badgeRevision })
 })
 
-app.post('/update-check', middlewareKey(), async (c) => {
+app.post('/update-check', middlewareAuth(), async (c) => {
   const body = await parseBody<UpdateCheckBody>(c)
   const appId = assertString(body.appId, 'appId', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
@@ -792,7 +792,7 @@ app.post('/update-check', middlewareKey(), async (c) => {
   return c.json({ ...BRES, campaignId, queued, queuedBuckets: plan.buckets.length, targeted: null })
 })
 
-app.post('/send', middlewareKey(), async (c) => {
+app.post('/send', middlewareAuth(), async (c) => {
   const body = await parseBody<SendBody>(c)
   const appId = assertString(body.appId, 'appId', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
@@ -828,7 +828,7 @@ app.post('/send', middlewareKey(), async (c) => {
   return c.json({ ...BRES, campaignId, queued, queuedBuckets: plan.buckets.length, targeted: null })
 })
 
-app.get('/campaigns', middlewareKey(), async (c) => {
+app.get('/campaigns', middlewareAuth(), async (c) => {
   const appId = assertString(c.req.query('app_id'), 'app_id', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
   let pgClient: ReturnType<typeof getPgClient> | undefined
@@ -850,12 +850,12 @@ app.get('/campaigns', middlewareKey(), async (c) => {
   }
 })
 
-app.post('/campaigns', middlewareKey(), async (c) => {
+app.post('/campaigns', middlewareAuth(), async (c) => {
   const body = await parseBody<CampaignBody>(c)
   return c.json(await createCampaignRecord(c, body))
 })
 
-app.get('/stats', middlewareKey(), async (c) => {
+app.get('/stats', middlewareAuth(), async (c) => {
   const appId = assertString(c.req.query('app_id'), 'app_id', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
   const days = Number(c.req.query('days') ?? 30)
@@ -864,7 +864,7 @@ app.get('/stats', middlewareKey(), async (c) => {
   return c.json({ data })
 })
 
-app.get('/providers', middlewareKey(), async (c) => {
+app.get('/providers', middlewareAuth(), async (c) => {
   const appId = assertString(c.req.query('app_id'), 'app_id', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)
   let pgClient: ReturnType<typeof getPgClient> | undefined
@@ -885,7 +885,7 @@ app.get('/providers', middlewareKey(), async (c) => {
   }
 })
 
-app.put('/providers', middlewareKey(), async (c) => {
+app.put('/providers', middlewareAuth(), async (c) => {
   const body = await parseBody<ProviderBody>(c)
   const appId = assertString(body.appId, 'appId', 128)
   await assertAppPermission(c, NOTIFICATION_MANAGE_PERMISSION, appId)

--- a/tests/native-notifications-api.unit.test.ts
+++ b/tests/native-notifications-api.unit.test.ts
@@ -15,6 +15,7 @@ const {
 }))
 
 vi.mock('../supabase/functions/_backend/utils/hono_middleware.ts', () => ({
+  middlewareAuth: () => async (_c: unknown, next: () => Promise<void>) => next(),
   middlewareKey: () => async (_c: unknown, next: () => Promise<void>) => next(),
   middlewareV2: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }))

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -456,8 +456,19 @@ describe('[POST] /updates', () => {
       expect(response.status).toBe(200)
 
       const json = await response.json<UpdateRes>()
-      expect(json.error).toBe('already_on_builtin')
+      // Kill-switch: device on OTA must get success { version: 'builtin' } with no error/kind
+      // so the plugin can reset to the store binary.
       expect(json.version).toBe('builtin')
+      expect(json.error).toBeUndefined()
+      expect(json.kind).toBeUndefined()
+
+      const alreadyOnBuiltin = getBaseData(APP_NAME_UPDATE)
+      alreadyOnBuiltin.version_name = 'builtin'
+      const upToDateResponse = await postUpdate(alreadyOnBuiltin)
+      expect(upToDateResponse.status).toBe(200)
+      const upToDateJson = await upToDateResponse.json<UpdateRes>()
+      expect(upToDateJson.error).toBe('already_on_builtin')
+      expect(upToDateJson.kind).toBe('up_to_date')
     }
     finally {
       await supabase

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -462,6 +462,8 @@ describe('[POST] /updates', () => {
       expect(json.error).toBeUndefined()
       expect(json.kind).toBeUndefined()
 
+      // Device on store binary: plugin sends version_name "builtin" (rewritten to
+      // version_build) or already reports version_name === version_build.
       const alreadyOnBuiltin = getBaseData(APP_NAME_UPDATE)
       alreadyOnBuiltin.version_name = 'builtin'
       const upToDateResponse = await postUpdate(alreadyOnBuiltin)
@@ -469,6 +471,14 @@ describe('[POST] /updates', () => {
       const upToDateJson = await upToDateResponse.json<UpdateRes>()
       expect(upToDateJson.error).toBe('already_on_builtin')
       expect(upToDateJson.kind).toBe('up_to_date')
+
+      const alreadyOnNativeBuild = getBaseData(APP_NAME_UPDATE)
+      alreadyOnNativeBuild.version_name = alreadyOnNativeBuild.version_build
+      const nativeResponse = await postUpdate(alreadyOnNativeBuild)
+      expect(nativeResponse.status).toBe(200)
+      const nativeJson = await nativeResponse.json<UpdateRes>()
+      expect(nativeJson.error).toBe('already_on_builtin')
+      expect(nativeJson.kind).toBe('up_to_date')
     }
     finally {
       await supabase


### PR DESCRIPTION
## Summary (AI generated)

- Switch notification manage routes from `middlewareKey` to `middlewareAuth` so the dashboard JWT can call `/notifications/update-check` (and related routes) without `Invalid apikey`.
- Fix channel built-in kill-switch: when a device is still on an OTA bundle and the channel points at built-in, `/updates` now returns success `{ version: "builtin" }` with no `error`/`kind`, so the plugin can reset to the store binary.
- Devices already on built-in still get `already_on_builtin` + `kind: up_to_date`.

## Motivation (AI generated)

A customer enabling silent push after reverting a channel to built-in hit two bugs:
1. Dashboard sends JWT, but notification routes only accepted Capgo API keys.
2. `/updates` always returned `already_on_builtin` + `kind: up_to_date` for built-in channels, so the plugin never entered its `version == "builtin"` reset path.

## Business Impact (AI generated)

Restores the intended emergency rollback / kill-switch (channel → built-in) and silent background update push from the console, which customers rely on for production incident response.

## Test Plan (AI generated)

- [ ] Call `/notifications/update-check` from the dashboard while logged in (JWT) and confirm it queues without `Invalid apikey`.
- [ ] Call the same endpoint with a Capgo API key and confirm it still works.
- [ ] Point a channel at built-in while a device runs an OTA bundle; confirm `/updates` returns `{ "version": "builtin" }` without `error`/`kind`, and the device resets to the store binary.
- [ ] Device already on built-in still receives `already_on_builtin` / `up_to_date`.
- [ ] Existing updates + native-notifications unit tests pass.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

