### PR TITLE
feat(users): add GitHub user ID

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -3346,6 +3346,7 @@ export type Database = {
           enable_notifications: boolean
           first_name: string | null
           format_locale: string | null
+          github_id: number | null
           github_username: string | null
           id: string
           image_url: string | null
@@ -3364,6 +3365,7 @@ export type Database = {
           enable_notifications?: boolean
           first_name?: string | null
           format_locale?: string | null
+          github_id?: number | null
           github_username?: string | null
           id: string
           image_url?: string | null
@@ -3382,6 +3384,7 @@ export type Database = {
           enable_notifications?: boolean
           first_name?: string | null
           format_locale?: string | null
+          github_id?: number | null
           github_username?: string | null
           id?: string
           image_url?: string | null

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -3346,6 +3346,7 @@ export type Database = {
           enable_notifications: boolean
           first_name: string | null
           format_locale: string | null
+          github_id: number | null
           github_username: string | null
           id: string
           image_url: string | null
@@ -3364,6 +3365,7 @@ export type Database = {
           enable_notifications?: boolean
           first_name?: string | null
           format_locale?: string | null
+          github_id?: number | null
           github_username?: string | null
           id: string
           image_url?: string | null
@@ -3382,6 +3384,7 @@ export type Database = {
           enable_notifications?: boolean
           first_name?: string | null
           format_locale?: string | null
+          github_id?: number | null
           github_username?: string | null
           id?: string
           image_url?: string | null

--- a/supabase/migrations/20260801063630_add_github_user_id.sql
+++ b/supabase/migrations/20260801063630_add_github_user_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."users"
+ADD COLUMN "github_id" bigint;

--- a/supabase/tests/65_test_github_user_id.sql
+++ b/supabase/tests/65_test_github_user_id.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+SELECT plan(3);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'github_id'
+  ),
+  'users.github_id exists'
+);
+
+SELECT is(
+  (
+    SELECT data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'github_id'
+  ),
+  'bigint',
+  'users.github_id is bigint'
+);
+
+SELECT is(
+  (
+    SELECT is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'github_id'
+  ),
+  'YES',
+  'users.github_id is nullable'
+);
+
+SELECT * FROM finish(); -- noqa: AM04
+
+ROLLBACK;

--- a/tests/format-locale.unit.test.ts
+++ b/tests/format-locale.unit.test.ts
@@ -25,6 +25,7 @@ describe('format locale helpers', () => {
       enable_notifications: true,
       first_name: 'Test',
       format_locale: 'fr-FR',
+      github_id: null,
       github_username: null,
       id: '00000000-0000-0000-0000-000000000000',
       image_url: null,


### PR DESCRIPTION
## Summary
- add a nullable `public.users.github_id` bigint column
- leave all existing rows as `NULL`; no backfill or application behavior changes

## Validation
- `bun lint:backend`
- `bun lint`
- `bun typecheck`
- `bun test:unit` *(2 existing unrelated failures: `private-analytics-validation.unit.test.ts` and `org-statistics-bandwidth-pagination.unit.test.ts`)*

Local migration application could not be run because Docker is unavailable in this environment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing a user’s GitHub account ID in their profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->