### PR TITLE
chore(readreplicate): bun commands for Supabase DB upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "readreplicate:replica": "bash read_replicate/replicate_to_replica.sh",
     "readreplicate:indexes": "bash read_replicate/replicate_ensure_indexes.sh",
     "readreplicate:status": "bash read_replicate/replicate_status.sh",
+    "readreplicate:upgrade:teardown": "bash read_replicate/replicate_upgrade_teardown.sh",
+    "readreplicate:upgrade:reconnect": "READ_REPLICA_FULL_RESET=1 bash read_replicate/replicate_to_replica.sh",
     "readreplicate:check-schema": "bash scripts/check-read-replica-schema.sh",
     "readreplicate:sync-schema": "bun scripts/sync-read-replica-schema.ts",
     "supabase:reset-postgres-config": "bash scripts/reset_supabase_postgres_config_defaults.sh",

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -28,6 +28,9 @@ bun run readreplicate:status
 because a Postgres upgrade invalidates WAL continuity. Do not use
 subscription-only reconnect after an upgrade.
 
+Both commands read `internal/cloudflare/.env.prod` for DB URLs and use the
+baked-in Capgo EU2 publication/subscription/slot names — no shell exports.
+
 ## Release reconciliation
 
 The release job rebuilds the selected schema catalog from the checked-out local

--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -4,6 +4,30 @@ These scripts manage the Supabase-to-Google Cloud SQL subscriber. Google then
 replicates this subscriber to the regional read replicas, so reconciliation
 always targets only this database.
 
+
+## Supabase Postgres upgrade
+
+Capgo-EU blocks upgrades while the active logical slot `capgo_google_eu_2_slot`
+exists. Use the premade bun commands (they load
+`internal/cloudflare/.env.prod`; no exports needed):
+
+```bash
+# 1) Drop Google subscription + Supabase slot (unblocks dashboard upgrade)
+bun run readreplicate:upgrade:teardown
+
+# 2) Run the Supabase Postgres upgrade in the Capgo-EU dashboard, wait healthy
+
+# 3) Rebuild subscriber data + recreate slot/subscription (WAL was wiped)
+bun run readreplicate:upgrade:reconnect
+
+# 4) Verify lag / active slot
+bun run readreplicate:status
+```
+
+`upgrade:reconnect` always runs a full reset (`READ_REPLICA_FULL_RESET=1`)
+because a Postgres upgrade invalidates WAL continuity. Do not use
+subscription-only reconnect after an upgrade.
+
 ## Release reconciliation
 
 The release job rebuilds the selected schema catalog from the checked-out local

--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -8,10 +8,10 @@ REPLICA_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPLICA_ENV_FILE="${REPLICA_ENV_FILE:-${REPLICA_SCRIPT_DIR}/../internal/cloudflare/.env.prod}"
 
 # Capgo production defaults for the single Google Cloud SQL eu-2 subscriber.
-# DB URLs come from .env.prod; names are fixed so bun scripts need zero exports.
+# DB URLs come from .env.prod; pub/sub/region are fixed so bun scripts need zero exports.
+# Slot name is discovered from the live subscription when present (fallback: <sub>_slot).
 : "${READ_REPLICA_PUBLICATION_NAME:=capgo_google_eu_2_pub}"
 : "${READ_REPLICA_SUBSCRIPTION_NAME:=capgo_google_eu_2}"
