### PR TITLE
fix(readreplicate): retry active slot drop on upgrade teardown

### DIFF
--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -317,6 +317,66 @@ replica_region_name() {
   sanitize_identifier_part "$host_part"
 }
 
+
+# Terminate any walsender holding the slot, then drop it. Retries until inactive.
+drop_source_slot_with_retry() {
+  local slot_name="${1:-${REPLICA_SLOT_NAME}}"
+  local source_url="${2:-${SOURCE_DB_URL}}"
+  local max_attempts="${3:-15}"
+
+  if [[ -z "$slot_name" || -z "$source_url" ]]; then
+    echo "Error: drop_source_slot_with_retry requires slot name and source URL"
+    exit 1
+  fi
+
+  echo "==> Dropping source slot ${slot_name} if present..."
+  psql-17 "$source_url" -v ON_ERROR_STOP=1 \
+    -v slot_name="$slot_name" \
+    -v max_attempts="$max_attempts" <<'SQL'
+DO $$
+DECLARE
+  target_slot text := :'slot_name';
+  max_attempts int := :'max_attempts'::int;
+  slot record;
+  attempt int := 0;
+BEGIN
+  LOOP
+    attempt := attempt + 1;
+    SELECT slot_name, active, active_pid
+    INTO slot
+    FROM pg_replication_slots
+    WHERE slot_name = target_slot;
+
+    IF slot.slot_name IS NULL THEN
+      RAISE NOTICE 'No source slot named %', target_slot;
+      RETURN;
+    END IF;
+
+    IF NOT COALESCE(slot.active, false) THEN
+      PERFORM pg_drop_replication_slot(slot.slot_name);
+      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+      RETURN;
+    END IF;
+
+    RAISE NOTICE 'Slot % still active (pid %, attempt %/%)',
+      slot.slot_name, slot.active_pid, attempt, max_attempts;
+
+    IF slot.active_pid IS NOT NULL THEN
+      PERFORM pg_terminate_backend(slot.active_pid);
+    END IF;
+
+    IF attempt >= max_attempts THEN
+      RAISE EXCEPTION 'replication slot % still active for PID % after % attempts',
+        slot.slot_name, slot.active_pid, attempt;
+    END IF;
+
+    PERFORM pg_sleep(2);
+  END LOOP;
+END
+$$;
+SQL
+}
+
 discover_publication_name() {
   local existing
   local count

--- a/read_replicate/replicate_to_replica.sh
+++ b/read_replicate/replicate_to_replica.sh
@@ -57,39 +57,8 @@ drop_target_subscription() {
 }
 
 drop_source_slot() {
-  echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
-  psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=0 <<SQL
-DO \$\$
-DECLARE
-  slot record;
-BEGIN
-  SELECT slot_name, active, active_pid
-  INTO slot
-  FROM pg_replication_slots
-  WHERE slot_name = '${REPLICA_SLOT_NAME}';
-
-  IF slot.slot_name IS NOT NULL THEN
-    RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
-
-    IF slot.active AND slot.active_pid IS NOT NULL THEN
-      PERFORM pg_terminate_backend(slot.active_pid);
-      PERFORM pg_sleep(2);
-    END IF;
-
-    BEGIN
-      PERFORM pg_drop_replication_slot(slot.slot_name);
-      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
-    EXCEPTION WHEN OTHERS THEN
-      RAISE NOTICE 'Could not drop slot: %', SQLERRM;
-    END;
-  ELSE
-    RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
-  END IF;
-END
-\$\$;
-SQL
+  drop_source_slot_with_retry "${REPLICA_SLOT_NAME}" "${SOURCE_DB_URL}"
 }
-
 source_slot_exists() {
   local exists
   exists=$(psql-17 "$SOURCE_DB_URL" -t -A -c "

--- a/read_replicate/replicate_upgrade_teardown.sh
+++ b/read_replicate/replicate_upgrade_teardown.sh
@@ -50,30 +50,45 @@ if [[ -n "$SUB_REMAINING" ]]; then
 fi
 
 echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
+# Walsender can stay attached briefly after subscription drop; terminate + retry
+# until inactive, then drop. A single terminate+2s sleep is not enough in prod.
 psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 <<SQL
 DO \$\$
 DECLARE
   slot record;
+  attempt int := 0;
 BEGIN
-  SELECT slot_name, active, active_pid
-  INTO slot
-  FROM pg_replication_slots
-  WHERE slot_name = '${REPLICA_SLOT_NAME}';
+  LOOP
+    attempt := attempt + 1;
+    SELECT slot_name, active, active_pid
+    INTO slot
+    FROM pg_replication_slots
+    WHERE slot_name = '${REPLICA_SLOT_NAME}';
 
-  IF slot.slot_name IS NULL THEN
-    RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
-    RETURN;
-  END IF;
+    IF slot.slot_name IS NULL THEN
+      RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
+      RETURN;
+    END IF;
 
-  RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
+    IF NOT COALESCE(slot.active, false) THEN
+      PERFORM pg_drop_replication_slot(slot.slot_name);
+      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+      RETURN;
+    END IF;
 
-  IF slot.active AND slot.active_pid IS NOT NULL THEN
-    PERFORM pg_terminate_backend(slot.active_pid);
+    RAISE NOTICE 'Slot % still active (pid %, attempt %/15)', slot.slot_name, slot.active_pid, attempt;
+
+    IF slot.active_pid IS NOT NULL THEN
+      PERFORM pg_terminate_backend(slot.active_pid);
+    END IF;
+
+    IF attempt >= 15 THEN
+      RAISE EXCEPTION 'replication slot % still active for PID % after % attempts',
+        slot.slot_name, slot.active_pid, attempt;
+    END IF;
+
     PERFORM pg_sleep(2);
-  END IF;
-
-  PERFORM pg_drop_replication_slot(slot.slot_name);
-  RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+  END LOOP;
 END
 \$\$;
 SQL

--- a/read_replicate/replicate_upgrade_teardown.sh
+++ b/read_replicate/replicate_upgrade_teardown.sh
@@ -49,49 +49,7 @@ if [[ -n "$SUB_REMAINING" ]]; then
   exit 1
 fi
 
-echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
-# Walsender can stay attached briefly after subscription drop; terminate + retry
-# until inactive, then drop. A single terminate+2s sleep is not enough in prod.
-psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 <<SQL
-DO \$\$
-DECLARE
-  slot record;
-  attempt int := 0;
-BEGIN
-  LOOP
-    attempt := attempt + 1;
-    SELECT slot_name, active, active_pid
-    INTO slot
-    FROM pg_replication_slots
-    WHERE slot_name = '${REPLICA_SLOT_NAME}';
-
-    IF slot.slot_name IS NULL THEN
-      RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
-      RETURN;
-    END IF;
-
-    IF NOT COALESCE(slot.active, false) THEN
-      PERFORM pg_drop_replication_slot(slot.slot_name);
-      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
-      RETURN;
-    END IF;
-
-    RAISE NOTICE 'Slot % still active (pid %, attempt %/15)', slot.slot_name, slot.active_pid, attempt;
-
-    IF slot.active_pid IS NOT NULL THEN
-      PERFORM pg_terminate_backend(slot.active_pid);
-    END IF;
-
-    IF attempt >= 15 THEN
-      RAISE EXCEPTION 'replication slot % still active for PID % after % attempts',
-        slot.slot_name, slot.active_pid, attempt;
-    END IF;
-
-    PERFORM pg_sleep(2);
-  END LOOP;
-END
-\$\$;
-SQL
+drop_source_slot_with_retry "${REPLICA_SLOT_NAME}" "${SOURCE_DB_URL}"
 
 echo "==> Verifying slot is gone on source..."
 REMAINING=$(psql-17 "$SOURCE_DB_URL" -t -A -v ON_ERROR_STOP=1 -c "


### PR DESCRIPTION
## Summary (AI generated)

- Upgrade teardown failed when `capgo_google_eu_2_slot` was still active for a walsender PID after one terminate + 2s sleep
- Loop terminate/wait (up to 15 attempts) until the slot is inactive, then drop it

## Motivation (AI generated)

`bun run readreplicate:upgrade:teardown` exited with code 3 on production because the slot was still active for PID 20522.

## Business Impact (AI generated)

Unblocks Capgo-EU Supabase Postgres upgrades without manual SQL.

## Test Plan (AI generated)

- [ ] `bun run readreplicate:upgrade:teardown` drops subscription then slot even when walsender is briefly active
- [ ] Script exits 0 only after slot verified gone

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

