### PR TITLE
feat(cli): detect incompatible PKCS#12 encryption in prescan

### DIFF
--- a/cli/src/build/prescan/checks/ios-certs.ts
+++ b/cli/src/build/prescan/checks/ios-certs.ts
@@ -13,19 +13,69 @@ type CertBag = forge.pkcs12.Bag
 const SHA1_OID = '1.3.14.3.2.26'
 const PBES2_OID = '1.2.840.113549.1.5.13'
 const PBESV1_SHA1_3DES_OID = '1.2.840.113549.1.12.1.3'
+const AES_CBC_OIDS = new Set([
+  '2.16.840.1.101.3.4.1.2',
+  '2.16.840.1.101.3.4.1.22',
+  '2.16.840.1.101.3.4.1.42',
+])
 
-function collectOids(node: forge.asn1.Asn1, oids: Set<string>, depth = 0): void {
+class MalformedP12Error extends Error {
+  constructor() {
+    super('malformed PKCS12 ASN.1')
+    this.name = 'MalformedP12Error'
+  }
+}
+
+interface PrivateKeyEncryption {
+  algorithmOid: string
+  encryptionSchemeOid: string | null
+}
+
+function asn1Children(node: forge.asn1.Asn1 | undefined): forge.asn1.Asn1[] {
+  return node && Array.isArray(node.value) ? node.value : []
+}
+
+function asn1Oid(node: forge.asn1.Asn1 | undefined): string | null {
+  if (!node || node.type !== forge.asn1.Type.OID || typeof node.value !== 'string')
+    return null
+  try {
+    return forge.asn1.derToOid(node.value)
+  }
+  catch {
+    return null
+  }
+}
+
+function privateKeyEncryptionFromSafeBag(node: forge.asn1.Asn1): PrivateKeyEncryption | null {
+  const bag = asn1Children(node)
+  if (asn1Oid(bag[0]) !== forge.pki.oids.pkcs8ShroudedKeyBag)
+    return null
+  const encryptedPrivateKeyInfo = asn1Children(bag[1])[0]
+  const algorithmIdentifier = asn1Children(encryptedPrivateKeyInfo)[0]
+  const algorithm = asn1Children(algorithmIdentifier)
+  const algorithmOid = asn1Oid(algorithm[0])
+  if (!algorithmOid)
+    return null
+  const pbes2Params = asn1Children(algorithm[1])
+  const encryptionScheme = asn1Children(pbes2Params[1])
+  return { algorithmOid, encryptionSchemeOid: asn1Oid(encryptionScheme[0]) }
+}
+
+function collectPrivateKeyEncryptions(node: forge.asn1.Asn1, result: PrivateKeyEncryption[], depth = 0): void {
   if (depth > 32)
     return
-  if (node.type === forge.asn1.Type.OID && typeof node.value === 'string')
-    oids.add(forge.asn1.derToOid(node.value))
+  const encryption = privateKeyEncryptionFromSafeBag(node)
+  if (encryption) {
+    result.push(encryption)
+    return // Never interpret encrypted private-key bytes as nested ASN.1.
+  }
   if (Array.isArray(node.value)) {
     for (const child of node.value)
-      collectOids(child, oids, depth + 1)
+      collectPrivateKeyEncryptions(child, result, depth + 1)
   }
   else if (node.type === forge.asn1.Type.OCTETSTRING && node.value.length > 0) {
     try {
-      collectOids(forge.asn1.fromDer(node.value), oids, depth + 1)
+      collectPrivateKeyEncryptions(forge.asn1.fromDer(node.value), result, depth + 1)
     }
     catch {
       // Most OCTET STRING values are encrypted bytes or certificate fields,
@@ -46,28 +96,44 @@ function p12MacAlgorithm(pfx: forge.asn1.Asn1): string | null {
   const algorithmIdentifier = digestInfo.value[0]
   if (!algorithmIdentifier || !Array.isArray(algorithmIdentifier.value))
     return null
-  const oid = algorithmIdentifier.value[0]
-  if (!oid || oid.type !== forge.asn1.Type.OID || typeof oid.value !== 'string')
-    return null
-  return forge.asn1.derToOid(oid.value)
+  return asn1Oid(algorithmIdentifier.value[0])
+}
+
+function parseP12Asn1(base64: string): forge.asn1.Asn1 {
+  try {
+    return forge.asn1.fromDer(forge.util.decode64(base64))
+  }
+  catch {
+    throw new MalformedP12Error()
+  }
 }
 
 function legacyP12CompatibilityProblems(base64: string): string[] {
   assertCredentialBlobSize(base64, 'certificate')
-  const der = forge.util.decode64(base64)
-  const pfx = forge.asn1.fromDer(der)
-  const oids = new Set<string>()
-  collectOids(pfx, oids)
+  const pfx = parseP12Asn1(base64)
+  const privateKeyEncryptions: PrivateKeyEncryption[] = []
+  collectPrivateKeyEncryptions(pfx, privateKeyEncryptions)
 
-  const problems: string[] = []
+  const problems = new Set<string>()
   const macAlgorithm = p12MacAlgorithm(pfx)
   if (macAlgorithm !== SHA1_OID)
-    problems.push(macAlgorithm === forge.pki.oids.sha256 ? 'SHA-256 MAC' : 'non-SHA-1 MAC')
-  if (oids.has(PBES2_OID))
-    problems.push('PBES2/AES encryption')
-  else if (!oids.has(PBESV1_SHA1_3DES_OID))
-    problems.push('missing PBESv1 SHA-1/3DES private-key encryption')
-  return problems
+    problems.add(macAlgorithm === forge.pki.oids.sha256 ? 'SHA-256 MAC' : 'non-SHA-1 MAC')
+  if (privateKeyEncryptions.length === 0) {
+    problems.add('missing PBESv1 SHA-1/3DES private-key encryption')
+  }
+  for (const encryption of privateKeyEncryptions) {
+    if (encryption.algorithmOid === PBESV1_SHA1_3DES_OID)
+      continue
+    if (encryption.algorithmOid === PBES2_OID) {
+      problems.add(AES_CBC_OIDS.has(encryption.encryptionSchemeOid ?? '')
+        ? 'PBES2/AES private-key encryption'
+        : 'PBES2 private-key encryption')
+    }
+    else {
+      problems.add('unsupported private-key encryption')
+    }
+  }
+  return [...problems]
 }
 
 function bagLocalKeyIdHex(bag: CertBag): string | null {
@@ -189,8 +255,10 @@ export const p12LegacyEncryption: PrescanCheck = {
     try {
       problems = legacyP12CompatibilityProblems(ctx.credentials!.BUILD_CERTIFICATE_BASE64)
     }
-    catch {
-      return [] // p12-opens owns malformed/invalid P12 failures
+    catch (error) {
+      if (error instanceof MalformedP12Error)
+        return [] // p12-opens owns malformed/invalid P12 failures
+      throw error
     }
     if (problems.length === 0)
       return []

--- a/cli/src/build/prescan/checks/ios-certs.ts
+++ b/cli/src/build/prescan/checks/ios-certs.ts
@@ -65,7 +65,7 @@ function legacyP12CompatibilityProblems(base64: string): string[] {
     problems.push(macAlgorithm === forge.pki.oids.sha256 ? 'SHA-256 MAC' : 'non-SHA-1 MAC')
   if (oids.has(PBES2_OID))
     problems.push('PBES2/AES encryption')
-  if (!oids.has(PBESV1_SHA1_3DES_OID))
+  else if (!oids.has(PBESV1_SHA1_3DES_OID))
     problems.push('missing PBESv1 SHA-1/3DES private-key encryption')
   return problems
 }

--- a/cli/src/build/prescan/checks/ios-certs.ts
+++ b/cli/src/build/prescan/checks/ios-certs.ts
@@ -19,6 +19,7 @@ const AES_CBC_OIDS = new Set([
   '2.16.840.1.101.3.4.1.42',
 ])
 
+/** Marks malformed outer PFX input that the existing p12-opens check owns. */
 class MalformedP12Error extends Error {
   constructor() {
     super('malformed PKCS12 ASN.1')
@@ -31,10 +32,12 @@ interface PrivateKeyEncryption {
   encryptionSchemeOid: string | null
 }
 
+/** Return constructed ASN.1 children, or an empty list for primitive nodes. */
 function asn1Children(node: forge.asn1.Asn1 | undefined): forge.asn1.Asn1[] {
   return node && Array.isArray(node.value) ? node.value : []
 }
 
+/** Decode an ASN.1 OID node without letting malformed OID bytes crash the scan. */
 function asn1Oid(node: forge.asn1.Asn1 | undefined): string | null {
   if (!node || node.type !== forge.asn1.Type.OID || typeof node.value !== 'string')
     return null
@@ -46,6 +49,7 @@ function asn1Oid(node: forge.asn1.Asn1 | undefined): string | null {
   }
 }
 
+/** Read the encryption algorithm attached to a PKCS8ShroudedKeyBag only. */
 function privateKeyEncryptionFromSafeBag(node: forge.asn1.Asn1): PrivateKeyEncryption | null {
   const bag = asn1Children(node)
   if (asn1Oid(bag[0]) !== forge.pki.oids.pkcs8ShroudedKeyBag)
@@ -61,6 +65,7 @@ function privateKeyEncryptionFromSafeBag(node: forge.asn1.Asn1): PrivateKeyEncry
   return { algorithmOid, encryptionSchemeOid: asn1Oid(encryptionScheme[0]) }
 }
 
+/** Find encrypted private-key bags through the nested PKCS#12 ContentInfo layers. */
 function collectPrivateKeyEncryptions(node: forge.asn1.Asn1, result: PrivateKeyEncryption[], depth = 0): void {
   if (depth > 32)
     return
@@ -84,6 +89,7 @@ function collectPrivateKeyEncryptions(node: forge.asn1.Asn1, result: PrivateKeyE
   }
 }
 
+/** Read the PFX MAC digest algorithm from the optional MacData block. */
 function p12MacAlgorithm(pfx: forge.asn1.Asn1): string | null {
   if (!Array.isArray(pfx.value))
     return null
@@ -99,6 +105,7 @@ function p12MacAlgorithm(pfx: forge.asn1.Asn1): string | null {
   return asn1Oid(algorithmIdentifier.value[0])
 }
 
+/** Parse the outer PFX while tagging malformed input for p12-opens to report. */
 function parseP12Asn1(base64: string): forge.asn1.Asn1 {
   try {
     return forge.asn1.fromDer(forge.util.decode64(base64))
@@ -108,6 +115,7 @@ function parseP12Asn1(base64: string): forge.asn1.Asn1 {
   }
 }
 
+/** List runner-incompatible MAC and private-key encryption choices in a P12. */
 function legacyP12CompatibilityProblems(base64: string): string[] {
   assertCredentialBlobSize(base64, 'certificate')
   const pfx = parseP12Asn1(base64)

--- a/cli/src/build/prescan/checks/ios-certs.ts
+++ b/cli/src/build/prescan/checks/ios-certs.ts
@@ -10,6 +10,66 @@ export interface OpenedP12 {
 
 type CertBag = forge.pkcs12.Bag
 
+const SHA1_OID = '1.3.14.3.2.26'
+const PBES2_OID = '1.2.840.113549.1.5.13'
+const PBESV1_SHA1_3DES_OID = '1.2.840.113549.1.12.1.3'
+
+function collectOids(node: forge.asn1.Asn1, oids: Set<string>, depth = 0): void {
+  if (depth > 32)
+    return
+  if (node.type === forge.asn1.Type.OID && typeof node.value === 'string')
+    oids.add(forge.asn1.derToOid(node.value))
+  if (Array.isArray(node.value)) {
+    for (const child of node.value)
+      collectOids(child, oids, depth + 1)
+  }
+  else if (node.type === forge.asn1.Type.OCTETSTRING && node.value.length > 0) {
+    try {
+      collectOids(forge.asn1.fromDer(node.value), oids, depth + 1)
+    }
+    catch {
+      // Most OCTET STRING values are encrypted bytes or certificate fields,
+      // not nested ASN.1. Only descend when forge can decode the whole value.
+    }
+  }
+}
+
+function p12MacAlgorithm(pfx: forge.asn1.Asn1): string | null {
+  if (!Array.isArray(pfx.value))
+    return null
+  const macData = pfx.value[2]
+  if (!macData || !Array.isArray(macData.value))
+    return null
+  const digestInfo = macData.value[0]
+  if (!digestInfo || !Array.isArray(digestInfo.value))
+    return null
+  const algorithmIdentifier = digestInfo.value[0]
+  if (!algorithmIdentifier || !Array.isArray(algorithmIdentifier.value))
+    return null
+  const oid = algorithmIdentifier.value[0]
+  if (!oid || oid.type !== forge.asn1.Type.OID || typeof oid.value !== 'string')
+    return null
+  return forge.asn1.derToOid(oid.value)
+}
+
+function legacyP12CompatibilityProblems(base64: string): string[] {
+  assertCredentialBlobSize(base64, 'certificate')
+  const der = forge.util.decode64(base64)
+  const pfx = forge.asn1.fromDer(der)
+  const oids = new Set<string>()
+  collectOids(pfx, oids)
+
+  const problems: string[] = []
+  const macAlgorithm = p12MacAlgorithm(pfx)
+  if (macAlgorithm !== SHA1_OID)
+    problems.push(macAlgorithm === forge.pki.oids.sha256 ? 'SHA-256 MAC' : 'non-SHA-1 MAC')
+  if (oids.has(PBES2_OID))
+    problems.push('PBES2/AES encryption')
+  if (!oids.has(PBESV1_SHA1_3DES_OID))
+    problems.push('missing PBESv1 SHA-1/3DES private-key encryption')
+  return problems
+}
+
 function bagLocalKeyIdHex(bag: CertBag): string | null {
   const attr = (bag.attributes as Record<string, unknown[]> | undefined)?.localKeyId?.[0]
   return typeof attr === 'string' ? forge.util.bytesToHex(attr) : null
@@ -117,6 +177,30 @@ export const p12Opens: PrescanCheck = {
         fix: 'Re-export the .p12 and re-run `build credentials save` with the correct --p12-password',
       }]
     }
+  },
+}
+
+export const p12LegacyEncryption: PrescanCheck = {
+  id: 'ios/p12-legacy-encryption',
+  platforms: ['ios'],
+  appliesTo: ctx => has(ctx, 'BUILD_CERTIFICATE_BASE64'),
+  async run(ctx): Promise<Finding[]> {
+    let problems: string[]
+    try {
+      problems = legacyP12CompatibilityProblems(ctx.credentials!.BUILD_CERTIFICATE_BASE64)
+    }
+    catch {
+      return [] // p12-opens owns malformed/invalid P12 failures
+    }
+    if (problems.length === 0)
+      return []
+    return [{
+      id: 'ios/p12-legacy-encryption',
+      severity: 'error',
+      title: 'The P12 certificate uses encryption that the macOS build runner cannot import',
+      detail: `Detected ${problems.join(' and ')}. Fastlane security import may report a wrong password even when the password is correct.`,
+      fix: 'Re-export the .p12 with PBESv1 SHA-1/3DES encryption and a SHA-1 MAC, then re-run `build credentials save`.',
+    }]
   },
 }
 

--- a/cli/src/build/prescan/registry.ts
+++ b/cli/src/build/prescan/registry.ts
@@ -34,7 +34,7 @@ import {
   versionFields,
 } from './checks/android-project'
 import { credentialsSaved } from './checks/credentials'
-import { ascKeyValid, p12Expiry, p12Opens } from './checks/ios-certs'
+import { ascKeyValid, p12Expiry, p12LegacyEncryption, p12Opens } from './checks/ios-certs'
 import { infoplistSanity } from './checks/ios-plist'
 import { certProfilePairing, profileBundleMatch, profileExpiry, profileTypeVsMode, targetsCovered } from './checks/ios-profiles'
 import {
@@ -87,6 +87,9 @@ import { ascKeyAccess, playSaAccess } from './checks/store-access'
 /** New iOS expansion checks become build-blocking at this UTC instant. */
 export const IOS_PRESCAN_EXPANSION_ENFORCE_AFTER = '2026-08-14T00:00:00.000Z'
 
+/** Legacy P12 encryption becomes mandatory for macOS runner compatibility at this UTC instant. */
+export const IOS_P12_LEGACY_ENFORCE_AFTER = '2026-08-17T00:00:00.000Z'
+
 const IOS_EXPANSION_CHECKS: PrescanCheck[] = [
   // ios plist (Info.plist / App Store)
   plistBundleIdFormat, plistVersionShortFormat, plistVersionBuildFormat,
@@ -113,7 +116,8 @@ export const ALL_CHECKS: PrescanCheck[] = [
   apikeyPermission, appExists, credentialsSaved,
   capSyncStale, nodeLinkerLayout, bundleIdConsistency,
   // ios certs / profiles / plist
-  p12Opens, p12Expiry, profileExpiry, profileBundleMatch, profileTypeVsMode,
+  p12Opens, { ...p12LegacyEncryption, enforceAfter: IOS_P12_LEGACY_ENFORCE_AFTER },
+  p12Expiry, profileExpiry, profileBundleMatch, profileTypeVsMode,
   certProfilePairing, targetsCovered, infoplistSanity, ascKeyValid,
   // android keystore / project
   keystoreOpens, keystoreExpiry, cordovaVarsPresent, gradlePropsHeuristics,

--- a/cli/test/prescan/checks-ios-certs.test.ts
+++ b/cli/test/prescan/checks-ios-certs.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from 'bun:test'
 import forge from 'node-forge'
 import { MAX_CREDENTIAL_B64_CHARS } from '../../src/build/prescan/checks/blob-limit'
-import { ascKeyValid, openP12, p12Expiry, p12Opens } from '../../src/build/prescan/checks/ios-certs'
+import { ascKeyValid, openP12, p12Expiry, p12LegacyEncryption, p12Opens } from '../../src/build/prescan/checks/ios-certs'
 import { makeChainP12, makeCtx, makeP12 } from './helpers'
 
 function ctxWith(creds: Record<string, string>) {
@@ -23,6 +23,38 @@ describe('ios/p12-opens', () => {
   it('errors on garbage base64', async () => {
     const f = await p12Opens.run(ctxWith({ BUILD_CERTIFICATE_BASE64: 'not-a-p12', P12_PASSWORD: '' }))
     expect(f[0]?.severity).toBe('error')
+  })
+})
+
+describe('ios/p12-legacy-encryption', () => {
+  it('passes legacy PBESv1 3DES with a SHA-1 MAC', async () => {
+    const p12 = makeP12()
+    expect(await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: p12.base64, P12_PASSWORD: p12.password }))).toEqual([])
+  })
+
+  it('errors on PBES2 AES encryption even though the password is valid', async () => {
+    const p12 = makeP12({ algorithm: 'aes256' })
+    expect(await p12Opens.run(ctxWith({ BUILD_CERTIFICATE_BASE64: p12.base64, P12_PASSWORD: p12.password }))).toEqual([])
+
+    const findings = await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: p12.base64, P12_PASSWORD: p12.password }))
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.severity).toBe('error')
+    expect(findings[0]?.title).toContain('macOS build runner')
+    expect(findings[0]?.detail).toContain('PBES2/AES')
+    expect(findings[0]?.fix).toContain('PBESv1 SHA-1/3DES')
+  })
+
+  it('errors on a SHA-256 MAC even when private-key encryption is legacy 3DES', async () => {
+    const p12 = makeP12({ macAlgorithm: 'sha256' })
+    expect(await p12Opens.run(ctxWith({ BUILD_CERTIFICATE_BASE64: p12.base64, P12_PASSWORD: p12.password }))).toEqual([])
+
+    const findings = await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: p12.base64, P12_PASSWORD: p12.password }))
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.detail).toContain('SHA-256 MAC')
+  })
+
+  it('defers malformed files to ios/p12-opens instead of duplicating its error', async () => {
+    expect(await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: 'not-a-p12', P12_PASSWORD: '' }))).toEqual([])
   })
 })
 

