### PR TITLE
fix(readreplicate): upgrade reconnect hardens (timeout, resume, slot drop)

### DIFF
--- a/read_replicate/README.md
+++ b/read_replicate/README.md
@@ -24,9 +24,11 @@ bun run readreplicate:upgrade:reconnect
 bun run readreplicate:status
 ```
 
-`upgrade:reconnect` always runs a full reset (`READ_REPLICA_FULL_RESET=1`)
-because a Postgres upgrade invalidates WAL continuity. Do not use
-subscription-only reconnect after an upgrade.
+`upgrade:reconnect` runs a full reset (`READ_REPLICA_FULL_RESET=1`) because a
+Postgres upgrade invalidates WAL continuity. Table copy is **resumable**:
+already-synced tables (matching row counts) are skipped, complete dump files
+are reused, and schema is not wiped if replica tables already exist. Do not
+use subscription-only reconnect after an upgrade.
 
 Both commands read `internal/cloudflare/.env.prod` for DB URLs and use the
 baked-in Capgo EU2 publication/subscription/slot names — no shell exports.

--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -317,6 +317,66 @@ replica_region_name() {
   sanitize_identifier_part "$host_part"
 }
 
+
+# Terminate any walsender holding the slot, then drop it. Retries until inactive.
+drop_source_slot_with_retry() {
+  local slot_name="${1:-${REPLICA_SLOT_NAME}}"
+  local source_url="${2:-${SOURCE_DB_URL}}"
+  local max_attempts="${3:-15}"
+
+  if [[ -z "$slot_name" || -z "$source_url" ]]; then
+    echo "Error: drop_source_slot_with_retry requires slot name and source URL"
+    exit 1
+  fi
+
+  echo "==> Dropping source slot ${slot_name} if present..."
+  psql-17 "$source_url" -v ON_ERROR_STOP=1 \
+    -v slot_name="$slot_name" \
+    -v max_attempts="$max_attempts" <<'SQL'
+DO $$
+DECLARE
+  target_slot text := :'slot_name';
+  max_attempts int := :'max_attempts'::int;
+  slot record;
+  attempt int := 0;
+BEGIN
+  LOOP
+    attempt := attempt + 1;
+    SELECT slot_name, active, active_pid
+    INTO slot
+    FROM pg_replication_slots
+    WHERE slot_name = target_slot;
+
+    IF slot.slot_name IS NULL THEN
+      RAISE NOTICE 'No source slot named %', target_slot;
+      RETURN;
+    END IF;
+
+    IF NOT COALESCE(slot.active, false) THEN
+      PERFORM pg_drop_replication_slot(slot.slot_name);
+      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+      RETURN;
+    END IF;
+
+    RAISE NOTICE 'Slot % still active (pid %, attempt %/%)',
+      slot.slot_name, slot.active_pid, attempt, max_attempts;
+
+    IF slot.active_pid IS NOT NULL THEN
+      PERFORM pg_terminate_backend(slot.active_pid);
+    END IF;
+
+    IF attempt >= max_attempts THEN
+      RAISE EXCEPTION 'replication slot % still active for PID % after % attempts',
+        slot.slot_name, slot.active_pid, attempt;
+    END IF;
+
+    PERFORM pg_sleep(2);
+  END LOOP;
+END
+$$;
+SQL
+}
+
 discover_publication_name() {
   local existing
   local count

--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -317,6 +317,15 @@ replica_region_name() {
   sanitize_identifier_part "$host_part"
 }
 
+
+# psql with statement/lock timeouts disabled (large COPY / INDEX on manifest).
+psql_no_timeout() {
+  local url="$1"
+  shift
+  PGOPTIONS="${PGOPTIONS:+${PGOPTIONS} }-c statement_timeout=0 -c lock_timeout=0" \
+    psql-17 "$url" "$@"
+}
+
 discover_publication_name() {
   local existing
   local count

--- a/read_replicate/common.sh
+++ b/read_replicate/common.sh
@@ -384,7 +384,6 @@ END
 $$;
 SQL
 }
-}
 
 discover_publication_name() {
   local existing

--- a/read_replicate/replicate_add_table.sh
+++ b/read_replicate/replicate_add_table.sh
@@ -79,7 +79,7 @@ DUMP_FILE="${DUMP_DIR}/${TABLE_NAME}.csv.gz"
 SCHEMA_FILE="${DUMP_DIR}/${TABLE_NAME}_schema.sql"
 
 echo "==> Exporting source data..."
-psql-17 "$SOURCE_DB_URL" -c "\\COPY public.${TABLE_NAME} TO STDOUT WITH (FORMAT csv, HEADER)" | gzip > "$DUMP_FILE"
+psql_no_timeout "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 -c "\\COPY public.${TABLE_NAME} TO STDOUT WITH (FORMAT csv, HEADER)" | gzip > "$DUMP_FILE"
 ROW_COUNT=$(gunzip -c "$DUMP_FILE" | wc -l | tr -d ' ')
 ROW_COUNT=$((ROW_COUNT - 1))
 echo "    Exported ${ROW_COUNT} rows."
@@ -150,7 +150,7 @@ else
 fi
 
 echo "==> Importing source data into target..."
-gunzip -c "$DUMP_FILE" | psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -c "\\COPY public.${TABLE_NAME} FROM STDIN WITH (FORMAT csv, HEADER)"
+gunzip -c "$DUMP_FILE" | psql_no_timeout "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -c "\\COPY public.${TABLE_NAME} FROM STDIN WITH (FORMAT csv, HEADER)"
 
 IMPORTED_COUNT=$(psql-17 "$REPLICA_TARGET_DB_URL" -t -A -c "SELECT COUNT(*) FROM public.${TABLE_NAME};")
 echo "    Imported ${IMPORTED_COUNT} rows."

--- a/read_replicate/replicate_to_replica.sh
+++ b/read_replicate/replicate_to_replica.sh
@@ -198,11 +198,35 @@ dump_table() {
 
   echo "    [${table_name}] Dumping from source..."
   # manifest (and similar) exceed Supabase statement_timeout on a full COPY.
+  rm -f "$dump_file"
   psql_no_timeout "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 \
     -c "\COPY public.${table_name} TO STDOUT WITH (FORMAT csv, HEADER)" \
     | gzip > "$dump_file"
 
   echo "    [${table_name}] Dump complete: $(du -h "$dump_file" | cut -f1)"
+}
+
+table_count() {
+  local url="$1"
+  local table_name="$2"
+  psql_no_timeout "$url" -t -A -v ON_ERROR_STOP=1 -c "
+    SELECT COUNT(*)::bigint
+    FROM public.${table_name};
+  "
+}
+
+dump_matches_count() {
+  local table_name="$1"
+  local expected="$2"
+  local dump_file="${DUMP_DIR}/${table_name}.csv.gz"
+  local lines
+  local rows
+
+  [[ -f "$dump_file" ]] || return 1
+  gzip -t "$dump_file" 2>/dev/null || return 1
+  lines=$(gunzip -c "$dump_file" | wc -l | tr -d ' ')
+  rows=$((lines - 1))
+  [[ "$rows" -eq "$expected" ]]
 }
 
 restore_table() {
@@ -222,7 +246,8 @@ restore_table() {
 
   echo "    [${table_name}] Truncating and loading..."
   psql_no_timeout "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -c "TRUNCATE TABLE public.${table_name};"
-  gunzip -c "$dump_file" | psql-17 "$REPLICA_TARGET_DB_URL" -c "\\COPY public.${table_name} FROM STDIN WITH (FORMAT csv, HEADER)"
+  gunzip -c "$dump_file" | psql_no_timeout "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 \
+    -c "\COPY public.${table_name} FROM STDIN WITH (FORMAT csv, HEADER)"
 
   echo "    [${table_name}] Recreating indexes..."
   awk "/CREATE (UNIQUE )?INDEX.*ON public\.${table_name}/,/;/" "${SCRIPT_DIR}/schema_replicate.sql" \
@@ -233,8 +258,60 @@ restore_table() {
       fi
     done
 
-  COUNT=$(psql-17 "$REPLICA_TARGET_DB_URL" -t -A -c "SELECT COUNT(*) FROM public.${table_name};")
+  COUNT=$(table_count "$REPLICA_TARGET_DB_URL" "$table_name")
   echo "    [${table_name}] Restored: ${COUNT} rows"
+}
+
+target_table_exists() {
+  local table_name="$1"
+  psql-17 "$REPLICA_TARGET_DB_URL" -t -A -c "SELECT to_regclass('public.${table_name}') IS NOT NULL;" | grep -q t
+}
+
+replica_schema_present() {
+  local table
+  for table in "${REPLICA_TABLES[@]}"; do
+    target_table_exists "$table" || return 1
+  done
+  return 0
+}
+
+# Resume-friendly sync: skip when source/target counts already match.
+# Reuse a complete dump file when present; otherwise dump then restore.
+sync_table() {
+  local table_name="$1"
+  local source_count
+  local target_count
+
+  source_count=$(table_count "$SOURCE_DB_URL" "$table_name")
+  if target_table_exists "$table_name"; then
+    target_count=$(table_count "$REPLICA_TARGET_DB_URL" "$table_name")
+  else
+    target_count=-1
+  fi
+
+  if [[ "$target_count" == "$source_count" ]]; then
+    echo "    [${table_name}] Already synced (${source_count} rows) — skipping"
+    return 0
+  fi
+
+  echo "    [${table_name}] Needs sync (source=${source_count} target=${target_count})"
+
+  if dump_matches_count "$table_name" "$source_count"; then
+    echo "    [${table_name}] Reusing complete dump file"
+  else
+    dump_table "$table_name"
+    if ! dump_matches_count "$table_name" "$source_count"; then
+      echo "Error: dump for ${table_name} does not match source count ${source_count}"
+      exit 1
+    fi
+  fi
+
+  restore_table "$table_name"
+  target_count=$(table_count "$REPLICA_TARGET_DB_URL" "$table_name")
+  if [[ "$target_count" != "$source_count" ]]; then
+    echo "Error: ${table_name} restore count ${target_count} != source ${source_count}"
+    exit 1
+  fi
 }
 
 drop_target_subscription
@@ -244,7 +321,7 @@ if [[ "$SUBSCRIPTION_ONLY" == "true" ]]; then
   ensure_publication_tables
   create_subscription
 else
-  echo "==> Full reset mode: resetting replica-managed schema and data."
+  echo "==> Full reset mode: syncing missing/outdated replica tables (resumable)."
   ensure_publication_tables
   ensure_source_slot_before_copy
 
@@ -253,24 +330,27 @@ CREATE SCHEMA IF NOT EXISTS public;
 GRANT ALL ON SCHEMA public TO PUBLIC;
 SQL
 
-  psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -f "${SCRIPT_DIR}/schema_replicate.sql"
-
   DUMP_DIR="${SCRIPT_DIR}/dumps"
   mkdir -p "$DUMP_DIR"
 
-  echo "==> Copying priority tables..."
+  if replica_schema_present; then
+    echo "==> Replica schema already present — skipping destructive schema reload (resume)."
+  else
+    echo "==> Applying replica schema (destructive first-time load)..."
+    psql-17 "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -f "${SCRIPT_DIR}/schema_replicate.sql"
+  fi
+
+  echo "==> Syncing priority tables..."
   for table in "${REPLICA_PRIORITY_TABLES[@]}"; do
     if psql-17 "$SOURCE_DB_URL" -t -A -c "SELECT to_regclass('public.${table}') IS NOT NULL;" | grep -q t; then
-      dump_table "$table"
-      restore_table "$table"
+      sync_table "$table"
     fi
   done
 
-  echo "==> Copying deferred tables..."
+  echo "==> Syncing deferred tables..."
   for table in "${REPLICA_DEFERRED_TABLES[@]}"; do
     if psql-17 "$SOURCE_DB_URL" -t -A -c "SELECT to_regclass('public.${table}') IS NOT NULL;" | grep -q t; then
-      dump_table "$table"
-      restore_table "$table"
+      sync_table "$table"
     fi
   done
 

--- a/read_replicate/replicate_to_replica.sh
+++ b/read_replicate/replicate_to_replica.sh
@@ -198,7 +198,10 @@ dump_table() {
 
   echo "    [${table_name}] Dumping from source..."
   # manifest (and similar) exceed Supabase statement_timeout on a full COPY.
-  psql_no_timeout "$SOURCE_DB_URL" -v ON_ERROR_STOP=1     -c "\\COPY public.${table_name} TO STDOUT WITH (FORMAT csv, HEADER)"     | gzip > "$dump_file"
+  psql_no_timeout "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 \
+    -c "\COPY public.${table_name} TO STDOUT WITH (FORMAT csv, HEADER)" \
+    | gzip > "$dump_file"
+
   echo "    [${table_name}] Dump complete: $(du -h "$dump_file" | cut -f1)"
 }
 

--- a/read_replicate/replicate_to_replica.sh
+++ b/read_replicate/replicate_to_replica.sh
@@ -57,39 +57,8 @@ drop_target_subscription() {
 }
 
 drop_source_slot() {
-  echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
-  psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=0 <<SQL
-DO \$\$
-DECLARE
-  slot record;
-BEGIN
-  SELECT slot_name, active, active_pid
-  INTO slot
-  FROM pg_replication_slots
-  WHERE slot_name = '${REPLICA_SLOT_NAME}';
-
-  IF slot.slot_name IS NOT NULL THEN
-    RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
-
-    IF slot.active AND slot.active_pid IS NOT NULL THEN
-      PERFORM pg_terminate_backend(slot.active_pid);
-      PERFORM pg_sleep(2);
-    END IF;
-
-    BEGIN
-      PERFORM pg_drop_replication_slot(slot.slot_name);
-      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
-    EXCEPTION WHEN OTHERS THEN
-      RAISE NOTICE 'Could not drop slot: %', SQLERRM;
-    END;
-  ELSE
-    RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
-  END IF;
-END
-\$\$;
-SQL
+  drop_source_slot_with_retry "${REPLICA_SLOT_NAME}" "${SOURCE_DB_URL}"
 }
-
 source_slot_exists() {
   local exists
   exists=$(psql-17 "$SOURCE_DB_URL" -t -A -c "

--- a/read_replicate/replicate_to_replica.sh
+++ b/read_replicate/replicate_to_replica.sh
@@ -194,14 +194,27 @@ SQL
 
 dump_table() {
   local table_name="$1"
+  local expected_count="${2:-}"
   local dump_file="${DUMP_DIR}/${table_name}.csv.gz"
+  local rows_file="${dump_file}.rows"
 
   echo "    [${table_name}] Dumping from source..."
   # manifest (and similar) exceed Supabase statement_timeout on a full COPY.
-  rm -f "$dump_file"
+  # Do NOT validate dumps with wc -l: CSV fields can contain newlines.
+  rm -f "$dump_file" "$rows_file"
   psql_no_timeout "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 \
     -c "\COPY public.${table_name} TO STDOUT WITH (FORMAT csv, HEADER)" \
     | gzip > "$dump_file"
+
+  if ! gzip -t "$dump_file" 2>/dev/null || [[ ! -s "$dump_file" ]]; then
+    echo "Error: dump for ${table_name} is missing or corrupt"
+    rm -f "$dump_file" "$rows_file"
+    exit 1
+  fi
+
+  if [[ -n "$expected_count" ]]; then
+    printf '%s\n' "$expected_count" > "$rows_file"
+  fi
 
   echo "    [${table_name}] Dump complete: $(du -h "$dump_file" | cut -f1)"
 }
@@ -215,18 +228,20 @@ table_count() {
   "
 }
 
-dump_matches_count() {
+# Reuse dump only when gzip is healthy and sidecar row marker matches source count.
+# Never use wc -l on CSV (embedded newlines break that check).
+dump_reusable() {
   local table_name="$1"
   local expected="$2"
   local dump_file="${DUMP_DIR}/${table_name}.csv.gz"
-  local lines
-  local rows
+  local rows_file="${dump_file}.rows"
+  local marked
 
-  [[ -f "$dump_file" ]] || return 1
+  [[ -f "$dump_file" && -f "$rows_file" ]] || return 1
   gzip -t "$dump_file" 2>/dev/null || return 1
-  lines=$(gunzip -c "$dump_file" | wc -l | tr -d ' ')
-  rows=$((lines - 1))
-  [[ "$rows" -eq "$expected" ]]
+  [[ -s "$dump_file" ]] || return 1
+  marked=$(tr -d '[:space:]' < "$rows_file")
+  [[ "$marked" == "$expected" ]]
 }
 
 restore_table() {
@@ -281,6 +296,7 @@ sync_table() {
   local table_name="$1"
   local source_count
   local target_count
+  local source_after
 
   source_count=$(table_count "$SOURCE_DB_URL" "$table_name")
   if target_table_exists "$table_name"; then
@@ -296,20 +312,30 @@ sync_table() {
 
   echo "    [${table_name}] Needs sync (source=${source_count} target=${target_count})"
 
-  if dump_matches_count "$table_name" "$source_count"; then
-    echo "    [${table_name}] Reusing complete dump file"
+  if dump_reusable "$table_name" "$source_count"; then
+    echo "    [${table_name}] Reusing dump marked for ${source_count} rows"
   else
-    dump_table "$table_name"
-    if ! dump_matches_count "$table_name" "$source_count"; then
-      echo "Error: dump for ${table_name} does not match source count ${source_count}"
-      exit 1
-    fi
+    dump_table "$table_name" "$source_count"
   fi
 
   restore_table "$table_name"
   target_count=$(table_count "$REPLICA_TARGET_DB_URL" "$table_name")
-  if [[ "$target_count" != "$source_count" ]]; then
-    echo "Error: ${table_name} restore count ${target_count} != source ${source_count}"
+  source_after=$(table_count "$SOURCE_DB_URL" "$table_name")
+
+  # Accept snapshot match (pre-dump count) or live match (writes during copy).
+  if [[ "$target_count" == "$source_count" || "$target_count" == "$source_after" ]]; then
+    echo "    [${table_name}] Sync ok (target=${target_count} source_now=${source_after})"
+    return 0
+  fi
+
+  echo "    [${table_name}] Count drift after restore (target=${target_count} snapshot=${source_count} source_now=${source_after}); retrying once"
+  source_count="$source_after"
+  dump_table "$table_name" "$source_count"
+  restore_table "$table_name"
+  target_count=$(table_count "$REPLICA_TARGET_DB_URL" "$table_name")
+  source_after=$(table_count "$SOURCE_DB_URL" "$table_name")
+  if [[ "$target_count" != "$source_count" && "$target_count" != "$source_after" ]]; then
+    echo "Error: ${table_name} restore count ${target_count} != source ${source_after}"
     exit 1
   fi
 }

--- a/read_replicate/replicate_to_replica.sh
+++ b/read_replicate/replicate_to_replica.sh
@@ -197,7 +197,8 @@ dump_table() {
   local dump_file="${DUMP_DIR}/${table_name}.csv.gz"
 
   echo "    [${table_name}] Dumping from source..."
-  psql-17 "$SOURCE_DB_URL" -c "\\COPY public.${table_name} TO STDOUT WITH (FORMAT csv, HEADER)" | gzip > "$dump_file"
+  # manifest (and similar) exceed Supabase statement_timeout on a full COPY.
+  psql_no_timeout "$SOURCE_DB_URL" -v ON_ERROR_STOP=1     -c "\\COPY public.${table_name} TO STDOUT WITH (FORMAT csv, HEADER)"     | gzip > "$dump_file"
   echo "    [${table_name}] Dump complete: $(du -h "$dump_file" | cut -f1)"
 }
 
@@ -217,7 +218,7 @@ restore_table() {
   " | psql-17 "$REPLICA_TARGET_DB_URL" 2>/dev/null || true
 
   echo "    [${table_name}] Truncating and loading..."
-  psql-17 "$REPLICA_TARGET_DB_URL" -c "TRUNCATE TABLE public.${table_name};"
+  psql_no_timeout "$REPLICA_TARGET_DB_URL" -v ON_ERROR_STOP=1 -c "TRUNCATE TABLE public.${table_name};"
   gunzip -c "$dump_file" | psql-17 "$REPLICA_TARGET_DB_URL" -c "\\COPY public.${table_name} FROM STDIN WITH (FORMAT csv, HEADER)"
 
   echo "    [${table_name}] Recreating indexes..."
@@ -225,7 +226,7 @@ restore_table() {
     | awk 'BEGIN{RS=";"} /CREATE.*INDEX/{print $0 ";"}' \
     | while read -r idx_sql; do
       if [[ -n "$idx_sql" ]]; then
-        psql-17 "$REPLICA_TARGET_DB_URL" -c "$idx_sql" 2>/dev/null || true
+        psql_no_timeout "$REPLICA_TARGET_DB_URL" -c "$idx_sql" 2>/dev/null || true
       fi
     done
 

--- a/read_replicate/replicate_upgrade_teardown.sh
+++ b/read_replicate/replicate_upgrade_teardown.sh
@@ -50,30 +50,45 @@ if [[ -n "$SUB_REMAINING" ]]; then
 fi
 
 echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
+# Walsender can stay attached briefly after subscription drop; terminate + retry
+# until inactive, then drop. A single terminate+2s sleep is not enough in prod.
 psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 <<SQL
 DO \$\$
 DECLARE
   slot record;
+  attempt int := 0;
 BEGIN
-  SELECT slot_name, active, active_pid
-  INTO slot
-  FROM pg_replication_slots
-  WHERE slot_name = '${REPLICA_SLOT_NAME}';
+  LOOP
+    attempt := attempt + 1;
+    SELECT slot_name, active, active_pid
+    INTO slot
+    FROM pg_replication_slots
+    WHERE slot_name = '${REPLICA_SLOT_NAME}';
 
-  IF slot.slot_name IS NULL THEN
-    RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
-    RETURN;
-  END IF;
+    IF slot.slot_name IS NULL THEN
+      RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
+      RETURN;
+    END IF;
 
-  RAISE NOTICE 'Found replication slot: % (active: %)', slot.slot_name, slot.active;
+    IF NOT COALESCE(slot.active, false) THEN
+      PERFORM pg_drop_replication_slot(slot.slot_name);
+      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+      RETURN;
+    END IF;
 
-  IF slot.active AND slot.active_pid IS NOT NULL THEN
-    PERFORM pg_terminate_backend(slot.active_pid);
+    RAISE NOTICE 'Slot % still active (pid %, attempt %/15)', slot.slot_name, slot.active_pid, attempt;
+
+    IF slot.active_pid IS NOT NULL THEN
+      PERFORM pg_terminate_backend(slot.active_pid);
+    END IF;
+
+    IF attempt >= 15 THEN
+      RAISE EXCEPTION 'replication slot % still active for PID % after % attempts',
+        slot.slot_name, slot.active_pid, attempt;
+    END IF;
+
     PERFORM pg_sleep(2);
-  END IF;
-
-  PERFORM pg_drop_replication_slot(slot.slot_name);
-  RAISE NOTICE 'Dropped slot: %', slot.slot_name;
+  END LOOP;
 END
 \$\$;
 SQL

--- a/read_replicate/replicate_upgrade_teardown.sh
+++ b/read_replicate/replicate_upgrade_teardown.sh
@@ -49,49 +49,7 @@ if [[ -n "$SUB_REMAINING" ]]; then
   exit 1
 fi
 
-echo "==> Dropping source slot ${REPLICA_SLOT_NAME} if present..."
-# Walsender can stay attached briefly after subscription drop; terminate + retry
-# until inactive, then drop. A single terminate+2s sleep is not enough in prod.
-psql-17 "$SOURCE_DB_URL" -v ON_ERROR_STOP=1 <<SQL
-DO \$\$
-DECLARE
-  slot record;
-  attempt int := 0;
-BEGIN
-  LOOP
-    attempt := attempt + 1;
-    SELECT slot_name, active, active_pid
-    INTO slot
-    FROM pg_replication_slots
-    WHERE slot_name = '${REPLICA_SLOT_NAME}';
-
-    IF slot.slot_name IS NULL THEN
-      RAISE NOTICE 'No source slot named ${REPLICA_SLOT_NAME}';
-      RETURN;
-    END IF;
-
-    IF NOT COALESCE(slot.active, false) THEN
-      PERFORM pg_drop_replication_slot(slot.slot_name);
-      RAISE NOTICE 'Dropped slot: %', slot.slot_name;
-      RETURN;
-    END IF;
-
-    RAISE NOTICE 'Slot % still active (pid %, attempt %/15)', slot.slot_name, slot.active_pid, attempt;
-
-    IF slot.active_pid IS NOT NULL THEN
-      PERFORM pg_terminate_backend(slot.active_pid);
-    END IF;
-
-    IF attempt >= 15 THEN
-      RAISE EXCEPTION 'replication slot % still active for PID % after % attempts',
-        slot.slot_name, slot.active_pid, attempt;
-    END IF;
-
-    PERFORM pg_sleep(2);
-  END LOOP;
-END
-\$\$;
-SQL
+drop_source_slot_with_retry "${REPLICA_SLOT_NAME}" "${SOURCE_DB_URL}"
 
 echo "==> Verifying slot is gone on source..."
 REMAINING=$(psql-17 "$SOURCE_DB_URL" -t -A -v ON_ERROR_STOP=1 -c "


### PR DESCRIPTION
## Summary (AI generated)

Single follow-up to the upgrade bun commands (#2809):

- Retry dropping active replication slots (walsender hold) during teardown
- Disable `statement_timeout` for large COPY/INDEX (`manifest`, etc.)
- Resumable full-reset reconnect (skip synced tables, reuse marked dumps)
- Stop validating CSV dumps with `wc -l` (embedded newlines false-fail)

## Motivation (AI generated)

Upgrade reconnect hit serial production failures (active slot, statement timeout, resume, bad dump line-count). Fixes were split across PRs; this consolidates them.

## Business Impact (AI generated)

One path to finish Capgo-EU Postgres upgrade + replica rebuild without manual SQL.

## Test Plan (AI generated)

- [x] `readreplicate:upgrade:teardown` drops active slot with retries
- [x] `readreplicate:upgrade:reconnect` completes large tables / resumes missing only

Generated with AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production replication teardown, logical slot drops, and bulk data sync on the Capgo-EU subscriber; mistakes could interrupt replication or leave count mismatches, though retries and count checks reduce blast radius.
> 
> **Overview**
> Hardens the **Supabase → Google read-replica** upgrade path (`upgrade:teardown` / `upgrade:reconnect`) so production rebuilds can finish without manual SQL.
> 
> **Replication slot teardown** now goes through shared `drop_source_slot_with_retry`: it loops until the slot is inactive, terminates the holding walsender, then drops the slot (replacing one-shot logic in reconnect and upgrade teardown).
> 
> **Large table COPY/INDEX** uses `psql_no_timeout` (`statement_timeout=0`, `lock_timeout=0`) on source/target dumps, restores, and index rebuilds so tables like `manifest` are not killed by Supabase timeouts.
> 
> **Full-reset reconnect is resumable**: `sync_table` skips tables when source and target row counts already match; healthy gzip dumps are reused when a `.rows` sidecar matches the current source count (no `wc -l` on CSV); and `schema_replicate.sql` is only applied on first load when replica tables are missing—not on every resume.
> 
> The README documents this resumable upgrade reconnect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1458d6b985a32ad688872327648e938b05f0d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->