### PR TITLE
test(plugin): block PRs that grow plugin worker size over 15%

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test:coverage:all": "bun run cli:build && bun run supabase:with-env -- bunx vitest run --coverage.enabled=true tests/*",
     "test:all": "bun run cli:build && bun run supabase:with-env -- bunx vitest run tests/*",
     "check:plugin-runtime": "bun scripts/check_plugin_runtime_isolation.mjs",
+    "check:plugin-worker-size": "bun scripts/check_plugin_worker_size.ts",
     "test:unit": "vitest run tests/*.unit.test.ts",
     "test:db": "bash scripts/test-db-tinbase.sh",
     "test:backend:integration": "bun run supabase:with-env -- bunx vitest run --exclude=tests/*.unit.test.ts --exclude=tests/cli*",

--- a/scripts/bench/plugin_worker_size_baseline.json
+++ b/scripts/bench/plugin_worker_size_baseline.json
@@ -1,0 +1,7 @@
+{
+  "generatedAt": "2026-07-31T10:44:27.260Z",
+  "gitHead": "b5a9950529c77acd521446a3c7e3d50f090348a9",
+  "note": "Committed CF plugin worker size budget (wrangler dry-run --minify, env=local). Update with: bun run check:plugin-worker-size -- --update-baseline",
+  "uploadBytes": 437443,
+  "gzipBytes": 128512
+}

--- a/scripts/check_plugin_worker_size.ts
+++ b/scripts/check_plugin_worker_size.ts
@@ -15,7 +15,7 @@
  */
 
 import { spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -23,6 +23,8 @@ const ROOT = resolve(import.meta.dirname, '..')
 const BASELINE_PATH = join(ROOT, 'scripts/bench/plugin_worker_size_baseline.json')
 const WARN_PCT = 5
 const FAIL_PCT = 15
+const WRANGLER_TIMEOUT_MS = 90_000
+const GIT_TIMEOUT_MS = 10_000
 
 interface SizeBaseline {
   generatedAt: string
@@ -47,40 +49,51 @@ function gitHead(): string {
   const result = spawnSync('git', ['rev-parse', 'HEAD'], {
     cwd: ROOT,
     encoding: 'utf8',
+    timeout: GIT_TIMEOUT_MS,
   })
   return result.status === 0 ? result.stdout.trim() : 'unknown'
 }
 
 function measurePluginWorkerSize(): MeasuredSize {
   const outDir = mkdtempSync(join(tmpdir(), 'capgo-plugin-size-'))
-  const result = spawnSync('bunx', [
-    'wrangler',
-    'deploy',
-    '--config',
-    'cloudflare_workers/plugin/wrangler.jsonc',
-    '--env=local',
-    '--dry-run',
-    '--minify',
-    `--outdir=${outDir}`,
-  ], {
-    cwd: ROOT,
-    encoding: 'utf8',
-    maxBuffer: 32 * 1024 * 1024,
-  })
-  if (result.status !== 0) {
-    throw new Error(`wrangler dry-run failed:\n${result.stdout}\n${result.stderr}`)
+  try {
+    const result = spawnSync('bunx', [
+      'wrangler',
+      'deploy',
+      '--config',
+      'cloudflare_workers/plugin/wrangler.jsonc',
+      '--env=local',
+      '--dry-run',
+      '--minify',
+      `--outdir=${outDir}`,
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: WRANGLER_TIMEOUT_MS,
+    })
+    if (result.error)
+      throw new Error(`wrangler dry-run failed to start: ${result.error.message}`)
+    if (result.signal)
+      throw new Error(`wrangler dry-run killed by signal ${result.signal} (timeout ${WRANGLER_TIMEOUT_MS}ms?)`)
+    if (result.status !== 0) {
+      throw new Error(`wrangler dry-run failed:\n${result.stdout}\n${result.stderr}`)
+    }
+    const uploadMatch = result.stdout.match(/Total Upload:\s*([\d.]+)\s*KiB\s*\/\s*gzip:\s*([\d.]+)\s*KiB/)
+    if (!uploadMatch) {
+      throw new Error(`Could not parse wrangler upload size from output:\n${result.stdout}`)
+    }
+    const uploadKiB = Number.parseFloat(uploadMatch[1])
+    const gzipKiB = Number.parseFloat(uploadMatch[2])
+    return {
+      uploadKiB,
+      gzipKiB,
+      uploadBytes: Math.round(uploadKiB * 1024),
+      gzipBytes: Math.round(gzipKiB * 1024),
+    }
   }
-  const uploadMatch = result.stdout.match(/Total Upload:\s*([\d.]+)\s*KiB\s*\/\s*gzip:\s*([\d.]+)\s*KiB/)
-  if (!uploadMatch) {
-    throw new Error(`Could not parse wrangler upload size from output:\n${result.stdout}`)
-  }
-  const uploadKiB = Number.parseFloat(uploadMatch[1])
-  const gzipKiB = Number.parseFloat(uploadMatch[2])
-  return {
-    uploadKiB,
-    gzipKiB,
-    uploadBytes: Math.round(uploadKiB * 1024),
-    gzipBytes: Math.round(gzipKiB * 1024),
+  finally {
+    rmSync(outDir, { recursive: true, force: true })
   }
 }
 

--- a/scripts/check_plugin_worker_size.ts
+++ b/scripts/check_plugin_worker_size.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env bun
+/**
+ * Guard Cloudflare plugin worker bundle size against the committed baseline.
+ *
+ * Builds with `wrangler deploy --dry-run --minify` (same path as production
+ * plugin deploys) and compares Total Upload / gzip against
+ * `scripts/bench/plugin_worker_size_baseline.json`.
+ *
+ * - Increase >5%: warning on stdout (still exits 0)
+ * - Increase >15%: fails (exit 1) so PRs cannot silently bloat the hot-path worker
+ *
+ * Usage:
+ *   bun run check:plugin-worker-size
+ *   bun run check:plugin-worker-size -- --update-baseline
+ */
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const ROOT = resolve(import.meta.dirname, '..')
+const BASELINE_PATH = join(ROOT, 'scripts/bench/plugin_worker_size_baseline.json')
+const WARN_PCT = 5
+const FAIL_PCT = 15
+
+interface SizeBaseline {
+  generatedAt: string
+  gitHead: string
+  note?: string
+  uploadBytes: number
+  gzipBytes: number
+}
+
+interface MeasuredSize {
+  uploadBytes: number
+  gzipBytes: number
+  uploadKiB: number
+  gzipKiB: number
+}
+
+function parseArgs(argv: string[]) {
+  return { updateBaseline: argv.includes('--update-baseline') }
+}
+
+function gitHead(): string {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  })
+  return result.status === 0 ? result.stdout.trim() : 'unknown'
+}
+
+function measurePluginWorkerSize(): MeasuredSize {
+  const outDir = mkdtempSync(join(tmpdir(), 'capgo-plugin-size-'))
+  const result = spawnSync('bunx', [
+    'wrangler',
+    'deploy',
+    '--config',
+    'cloudflare_workers/plugin/wrangler.jsonc',
+    '--env=local',
+    '--dry-run',
+    '--minify',
+    `--outdir=${outDir}`,
+  ], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  if (result.status !== 0) {
+    throw new Error(`wrangler dry-run failed:\n${result.stdout}\n${result.stderr}`)
+  }
+  const uploadMatch = result.stdout.match(/Total Upload:\s*([\d.]+)\s*KiB\s*\/\s*gzip:\s*([\d.]+)\s*KiB/)
+  if (!uploadMatch) {
+    throw new Error(`Could not parse wrangler upload size from output:\n${result.stdout}`)
+  }
+  const uploadKiB = Number.parseFloat(uploadMatch[1])
+  const gzipKiB = Number.parseFloat(uploadMatch[2])
+  return {
+    uploadKiB,
+    gzipKiB,
+    uploadBytes: Math.round(uploadKiB * 1024),
+    gzipBytes: Math.round(gzipKiB * 1024),
+  }
+}
+
+function loadBaseline(): SizeBaseline {
+  return JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as SizeBaseline
+}
+
+function pctChange(before: number, after: number): number {
+  if (before <= 0)
+    return after === 0 ? 0 : Infinity
+  return ((after - before) / before) * 100
+}
+
+function formatPct(value: number): string {
+  if (!Number.isFinite(value))
+    return 'n/a'
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
+}
+
+function kib(bytes: number): string {
+  return `${(bytes / 1024).toFixed(2)} KiB`
+}
+
+function writeBaseline(measured: MeasuredSize) {
+  mkdirSync(resolve(BASELINE_PATH, '..'), { recursive: true })
+  const baseline: SizeBaseline = {
+    generatedAt: new Date().toISOString(),
+    gitHead: gitHead(),
+    note: 'Committed CF plugin worker size budget (wrangler dry-run --minify, env=local). Update with: bun run check:plugin-worker-size -- --update-baseline',
+    uploadBytes: measured.uploadBytes,
+    gzipBytes: measured.gzipBytes,
+  }
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`)
+  console.log(`Updated baseline at ${BASELINE_PATH}`)
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  console.log('Building Cloudflare plugin worker (dry-run --minify)...')
+  const measured = measurePluginWorkerSize()
+
+  if (args.updateBaseline) {
+    writeBaseline(measured)
+    console.log(`upload ${kib(measured.uploadBytes)} / gzip ${kib(measured.gzipBytes)}`)
+    return
+  }
+
+  const baseline = loadBaseline()
+  const uploadDelta = pctChange(baseline.uploadBytes, measured.uploadBytes)
+  const gzipDelta = pctChange(baseline.gzipBytes, measured.gzipBytes)
+  const maxDelta = Math.max(uploadDelta, gzipDelta)
+
+  console.log('Plugin worker size vs baseline:')
+  console.log(`  upload: ${kib(baseline.uploadBytes)} → ${kib(measured.uploadBytes)} (${formatPct(uploadDelta)})`)
+  console.log(`  gzip:   ${kib(baseline.gzipBytes)} → ${kib(measured.gzipBytes)} (${formatPct(gzipDelta)})`)
+  console.log(`  baseline: ${BASELINE_PATH} (git ${baseline.gitHead})`)
+  console.log(`  thresholds: warn >${WARN_PCT}% | fail >${FAIL_PCT}%`)
+
+  if (maxDelta > FAIL_PCT) {
+    console.error(`\nFAIL: plugin worker size grew ${formatPct(maxDelta)} (limit +${FAIL_PCT}%).`)
+    console.error('Keep the plugin isolate light. Revert heavy imports or raise the budget intentionally with:')
+    console.error('  bun run check:plugin-worker-size -- --update-baseline')
+    console.error('and justify the baseline bump in the PR.')
+    process.exit(1)
+  }
+
+  if (maxDelta > WARN_PCT) {
+    console.warn(`\nWARNING: plugin worker size grew ${formatPct(maxDelta)} (warn >${WARN_PCT}%).`)
+    console.warn('Prefer keeping growth near zero on the hot plugin worker path.')
+  }
+  else if (maxDelta > 0) {
+    console.log(`\nOK: size increase ${formatPct(maxDelta)} is under the ${WARN_PCT}% warning threshold.`)
+  }
+  else if (maxDelta < 0) {
+    console.log(`\nOK: plugin worker got smaller (${formatPct(maxDelta)}). Consider --update-baseline.`)
+  }
+  else {
+    console.log('\nOK: plugin worker size unchanged vs baseline.')
+  }
+}
+
+main()

--- a/scripts/check_plugin_worker_size.ts
+++ b/scripts/check_plugin_worker_size.ts
@@ -23,6 +23,7 @@ const ROOT = resolve(import.meta.dirname, '..')
 const BASELINE_PATH = join(ROOT, 'scripts/bench/plugin_worker_size_baseline.json')
 const WARN_PCT = 5
 const FAIL_PCT = 15
+// Keep these well under the unit-test SCRIPT_TIMEOUT_MS (120s) so CI gets a clean size failure, not a killed process.
 const WRANGLER_TIMEOUT_MS = 90_000
 const GIT_TIMEOUT_MS = 10_000
 

--- a/scripts/check_plugin_worker_size.ts
+++ b/scripts/check_plugin_worker_size.ts
@@ -73,10 +73,10 @@ function measurePluginWorkerSize(): MeasuredSize {
       maxBuffer: 32 * 1024 * 1024,
       timeout: WRANGLER_TIMEOUT_MS,
     })
-    if (result.error)
-      throw new Error(`wrangler dry-run failed to start: ${result.error.message}`)
     if (result.signal)
       throw new Error(`wrangler dry-run killed by signal ${result.signal} (timeout ${WRANGLER_TIMEOUT_MS}ms?)`)
+    if (result.error)
+      throw new Error(`wrangler dry-run failed to start: ${result.error.message}`)
     if (result.status !== 0) {
       throw new Error(`wrangler dry-run failed:\n${result.stdout}\n${result.stderr}`)
     }

--- a/tests/plugin-worker-size.unit.test.ts
+++ b/tests/plugin-worker-size.unit.test.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('plugin worker size budget', () => {
+  it('keeps the Cloudflare plugin worker within +15% of the committed size baseline', () => {
+    let output = ''
+    try {
+      output = execFileSync('bun', [resolve('scripts/check_plugin_worker_size.ts')], {
+        cwd: resolve('.'),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    }
+    catch (error) {
+      const err = error as { stdout?: string, stderr?: string, message?: string }
+      output = `${err.stdout || ''}${err.stderr || ''}${err.message || ''}`
+      console.error(output)
+      expect.fail(`plugin worker size check failed:\n${output}`)
+    }
+    // Surface warnings / size deltas in CI logs even on success.
+    if (output)
+      console.log(output)
+    expect(output).toContain('Plugin worker size vs baseline:')
+  }, 120_000)
+})

--- a/tests/plugin-worker-size.unit.test.ts
+++ b/tests/plugin-worker-size.unit.test.ts
@@ -2,8 +2,9 @@ import { execFileSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const SCRIPT_TIMEOUT_MS = 100_000
-const TEST_TIMEOUT_MS = 120_000
+// Must exceed scripts/check_plugin_worker_size.ts inner budgets (wrangler 90s + git 10s) with margin.
+const SCRIPT_TIMEOUT_MS = 120_000
+const TEST_TIMEOUT_MS = 150_000
 
 describe('plugin worker size budget', () => {
   it('keeps the Cloudflare plugin worker within +15% of the committed size baseline', () => {
@@ -12,7 +13,8 @@ describe('plugin worker size budget', () => {
       output = execFileSync('bun', [resolve('scripts/check_plugin_worker_size.ts')], {
         cwd: resolve('.'),
         encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
+        // Inherit stderr so WARNING (>5%) console.warn lines show in CI logs.
+        stdio: ['ignore', 'pipe', 'inherit'],
         timeout: SCRIPT_TIMEOUT_MS,
       })
     }
@@ -22,7 +24,7 @@ describe('plugin worker size budget', () => {
       console.error(output)
       expect.fail(`plugin worker size check failed:\n${output}`)
     }
-    // Surface warnings / size deltas in CI logs even on success.
+    // Surface size deltas in CI logs even on success.
     if (output)
       console.log(output)
     expect(output).toContain('Plugin worker size vs baseline:')

--- a/tests/plugin-worker-size.unit.test.ts
+++ b/tests/plugin-worker-size.unit.test.ts
@@ -2,6 +2,9 @@ import { execFileSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
+const SCRIPT_TIMEOUT_MS = 100_000
+const TEST_TIMEOUT_MS = 120_000
+
 describe('plugin worker size budget', () => {
   it('keeps the Cloudflare plugin worker within +15% of the committed size baseline', () => {
     let output = ''
@@ -10,6 +13,7 @@ describe('plugin worker size budget', () => {
         cwd: resolve('.'),
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: SCRIPT_TIMEOUT_MS,
       })
     }
     catch (error) {
@@ -22,5 +26,5 @@ describe('plugin worker size budget', () => {
     if (output)
       console.log(output)
     expect(output).toContain('Plugin worker size vs baseline:')
-  }, 120_000)
+  }, TEST_TIMEOUT_MS)
 })

--- a/tests/private-analytics-validation.unit.test.ts
+++ b/tests/private-analytics-validation.unit.test.ts
@@ -161,7 +161,13 @@ describe('private analytics route validation', () => {
       [],
       '2.0.0',
       undefined,
-      'android',
+      {
+        platform: 'android',
+        updatedAt: {
+          gt: undefined,
+          lte: undefined,
+        },
+      },
     )
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Add `bun run check:plugin-worker-size` which dry-runs the Cloudflare plugin worker (`wrangler deploy --minify`) and compares upload/gzip size to a committed baseline (`scripts/bench/plugin_worker_size_baseline.json`).
- Wire it into the unit test suite (`tests/plugin-worker-size.unit.test.ts`) so every Capgo PR CI run surfaces size deltas.
- **Warn** when size grows **>5%**; **fail** when it grows **>15%** (either upload or gzip).
- Baseline captured from current `main`: **427.19 KiB upload / 125.50 KiB gzip**.

## Motivation (AI generated)

The plugin worker was recently isolated so the hot path stays light. Without a CI gate, heavy imports (Stripe, supabase-js, etc.) can silently return and undo that boot/size win. This check makes size regressions visible on every PR and blocks large jumps.

## Business Impact (AI generated)

Protects cold-start and isolate CPU cost on `/updates`, `/stats`, and `/channel_self`, which carry the majority of Capgo device traffic. Keeps operational cost and latency from drifting upward after the isolation work.

## Test Plan (AI generated)

- [ ] `bun run check:plugin-worker-size` prints unchanged size vs baseline and exits 0
- [ ] `bunx vitest run tests/plugin-worker-size.unit.test.ts` passes
- [ ] Temporarily shrink baseline by ~6% → warning, exit 0
- [ ] Temporarily shrink baseline by ~20% → fail, exit 1 / unit test fails
- [ ] `bun run check:plugin-worker-size -- --update-baseline` refreshes the committed budget after an intentional under-threshold change

### How to update the budget

After an intentional size change under +15%:

```bash
bun run check:plugin-worker-size -- --update-baseline
```

Commit the updated `scripts/bench/plugin_worker_size_baseline.json` and justify the bump in the PR.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated monitoring of plugin worker upload and compressed sizes.
  * Added baseline tracking with warnings for significant growth and build failures when size increases exceed defined limits.
  * Added clearer reporting of size changes during build validation.

* **Tests**
  * Added coverage for plugin worker size comparisons and diagnostic reporting.
  * Updated private analytics validation to reflect refined Android device filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->