--- a/cli/test/prescan/checks-ios-certs.test.ts
+++ b/cli/test/prescan/checks-ios-certs.test.ts
@@ -9,6 +9,75 @@ function ctxWith(creds: Record<string, string>) {
   return makeCtx({ projectDir: '/tmp', platform: 'ios', credentials: creds })
 }
 
+function asn1Children(node: forge.asn1.Asn1): forge.asn1.Asn1[] {
+  return Array.isArray(node.value) ? node.value : []
+}
+
+function asn1Oid(node: forge.asn1.Asn1 | undefined): string | null {
+  if (!node || node.type !== forge.asn1.Type.OID || typeof node.value !== 'string')
+    return null
+  return forge.asn1.derToOid(node.value)
+}
+
+function mutateSafeBag(root: forge.asn1.Asn1, bagOid: string, mutate: (bag: forge.asn1.Asn1) => void): boolean {
+  const children = asn1Children(root)
+  if (asn1Oid(children[0]) === bagOid) {
+    mutate(root)
+    return true
+  }
+  for (const child of children) {
+    if (mutateSafeBag(child, bagOid, mutate))
+      return true
+  }
+  if (root.type === forge.asn1.Type.OCTETSTRING && typeof root.value === 'string') {
+    try {
+      const nested = forge.asn1.fromDer(root.value)
+      if (mutateSafeBag(nested, bagOid, mutate)) {
+        root.value = forge.asn1.toDer(nested).getBytes()
+        return true
+      }
+    }
+    catch {
+      // Encrypted and certificate OCTET STRING values are not nested ASN.1.
+    }
+  }
+  return false
+}
+
+function mutatePrivateKeyEncryption(
+  base64: string,
+  algorithmOid: string,
+  encryptionSchemeOid?: string,
+  unrelatedLegacyOidInCertBag = false,
+): string {
+  const pfx = forge.asn1.fromDer(forge.util.decode64(base64))
+  const foundKeyBag = mutateSafeBag(pfx, forge.pki.oids.pkcs8ShroudedKeyBag, (keyBag) => {
+    const encryptedPrivateKeyInfo = asn1Children(asn1Children(keyBag)[1]!)[0]!
+    const algorithmIdentifier = asn1Children(encryptedPrivateKeyInfo)[0]!
+    const algorithm = asn1Children(algorithmIdentifier)
+    algorithm[0]!.value = forge.asn1.oidToDer(algorithmOid).getBytes()
+    if (encryptionSchemeOid) {
+      const pbes2Params = asn1Children(algorithm[1]!)
+      const encryptionScheme = asn1Children(pbes2Params[1]!)
+      encryptionScheme[0]!.value = forge.asn1.oidToDer(encryptionSchemeOid).getBytes()
+    }
+  })
+  if (!foundKeyBag)
+    throw new Error('fixture has no shrouded private-key bag')
+  if (unrelatedLegacyOidInCertBag) {
+    const foundCertBag = mutateSafeBag(pfx, forge.pki.oids.certBag, (certBag) => {
+      const attributes = asn1Children(certBag)[2]!
+      asn1Children(attributes).push(forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
+        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, forge.asn1.oidToDer('1.2.840.113549.1.12.1.3').getBytes()),
+        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SET, true, []),
+      ]))
+    })
+    if (!foundCertBag)
+      throw new Error('fixture has no certificate bag')
+  }
+  return forge.util.encode64(forge.asn1.toDer(pfx).getBytes())
+}
+
 describe('ios/p12-opens', () => {
   it('errors on wrong password', async () => {
     const p12 = makeP12({ password: 'right' })
@@ -44,6 +113,25 @@ describe('ios/p12-legacy-encryption', () => {
     expect(findings[0]?.fix).toContain('PBESv1 SHA-1/3DES')
   })
 
+  it('identifies a non-AES PBES2 private-key scheme without calling it AES', async () => {
+    const p12 = makeP12({ algorithm: 'aes256' })
+    const base64 = mutatePrivateKeyEncryption(p12.base64, '1.2.840.113549.1.5.13', '1.2.840.113549.3.2')
+
+    const findings = await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: base64, P12_PASSWORD: p12.password }))
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.detail).toContain('PBES2 private-key encryption')
+    expect(findings[0]?.detail).not.toContain('PBES2/AES')
+  })
+
+  it('does not let a legacy OID in a certificate bag hide incompatible private-key encryption', async () => {
+    const p12 = makeP12({ algorithm: '3des' })
+    const base64 = mutatePrivateKeyEncryption(p12.base64, '1.2.3.4', undefined, true)
+
+    const findings = await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: base64, P12_PASSWORD: p12.password }))
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.detail).toContain('unsupported private-key encryption')
+  })
+
   it('errors on a SHA-256 MAC even when private-key encryption is legacy 3DES', async () => {
     const p12 = makeP12({ macAlgorithm: 'sha256' })
     expect(await p12Opens.run(ctxWith({ BUILD_CERTIFICATE_BASE64: p12.base64, P12_PASSWORD: p12.password }))).toEqual([])
@@ -55,6 +143,11 @@ describe('ios/p12-legacy-encryption', () => {
 
   it('defers malformed files to ios/p12-opens instead of duplicating its error', async () => {
     expect(await p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: 'not-a-p12', P12_PASSWORD: '' }))).toEqual([])
+  })
+
+  it('does not suppress non-parsing failures', async () => {
+    const huge = 'A'.repeat(MAX_CREDENTIAL_B64_CHARS + 1)
+    await expect(p12LegacyEncryption.run(ctxWith({ BUILD_CERTIFICATE_BASE64: huge, P12_PASSWORD: '' }))).rejects.toThrow('limit 10 MB')
   })
 })
 

