### PR TITLE
fix(channel): auto-unlink second bundle when disabling progressive rollout

### DIFF
--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -190,7 +190,7 @@ export async function setChannelInternal(channel: string, appId: string, options
   }
 
   const hasStableBundlePromotion = bundle != null || latest === true || latestRemote === true
-  const hasRolloutTargetChange = rolloutBundle != null || rolloutRollback === true || rolloutPromote === true
+  const hasRolloutTargetChange = rolloutBundle != null || rolloutRollback === true || rolloutPromote === true || rolloutDisable === true
   const hasRolloutConfiguration = rolloutPercentage != null
     || rolloutPercentageBps != null
     || rolloutEnable != null

--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -424,8 +424,13 @@ export async function setChannelInternal(channel: string, appId: string, options
 
   if (rolloutEnable != null)
     channelPayload.rollout_enabled = !!rolloutEnable
-  if (rolloutDisable)
+  if (rolloutDisable) {
+    bundleLinkChanged = bundleLinkChanged || existingChannel.rollout_version != null
     channelPayload.rollout_enabled = false
+    channelPayload.rollout_version = null
+    channelPayload.rollout_paused_at = null
+    channelPayload.rollout_pause_reason = null
+  }
 
   if (rolloutPause) {
     channelPayload.rollout_paused_at = new Date().toISOString()

--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -190,7 +190,7 @@ export async function setChannelInternal(channel: string, appId: string, options
   }
 
   const hasStableBundlePromotion = bundle != null || latest === true || latestRemote === true
-  const hasRolloutTargetChange = rolloutBundle != null || rolloutRollback === true || rolloutPromote === true || rolloutDisable === true
+  const hasRolloutTargetChange = rolloutBundle != null || rolloutRollback === true || rolloutPromote === true
   const hasRolloutConfiguration = rolloutPercentage != null
     || rolloutPercentageBps != null
     || rolloutEnable != null
@@ -227,9 +227,11 @@ export async function setChannelInternal(channel: string, appId: string, options
     throw new Error(`Cannot find channel ${channel}`)
   }
 
+  // Disable unlinks only when a rollout bundle is linked; match API promote gating.
+  const disableUnlinksRollout = rolloutDisable === true && existingChannel.rollout_version != null
   if (hasSettingsUpdate)
     await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, 'channel.update_settings', silent, true, existingChannel.id)
-  if (hasBundlePromotion)
+  if (hasBundlePromotion || disableUnlinksRollout)
     await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, 'channel.promote_bundle', silent, true, existingChannel.id)
 
   const orgId = existingChannel.owner_org

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -583,7 +583,7 @@ Example: npx @capgo/cli@latest channel set production com.example.app --bundle 1
   .option('--rollout-percentage <rolloutPercentage>', `Rollout percentage from 0 to 100`, value => Number.parseFloat(value))
   .option('--rollout-percentage-bps <rolloutPercentageBps>', `Rollout percentage in basis points from 0 to 10000`, value => Number.parseInt(value, 10))
   .option('--rollout-enable', `Enable the configured rollout`)
