### PR TITLE
fix(frontend): skip push prompt when notifications are not configured

### DIFF
--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -325,8 +325,27 @@ async function queueChannelUpdateNotification() {
   toast.success(t('notification-update-push-success'))
 }
 
+async function isPushUpdateReady() {
+  try {
+    const query = encodeURIComponent(packageId.value)
+    const [settings, providersResponse] = await Promise.all([
+      notificationFetch<{ pushUpdateEnabled: boolean }>(`/settings?app_id=${query}`),
+      notificationFetch<{ data: Array<{ status: string }> }>(`/providers?app_id=${query}`),
+    ])
+    if (!settings.pushUpdateEnabled)
+      return false
+    return (providersResponse.data || []).some(provider => provider.status === 'configured')
+  }
+  catch {
+    // No permission, network error, or notifications unavailable — skip prompt.
+    return false
+  }
+}
+
 async function askUpdateNotificationAfterBundleChange() {
   if (!channel.value)
+    return
+  if (!(await isPushUpdateReady()))
     return
 
   dialogStore.openDialog({

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -355,8 +355,9 @@ async function askUpdateNotificationAfterBundleChange() {
     || !route.path.includes('/channel/')
     || packageId.value !== appId
     || channel.value?.name !== channelName
-  )
+  ) {
     return
+  }
 
   dialogStore.openDialog({
     title: t('notification-send-update-title'),

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -308,16 +308,13 @@ async function notificationFetch<T>(path: string, init: RequestInit = {}) {
   return await response.json() as T
 }
 
-async function queueChannelUpdateNotification() {
-  if (!channel.value)
-    return
-
+async function queueChannelUpdateNotification(appId: string, channelName: string) {
   const response = await notificationFetch<NotificationQueueResponse>('/update-check', {
     method: 'POST',
     body: JSON.stringify({
-      appId: packageId.value,
+      appId,
       target: { broadcast: true },
-      channel: channel.value.name,
+      channel: channelName,
     }),
   })
   if (!response.queued)
@@ -325,9 +322,9 @@ async function queueChannelUpdateNotification() {
   toast.success(t('notification-update-push-success'))
 }
 
-async function isPushUpdateReady() {
+async function isPushUpdateReady(appId: string) {
   try {
-    const query = encodeURIComponent(packageId.value)
+    const query = encodeURIComponent(appId)
     const [settings, providersResponse] = await Promise.all([
       notificationFetch<{ pushUpdateEnabled: boolean }>(`/settings?app_id=${query}`),
       notificationFetch<{ data: Array<{ status: string }> }>(`/providers?app_id=${query}`),
@@ -345,12 +342,19 @@ async function isPushUpdateReady() {
 async function askUpdateNotificationAfterBundleChange() {
   if (!channel.value)
     return
-  if (!(await isPushUpdateReady()))
+
+  const appId = packageId.value
+  const channelName = channel.value.name
+  if (!appId || !channelName)
+    return
+  if (!(await isPushUpdateReady(appId)))
+    return
+  if (packageId.value !== appId || channel.value?.name !== channelName)
     return
 
   dialogStore.openDialog({
     title: t('notification-send-update-title'),
-    description: t('notification-send-update-description', { channel: channel.value.name }),
+    description: t('notification-send-update-description', { channel: channelName }),
     buttons: [
       {
         text: t('button-cancel'),
@@ -361,7 +365,7 @@ async function askUpdateNotificationAfterBundleChange() {
         role: 'primary',
         handler: async () => {
           try {
-            await queueChannelUpdateNotification()
+            await queueChannelUpdateNotification(appId, channelName)
           }
           catch (error) {
             console.error(error)

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -343,13 +343,19 @@ async function askUpdateNotificationAfterBundleChange() {
   if (!channel.value)
     return
 
+  const routePath = route.path
   const appId = packageId.value
   const channelName = channel.value.name
   if (!appId || !channelName)
     return
   if (!(await isPushUpdateReady(appId)))
     return
-  if (packageId.value !== appId || channel.value?.name !== channelName)
+  if (
+    route.path !== routePath
+    || !route.path.includes('/channel/')
+    || packageId.value !== appId
+    || channel.value?.name !== channelName
+  )
     return
 
   dialogStore.openDialog({

--- a/src/pages/app/[app].notifications.vue
+++ b/src/pages/app/[app].notifications.vue
@@ -811,7 +811,7 @@ watch(activeNotificationTab, () => {
                       <IconCheckCircle v-else class="w-4 h-4" aria-hidden="true" />
                       {{ t('notification-save-settings') }}
                     </button>
-                    <button class="d-btn d-btn-sm d-btn-primary" :disabled="isSaving || !settings.pushUpdateEnabled" @click="pushUpdateNow">
+                    <button class="d-btn d-btn-sm d-btn-primary" :disabled="isSaving || configuredProviders === 0 || !settings.pushUpdateEnabled" @click="pushUpdateNow">
                       <span v-if="isSaving" class="d-loading d-loading-spinner d-loading-xs" />
                       <IconZap v-else class="w-4 h-4" aria-hidden="true" />
                       {{ t('notification-push-update-now') }}
@@ -854,7 +854,7 @@ watch(activeNotificationTab, () => {
                     <h2 class="text-base font-semibold text-slate-950 dark:text-white">
                       {{ t('notification-create-broadcast') }}
                     </h2>
-                    <button class="self-start d-btn d-btn-sm d-btn-primary sm:self-auto" :disabled="isSaving || !campaignForm.name.trim() || (!campaignForm.title.trim() && !campaignForm.body.trim())" @click="createBroadcast">
+                    <button class="self-start d-btn d-btn-sm d-btn-primary sm:self-auto" :disabled="isSaving || configuredProviders === 0 || !campaignForm.name.trim() || (!campaignForm.title.trim() && !campaignForm.body.trim())" @click="createBroadcast">
                       <span v-if="isSaving" class="d-loading d-loading-spinner d-loading-xs" />
                       <IconSend v-else class="w-4 h-4" aria-hidden="true" />
                       {{ t('notification-create-broadcast') }}
@@ -944,7 +944,7 @@ watch(activeNotificationTab, () => {
                       <span class="text-sm font-medium text-slate-700 dark:text-slate-200">{{ t('notification-message-body') }}</span>
                       <textarea v-model="sendBody" class="w-full d-textarea d-textarea-bordered min-h-24" :placeholder="t('notification-message-body')" />
                     </label>
-                    <button class="w-full d-btn d-btn-sm d-btn-primary" :disabled="isSaving || !sendExternalId.trim()" @click="sendTest">
+                    <button class="w-full d-btn d-btn-sm d-btn-primary" :disabled="isSaving || configuredProviders === 0 || !sendExternalId.trim()" @click="sendTest">
                       <span v-if="isSaving" class="d-loading d-loading-spinner d-loading-xs" />
                       <IconSend v-else class="w-4 h-4" aria-hidden="true" />
                       {{ t('notification-send-test') }}


### PR DESCRIPTION
## Summary (AI generated)

- Skip the post-bundle-change “send update push” dialog when push updates are disabled or no notification provider is configured
- Disable Notifications page send/broadcast/push-update actions until at least one provider is configured

## Motivation (AI generated)

After linking a bundle to a channel, Capgo asked users to send a push update even when push notifications were not set up. Accepting the prompt then failed with a “not configured” error. That is a dead-end UX.

## Business Impact (AI generated)

Fewer confusing failures for users who have not adopted native push. Channel promotion stays clean for apps without notification credentials.

## Test Plan (AI generated)

- [ ] App with no notification providers: link/unlink/revert/promote a channel bundle — no push dialog appears
- [ ] App with providers configured but push update disabled — no push dialog appears
- [ ] App with providers configured and push update enabled — dialog still appears and send works
- [ ] Notifications page: send/broadcast/push-update buttons stay disabled with zero configured providers

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented update-notification prompts from appearing when push updates or notification providers aren’t ready.
  * Notification actions are now unavailable until at least one provider is configured.
  * Improved handling of permission, network, and service availability errors during notification setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->