### PR TITLE
fix(tracking): include reporting API key ID in PostHog events

### DIFF
--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -3,8 +3,8 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { BentoTrackingPayload } from '../utils/tracking.ts'
 import { Hono } from 'hono/tiny'
-import { BUILDER_RECOVERY_MILESTONES, buildBuilderOnboardingBentoEvent } from '../utils/builder_onboarding_recovery.ts'
-import { BUNDLE_INCOMPATIBLE_EVENT, buildBundleCompatibilityBentoEvent } from '../utils/bundle_compatibility_recovery.ts'
+import { buildBuilderOnboardingBentoEvent, BUILDER_RECOVERY_MILESTONES } from '../utils/builder_onboarding_recovery.ts'
+import { buildBundleCompatibilityBentoEvent, BUNDLE_INCOMPATIBLE_EVENT } from '../utils/bundle_compatibility_recovery.ts'
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareAuth } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
@@ -238,8 +238,9 @@ async function buildBuilderBentoEvent(
     !onboardingOrgId || !appId
     || trackedBody.event !== 'Builder Onboarding Step'
     || !builderStep || !BUILDER_RECOVERY_MILESTONES.has(builderStep)
-  )
+  ) {
     return undefined
+  }
 
   const [orgResult, appResult] = await Promise.all([
     supabase.from('orgs').select('id, name').eq('id', onboardingOrgId).single(),
@@ -395,11 +396,15 @@ app.post('/', middlewareAuth(), async (c) => {
 
   // Exactly one of these is ever set (distinct event names); `??` picks the active one.
   const bentoEvent = onboardingBentoEvent ?? builderBentoEvent ?? bundleIncompatibleBentoEvent
+  const apikeyId = c.get('apikey')?.id
   await sendEventToTracking(c, {
     ...trackedBody,
     bento: bentoEvent,
     sentToBento: Boolean(bentoEvent),
     groups: verifiedOrgId ? { organization: verifiedOrgId } : undefined,
+    // Use the authenticated record id, rather than a caller-provided tag, and
+    // keep it out of PostHog person properties.
+    nonPersonTags: apikeyId === undefined ? undefined : { apikey_id: apikeyId },
   })
 
   return c.json(BRES)

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -12,7 +12,7 @@ import { trackPosthogEvent } from '../utils/posthog.ts'
 import { checkPermission } from '../utils/rbac.ts'
 import { broadcastCLIEvent } from '../utils/realtime_broadcast.ts'
 import { supabaseWithAuth } from '../utils/supabase.ts'
-import { sendEventToTracking } from '../utils/tracking.ts'
+import { addAuthenticatedApiKeyIdToTrackingPayload, sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
 
 // PostHog event recording whether the org-member incompatibility email was sent
@@ -397,15 +397,12 @@ app.post('/', middlewareAuth(), async (c) => {
   // Exactly one of these is ever set (distinct event names); `??` picks the active one.
   const bentoEvent = onboardingBentoEvent ?? builderBentoEvent ?? bundleIncompatibleBentoEvent
   const apikeyId = c.get('apikey')?.id
-  await sendEventToTracking(c, {
+  await sendEventToTracking(c, addAuthenticatedApiKeyIdToTrackingPayload({
     ...trackedBody,
     bento: bentoEvent,
     sentToBento: Boolean(bentoEvent),
     groups: verifiedOrgId ? { organization: verifiedOrgId } : undefined,
-    // Use the authenticated record id, rather than a caller-provided tag, and
-    // keep it out of PostHog person properties.
-    nonPersonTags: apikeyId === undefined ? undefined : { apikey_id: apikeyId },
-  })
+  }, apikeyId))
 
   return c.json(BRES)
 })

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -290,6 +290,7 @@ async function buildBundleIncompatibleBentoEvent(
     updateStrategy = channelRow?.disable_auto_update ?? null
   }
   const skippedForMetadata = updateStrategy === 'version_number'
+  const apikeyId = c.get('apikey')?.id
 
   await backgroundTask(c, trackPosthogEvent(c, {
     event: BUNDLE_INCOMPATIBLE_EMAIL_EVENT,
@@ -303,6 +304,7 @@ async function buildBundleIncompatibleBentoEvent(
       app_id: appId,
       ...(incompatibleChannel ? { channel_name: incompatibleChannel } : {}),
     },
+    nonPersonTags: apikeyId === undefined ? undefined : { apikey_id: apikeyId },
   }))
 
   if (skippedForMetadata)

--- a/supabase/functions/_backend/utils/tracking.ts
+++ b/supabase/functions/_backend/utils/tracking.ts
@@ -39,6 +39,23 @@ export interface SendEventToTrackingOptions {
   strict?: boolean
 }
 
+export function addAuthenticatedApiKeyIdToTrackingPayload(
+  payload: SendEventToTrackingPayload,
+  apikeyId: number | undefined,
+): SendEventToTrackingPayload {
+  if (apikeyId === undefined)
+    return payload
+
+  const hasCallerProvidedApiKeyId = payload.tags && Object.hasOwn(payload.tags, 'apikey_id')
+  const { apikey_id: _callerProvidedApiKeyId, ...tags } = payload.tags ?? {}
+
+  return {
+    ...payload,
+    ...(hasCallerProvidedApiKeyId ? { tags } : {}),
+    nonPersonTags: { ...payload.nonPersonTags, apikey_id: apikeyId },
+  }
+}
+
 async function runTrackedCall(c: Context, provider: string, task: () => Promise<unknown>, strict = false) {
   try {
     const result = await task()

--- a/supabase/functions/_backend/utils/tracking.ts
+++ b/supabase/functions/_backend/utils/tracking.ts
@@ -43,10 +43,16 @@ export function addAuthenticatedApiKeyIdToTrackingPayload(
   payload: SendEventToTrackingPayload,
   apikeyId: number | undefined,
 ): SendEventToTrackingPayload {
-  const hasCallerProvidedApiKeyId = payload.tags && Object.hasOwn(payload.tags, 'apikey_id')
+  const hasCallerProvidedTagApiKeyId = payload.tags && Object.hasOwn(payload.tags, 'apikey_id')
+  const hasCallerProvidedNonPersonApiKeyId = payload.nonPersonTags && Object.hasOwn(payload.nonPersonTags, 'apikey_id')
   const { apikey_id: _callerProvidedApiKeyId, ...tags } = payload.tags ?? {}
-  const payloadWithoutCallerApiKeyId = hasCallerProvidedApiKeyId
-    ? { ...payload, tags }
+  const { apikey_id: _callerProvidedNonPersonApiKeyId, ...nonPersonTags } = payload.nonPersonTags ?? {}
+  const payloadWithoutCallerApiKeyId = hasCallerProvidedTagApiKeyId || hasCallerProvidedNonPersonApiKeyId
+    ? {
+        ...payload,
+        ...(hasCallerProvidedTagApiKeyId ? { tags } : {}),
+        ...(hasCallerProvidedNonPersonApiKeyId ? { nonPersonTags } : {}),
+      }
     : payload
 
   if (apikeyId === undefined)
@@ -54,7 +60,7 @@ export function addAuthenticatedApiKeyIdToTrackingPayload(
 
   return {
     ...payloadWithoutCallerApiKeyId,
-    nonPersonTags: { ...payload.nonPersonTags, apikey_id: apikeyId },
+    nonPersonTags: { ...nonPersonTags, apikey_id: apikeyId },
   }
 }
 

--- a/supabase/functions/_backend/utils/tracking.ts
+++ b/supabase/functions/_backend/utils/tracking.ts
@@ -43,15 +43,17 @@ export function addAuthenticatedApiKeyIdToTrackingPayload(
   payload: SendEventToTrackingPayload,
   apikeyId: number | undefined,
 ): SendEventToTrackingPayload {
-  if (apikeyId === undefined)
-    return payload
-
   const hasCallerProvidedApiKeyId = payload.tags && Object.hasOwn(payload.tags, 'apikey_id')
   const { apikey_id: _callerProvidedApiKeyId, ...tags } = payload.tags ?? {}
+  const payloadWithoutCallerApiKeyId = hasCallerProvidedApiKeyId
+    ? { ...payload, tags }
+    : payload
+
+  if (apikeyId === undefined)
+    return payloadWithoutCallerApiKeyId
 
   return {
-    ...payload,
-    ...(hasCallerProvidedApiKeyId ? { tags } : {}),
+    ...payloadWithoutCallerApiKeyId,
     nonPersonTags: { ...payload.nonPersonTags, apikey_id: apikeyId },
   }
 }

--- a/tests/posthog.unit.test.ts
+++ b/tests/posthog.unit.test.ts
@@ -83,6 +83,24 @@ describe('posthog helper', () => {
     expect(body.properties.$set).toEqual({ app_id: 'app-id' })
   })
 
+  it('sends non-person API key context only with the event', async () => {
+    const { trackPosthogEvent } = await import('../supabase/functions/_backend/utils/posthog.ts')
+
+    await trackPosthogEvent(createContext(), {
+      event: 'Tracked Event',
+      channel: 'usage',
+      nonPersonTags: { apikey_id: 87015 },
+      user_id: 'user-id',
+      tags: { app_id: 'app-id' },
+    })
+
+    const request = fetchMock.mock.calls[0]
+    const body = JSON.parse(request?.[1]?.body as string)
+
+    expect(body.properties.apikey_id).toBe(87015)
+    expect(body.properties.$set).not.toHaveProperty('apikey_id')
+  })
+
   it('can send historical events without updating person properties', async () => {
     const { trackPosthogEvent } = await import('../supabase/functions/_backend/utils/posthog.ts')
 

--- a/tests/tracking.unit.test.ts
+++ b/tests/tracking.unit.test.ts
@@ -98,10 +98,11 @@ describe('sendEventToTracking', () => {
       event: 'Tracked Event',
       notify: false,
       tags: { apikey_id: 'caller-supplied', app_id: 'app-id' },
+      nonPersonTags: { apikey_id: 'caller-supplied', cli_version: '8.31.3' },
     }, undefined)
 
     expect(payload.tags).toEqual({ app_id: 'app-id' })
-    expect(payload.nonPersonTags).toBeUndefined()
+    expect(payload.nonPersonTags).toEqual({ cli_version: '8.31.3' })
   })
 
   it('runs all tracking providers in the background by default', async () => {

--- a/tests/tracking.unit.test.ts
+++ b/tests/tracking.unit.test.ts
@@ -94,6 +94,7 @@ describe('sendEventToTracking', () => {
       notify: false,
       sentToBento: true,
       tags: { app_id: 'app-id' },
+      nonPersonTags: { apikey_id: 87015 },
     })
 
     expect(backgroundTaskMock).toHaveBeenCalledTimes(2)
@@ -101,6 +102,7 @@ describe('sendEventToTracking', () => {
     expect(posthogMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       event: 'Tracked Event',
       ip: '1.2.3.4',
+      nonPersonTags: { apikey_id: 87015 },
       user_id: 'org-id',
     }))
     expect(notifToOrgMembersMock).toHaveBeenCalledWith(

--- a/tests/tracking.unit.test.ts
+++ b/tests/tracking.unit.test.ts
@@ -90,6 +90,20 @@ describe('sendEventToTracking', () => {
     expect(payload.nonPersonTags).toEqual({ apikey_id: 87015 })
   })
 
+  it('does not allow callers without an API key to report an API key ID', async () => {
+    const { addAuthenticatedApiKeyIdToTrackingPayload } = await import('../supabase/functions/_backend/utils/tracking.ts')
+
+    const payload = addAuthenticatedApiKeyIdToTrackingPayload({
+      channel: 'usage',
+      event: 'Tracked Event',
+      notify: false,
+      tags: { apikey_id: 'caller-supplied', app_id: 'app-id' },
+    }, undefined)
+
+    expect(payload.tags).toEqual({ app_id: 'app-id' })
+    expect(payload.nonPersonTags).toBeUndefined()
+  })
+
   it('runs all tracking providers in the background by default', async () => {
     const { sendEventToTracking } = await import('../supabase/functions/_backend/utils/tracking.ts')
 

--- a/tests/tracking.unit.test.ts
+++ b/tests/tracking.unit.test.ts
@@ -76,6 +76,20 @@ afterEach(() => {
 })
 
 describe('sendEventToTracking', () => {
+  it('uses the authenticated API key ID instead of a caller-provided tag', async () => {
+    const { addAuthenticatedApiKeyIdToTrackingPayload } = await import('../supabase/functions/_backend/utils/tracking.ts')
+
+    const payload = addAuthenticatedApiKeyIdToTrackingPayload({
+      channel: 'usage',
+      event: 'Tracked Event',
+      notify: false,
+      tags: { apikey_id: 'caller-supplied', app_id: 'app-id' },
+    }, 87015)
+
+    expect(payload.tags).toEqual({ app_id: 'app-id' })
+    expect(payload.nonPersonTags).toEqual({ apikey_id: 87015 })
+  })
+
   it('runs all tracking providers in the background by default', async () => {
     const { sendEventToTracking } = await import('../supabase/functions/_backend/utils/tracking.ts')
 


### PR DESCRIPTION
## Summary (AI generated)

- Add the authenticated API key record ID as `apikey_id` to PostHog events sent through `/private/events`.
- Send it as an event-only property, never as a PostHog person property.
- Add regression coverage for the event payload and tracking handoff.

## Motivation (AI generated)

Support investigations need to correlate CLI telemetry with the API key that submitted it, without collecting the private key value.

## Business Impact (AI generated)

Improves support diagnosis for permission and plan-gate failures while preserving API-key secrecy and avoiding persistent person-profile changes.

## Test Plan (AI generated)

- [x] `bun lint:backend`
- [x] Focused ESLint: `bunx eslint supabase/functions/_backend/private/events.ts tests/posthog.unit.test.ts tests/tracking.unit.test.ts`
- [x] Focused tests: `bunx vitest run tests/posthog.unit.test.ts tests/tracking.unit.test.ts` (8 passed)
- [x] `bun typecheck`
- [ ] Full `bun test:backend` could not run locally because Docker Desktop is not running, so the worktree's Supabase stack cannot start.

Generated with AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracking events now include the authenticated API key identifier when available, improving event attribution.

* **Bug Fixes**
  * API key identifiers are correctly recorded as event-level data without being added to personal profiles.
  * Caller-supplied API key identifiers are removed to prevent inaccurate tracking data.

* **Tests**
  * Added coverage for API key tag handling in tracking and analytics event payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->