### PR TITLE
fix(frontend): skip URL session confirm for Capgo referrers

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -17,6 +17,7 @@ import mfaIcon from '~icons/simple-icons/2fas?raw'
 import { hideLoader } from '~/services/loader'
 import { autoAuth, defaultApiHost, hashEmail, useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
+import { isCapgoDomainReferrer } from '~/utils/capgoReferrer'
 
 const route = useRoute('/login')
 const supabase = useSupabase()
@@ -566,6 +567,15 @@ async function checkLogin() {
 
       querySessionAccessToken.value = accessToken
       querySessionRefreshToken.value = refreshToken
+
+      // Landing/register handoff from Capgo domains is expected; skip the
+      // confirm step that causes onboarding drop-off. Keep confirmation when
+      // the referrer is missing or external (shared/leaked session links).
+      if (isCapgoDomainReferrer(document.referrer)) {
+        await acceptQuerySession()
+        return
+      }
+
       hasQuerySession.value = true
       isLoading.value = false
       hideLoader()

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -580,6 +580,9 @@ async function handleQuerySessionHandoff(accessToken: string, refreshToken: stri
   // the referrer is missing or external (shared/leaked session links).
   if (isCapgoDomainReferrer(document.referrer)) {
     await acceptQuerySession()
+    // setSession failed: tokens remain in memory — show confirm so user can retry
+    if (querySessionAccessToken.value)
+      hasQuerySession.value = true
     return
   }
 

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -546,6 +546,48 @@ async function openScan() {
   router.push('/scan')
 }
 
+async function acceptQuerySession() {
+  isLoading.value = true
+  const res = await supabase.auth.setSession({
+    access_token: querySessionAccessToken.value,
+    refresh_token: querySessionRefreshToken.value,
+  })
+  if (res.error) {
+    if (res.error.name === 'AuthSessionMissingError')
+      console.warn('Cannot set auth', res.error)
+    else
+      console.error('Cannot set auth', res.error)
+    isLoading.value = false
+    return
+  }
+
+  hasQuerySession.value = false
+  querySessionAccessToken.value = ''
+  querySessionRefreshToken.value = ''
+  nextLogin()
+}
+
+async function handleQuerySessionHandoff(accessToken: string, refreshToken: string, parsedUrl: URL) {
+  parsedUrl.searchParams.delete('access_token')
+  parsedUrl.searchParams.delete('refresh_token')
+  globalThis.history.replaceState({}, '', parsedUrl.toString())
+
+  querySessionAccessToken.value = accessToken
+  querySessionRefreshToken.value = refreshToken
+
+  // Landing/register handoff from Capgo domains is expected; skip the
+  // confirm step that causes onboarding drop-off. Keep confirmation when
+  // the referrer is missing or external (shared/leaked session links).
+  if (isCapgoDomainReferrer(document.referrer)) {
+    await acceptQuerySession()
+    return
+  }
+
+  hasQuerySession.value = true
+  isLoading.value = false
+  hideLoader()
+}
+
 async function checkLogin() {
   try {
     const parsedUrl = new URL(route.fullPath, globalThis.location.origin)
@@ -560,25 +602,8 @@ async function checkLogin() {
     const accessToken = params.get('access_token')
     const refreshToken = params.get('refresh_token')
 
-    if (!!accessToken && !!refreshToken) {
-      parsedUrl.searchParams.delete('access_token')
-      parsedUrl.searchParams.delete('refresh_token')
-      globalThis.history.replaceState({}, '', parsedUrl.toString())
-
-      querySessionAccessToken.value = accessToken
-      querySessionRefreshToken.value = refreshToken
-
-      // Landing/register handoff from Capgo domains is expected; skip the
-      // confirm step that causes onboarding drop-off. Keep confirmation when
-      // the referrer is missing or external (shared/leaked session links).
-      if (isCapgoDomainReferrer(document.referrer)) {
-        await acceptQuerySession()
-        return
-      }
-
-      hasQuerySession.value = true
-      isLoading.value = false
-      hideLoader()
+    if (accessToken && refreshToken) {
+      await handleQuerySessionHandoff(accessToken, refreshToken, parsedUrl)
       return
     }
 
@@ -616,27 +641,6 @@ async function checkLogin() {
   finally {
     isCheckingSavedSession.value = false
   }
-}
-
-async function acceptQuerySession() {
-  isLoading.value = true
-  const res = await supabase.auth.setSession({
-    access_token: querySessionAccessToken.value,
-    refresh_token: querySessionRefreshToken.value,
-  })
-  if (res.error) {
-    if (res.error.name === 'AuthSessionMissingError')
-      console.warn('Cannot set auth', res.error)
-    else
-      console.error('Cannot set auth', res.error)
-    isLoading.value = false
-    return
-  }
-
-  hasQuerySession.value = false
-  querySessionAccessToken.value = ''
-  querySessionRefreshToken.value = ''
-  nextLogin()
 }
 
 function declineQuerySession() {

--- a/src/utils/capgoReferrer.ts
+++ b/src/utils/capgoReferrer.ts
@@ -1,0 +1,17 @@
+/**
+ * Trusted Capgo origins for URL session login handoff (landing → console).
+ * External or missing referrers still require explicit confirmation.
+ */
+export function isCapgoDomainReferrer(referrer: string | null | undefined): boolean {
+  const trimmed = referrer?.trim()
+  if (!trimmed)
+    return false
+
+  try {
+    const { hostname } = new URL(trimmed)
+    return hostname === 'capgo.app' || hostname.endsWith('.capgo.app')
+  }
+  catch {
+    return false
+  }
+}

--- a/tests/capgo-referrer.unit.test.ts
+++ b/tests/capgo-referrer.unit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { isCapgoDomainReferrer } from '../src/utils/capgoReferrer'
+
+describe('isCapgoDomainReferrer', () => {
+  it.concurrent('accepts Capgo marketing and console hosts', () => {
+    expect(isCapgoDomainReferrer('https://capgo.app/register/')).toBe(true)
+    expect(isCapgoDomainReferrer('https://www.capgo.app/register/')).toBe(true)
+    expect(isCapgoDomainReferrer('https://console.capgo.app/login')).toBe(true)
+    expect(isCapgoDomainReferrer('https://development.capgo.app/register')).toBe(true)
+    expect(isCapgoDomainReferrer('https://sb.capgo.app/auth/v1/verify')).toBe(true)
+  })
+
+  it.concurrent('rejects missing, invalid, and non-Capgo referrers', () => {
+    expect(isCapgoDomainReferrer(undefined)).toBe(false)
+    expect(isCapgoDomainReferrer(null)).toBe(false)
+    expect(isCapgoDomainReferrer('')).toBe(false)
+    expect(isCapgoDomainReferrer('not-a-url')).toBe(false)
+    expect(isCapgoDomainReferrer('https://evil.com/')).toBe(false)
+    expect(isCapgoDomainReferrer('https://capgo.app.evil.com/')).toBe(false)
+    expect(isCapgoDomainReferrer('https://notcapgo.app/')).toBe(false)
+    expect(isCapgoDomainReferrer('http://localhost:5173/register')).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Auto-accept `access_token` / `refresh_token` login handoff when `document.referrer` is a Capgo domain (`capgo.app` or `*.capgo.app`)
- Keep the existing “This link contains a login session…” confirmation for missing or external referrers (shared/leaked session links)
- If Capgo auto-accept `setSession` fails, fall back to the confirmation UI (and hide the loader) so users can retry
- Add a small pure helper + unit tests for Capgo referrer detection

## Motivation (AI generated)

After registration on the Capgo landing page, users are redirected to the console login with session tokens in the URL. The security confirmation step feels unexpected in that first-party flow and causes meaningful onboarding drop-off (~20%). That confirmation should only protect non-Capgo sources.

## Business Impact (AI generated)

Improves signup → console conversion by removing an unnecessary friction step for people coming from Capgo domains, while preserving the security guard for suspicious external session links.

## Test Plan (AI generated)

- [x] Unit tests for `isCapgoDomainReferrer` (`bunx vitest run tests/capgo-referrer.unit.test.ts`)
- [x] CI green on latest PR run
- [ ] From `https://capgo.app` (or another Capgo host), open `/login?access_token=...&refresh_token=...` and confirm session is accepted without the prompt
- [ ] Open the same URL from a non-Capgo site (or with no referrer) and confirm the prompt still appears
- [ ] Accept/decline still work on the confirmation prompt for external referrers

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc3a1-8958-7a87-9de2-007b35f4b799?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc3a1-8958-7a87-9de2-007b35f4b799&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capgo-originated login links now complete session handoff automatically.
  * Other login link sources continue to display a confirmation prompt.
  * Login tokens are removed from the URL after processing for improved security.

* **Bug Fixes**
  * Improved referrer validation to accept only genuine Capgo domains and reject invalid or deceptive URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->