-: "${READ_REPLICA_SLOT_NAME:=capgo_google_eu_2_slot}"
 : "${READ_REPLICA_REGION:=eu_2}"
 
 REPLICA_TABLES=(
@@ -371,7 +371,12 @@ discover_subscription() {
       WHERE subname = '${REPLICA_SUBSCRIPTION_NAME}'
       LIMIT 1;
     " 2>/dev/null || true)
-    REPLICA_SLOT_NAME="${READ_REPLICA_SLOT_NAME:-${slotname:-${REPLICA_SUBSCRIPTION_NAME}_slot}}"
+    # Prefer the live subscription slot when present; only then fall back.
+    if [[ -n "$slotname" ]]; then
+      REPLICA_SLOT_NAME="$slotname"
+    else
+      REPLICA_SLOT_NAME="${READ_REPLICA_SLOT_NAME:-${REPLICA_SUBSCRIPTION_NAME}_slot}"
+    fi
     return 0
   fi
 
@@ -386,7 +391,11 @@ discover_subscription() {
     subname="${rows%%|*}"
     slotname="${rows#*|}"
     REPLICA_SUBSCRIPTION_NAME="$subname"
-    REPLICA_SLOT_NAME="${READ_REPLICA_SLOT_NAME:-${slotname:-${subname}_slot}}"
+    if [[ -n "$slotname" ]]; then
+      REPLICA_SLOT_NAME="$slotname"
+    else
+      REPLICA_SLOT_NAME="${READ_REPLICA_SLOT_NAME:-${subname}_slot}"
+    fi
     return 0
   fi
 

--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -7,6 +7,13 @@
 REPLICA_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPLICA_ENV_FILE="${REPLICA_ENV_FILE:-${REPLICA_SCRIPT_DIR}/../internal/cloudflare/.env.prod}"
 
+# Capgo production defaults for the single Google Cloud SQL eu-2 subscriber.
+# DB URLs come from .env.prod; names are fixed so bun scripts need zero exports.
+: "${READ_REPLICA_PUBLICATION_NAME:=capgo_google_eu_2_pub}"
+: "${READ_REPLICA_SUBSCRIPTION_NAME:=capgo_google_eu_2}"
+: "${READ_REPLICA_SLOT_NAME:=capgo_google_eu_2_slot}"
+: "${READ_REPLICA_REGION:=eu_2}"
+
 REPLICA_TABLES=(
   "orgs"
   "stripe_info"
@@ -334,14 +341,18 @@ discover_publication_name() {
   existing=$(psql-17 "$SOURCE_DB_URL" -t -A -c "
     SELECT pubname
     FROM pg_publication
-    WHERE pubname = 'capgo_google_replicate'
+    WHERE pubname IN ('capgo_google_eu_2_pub', 'capgo_google_replicate')
+    ORDER BY CASE pubname
+      WHEN 'capgo_google_eu_2_pub' THEN 0
+      ELSE 1
+    END
     LIMIT 1;
   " 2>/dev/null || true)
 
   if [[ -n "$existing" ]]; then
     printf "%s" "$existing"
   else
-    printf "%s" "capgo_google_replicate"
+    printf "%s" "capgo_google_eu_2_pub"
   fi
 }
 

--- a/read_replicate/replicate_upgrade_teardown.sh
+++ b/read_replicate/replicate_upgrade_teardown.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Drop the Capgo Google EU2 subscription + source slot so Supabase can upgrade.
+# Loads DB URLs from internal/cloudflare/.env.prod. No env exports required.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=read_replicate/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+echo "==> Preparing Capgo-EU for Supabase Postgres upgrade (teardown replication)..."
+
+load_replica_target
+load_source
+
+PUBLICATION_NAME="$(discover_publication_name)"
+DEFAULT_SUBSCRIPTION_NAME="capgo_google_$(replica_region_name)"
+discover_subscription "$DEFAULT_SUBSCRIPTION_NAME"
+print_target_summary
+echo "==> Publication: ${PUBLICATION_NAME}"
+
+echo "==> Dropping target subscription ${REPLICA_SUBSCRIPTION_NAME} if present..."
+SUB_EXISTS=$(psql-17 "$REPLICA_TARGET_DB_URL" -t -A -c "
+  SELECT 1
+  FROM pg_subscription
+  WHERE subname = '${REPLICA_SUBSCRIPTION_NAME}';
+" || true)
+
+if [[ -n "$SUB_EXISTS" ]]; then
+  psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=0 -c "ALTER SUBSCRIPTION ${REPLICA_SUBSCRIPTION_NAME} DISABLE;" || true
+  sleep 2
+  psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=0 -c "ALTER SUBSCRIPTION ${REPLICA_SUBSCRIPTION_NAME} SET (slot_name = NONE);" || true
+  psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=0 -c "DROP SUBSCRIPTION ${REPLICA_SUBSCRIPTION_NAME};" || true
+  echo "    Dropped subscription ${REPLICA_SUBSCRIPTION_NAME}"
+else
+  echo "    No target subscription named ${REPLICA_SUBSCRIPTION_NAME}"
+fi
+
+echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
+psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=0 <<SQL
+DO \$\$
+DECLARE
+  slot record;
+BEGIN
+  SELECT slot_name, active, active_pid
+  INTO slot
+  FROM pg_replication_slots
+  WHERE slot_name = '${REPLICA_SLOT_NAME}';
+
+  IF slot.slot_name IS NOT NULL THEN
+    RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
+
+    IF slot.active AND slot.active_pid IS NOT NULL THEN
+      PERFORM pg_terminate_backend(slot.active_pid);
+      PERFORM pg_sleep(2);
+    END IF;
+
+    BEGIN
+      PERFORM pg_drop_replication_slot(slot.slot_name);
+      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Could not drop slot: %', SQLERRM;
+    END;
+  ELSE
+    RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
+  END IF;
+END
+\$\$;
+SQL
+
+echo "==> Verifying slot is gone on source..."
+REMAINING=$(psql-17 "$SOURCE_DB_URL" -t -A -c "
+  SELECT slot_name
+  FROM pg_replication_slots
+  WHERE slot_name = '${REPLICA_SLOT_NAME}';
+" || true)
+
+if [[ -n "$REMAINING" ]]; then
+  echo "Error: slot ${REPLICA_SLOT_NAME} still exists. Fix before upgrading."
+  exit 1
+fi
+
+echo ""
+echo "Teardown complete. Next:"
+echo "  1) Run the Supabase Postgres upgrade in the Capgo-EU dashboard"
+echo "  2) After the project is healthy: bun run readreplicate:upgrade:reconnect"
+echo "  3) Verify: bun run readreplicate:status"

--- a/read_replicate/replicate_upgrade_teardown.sh
+++ b/read_replicate/replicate_upgrade_teardown.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Drop the Capgo Google EU2 subscription + source slot so Supabase can upgrade.
 # Loads DB URLs from internal/cloudflare/.env.prod. No env exports required.
+# Exits nonzero unless subscription and source slot are verified gone.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=read_replicate/common.sh
@@ -20,24 +21,36 @@ print_target_summary
 echo "==> Publication: ${PUBLICATION_NAME}"
 
 echo "==> Dropping target subscription ${REPLICA_SUBSCRIPTION_NAME} if present..."
-SUB_EXISTS=$(psql-17 "$REPLICA_TARGET_DB_URL" -t -A -c "
+SUB_EXISTS=$(psql-17 "$REPLICA_TARGET_DB_URL" -t -A -v ON_ERROR_STOP=1 -c "
   SELECT 1
   FROM pg_subscription
   WHERE subname = '${REPLICA_SUBSCRIPTION_NAME}';
-" || true)
+")
 
 if [[ -n "$SUB_EXISTS" ]]; then
+  # DISABLE / detach slot may already be done; ignore those, but DROP must succeed.
   psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=0 -c "ALTER SUBSCRIPTION ${REPLICA_SUBSCRIPTION_NAME} DISABLE;" || true
   sleep 2
   psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=0 -c "ALTER SUBSCRIPTION ${REPLICA_SUBSCRIPTION_NAME} SET (slot_name = NONE);" || true
-  psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=0 -c "DROP SUBSCRIPTION ${REPLICA_SUBSCRIPTION_NAME};" || true
+  psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -c "DROP SUBSCRIPTION IF EXISTS ${REPLICA_SUBSCRIPTION_NAME};"
   echo "    Dropped subscription ${REPLICA_SUBSCRIPTION_NAME}"
 else
   echo "    No target subscription named ${REPLICA_SUBSCRIPTION_NAME}"
 fi
 
+echo "==> Verifying subscription is gone on target..."
+SUB_REMAINING=$(psql-17 "$REPLICA_TARGET_DB_URL" -t -A -v ON_ERROR_STOP=1 -c "
+  SELECT subname
+  FROM pg_subscription
+  WHERE subname = '${REPLICA_SUBSCRIPTION_NAME}';
+")
+if [[ -n "$SUB_REMAINING" ]]; then
+  echo "Error: subscription ${REPLICA_SUBSCRIPTION_NAME} still exists on target. Fix before upgrading."
+  exit 1
+fi
+
 echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
-psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=0 <<SQL
+psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 <<SQL
 DO \$\$
 DECLARE
   slot record;
@@ -47,33 +60,30 @@ BEGIN
   FROM pg_replication_slots
   WHERE slot_name = '${REPLICA_SLOT_NAME}';
 
-  IF slot.slot_name IS NOT NULL THEN
-    RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
-
-    IF slot.active AND slot.active_pid IS NOT NULL THEN
-      PERFORM pg_terminate_backend(slot.active_pid);
-      PERFORM pg_sleep(2);
-    END IF;
-
-    BEGIN
-      PERFORM pg_drop_replication_slot(slot.slot_name);
-      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
-    EXCEPTION WHEN OTHERS THEN
-      RAISE NOTICE 'Could not drop slot: %', SQLERRM;
-    END;
-  ELSE
+  IF slot.slot_name IS NULL THEN
     RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
+    RETURN;
   END IF;
+
+  RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
+
+  IF slot.active AND slot.active_pid IS NOT NULL THEN
+    PERFORM pg_terminate_backend(slot.active_pid);
+    PERFORM pg_sleep(2);
+  END IF;
+
+  PERFORM pg_drop_replication_slot(slot.slot_name);
+  RAISE NOTICE 'Dropped slot: %', slot.slot_name;
 END
 \$\$;
 SQL
 
 echo "==> Verifying slot is gone on source..."
-REMAINING=$(psql-17 "$SOURCE_DB_URL" -t -A -c "
+REMAINING=$(psql-17 "$SOURCE_DB_URL" -t -A -v ON_ERROR_STOP=1 -c "
   SELECT slot_name
   FROM pg_replication_slots
   WHERE slot_name = '${REPLICA_SLOT_NAME}';
-" || true)
+")
 
 if [[ -n "$REMAINING" ]]; then
   echo "Error: slot ${REPLICA_SLOT_NAME} still exists. Fix before upgrading."

--- a/tests/private-analytics-validation.unit.test.ts
+++ b/tests/private-analytics-validation.unit.test.ts
@@ -161,7 +161,13 @@ describe('private analytics route validation', () => {
       [],
       '2.0.0',
       undefined,
-      'android',
+      {
+        platform: 'android',
+        updatedAt: {
+          gt: undefined,
+          lte: undefined,
+        },
+      },
     )
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Bake Capgo EU2 production replication names into `read_replicate/common.sh` (`capgo_google_eu_2_pub` / `capgo_google_eu_2` / `capgo_google_eu_2_slot`) so scripts load `internal/cloudflare/.env.prod` with **zero exports**
- Add `bun run readreplicate:upgrade:teardown` to drop the Google subscription + Supabase slot (unblocks dashboard Postgres upgrade)
- Add `bun run readreplicate:upgrade:reconnect` for post-upgrade FULL_RESET reconnect after WAL wipe
- Document the upgrade flow in `read_replicate/README.md`

## Motivation (AI generated)

Supabase Capgo-EU upgrades are blocked by active slot `capgo_google_eu_2_slot`. The existing runbook required manual env exports and interactive mode selection; operators need one-liner bun commands that always target prod EU2 correctly.

## Business Impact (AI generated)

Faster, safer Postgres upgrades with less risk of reconnecting to the wrong publication/slot or leaving plugin read replicas on stale WAL after an upgrade.

## Test Plan (AI generated)

- [ ] `bun run readreplicate:status` prints subscription `capgo_google_eu_2`, slot `capgo_google_eu_2_slot`, publication `capgo_google_eu_2_pub` without any exports
- [ ] `bun run readreplicate:upgrade:teardown` drops subscription then slot and exits 0 when slot is gone
- [ ] After dashboard upgrade: `bun run readreplicate:upgrade:reconnect` recreates slot/subscription with full data reload
- [ ] `bun run readreplicate:status` shows active slot and healthy subscription lag

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

