### PR TITLE
fix(cli): honor scalar wildcard provisioning entitlements

### DIFF
--- a/cli/src/build/prescan/checks/ios-entitlements-checks.ts
+++ b/cli/src/build/prescan/checks/ios-entitlements-checks.ts
@@ -156,7 +156,9 @@ export const entitlementsVsProfileCapability: PrescanCheck = {
         if (isArray) {
           const appMembers = entArray(app.raw, key)
           const profileValue = profileEnt[key]
-          const profileMembers = Array.isArray(profileValue) ? profileValue : []
+          const profileMembers = Array.isArray(profileValue)
+            ? profileValue
+            : typeof profileValue === 'string' ? [profileValue] : []
           if (profileMembers.some(isWildcardMember))
             continue
           // Compare on the prefix-normalized suffix: app members carry the

--- a/cli/test/prescan/checks-ios-entitlements-config.test.ts
+++ b/cli/test/prescan/checks-ios-entitlements-config.test.ts
@@ -183,6 +183,14 @@ describe('ios/entitlements-vs-profile-capability', () => {
     expect(await entitlementsVsProfileCapability.run(ctx)).toEqual([])
   })
 
+  it('treats a scalar profile wildcard (*) as covering all app members', async () => {
+    const ctx = ctxWithEntitlements(
+      '<key>com.apple.developer.associated-domains</key><array><string>applinks:example.com</string></array>',
+      { credentials: { CAPGO_IOS_PROVISIONING_MAP: mapWith(profileXml('<key>com.apple.developer.associated-domains</key><string>*</string>')) } },
+    )
+    expect(await entitlementsVsProfileCapability.run(ctx)).toEqual([])
+  })
+
   it('treats a $(AppIdentifierPrefix)* profile member as covering all app members', async () => {
     const ctx = ctxWithEntitlements(
       '<key>keychain-access-groups</key><array><string>TEAM123456.com.demo.app</string></array>',


### PR DESCRIPTION
## What changed

- Normalize scalar provisioning-profile entitlement values into the member-list comparison used by the iOS prescan.
- Add regression coverage for `com.apple.developer.associated-domains = *` covering a concrete app domain.

## Root cause

App associated domains are array-valued, while Apple may encode the provisioning-profile wildcard grant as the scalar string `*`. The prescan previously discarded non-array profile values before wildcard matching, producing an empty grant and a false-positive blocking finding.

## Impact

Cloud Build prescan now accepts Apple's wildcard associated-domains grant and no longer reports `associated-domains not fully covered` for valid profiles.

## Validation

- `bun lint`
- `bun run cli:check`
- Regression verified red before the implementation and green afterward.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed iOS entitlement validation so scalar string values in provisioning profiles are correctly recognized when checking array-based entitlements.
  - Wildcard provisioning-profile entitlements now properly cover associated-domain entries.

- **Tests**
  - Added regression coverage for wildcard entitlement handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->