### PR TITLE
fix(frontend): hide loader when Capgo session auto-accept fails

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -581,8 +581,10 @@ async function handleQuerySessionHandoff(accessToken: string, refreshToken: stri
   if (isCapgoDomainReferrer(document.referrer)) {
     await acceptQuerySession()
     // setSession failed: tokens remain in memory — show confirm so user can retry
-    if (querySessionAccessToken.value)
+    if (querySessionAccessToken.value) {
       hasQuerySession.value = true
+      hideLoader()
+    }
     return
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Call `hideLoader()` when Capgo-referrer session auto-accept fails and we fall back to the retry confirmation UI
- Fixes a follow-up finding from [#2830](https://github.com/Cap-go/capgo.app/pull/2830): without this, `#app-loader` stays up and the Continue/Cancel prompt is unreachable

## Motivation (AI generated)

PR #2830 auto-accepts login session tokens for Capgo referrers and falls back to the confirmation prompt if `setSession` fails. That fallback set `hasQuerySession` but did not hide the full-screen loader, so the retry UI could be invisible. CodeRabbit, Cubic, and Bugbot all flagged this after merge.

## Business Impact (AI generated)

Prevents a rare but blocking recovery path for users coming from Capgo registration when session handoff fails, so they can still continue or cancel instead of being stuck behind the loader.

## Test Plan (AI generated)

- [ ] On `/login?access_token=...&refresh_token=...` with a Capgo `document.referrer`, force `setSession` to fail and confirm the session prompt is visible (loader gone)
- [ ] Successful Capgo auto-accept still proceeds without showing the confirm prompt
- [ ] External/missing referrer path still shows confirm and hides loader as before

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc3a1-8958-7a87-9de2-007b35f4b799?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc3a1-8958-7a87-9de2-007b35f4b799&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query-session handoff behavior when session acceptance fails.
  * The loading indicator now hides while keeping available tokens for retry.
  * Confirmation is shown only when the access token remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->