### PR TITLE
fix(auth): restore valid spoof admin session

### DIFF
--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -100,6 +100,11 @@ function shouldRefreshSpoofedAdminJwt(jwt: string) {
   return expiresAt - Date.now() / 1000 <= SPOOF_ADMIN_TOKEN_REFRESH_WINDOW_SECONDS
 }
 
+function isSpoofedAdminJwtUsable(jwt: string) {
+  const expiresAt = getJwtExpiresAt(jwt)
+  return expiresAt !== null && expiresAt > Date.now() / 1000
+}
+
 function createSpoofAdminSupabase() {
   return createClient<Database>(getSupabaseHost(), config.supaKey, {
     auth: {
@@ -227,7 +232,12 @@ export async function unspoofUser() {
   if (!spoofedAdminSession)
     return false
 
-  const restoredAdminSession = await refreshSpoofedAdminSession(spoofedAdminSession).catch(() => null)
+  // A refresh token may have been invalidated while its paired access token is
+  // still valid. Restore that access token directly so stopping impersonation
+  // does not strand the user in the spoofed session.
+  const restoredAdminSession = isSpoofedAdminJwtUsable(spoofedAdminSession.jwt)
+    ? spoofedAdminSession
+    : await refreshSpoofedAdminSession(spoofedAdminSession).catch(() => null)
   if (!restoredAdminSession) {
     clearSpoof()
     return false
@@ -235,11 +245,11 @@ export async function unspoofUser() {
 
   const supabase = useSupabase()
   const { data, error } = await supabase.auth.setSession({ access_token: restoredAdminSession.jwt, refresh_token: restoredAdminSession.refreshToken })
-  clearSpoof()
 
   if (error || !data.session)
     return false
 
+  clearSpoof()
   return true
 }
 

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -243,10 +243,20 @@ export async function unspoofUser() {
     return false
   }
 
-  const supabase = useSupabase()
-  const { data, error } = await supabase.auth.setSession({ access_token: restoredAdminSession.jwt, refresh_token: restoredAdminSession.refreshToken })
+  if (restoredAdminSession !== spoofedAdminSession)
+    saveSpoofedAdminSession(restoredAdminSession)
 
-  if (error || !data.session)
+  const supabase = useSupabase()
+  let data: { session?: unknown } | null | undefined
+  let error: unknown
+  try {
+    ({ data, error } = await supabase.auth.setSession({ access_token: restoredAdminSession.jwt, refresh_token: restoredAdminSession.refreshToken }))
+  }
+  catch {
+    return false
+  }
+
+  if (error || !data?.session)
     return false
 
   clearSpoof()

--- a/tests/supabase-spoof.unit.test.ts
+++ b/tests/supabase-spoof.unit.test.ts
@@ -84,6 +84,38 @@ describe('spoof session storage', () => {
     expect(isSpoofed()).toBe(false)
   })
 
+  it('restores a valid stored admin session even when its refresh token is stale', async () => {
+    const refreshSession = vi.fn()
+    const setSession = vi.fn().mockResolvedValue({ data: { session: {} }, error: null })
+    mocks.createClient.mockReturnValueOnce({ auth: { refreshSession, setSession } })
+
+    const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(Math.floor(Date.now() / 1000) + 300), 'stale-refresh-token')
+
+    await expect(unspoofUser()).resolves.toBe(true)
+
+    expect(refreshSession).not.toHaveBeenCalled()
+    expect(setSession).toHaveBeenCalledWith({
+      access_token: expect.any(String),
+      refresh_token: 'stale-refresh-token',
+    })
+    expect(isSpoofed()).toBe(false)
+  })
+
+  it('keeps spoof recovery storage when restoring the admin session fails', async () => {
+    const setSession = vi.fn().mockResolvedValue({ data: { session: null }, error: new Error('session write failed') })
+    mocks.createClient.mockReturnValueOnce({ auth: { setSession } })
+
+    const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(Math.floor(Date.now() / 1000) + 300), 'admin-refresh-token')
+
+    await expect(unspoofUser()).resolves.toBe(false)
+
+    expect(isSpoofed()).toBe(true)
+  })
+
   it('clears expired spoof storage when the stored admin jwt cannot be refreshed', async () => {
     const refreshSession = vi.fn().mockResolvedValue({ data: { session: null }, error: new Error('invalid refresh token') })
     mocks.createClient.mockReturnValueOnce({ auth: { refreshSession } })

--- a/tests/supabase-spoof.unit.test.ts
+++ b/tests/supabase-spoof.unit.test.ts
@@ -133,6 +133,34 @@ describe('spoof session storage', () => {
     expect(isSpoofed()).toBe(true)
   })
 
+  it('keeps the refreshed spoof recovery session when restoring it throws', async () => {
+    const refreshSession = vi.fn().mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'fresh-admin-jwt',
+          refresh_token: 'fresh-admin-refresh-token',
+        },
+      },
+      error: null,
+    })
+    const setSession = vi.fn().mockRejectedValue(new Error('session write failed'))
+    mocks.createClient
+      .mockReturnValueOnce({ auth: { refreshSession } })
+      .mockReturnValueOnce({ auth: { setSession } })
+
+    const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(1), 'stale-refresh-token')
+
+    await expect(unspoofUser()).resolves.toBe(false)
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect.stringContaining('.spoof_admin_jwt'),
+      JSON.stringify({ jwt: 'fresh-admin-jwt', refreshToken: 'fresh-admin-refresh-token' }),
+    )
+    expect(isSpoofed()).toBe(true)
+  })
+
   it('clears expired spoof storage when the stored admin jwt cannot be refreshed', async () => {
     const refreshSession = vi.fn().mockResolvedValue({ data: { session: null }, error: new Error('invalid refresh token') })
     mocks.createClient.mockReturnValueOnce({ auth: { refreshSession } })

--- a/tests/supabase-spoof.unit.test.ts
+++ b/tests/supabase-spoof.unit.test.ts
@@ -81,6 +81,10 @@ describe('spoof session storage', () => {
       access_token: 'fresh-admin-jwt',
       refresh_token: 'fresh-admin-refresh-token',
     })
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect.stringContaining('.spoof_admin_jwt'),
+      JSON.stringify({ jwt: 'fresh-admin-jwt', refreshToken: 'fresh-admin-refresh-token' }),
+    )
     expect(isSpoofed()).toBe(false)
   })
 
