### PR TITLE
fix(frontend): allow channel link when native metadata missing

### DIFF
--- a/src/pages/app/[app].bundle.[bundle].vue
+++ b/src/pages/app/[app].bundle.[bundle].vue
@@ -329,7 +329,7 @@ async function handleChannelLink(chan: Database['public']['Tables']['channels'][
         return
     }
     else if (localDependencies.length === 0 || finalCompatibility.length === 0) {
-      toast.info('ignore-compatibility')
+      toast.info(t('ignore-compatibility'))
     }
     else {
       toast.info(t('bundle-compatible-with-channel', { channel: chan.name }))

--- a/src/pages/app/[app].bundle.[bundle].vue
+++ b/src/pages/app/[app].bundle.[bundle].vue
@@ -328,7 +328,7 @@ async function handleChannelLink(chan: Database['public']['Tables']['channels'][
       if (await dialogStore.onDialogDismiss())
         return
     }
-    else if (localDependencies.length === 0) {
+    else if (localDependencies.length === 0 || finalCompatibility.length === 0) {
       toast.info('ignore-compatibility')
     }
     else {

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -451,7 +451,7 @@ async function handleVersionLink(appVersion: Database['public']['Tables']['app_v
       return
   }
   else if (localDependencies.length === 0 || finalCompatibility.length === 0) {
-    toast.info('ignore-compatibility')
+    toast.info(t('ignore-compatibility'))
   }
   else {
     toast.info(t('bundle-compatible-with-channel', { channel: channel.value.name }))

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -450,7 +450,7 @@ async function handleVersionLink(appVersion: Database['public']['Tables']['app_v
     if (await dialogStore.onDialogDismiss())
       return
   }
-  else if (localDependencies.length === 0) {
+  else if (localDependencies.length === 0 || finalCompatibility.length === 0) {
     toast.info('ignore-compatibility')
   }
   else {

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -647,10 +647,10 @@ export async function findBestPlan(stats: Database['public']['Functions']['find_
   return data
 }
 
-export function convertNativePackages(nativePackages: { name: string, version: string }[]) {
-  if (!nativePackages) {
-    throw new Error(`Error parsing native packages, perhaps the metadata does not exist in Capgo?`)
-  }
+export function convertNativePackages(nativePackages: { name: string, version: string }[] | null | undefined) {
+  // Missing metadata is normal for older bundles / empty channels — treat as empty.
+  if (!nativePackages)
+    return new Map<string, { name: string, version: string }>()
 
   // Check types
   nativePackages.forEach((data) => {
@@ -688,9 +688,11 @@ export async function getRemoteDependencies(appId: string, channel: string) {
     throw new Error(error.message)
   }
   const version = remoteNativePackages.version as { native_packages?: unknown } | null
-  const nativePackages = version?.native_packages
-  if (!Array.isArray(nativePackages))
-    throw new Error('Error parsing native packages, perhaps the metadata does not exist in Capgo?')
+  // Channel may have no linked version, or an older version without metadata.
+  // Match CLI: fall back to [] so linking still works.
+  const nativePackages = Array.isArray(version?.native_packages)
+    ? version.native_packages
+    : []
   return convertNativePackages(nativePackages as { name: string, version: string }[])
 }
 
@@ -717,6 +719,14 @@ export function isCompatible(pkg: Compatibility): boolean {
 
 export async function checkCompatibilityNativePackages(appId: string, channel: string, nativePackages: { name: string, version: string }[]) {
   const mappedRemoteNativePackages = await getRemoteDependencies(appId, channel)
+
+  // Nothing on the channel to compare against → skip gate (same as missing local metadata).
+  if (mappedRemoteNativePackages.size === 0) {
+    return {
+      finalCompatibility: [] as Compatibility[],
+      localDependencies: nativePackages,
+    }
+  }
 
   const finalDependencies: Compatibility[] = nativePackages
     .map((local) => {


### PR DESCRIPTION
## Summary (AI generated)

- Stop throwing when a channel’s current version has null/missing `native_packages` during bundle ↔ channel linking
- Align frontend remote-dependency loading with CLI (`[]` fallback)
- Skip the native-compatibility gate when the channel has nothing to compare against

## Motivation (AI generated)

Linking a bundle to a channel from the console failed with `Error parsing native packages, perhaps the metadata does not exist in Capgo?` even when the selected bundle had metadata. The check reads the **channel’s current** version metadata; empty channels and older bundles without metadata incorrectly aborted the whole link flow.

## Business Impact (AI generated)

Console users can promote/link bundles again without a false metadata error, reducing support friction for normal channel operations.

## Test Plan (AI generated)

- [ ] Link a bundle to a channel that has no current version (or null `native_packages`) — should succeed and ignore compatibility
- [ ] Link a bundle with native metadata to a channel whose current version also has metadata — compatibility check still runs
- [ ] Confirm incompatible native packages still show the confirm dialog
- [ ] Repeat from both bundle page and channel page

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility handling for bundles and channels without local dependencies or available compatibility results.
  * Prevented errors when package or channel metadata is missing.
  * Compatibility checks now complete successfully when no remote dependency information is available.
  * Such cases are treated as informational and can be safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->