-  .option('--rollout-disable', `Disable the configured rollout`)
+  .option('--rollout-disable', `Disable the configured rollout and unlink the rollout bundle`)
   .option('--rollout-pause', `Pause rollout exposure without rolling back selected devices`)
   .option('--rollout-resume', `Resume a paused rollout`)
   .option('--rollout-rollback', `Clear rollout state and return devices to stable`)

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -234,7 +234,13 @@ async function getChannel(force = false) {
 async function saveChannelChanges(update: ChannelUpdate) {
   const changesStableVersion = Object.prototype.hasOwnProperty.call(update, 'version')
   const changesRolloutVersion = Object.prototype.hasOwnProperty.call(update, 'rollout_version')
-  const canUpdate = changesStableVersion || changesRolloutVersion
+  // Disable unlinks the rollout target; keep that on channel settings permission like the enable/disable toggle.
+  const isDisableRolloutUnlink = update.rollout_enabled === false
+    && Object.prototype.hasOwnProperty.call(update, 'rollout_version')
+    && update.rollout_version === null
+    && !Object.prototype.hasOwnProperty.call(update, 'version')
+    && !Object.prototype.hasOwnProperty.call(update, 'rollout_percentage_bps')
+  const canUpdate = (changesStableVersion || (changesRolloutVersion && !isDisableRolloutUnlink))
     ? canPromoteBundle.value
     : canUpdateChannelSettings.value
 
@@ -587,6 +593,17 @@ async function enableRollout() {
     return
   }
   await saveChannelChange('rollout_enabled', true as any)
+}
+
+async function disableRollout() {
+  if (await saveChannelChanges({
+    rollout_enabled: false,
+    rollout_version: null,
+    rollout_paused_at: null,
+    rollout_pause_reason: null,
+  })) {
+    await askUpdateNotificationAfterBundleChange()
+  }
 }
 
 async function saveRolloutPercentage(value: string) {
@@ -1051,7 +1068,7 @@ async function copyCurlCommand() {
                       <button class="min-h-11 d-btn d-btn-ghost" :disabled="!canPromoteBundle" @click="openSelectRolloutVersion()">
                         {{ t('set-rollout-target') }}
                       </button>
-                      <button class="min-h-11 d-btn d-btn-outline" :disabled="rolloutActionsDisabled" @click="saveChannelChange('rollout_enabled', !channel.rollout_enabled as any)">
+                      <button class="min-h-11 d-btn d-btn-outline" :disabled="rolloutActionsDisabled" @click="channel.rollout_enabled ? disableRollout() : enableRollout()">
                         {{ channel.rollout_enabled ? t('disable') : t('enable') }}
                       </button>
                       <button class="min-h-11 d-btn d-btn-outline" :disabled="rolloutPauseDisabled" @click="toggleRolloutPause()">

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -234,13 +234,8 @@ async function getChannel(force = false) {
 async function saveChannelChanges(update: ChannelUpdate) {
   const changesStableVersion = Object.prototype.hasOwnProperty.call(update, 'version')
   const changesRolloutVersion = Object.prototype.hasOwnProperty.call(update, 'rollout_version')
-  // Disable unlinks the rollout target; keep that on channel settings permission like the enable/disable toggle.
-  const isDisableRolloutUnlink = update.rollout_enabled === false
-    && Object.prototype.hasOwnProperty.call(update, 'rollout_version')
-    && update.rollout_version === null
-    && !Object.prototype.hasOwnProperty.call(update, 'version')
-    && !Object.prototype.hasOwnProperty.call(update, 'rollout_percentage_bps')
-  const canUpdate = (changesStableVersion || (changesRolloutVersion && !isDisableRolloutUnlink))
+  // Unlinking rollout_version (including disable) requires promote_bundle — matches refresh_channel_rollout_id.
+  const canUpdate = changesStableVersion || changesRolloutVersion
     ? canPromoteBundle.value
     : canUpdateChannelSettings.value
 
@@ -1068,7 +1063,7 @@ async function copyCurlCommand() {
                       <button class="min-h-11 d-btn d-btn-ghost" :disabled="!canPromoteBundle" @click="openSelectRolloutVersion()">
                         {{ t('set-rollout-target') }}
                       </button>
-                      <button class="min-h-11 d-btn d-btn-outline" :disabled="rolloutActionsDisabled" @click="channel.rollout_enabled ? disableRollout() : enableRollout()">
+                      <button class="min-h-11 d-btn d-btn-outline" :disabled="channel.rollout_enabled ? rolloutTargetActionsDisabled : rolloutEnableDisabled" @click="channel.rollout_enabled ? disableRollout() : enableRollout()">
                         {{ channel.rollout_enabled ? t('disable') : t('enable') }}
                       </button>
                       <button class="min-h-11 d-btn d-btn-outline" :disabled="rolloutPauseDisabled" @click="toggleRolloutPause()">

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -1063,7 +1063,7 @@ async function copyCurlCommand() {
                       <button class="min-h-11 d-btn d-btn-ghost" :disabled="!canPromoteBundle" @click="openSelectRolloutVersion()">
                         {{ t('set-rollout-target') }}
                       </button>
-                      <button class="min-h-11 d-btn d-btn-outline" :disabled="channel.rollout_enabled ? rolloutTargetActionsDisabled : rolloutEnableDisabled" @click="channel.rollout_enabled ? disableRollout() : enableRollout()">
+                      <button class="min-h-11 d-btn d-btn-outline" :disabled="channel.rollout_enabled ? (rolloutTargetActionsDisabled || rolloutControlsDisabled) : rolloutEnableDisabled" @click="channel.rollout_enabled ? disableRollout() : enableRollout()">
                         {{ channel.rollout_enabled ? t('disable') : t('enable') }}
                       </button>
                       <button class="min-h-11 d-btn d-btn-outline" :disabled="rolloutPauseDisabled" @click="toggleRolloutPause()">

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -470,6 +470,14 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
     channel.rollout_paused_at = null
     channel.rollout_pause_reason = null
   }
+
+  // Disabling progressive rollout unlinks the second bundle so both stay connected only while rollout is active.
+  if (body.rolloutEnabled === false && body.rolloutVersion === undefined && !body.rollback && !body.promoteToStable) {
+    channel.rollout_version = null
+    channel.rollout_paused_at = null
+    channel.rollout_pause_reason = null
+  }
+
   if (!existingChannel && requestedVersionName) {
     const createdChannel = await createAndPromoteChannelInTransaction(c, channel, requestedVersionName, apikey)
     return c.json({ ...BRES, ...createdChannel })

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -390,7 +390,12 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   if (body.autoPauseAction && !['pause', 'rollback', 'notify'].includes(body.autoPauseAction)) {
     throw simpleError('invalid_auto_pause_action', 'Auto-pause action must be pause, rollback, or notify', { autoPauseAction: body.autoPauseAction })
   }
-  const changesRolloutTarget = body.rolloutVersion !== undefined || !!body.rollback || !!body.promoteToStable
+  const disablesRollout = body.rolloutEnabled === false && !body.rollback && !body.promoteToStable
+  // Clearing rollout_version (disable unlink / explicit target / rollback / promote) is gated by the DB trigger with channel.promote_bundle.
+  const changesRolloutTarget = body.rolloutVersion !== undefined
+    || !!body.rollback
+    || !!body.promoteToStable
+    || (disablesRollout && existingRolloutVersion != null)
   if (changesRolloutTarget) {
     if (existingChannelId === null) {
       throw simpleError('cannot_find_channel', 'Cannot find channel', { app_id: body.app_id, channel: body.channel })
@@ -471,8 +476,8 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
     channel.rollout_pause_reason = null
   }
 
-  // Disabling progressive rollout unlinks the second bundle so both stay connected only while rollout is active.
-  if (body.rolloutEnabled === false && body.rolloutVersion === undefined && !body.rollback && !body.promoteToStable) {
+  // Disabling progressive rollout always unlinks the second bundle (ignore any parallel rolloutVersion).
+  if (disablesRollout) {
     channel.rollout_version = null
     channel.rollout_paused_at = null
     channel.rollout_pause_reason = null

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -358,12 +358,58 @@ describe('public channel post', () => {
     }, apiKey())
 
     expect(checkPermission).toHaveBeenCalledWith(c, 'channel.update_settings', { appId: 'com.test.disable-rollout', channelId: 42 })
-    expect(checkPermission).not.toHaveBeenCalledWith(c, 'channel.promote_bundle', expect.anything())
+    expect(checkPermission).toHaveBeenCalledWith(c, 'channel.promote_bundle', { appId: 'com.test.disable-rollout', channelId: 42 })
     expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({
       rollout_enabled: false,
       rollout_version: null,
       rollout_paused_at: null,
       rollout_pause_reason: null,
+    }), 42, true)
+  })
+
+  it('forces unlink on disable even when rolloutVersion is also sent', async () => {
+    supabaseAdmin.mockImplementation(() => buildAdminChain({
+      existingChannelId: 42,
+      existingChannelVersion: 123,
+      existingRolloutVersion: 456,
+      versionId: 789,
+    }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+    const c = context()
+
+    await post(c, {
+      app_id: 'com.test.disable-with-version',
+      channel: 'production',
+      rolloutEnabled: false,
+      rolloutVersion: '2.0.0',
+    }, apiKey())
+
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({
+      rollout_enabled: false,
+      rollout_version: null,
+    }), 42, true)
+  })
+
+  it('does not require promote when disabling with no linked rollout bundle', async () => {
+    supabaseAdmin.mockImplementation(() => buildAdminChain({
+      existingChannelId: 42,
+      existingChannelVersion: 123,
+      existingRolloutVersion: null,
+    }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+    const c = context()
+
+    await post(c, {
+      app_id: 'com.test.disable-no-rollout',
+      channel: 'production',
+      rolloutEnabled: false,
+    }, apiKey())
+
+    expect(checkPermission).toHaveBeenCalledWith(c, 'channel.update_settings', { appId: 'com.test.disable-no-rollout', channelId: 42 })
+    expect(checkPermission).not.toHaveBeenCalledWith(c, 'channel.promote_bundle', expect.anything())
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({
+      rollout_enabled: false,
+      rollout_version: null,
     }), 42, true)
   })
 

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -342,6 +342,31 @@ describe('public channel post', () => {
     expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({ version: 456, rollout_version: null }), 42, false)
   })
 
+  it('unlinks the rollout bundle when progressive rollout is disabled', async () => {
+    supabaseAdmin.mockImplementation(() => buildAdminChain({
+      existingChannelId: 42,
+      existingChannelVersion: 123,
+      existingRolloutVersion: 456,
+    }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+    const c = context()
+
+    await post(c, {
+      app_id: 'com.test.disable-rollout',
+      channel: 'production',
+      rolloutEnabled: false,
+    }, apiKey())
+
+    expect(checkPermission).toHaveBeenCalledWith(c, 'channel.update_settings', { appId: 'com.test.disable-rollout', channelId: 42 })
+    expect(checkPermission).not.toHaveBeenCalledWith(c, 'channel.promote_bundle', expect.anything())
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({
+      rollout_enabled: false,
+      rollout_version: null,
+      rollout_paused_at: null,
+      rollout_pause_reason: null,
+    }), 42, true)
+  })
+
   it('creates and promotes a new channel in one transaction after its scoped grant exists', async () => {
     const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
     const c = context()


### PR DESCRIPTION
## Summary (AI generated)

- When progressive rollout is disabled, automatically unlink `rollout_version` (the second bundle) and clear pause state
- Applied in channel API (`POST /channel`), Capgo console channel page, and CLI `--rollout-disable`
- Added unit coverage for the API disable path

## Motivation (AI generated)

Disabling progressive rollout previously only flipped `rollout_enabled` to `false`, so both the stable and rollout bundles stayed linked to the channel. That looked odd and confusing in the console.

## Business Impact (AI generated)

Clearer channel state for users managing progressive rollouts; less accidental leftover second-bundle linkage after turning rollout off.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/channel-post.unit.test.ts`
- [ ] In console: enable progressive rollout with a second bundle, click Disable, confirm only the stable bundle remains linked
- [ ] Via API/CLI: `rollout_enabled: false` / `--rollout-disable` clears `rollout_version`
- [ ] Rollback and promote still behave as before

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disabling a progressive rollout now clears its target, pause details, and rollout bundle link.
  * Added clearer permission handling for enabling and disabling rollouts.
  * Disabling a rollout no longer requires promotion permission when no bundle is linked.

* **Bug Fixes**
  * Rollout unlinking now works reliably, including when another rollout version is provided.
  * Added update notifications after disabling a rollout.

* **Tests**
  * Added coverage for rollout cleanup, unlinking, and permission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->