@@ -105,6 +109,19 @@ describe('spoof session storage', () => {
 
   it('keeps spoof recovery storage when restoring the admin session fails', async () => {
     const setSession = vi.fn().mockResolvedValue({ data: { session: null }, error: new Error('session write failed') })
+    mocks.createClient.mockReturnValueOnce({ auth: { setSession } })
+
+    const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+
+    saveSpoof(createJwt(Math.floor(Date.now() / 1000) + 300), 'admin-refresh-token')
+
+    await expect(unspoofUser()).resolves.toBe(false)
+
+    expect(isSpoofed()).toBe(true)
+  })
+
+  it('keeps spoof recovery storage when restoring the admin session throws', async () => {
+    const setSession = vi.fn().mockRejectedValue(new Error('session write failed'))
     mocks.createClient.mockReturnValueOnce({ auth: { setSession } })
 
     const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')

--- a/tests/supabase-spoof.unit.test.ts
+++ b/tests/supabase-spoof.unit.test.ts
@@ -94,14 +94,15 @@ describe('spoof session storage', () => {
     mocks.createClient.mockReturnValueOnce({ auth: { refreshSession, setSession } })
 
     const { isSpoofed, saveSpoof, unspoofUser } = await import('../src/services/supabase.ts')
+    const validJwt = createJwt(Math.floor(Date.now() / 1000) + 300)
 
-    saveSpoof(createJwt(Math.floor(Date.now() / 1000) + 300), 'stale-refresh-token')
+    saveSpoof(validJwt, 'stale-refresh-token')
 
     await expect(unspoofUser()).resolves.toBe(true)
 
     expect(refreshSession).not.toHaveBeenCalled()
     expect(setSession).toHaveBeenCalledWith({
-      access_token: expect.any(String),
+      access_token: validJwt,
       refresh_token: 'stale-refresh-token',
     })
     expect(isSpoofed()).toBe(false)
@@ -154,6 +155,11 @@ describe('spoof session storage', () => {
 
     await expect(unspoofUser()).resolves.toBe(false)
 
+    expect(refreshSession).toHaveBeenCalledWith({ refresh_token: 'stale-refresh-token' })
+    expect(setSession).toHaveBeenCalledWith({
+      access_token: 'fresh-admin-jwt',
+      refresh_token: 'fresh-admin-refresh-token',
+    })
     expect(localStorage.setItem).toHaveBeenCalledWith(
       expect.stringContaining('.spoof_admin_jwt'),
       JSON.stringify({ jwt: 'fresh-admin-jwt', refreshToken: 'fresh-admin-refresh-token' }),


### PR DESCRIPTION
## Summary

- restore the saved admin session directly when its access token is still valid
- retain spoof recovery state if writing the restored session fails
- cover stale refresh-token and failed restore cases with unit tests

## Root cause

Stopping spoofing always attempted to refresh the saved admin session first. A stale refresh token caused that attempt to fail and cleared the recovery state, leaving the browser signed in as the spoofed user even when the saved admin access token remained valid.

## Validation

- `bun lint`
- `TZ=UTC bun test:unit` (173 files, 1,190 tests)
- `bun typecheck`

The normal-timezone local run has one pre-existing, unrelated date-only test failure in `org-statistics-bandwidth-pagination`; the full suite passes in CI equivalent UTC.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when restoring an administrator session with a still-valid access token.
  * Prevented valid session data from being unnecessarily discarded when token refresh fails.
  * Preserved recovery information when session restoration fails, enabling another recovery attempt.
  * Improved handling of errors while applying restored session data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->