### PR TITLE
fix(frontend): org selector row opens org dashboard

### DIFF
--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -422,26 +422,24 @@ watch(
                 >
                   {{ acronym(org.name) }}
                 </div>
-                <span class="block truncate">{{ org.name }}</span>
-              </button>
-              <div class="flex items-center justify-end min-w-0 shrink-0">
+                <span class="block truncate min-w-0">{{ org.name }}</span>
                 <span
                   v-if="isInvitation(org)"
-                  class="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium rounded-full border border-amber-400/25 bg-amber-500/8 text-amber-200"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 ml-auto text-[10px] font-medium rounded-full border border-amber-400/25 bg-amber-500/8 text-amber-200 shrink-0"
                 >
                   <span class="size-1.5 rounded-full bg-amber-300" />
                   {{ t('sso-status-pending') }}
                 </span>
-                <button
-                  v-else
-                  type="button"
-                  class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white"
-                  :aria-label="`${t('settings')} ${org.name}`"
-                  @click="openOrganizationSettings(org, $event)"
-                >
-                  <IconSettings class="size-4" />
-                </button>
-              </div>
+              </button>
+              <button
+                v-if="!isInvitation(org)"
+                type="button"
+                class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white shrink-0"
+                :aria-label="`${t('settings')} ${org.name}`"
+                @click="openOrganizationSettings(org, $event)"
+              >
+                <IconSettings class="size-4" />
+              </button>
             </div>
             <div v-if="!isInvitation(org)" class="pb-2 pl-8 pr-1">
               <div v-if="getOrgApps(org).length > 0" class="space-y-1">

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -324,17 +324,6 @@ function acronym(name: string) {
   return (first + second).toUpperCase()
 }
 
-function onOrgItemKeydown(org: Organization, e: KeyboardEvent) {
-  if (e.target !== e.currentTarget)
-    return
-
-  if (e.key !== 'Enter' && e.key !== ' ')
-    return
-
-  e.preventDefault()
-  onOrganizationClick(org)
-}
-
 watch(
   () => route.query.invite_org,
   (inviteOrg) => {
@@ -403,16 +392,13 @@ watch(
             class="block px-1 my-1 rounded-lg"
             :class="isSelected(org) ? 'bg-gray-700/80' : ''"
           >
-            <div
-              class="flex items-center gap-2 px-3 py-3 text-white rounded-md cursor-pointer hover:bg-gray-600"
-              :aria-current="isSelected(org) ? 'true' : undefined"
-              role="button"
-              tabindex="0"
-              @click="onOrganizationClick(org)"
-              @keydown="onOrgItemKeydown(org, $event)"
-            >
-              <div
-                class="flex flex-1 items-center min-w-0 text-left"
+            <div class="flex items-center gap-2 px-3 py-3 text-white rounded-md hover:bg-gray-600">
+              <button
+                type="button"
+                class="flex flex-1 items-center min-w-0 text-left cursor-pointer"
+                :aria-current="isSelected(org) ? 'true' : undefined"
+                :aria-label="org.name"
+                @click="onOrganizationClick(org)"
               >
                 <img
                   v-if="org.logo"
@@ -436,7 +422,7 @@ watch(
                   {{ acronym(org.name) }}
                 </div>
                 <span class="block truncate">{{ org.name }}</span>
-              </div>
+              </button>
               <div class="flex items-center justify-end min-w-0 shrink-0">
                 <span
                   v-if="isInvitation(org)"

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -242,12 +242,12 @@ function onOrganizationClick(org: Organization) {
   }
 
   organizationStore.setCurrentOrganization(org.gid)
-  // if current path is not home, redirect to the org home page
-  // route.params.app
+  closeDropdown()
+  // Org row opens the org global dashboard; settings gear opens org settings.
+  // When already on dashboard, the watch on currentOrganization in
+  // organization.ts will trigger data reload via main.updateDashboard().
   if (router.currentRoute.value.path !== '/dashboard')
-    router.push(`/dashboard`)
-  // Note: When already on dashboard, the watch on currentOrganization in
-  // organization.ts will trigger data reload via main.updateDashboard()
+    router.push('/dashboard')
 }
 
 async function createNewOrg() {
@@ -324,31 +324,14 @@ function acronym(name: string) {
   return (first + second).toUpperCase()
 }
 
-function onOrgItemClick(org: Organization, e: MouseEvent) {
-  if (isSelected(org)) {
-    e.preventDefault()
-    e.stopPropagation()
-    return
-  }
-  onOrganizationClick(org)
-}
-
-function isRowInteractive(org: Organization) {
-  return isInvitation(org) || !isSelected(org)
-}
-
 function onOrgItemKeydown(org: Organization, e: KeyboardEvent) {
   if (e.target !== e.currentTarget)
-    return
-
-  if (!isRowInteractive(org))
     return
 
   if (e.key !== 'Enter' && e.key !== ' ')
     return
 
   e.preventDefault()
-  closeDropdown()
   onOrganizationClick(org)
 }
 
@@ -421,12 +404,11 @@ watch(
             :class="isSelected(org) ? 'bg-gray-700/80' : ''"
           >
             <div
-              class="flex items-center gap-2 px-3 py-3 text-white rounded-md"
-              :class="isRowInteractive(org) ? 'cursor-pointer hover:bg-gray-600' : 'cursor-default'"
+              class="flex items-center gap-2 px-3 py-3 text-white rounded-md cursor-pointer hover:bg-gray-600"
               :aria-current="isSelected(org) ? 'true' : undefined"
-              :role="isRowInteractive(org) ? 'button' : undefined"
-              :tabindex="isRowInteractive(org) ? 0 : -1"
-              @click="onOrgItemClick(org, $event)"
+              role="button"
+              tabindex="0"
+              @click="onOrganizationClick(org)"
               @keydown="onOrgItemKeydown(org, $event)"
             >
               <div

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -235,6 +235,8 @@ async function refreshOrganizationLogosIfNeeded(force = false) {
 }
 
 function onOrganizationClick(org: Organization) {
+  closeDropdown()
+
   // Check if the user is invited to the organization
   if (isPendingOrganizationInvite(org)) {
     handleOrganizationInvitation(org)
@@ -242,7 +244,6 @@ function onOrganizationClick(org: Organization) {
   }
 
   organizationStore.setCurrentOrganization(org.gid)
-  closeDropdown()
   // Org row opens the org global dashboard; settings gear opens org settings.
   // When already on dashboard, the watch on currentOrganization in
   // organization.ts will trigger data reload via main.updateDashboard().
@@ -395,7 +396,7 @@ watch(
             <div class="flex items-center gap-2 px-3 py-3 text-white rounded-md hover:bg-gray-600">
               <button
                 type="button"
-                class="flex flex-1 items-center min-w-0 text-left cursor-pointer"
+                class="d-btn d-btn-ghost d-btn-sm h-auto min-h-0 flex-1 items-center justify-start min-w-0 border-none px-0 shadow-none text-white hover:bg-transparent"
                 :aria-current="isSelected(org) ? 'true' : undefined"
                 :aria-label="org.name"
                 @click="onOrganizationClick(org)"
@@ -434,7 +435,7 @@ watch(
                 <button
                   v-else
                   type="button"
-                  class="flex items-center justify-center size-8 rounded-md cursor-pointer text-slate-300 transition-colors hover:bg-slate-500/30 hover:text-white"
+                  class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white"
                   :aria-label="`${t('settings')} ${org.name}`"
                   @click="openOrganizationSettings(org, $event)"
                 >


### PR DESCRIPTION
## Summary (AI generated)

- Clicking an organization row in the org/app switcher now always opens that org's global dashboard
- Includes the currently selected org (previously a no-op when already selected)
- Settings gear still opens organization settings without triggering the dashboard navigation

## Motivation (AI generated)

Users expect the org row itself to navigate to the org dashboard. Only the gear icon should go to settings. Selected orgs were incorrectly non-interactive, so you could not jump from an app page back to the org dashboard by clicking the org name.

## Business Impact (AI generated)

Improves console navigation UX for multi-org users and reduces confusion when switching context between apps and the org-level dashboard.

## Test Plan (AI generated)

- [ ] Open the org selector while on an app page for the current org
- [ ] Click the current org row (not the gear) → lands on `/dashboard` for that org
- [ ] Click another org row → switches org and lands on `/dashboard`
- [ ] Click the gear icon on an org → lands on `/settings/organization` for that org
- [ ] Pending invite orgs still open the invitation dialog

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization selection now consistently closes the dropdown and navigates to the dashboard.
  * Selected organizations can be activated using the keyboard.
  * Organization options are consistently focusable and clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->