--- a/cli/test/prescan/engine.test.ts
+++ b/cli/test/prescan/engine.test.ts
@@ -150,14 +150,14 @@ describe('fixture helpers', () => {
 })
 
 describe('registry', () => {
-  it('contains all 80 checks with unique ids', () => {
+  it('contains all 81 checks with unique ids', () => {
     const ids = ALL_CHECKS.map(c => c.id)
     expect(new Set(ids).size).toBe(ids.length)
-    expect(ids.length).toBe(80)
+    expect(ids.length).toBe(81)
     for (const expected of [
       'shared/apikey-permission', 'shared/app-exists', 'shared/credentials-saved',
       'shared/cap-sync-stale', 'shared/node-linker-layout', 'shared/bundle-id-consistency',
-      'ios/p12-opens', 'ios/p12-expiry', 'ios/profile-expiry', 'ios/profile-bundle-match',
+      'ios/p12-opens', 'ios/p12-legacy-encryption', 'ios/p12-expiry', 'ios/profile-expiry', 'ios/profile-bundle-match',
       'ios/profile-type-vs-mode', 'ios/cert-profile-pairing', 'ios/targets-covered',
       'ios/infoplist-sanity', 'ios/asc-key-valid',
       // 10 ios plist checks

--- a/cli/test/prescan/engine.test.ts
+++ b/cli/test/prescan/engine.test.ts
@@ -1,7 +1,7 @@
 // test/prescan/engine.test.ts
 import { describe, expect, it } from 'bun:test'
 import { decideOutcome, runPrescan } from '../../src/build/prescan/engine'
-import { ALL_CHECKS, IOS_PRESCAN_EXPANSION_ENFORCE_AFTER } from '../../src/build/prescan/registry'
+import { ALL_CHECKS, IOS_P12_LEGACY_ENFORCE_AFTER, IOS_PRESCAN_EXPANSION_ENFORCE_AFTER } from '../../src/build/prescan/registry'
 import type { PrescanCheck, ScanContext } from '../../src/build/prescan/types'
 import { makeP12, makeProfileXmlWithCert, makeProject } from './helpers'
 
@@ -201,6 +201,26 @@ describe('registry', () => {
     expect(deferred.length).toBe(33)
     expect(deferred.every(check => check.id.startsWith('ios/'))).toBe(true)
     expect(ALL_CHECKS.find(check => check.id === 'ios/p12-opens')?.enforceAfter).toBeUndefined()
+  })
+
+  it('makes legacy P12 encryption fatal after its dedicated 14-day rollout', () => {
+    expect(IOS_P12_LEGACY_ENFORCE_AFTER).toBe('2026-08-17T00:00:00.000Z')
+    expect(ALL_CHECKS.find(check => check.id === 'ios/p12-legacy-encryption')?.enforceAfter).toBe(IOS_P12_LEGACY_ENFORCE_AFTER)
+
+    const rolloutReport = {
+      findings: [{
+        id: 'ios/p12-legacy-encryption',
+        severity: 'error' as const,
+        title: 'modern P12',
+        enforceAfter: IOS_P12_LEGACY_ENFORCE_AFTER,
+      }],
+      counts: { error: 1, warning: 0, info: 0 },
+      skippedRemote: 0,
+      durationMs: 0,
+      checksRun: 1,
+    }
+    expect(decideOutcome(rolloutReport, { now: new Date('2026-08-16T23:59:59.999Z') })).toBe('proceed')
+    expect(decideOutcome(rolloutReport, { now: new Date(IOS_P12_LEGACY_ENFORCE_AFTER) })).toBe('block')
   })
 })
 

--- a/cli/test/prescan/helpers.ts
+++ b/cli/test/prescan/helpers.ts
@@ -43,7 +43,13 @@ export function certDerFromP12(p12: MadeP12): Buffer {
 }
 
 /** Self-signed cert + key wrapped in a password-protected P12 (pure node-forge, no binaries). */
-export function makeP12(opts: { password?: string, notAfter?: Date, cn?: string } = {}): MadeP12 {
+export function makeP12(opts: {
+  password?: string
+  notAfter?: Date
+  cn?: string
+  algorithm?: '3des' | 'aes256'
+  macAlgorithm?: 'sha1' | 'sha256'
+} = {}): MadeP12 {
   const password = opts.password ?? 'test-pass'
   const keys = forge.pki.rsa.generateKeyPair(2048)
   const cert = forge.pki.createCertificate()
@@ -56,7 +62,24 @@ export function makeP12(opts: { password?: string, notAfter?: Date, cn?: string 
   cert.setIssuer(attrs)
   cert.sign(keys.privateKey, forge.md.sha256.create())
 
-  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, [cert], password, { algorithm: '3des' })
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, [cert], password, { algorithm: opts.algorithm ?? '3des' })
+  if (opts.macAlgorithm === 'sha256') {
+    const pfx = p12Asn1.value as forge.asn1.Asn1[]
+    const authSafeContentInfo = pfx[1]!.value as forge.asn1.Asn1[]
+    const authSafeWrapper = authSafeContentInfo[1]!.value as forge.asn1.Asn1[]
+    const authSafeBytes = authSafeWrapper[0]!.value as string
+    const macData = pfx[2]!.value as forge.asn1.Asn1[]
+    const digestInfo = macData[0]!.value as forge.asn1.Asn1[]
+    const digestAlgorithm = digestInfo[0]!.value as forge.asn1.Asn1[]
+    const macSalt = forge.util.createBuffer(macData[1]!.value as string)
+    const md = forge.md.sha256.create()
+    const macKey = forge.pkcs12.generateKey(password, macSalt, 3, 2048, 32, md)
+    const mac = forge.hmac.create()
+    mac.start(md, macKey)
+    mac.update(authSafeBytes)
+    digestAlgorithm[0]!.value = forge.asn1.oidToDer(forge.pki.oids.sha256).getBytes()
+    digestInfo[1]!.value = mac.getMac().getBytes()
+  }
   const der = forge.asn1.toDer(p12Asn1).getBytes()
   const base64 = forge.util.encode64(der)
 

--- a/cli/test/prescan/helpers.ts
+++ b/cli/test/prescan/helpers.ts
@@ -72,8 +72,9 @@ export function makeP12(opts: {
     const digestInfo = macData[0]!.value as forge.asn1.Asn1[]
     const digestAlgorithm = digestInfo[0]!.value as forge.asn1.Asn1[]
     const macSalt = forge.util.createBuffer(macData[1]!.value as string)
+    const macIterations = forge.asn1.derToInteger(macData[2]!.value as string)
     const md = forge.md.sha256.create()
-    const macKey = forge.pkcs12.generateKey(password, macSalt, 3, 2048, 32, md)
+    const macKey = forge.pkcs12.generateKey(password, macSalt, 3, macIterations, 32, md)
     const mac = forge.hmac.create()
     mac.start(md, macKey)
     mac.update(authSafeBytes)


### PR DESCRIPTION
## Summary

- detect PKCS#12 files that use PBES2/AES encryption or a non-SHA-1 MAC
- report the finding as informational until 2026-08-17, then make it fatal
- explain the misleading macOS `security import` “wrong password” failure and how to re-export credentials
- cover legacy-compatible, AES-encrypted, SHA-256 MAC, malformed-file, registry, and rollout-boundary cases

## Why

The existing prescan only proves that the supplied password can parse the P12. Modern OpenSSL 3 / Python cryptography output can pass that check but still fail when Fastlane imports it into the macOS keychain.

## Validation

- `bun lint`
- `bun run cli:check`
- `bun test --coverage cli/test/prescan/checks-ios-certs.test.ts cli/test/prescan/engine.test.ts`

The full prescan suite reports 654 passing tests and 0 failures.
