### PR TITLE
fix(cli): classify App Store Connect prescan failures precisely

### DIFF
--- a/cli/src/build/onboarding/apple-access.ts
+++ b/cli/src/build/onboarding/apple-access.ts
@@ -67,7 +67,8 @@ function safeErrorField(value: unknown, credentialValues: string[]): string | un
 /**
  * Probe App Store Connect for app access. Never throws - every failure shape is
  * returned as `{ ok: false, kind }` so the prescan check can self-classify the
- * severity (auth-error -> error, no-app-access -> error, network -> info).
+ * severity from the HTTP status and sanitized Apple reason. Network failures
+ * remain distinguishable so prescan can surface them as warnings.
  */
 export async function assertAscAccess(opts: AssertAscAccessOptions): Promise<AscAccessResult> {
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis)

--- a/cli/src/build/onboarding/apple-access.ts
+++ b/cli/src/build/onboarding/apple-access.ts
@@ -46,8 +46,8 @@ interface AscProviderFailure {
 
 export type AscAccessResult
   = | { ok: true }
-    | { ok: false, kind: 'no-app-access' | 'auth-error' | 'network', message: string }
-      & AscProviderFailure
+    | ({ ok: false, kind: 'no-app-access' | 'auth-error' | 'network', message: string }
+      & AscProviderFailure)
 
 const NETWORKY_RE = /timeout|timed out|network|fetch failed|aborted|ENOTFOUND|EAI_AGAIN|ECONNRESET|ECONNREFUSED/i
 const MAX_ERROR_FIELD_LENGTH = 500

--- a/cli/src/build/onboarding/apple-access.ts
+++ b/cli/src/build/onboarding/apple-access.ts
@@ -11,6 +11,7 @@
 // Authorization header, or any credential field value - only Apple's
 // human-readable error copy (or the shared verifyApiKey wording).
 import { appendInternalLog, safeHeaders } from '../../support/internal-log.js'
+import { redactSecrets } from '../../support/redact.js'
 import {
   AppleApiHttpError,
   classifyAscAuthError,
@@ -35,11 +36,33 @@ export interface AssertAscAccessOptions {
   fetchImpl?: typeof fetch
 }
 
+interface AscProviderFailure {
+  /** Apple HTTP status and sanitized structured error fields, when available. */
+  status?: number
+  code?: string
+  title?: string
+  detail?: string
+}
+
 export type AscAccessResult
   = | { ok: true }
     | { ok: false, kind: 'no-app-access' | 'auth-error' | 'network', message: string }
+      & AscProviderFailure
 
 const NETWORKY_RE = /timeout|timed out|network|fetch failed|aborted|ENOTFOUND|EAI_AGAIN|ECONNRESET|ECONNREFUSED/i
+const MAX_ERROR_FIELD_LENGTH = 500
+
+function safeErrorField(value: unknown, credentialValues: string[]): string | undefined {
+  if (typeof value !== 'string')
+    return undefined
+  let safe = redactSecrets(value)
+  for (const credential of credentialValues) {
+    if (credential)
+      safe = safe.replaceAll(credential, '[REDACTED IDENTIFIER]')
+  }
+  safe = safe.replace(/\p{Cc}+/gu, ' ').replace(/\s+/g, ' ').trim()
+  return safe ? safe.slice(0, MAX_ERROR_FIELD_LENGTH) : undefined
+}
 
 /**
  * Probe App Store Connect for app access. Never throws - every failure shape is
@@ -93,10 +116,17 @@ export async function assertAscAccess(opts: AssertAscAccessOptions): Promise<Asc
         first?.code,
       )
       const cls = classifyAscAuthError(httpErr)
+      const credentialValues = [opts.keyId, opts.issuerId]
+      const providerFailure: AscProviderFailure = {
+        status: res.status,
+        code: safeErrorField(first?.code, credentialValues),
+        title: safeErrorField(first?.title, credentialValues),
+        detail: safeErrorField(first?.detail, credentialValues),
+      }
       if (cls.is401or403)
-        return { ok: false, kind: 'auth-error', message: cls.message }
-      // 5xx / 429 / other transport-ish HTTP: non-blocking info upstream.
-      return { ok: false, kind: 'network', message: `App Store Connect returned HTTP ${res.status}.` }
+        return { ok: false, kind: 'auth-error', message: cls.message, ...providerFailure }
+      // 5xx / 429 / other transport-ish HTTP: warning upstream.
+      return { ok: false, kind: 'network', message: `App Store Connect returned HTTP ${res.status}.`, ...providerFailure }
     }
 
     appendInternalLog(`apple-access GET ${path}: HTTP ${res.status} | ${safeHeaders(res.headers)}`)

--- a/cli/src/build/onboarding/apple-api.ts
+++ b/cli/src/build/onboarding/apple-api.ts
@@ -129,13 +129,13 @@ export interface AscAuthClassification {
 export function classifyAscAuthError(err: any): AscAuthClassification {
   const status = typeof err?.status === 'number' ? err.status : undefined
   const code = typeof err?.code === 'string' ? err.code : undefined
-  const is401 = status === 401 || err?.message?.includes('401')
-  const is403 = status === 403 || err?.message?.includes('403')
+  const is401 = status === 401
+  const is403 = status === 403
   const isAgreements = Boolean(is403 && (code === 'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED' || code === 'FORBIDDEN_ERROR.PLA_NOT_ACCEPTED' || /\bPLA_NOT_ACCEPTED\b|required agreement|program license agreement/i.test(err?.message ?? '')))
   return {
     is401or403: Boolean(is401 || is403),
     isAgreements,
-    status: status ?? (is403 ? 403 : is401 ? 401 : undefined),
+    status,
     code,
     message: isAgreements ? ASC_AGREEMENTS_MESSAGE : ASC_KEY_REJECTED_MESSAGE,
   }

--- a/cli/src/build/prescan/checks/store-access.ts
+++ b/cli/src/build/prescan/checks/store-access.ts
@@ -66,6 +66,58 @@ function isDefinitiveAuthFailure(result: Extract<AscAccessResult, { ok: false }>
     || ASC_AUTH_TEXT_RE.test(`${result.title ?? ''} ${result.detail ?? ''}`)
 }
 
+/** Classify an ASC auth result without depending on scan context or I/O. */
+export function classifyAscAuthFinding(result: Extract<AscAccessResult, { ok: false }>): Finding {
+  const reason = ascReason(result)
+  if (isAgreementFailure(result)) {
+    return {
+      id: 'ios/asc-key-access',
+      severity: 'error',
+      enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+      title: 'Apple requires an App Store Connect agreement (HTTP 403)',
+      detail: reason,
+      fix: 'Ask the Account Holder to accept pending agreements in App Store Connect → Business, then retry.',
+    }
+  }
+  if (isDefinitiveAuthFailure(result)) {
+    return {
+      id: 'ios/asc-key-access',
+      severity: 'error',
+      enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+      title: `App Store Connect authentication failed during preflight (HTTP ${result.status})`,
+      detail: reason,
+      fix: ASC_FIX,
+    }
+  }
+  if (result.status === 403) {
+    return {
+      id: 'ios/asc-key-access',
+      severity: 'warning',
+      title: 'Apple denied the App Store Connect preflight request (HTTP 403)',
+      detail: `${reason} This /v1/apps probe differs from the TestFlight upload path, so the build may still succeed.`,
+      fix: 'Review Apple\'s reason and confirm the key can access the target app. Use --fail-on-warnings only if this probe must be strict.',
+    }
+  }
+  if (result.status !== undefined) {
+    return {
+      id: 'ios/asc-key-access',
+      severity: 'warning',
+      title: `App Store Connect preflight returned HTTP ${result.status}`,
+      detail: reason,
+      fix: 'Retry the preflight. The build will still attempt the upload because this response does not prove the credentials are invalid.',
+    }
+  }
+  // A local signing failure has no HTTP status. It is definitive because the
+  // CLI could not construct a token from the supplied key material.
+  return {
+    id: 'ios/asc-key-access',
+    severity: 'error',
+    title: 'Could not authenticate the App Store Connect API key',
+    detail: reason,
+    fix: ASC_FIX,
+  }
+}
+
 /** Injectable validator type so tests can supply a fake without any network. */
 type PlayValidator = (opts: ValidateOptions) => Promise<ValidationResult>
 type AscAsserter = (opts: AssertAscAccessOptions) => Promise<AscAccessResult>
@@ -216,47 +268,8 @@ export function makeAscKeyAccess(asserter: AscAsserter): PrescanCheck {
         return []
 
       switch (result.kind) {
-        case 'auth-error': {
-          const reason = ascReason(result)
-          if (isAgreementFailure(result)) {
-            return [{
-              id: 'ios/asc-key-access',
-              severity: 'error',
-              enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
-              title: 'Apple requires an App Store Connect agreement (HTTP 403)',
-              detail: reason,
-              fix: 'Ask the Account Holder to accept pending agreements in App Store Connect → Business, then retry.',
-            }]
-          }
-          if (isDefinitiveAuthFailure(result)) {
-            return [{
-              id: 'ios/asc-key-access',
-              severity: 'error',
-              enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
-              title: `App Store Connect authentication failed during preflight (HTTP ${result.status})`,
-              detail: reason,
-              fix: ASC_FIX,
-            }]
-          }
-          if (result.status === 403) {
-            return [{
-              id: 'ios/asc-key-access',
-              severity: 'warning',
-              title: 'Apple denied the App Store Connect preflight request (HTTP 403)',
-              detail: `${reason} This /v1/apps probe differs from the TestFlight upload path, so the build may still succeed.`,
-              fix: 'Review Apple\'s reason and confirm the key can access the target app. Use --fail-on-warnings only if this probe must be strict.',
-            }]
-          }
-          // A local signing failure has no HTTP status. It is definitive because
-          // the CLI could not construct a token from the supplied key material.
-          return [{
-            id: 'ios/asc-key-access',
-            severity: 'error',
-            title: 'Could not authenticate the App Store Connect API key',
-            detail: reason,
-            fix: ASC_FIX,
-          }]
-        }
+        case 'auth-error':
+          return [classifyAscAuthFinding(result)]
         case 'no-app-access':
           // 2xx but the project bundle id is absent from /apps -> warning.
           return [{

--- a/cli/src/build/prescan/checks/store-access.ts
+++ b/cli/src/build/prescan/checks/store-access.ts
@@ -2,20 +2,21 @@
 //
 // Group C - remote store-access checks. They reach Google Play / App Store
 // Connect to confirm the upload credentials actually have access to the target
-// app BEFORE the build runs (fastlane's exact auth paths), turning a slow
-// upload-time failure into a fast prescan error.
+// app BEFORE the build runs. These probes use related store API endpoints, not
+// Fastlane's exact upload path, so endpoint-specific denials stay warnings.
 //
 // They are NOT marked `remote: true`: the engine's remote-skip predicate keys
 // off `ctx.supabase` (Capgo's backend), which is the wrong signal here. Instead
 // they gate on intent-to-upload via `appliesTo` (willUploadToPlay /
-// willUploadToAppStore) and self-classify offline/transport failures as `info`
-// so an offline scan degrades to non-blocking notices.
+// willUploadToAppStore) and self-classify offline/transport failures as warnings
+// so users see that verification did not complete without treating it as proof
+// that the upload itself will fail.
 //
 // SECRET-HANDLING (mandatory): PLAY_CONFIG_JSON / APPLE_KEY_CONTENT /
 // APPLE_KEY_ID / APPLE_ISSUER_ID raw values NEVER appear in Finding
 // title/detail/fix. The injected validators only surface safe copy (SA email,
-// package name, Apple's human-readable error wording); for token-error we keep
-// the finding terse and do not echo the validator message verbatim.
+// package name, sanitized Apple error fields); for Play token-error we keep the
+// finding terse and do not echo the validator message verbatim.
 import type { ValidateOptions, ValidationResult } from '../../onboarding/android/service-account-validation.js'
 import type { AscAccessResult, AssertAscAccessOptions } from '../../onboarding/apple-access.js'
 import type { Finding, PrescanCheck, ScanContext } from '../types'

--- a/cli/src/build/prescan/checks/store-access.ts
+++ b/cli/src/build/prescan/checks/store-access.ts
@@ -29,8 +29,41 @@ import { willUploadToAppStore, willUploadToPlay } from '../upload-intent'
 /** 7s per-request budget so the fetch aborts cleanly before the engine's 10s race. */
 const STORE_ACCESS_TIMEOUT_MS = 7000
 
+/** ASC authentication failures become build-blocking after a 14-day rollout. */
+export const ASC_PRESCAN_AUTH_ENFORCE_AFTER = '2026-08-17T00:00:00.000Z'
+
 const PLAY_FIX = 'Invite the service-account email in Play Console -> Users and permissions, then grant it release access for this app.'
 const ASC_FIX = 'App Store Connect rejected the API key - check the Key ID / Issuer ID / .p8 and that the key has Admin or Developer access (or sign the pending agreement).'
+const ASC_AGREEMENT_CODES = new Set([
+  'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED',
+  'FORBIDDEN_ERROR.PLA_NOT_ACCEPTED',
+])
+const ASC_AUTH_CODE_RE = /(?:^|[._-])(NOT_AUTHORIZED|UNAUTHORIZED|AUTHENTICATION(?:_ERROR)?|INVALID_(?:TOKEN|CREDENTIALS?))(?:$|[._-])/i
+const ASC_AUTH_TEXT_RE = /authentication credentials? (?:are )?(?:missing or invalid)|invalid (?:bearer )?token|token (?:is )?(?:invalid|expired)/i
+
+function ascReason(result: Extract<AscAccessResult, { ok: false }>): string {
+  const heading = [result.code ? `[${result.code}]` : '', result.title ?? ''].filter(Boolean).join(' ')
+  return [heading, result.detail].filter(Boolean).join(' - ') || result.message
+}
+
+function isAgreementFailure(result: Extract<AscAccessResult, { ok: false }>): boolean {
+  return Boolean(
+    result.status === 403
+    && (
+      (result.code && ASC_AGREEMENT_CODES.has(result.code))
+      || /\bPLA_NOT_ACCEPTED\b|required agreement|program license agreement/i.test(`${result.code ?? ''} ${result.title ?? ''} ${result.detail ?? ''}`)
+    ),
+  )
+}
+
+function isDefinitiveAuthFailure(result: Extract<AscAccessResult, { ok: false }>): boolean {
+  if (result.status === 401)
+    return true
+  if (result.status !== 403)
+    return false
+  return ASC_AUTH_CODE_RE.test(result.code ?? '')
+    || ASC_AUTH_TEXT_RE.test(`${result.title ?? ''} ${result.detail ?? ''}`)
+}
 
 /** Injectable validator type so tests can supply a fake without any network. */
 type PlayValidator = (opts: ValidateOptions) => Promise<ValidationResult>
@@ -182,16 +215,47 @@ export function makeAscKeyAccess(asserter: AscAsserter): PrescanCheck {
         return []
 
       switch (result.kind) {
-        case 'auth-error':
-          // 401/403 incl. the agreements branch. The helper's message reuses
-          // verifyApiKey's copy (no credential material).
+        case 'auth-error': {
+          const reason = ascReason(result)
+          if (isAgreementFailure(result)) {
+            return [{
+              id: 'ios/asc-key-access',
+              severity: 'error',
+              enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+              title: 'Apple requires an App Store Connect agreement (HTTP 403)',
+              detail: reason,
+              fix: 'Ask the Account Holder to accept pending agreements in App Store Connect → Business, then retry.',
+            }]
+          }
+          if (isDefinitiveAuthFailure(result)) {
+            return [{
+              id: 'ios/asc-key-access',
+              severity: 'error',
+              enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+              title: `App Store Connect authentication failed during preflight (HTTP ${result.status})`,
+              detail: reason,
+              fix: ASC_FIX,
+            }]
+          }
+          if (result.status === 403) {
+            return [{
+              id: 'ios/asc-key-access',
+              severity: 'warning',
+              title: 'Apple denied the App Store Connect preflight request (HTTP 403)',
+              detail: `${reason} This /v1/apps probe differs from the TestFlight upload path, so the build may still succeed.`,
+              fix: 'Review Apple\'s reason and confirm the key can access the target app. Use --fail-on-warnings only if this probe must be strict.',
+            }]
+          }
+          // A local signing failure has no HTTP status. It is definitive because
+          // the CLI could not construct a token from the supplied key material.
           return [{
             id: 'ios/asc-key-access',
             severity: 'error',
-            title: 'App Store Connect rejected the API key',
-            detail: result.message,
+            title: 'Could not authenticate the App Store Connect API key',
+            detail: reason,
             fix: ASC_FIX,
           }]
+        }
         case 'no-app-access':
           // 2xx but the project bundle id is absent from /apps -> warning.
           return [{
@@ -204,9 +268,13 @@ export function makeAscKeyAccess(asserter: AscAsserter): PrescanCheck {
         case 'network':
           return [{
             id: 'ios/asc-key-access',
-            severity: 'info',
-            title: 'Could not verify App Store Connect access (network error or timeout)',
-            detail: 'The build will still attempt the upload; this check is best-effort and skipped offline.',
+            severity: 'warning',
+            title: result.status
+              ? `App Store Connect preflight returned HTTP ${result.status}`
+              : 'Could not verify App Store Connect access (network error or timeout)',
+            detail: result.status
+              ? `${ascReason(result)} The build will still attempt the upload.`
+              : 'The build will still attempt the upload; retry when network access is available.',
           }]
         default:
           return []

--- a/cli/test/prescan/apple-access.test.ts
+++ b/cli/test/prescan/apple-access.test.ts
@@ -139,4 +139,25 @@ describe('assertAscAccess', () => {
       expect(res.message.toLowerCase()).not.toContain('bearer')
     }
   })
+
+  it('redacts credential identifiers and secret-looking values from Apple error fields', async () => {
+    const fetchImpl = (async () => jsonResponse(403, {
+      errors: [{
+        status: '403',
+        code: 'FORBIDDEN',
+        title: `Key ${creds.keyId} was denied`,
+        detail: `issuer ${creds.issuerId}\ntoken=super-secret-value`,
+      }],
+    })) as unknown as typeof fetch
+    const res = await assertAscAccess({ ...creds, fetchImpl })
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      const serialized = JSON.stringify(res)
+      expect(serialized).not.toContain(creds.keyId)
+      expect(serialized).not.toContain(creds.issuerId)
+      expect(serialized).not.toContain('super-secret-value')
+      expect(res.title).toContain('[REDACTED IDENTIFIER]')
+      expect(res.detail).not.toContain('\n')
+    }
+  })
 })

--- a/cli/test/prescan/apple-access.test.ts
+++ b/cli/test/prescan/apple-access.test.ts
@@ -114,6 +114,19 @@ describe('assertAscAccess', () => {
     }
   })
 
+  it('does not infer auth failure from 403 text on an HTTP 500 response', async () => {
+    const fetchImpl = (async () => jsonResponse(500, {
+      errors: [{ status: '500', code: 'INTERNAL_ERROR', title: 'Upstream HTTP 403', detail: 'Retry later.' }],
+    })) as unknown as typeof fetch
+    const res = await assertAscAccess({ ...creds, bundleId: 'com.demo.app', fetchImpl })
+    expect(res).toMatchObject({
+      ok: false,
+      kind: 'network',
+      status: 500,
+      code: 'INTERNAL_ERROR',
+    })
+  })
+
   it('network when the provided signal is already aborted (no fetch fires)', async () => {
     let fetchCalled = false
     const fetchImpl = (async () => {

--- a/cli/test/prescan/apple-access.test.ts
+++ b/cli/test/prescan/apple-access.test.ts
@@ -53,16 +53,30 @@ describe('assertAscAccess', () => {
     const fetchImpl = (async () => jsonResponse(401, { errors: [{ status: '401', code: 'NOT_AUTHORIZED', title: 'Authentication failed', detail: 'bad token' }] })) as unknown as typeof fetch
     const res = await assertAscAccess({ ...creds, bundleId: 'com.demo.app', fetchImpl })
     expect(res.ok).toBe(false)
-    if (!res.ok)
+    if (!res.ok) {
       expect(res.kind).toBe('auth-error')
+      expect(res).toMatchObject({
+        status: 401,
+        code: 'NOT_AUTHORIZED',
+        title: 'Authentication failed',
+        detail: 'bad token',
+      })
+    }
   })
 
   it('auth-error on 403', async () => {
     const fetchImpl = (async () => jsonResponse(403, { errors: [{ status: '403', code: 'FORBIDDEN', title: 'Forbidden', detail: 'no access' }] })) as unknown as typeof fetch
     const res = await assertAscAccess({ ...creds, fetchImpl })
     expect(res.ok).toBe(false)
-    if (!res.ok)
+    if (!res.ok) {
       expect(res.kind).toBe('auth-error')
+      expect(res).toMatchObject({
+        status: 403,
+        code: 'FORBIDDEN',
+        title: 'Forbidden',
+        detail: 'no access',
+      })
+    }
   })
 
   it('auth-error on 403 agreements branch (REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED) with agreements copy', async () => {
@@ -89,8 +103,15 @@ describe('assertAscAccess', () => {
     const fetchImpl = (async () => jsonResponse(503, { errors: [{ status: '503', code: 'X', title: 'Service Unavailable', detail: 'down' }] })) as unknown as typeof fetch
     const res = await assertAscAccess({ ...creds, fetchImpl })
     expect(res.ok).toBe(false)
-    if (!res.ok)
+    if (!res.ok) {
       expect(res.kind).toBe('network')
+      expect(res).toMatchObject({
+        status: 503,
+        code: 'X',
+        title: 'Service Unavailable',
+        detail: 'down',
+      })
+    }
   })
 
   it('network when the provided signal is already aborted (no fetch fires)', async () => {

--- a/cli/test/prescan/checks-store-access.test.ts
+++ b/cli/test/prescan/checks-store-access.test.ts
@@ -12,6 +12,7 @@ import { generateKeyPairSync } from 'node:crypto'
 import { describe, expect, it } from 'bun:test'
 import forge from 'node-forge'
 import {
+  ASC_PRESCAN_AUTH_ENFORCE_AFTER,
   makeAscKeyAccess,
   makePlaySaAccess,
   playSaAccess,
@@ -299,18 +300,65 @@ describe('ios/asc-key-access', () => {
     expect(received!.bundleId).toBe('com.demo.app')
   })
 
-  it('auth-error -> error (reuses helper message)', async () => {
+  it('HTTP 401 -> deferred error with Apple reason and a 14-day deadline', async () => {
     const fakeAssert = async (): Promise<AscAccessResult> => ({
       ok: false,
       kind: 'auth-error',
-      message: 'API key verification failed. Please check the Key ID / Issuer ID / .p8.',
+      message: 'API key verification failed.',
+      status: 401,
+      code: 'NOT_AUTHORIZED',
+      title: 'Authentication credentials are missing or invalid.',
+      detail: 'Provide a properly configured bearer token.',
     })
     const check = makeAscKeyAccess(fakeAssert)
     const findings = await check.run(iosCtx())
     expect(findings.length).toBe(1)
     expect(findings[0]!.severity).toBe('error')
     expect(findings[0]!.id).toBe('ios/asc-key-access')
-    expect(findings[0]!.detail).toContain('verification failed')
+    expect(findings[0]!.title).toContain('HTTP 401')
+    expect(findings[0]!.detail).toContain('NOT_AUTHORIZED')
+    expect(findings[0]!.detail).toContain('properly configured bearer token')
+    expect(findings[0]!.enforceAfter).toBe(ASC_PRESCAN_AUTH_ENFORCE_AFTER)
+    expect(ASC_PRESCAN_AUTH_ENFORCE_AFTER).toBe('2026-08-17T00:00:00.000Z')
+  })
+
+  it('known agreement HTTP 403 -> deferred error with targeted guidance', async () => {
+    const fakeAssert = async (): Promise<AscAccessResult> => ({
+      ok: false,
+      kind: 'auth-error',
+      message: 'Apple requires an agreement.',
+      status: 403,
+      code: 'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED',
+      title: 'A required agreement is missing.',
+      detail: 'The Account Holder must accept the agreement.',
+    })
+    const findings = await makeAscKeyAccess(fakeAssert).run(iosCtx())
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+    })
+    expect(findings[0]!.title).toContain('HTTP 403')
+    expect(findings[0]!.detail).toContain('REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED')
+    expect(findings[0]!.fix).toContain('Account Holder')
+  })
+
+  it('unknown HTTP 403 -> warning with Apple reason because the probe differs from upload', async () => {
+    const fakeAssert = async (): Promise<AscAccessResult> => ({
+      ok: false,
+      kind: 'auth-error',
+      message: 'API key verification failed.',
+      status: 403,
+      code: 'FORBIDDEN.SOME_NEW_REASON',
+      title: 'This operation is forbidden.',
+      detail: 'The caller cannot list this resource.',
+    })
+    const findings = await makeAscKeyAccess(fakeAssert).run(iosCtx())
+    expect(findings[0]!.severity).toBe('warning')
+    expect(findings[0]!.title).toContain('HTTP 403')
+    expect(findings[0]!.detail).toContain('FORBIDDEN.SOME_NEW_REASON')
+    expect(findings[0]!.detail).toContain('cannot list this resource')
+    expect(findings[0]!.detail).toContain('differs from the TestFlight upload path')
+    expect(findings[0]!.enforceAfter).toBeUndefined()
   })
 
   it('no-app-access (2xx but bundle id absent) -> warning', async () => {
@@ -325,7 +373,7 @@ describe('ios/asc-key-access', () => {
     expect(findings[0]!.severity).toBe('warning')
   })
 
-  it('network -> info (offline degrades to non-blocking)', async () => {
+  it('network/timeout -> warning', async () => {
     const fakeAssert = async (): Promise<AscAccessResult> => ({
       ok: false,
       kind: 'network',
@@ -334,7 +382,24 @@ describe('ios/asc-key-access', () => {
     const check = makeAscKeyAccess(fakeAssert)
     const findings = await check.run(iosCtx())
     expect(findings.length).toBe(1)
-    expect(findings[0]!.severity).toBe('info')
+    expect(findings[0]!.severity).toBe('warning')
+  })
+
+  it('HTTP 5xx -> warning with the sanitized Apple reason', async () => {
+    const fakeAssert = async (): Promise<AscAccessResult> => ({
+      ok: false,
+      kind: 'network',
+      message: 'App Store Connect returned HTTP 503.',
+      status: 503,
+      code: 'SERVICE_UNAVAILABLE',
+      title: 'Service unavailable',
+      detail: 'Try again later.',
+    })
+    const findings = await makeAscKeyAccess(fakeAssert).run(iosCtx())
+    expect(findings[0]!.severity).toBe('warning')
+    expect(findings[0]!.title).toContain('HTTP 503')
+    expect(findings[0]!.detail).toContain('SERVICE_UNAVAILABLE')
+    expect(findings[0]!.detail).toContain('Try again later')
   })
 
   it('skips cleanly (no finding) when APPLE_KEY_CONTENT does not decode to a PEM', async () => {

--- a/cli/test/prescan/checks-store-access.test.ts
+++ b/cli/test/prescan/checks-store-access.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from 'bun:test'
 import forge from 'node-forge'
 import {
   ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+  classifyAscAuthFinding,
   makeAscKeyAccess,
   makePlaySaAccess,
   playSaAccess,
@@ -400,6 +401,23 @@ describe('ios/asc-key-access', () => {
     expect(findings[0]!.title).toContain('HTTP 503')
     expect(findings[0]!.detail).toContain('SERVICE_UNAVAILABLE')
     expect(findings[0]!.detail).toContain('Try again later')
+  })
+
+  it('classifies a non-auth HTTP status independently without losing its status', () => {
+    const finding = classifyAscAuthFinding({
+      ok: false,
+      kind: 'auth-error',
+      message: 'Upstream mentioned HTTP 403 while returning HTTP 500.',
+      status: 500,
+      code: 'INTERNAL_ERROR',
+      title: 'Internal error',
+      detail: 'Retry later.',
+    })
+    expect(finding).toMatchObject({
+      severity: 'warning',
+      title: 'App Store Connect preflight returned HTTP 500',
+    })
+    expect(finding.detail).toContain('INTERNAL_ERROR')
   })
 
   it('skips cleanly (no finding) when APPLE_KEY_CONTENT does not decode to a PEM', async () => {

--- a/cli/test/prescan/command.test.ts
+++ b/cli/test/prescan/command.test.ts
@@ -2,6 +2,7 @@
 import type { Finding, PrescanReport, Severity } from '../../src/build/prescan/types'
 import { describe, expect, it } from 'bun:test'
 import { exitCodeFor, runPrescanGate, validateFlags } from '../../src/build/prescan/command'
+import { ASC_PRESCAN_AUTH_ENFORCE_AFTER } from '../../src/build/prescan/checks/store-access'
 import { IOS_PRESCAN_EXPANSION_ENFORCE_AFTER } from '../../src/build/prescan/registry'
 
 describe('validateFlags', () => {
@@ -30,6 +31,16 @@ describe('exitCodeFor', () => {
       enforceAfter: IOS_PRESCAN_EXPANSION_ENFORCE_AFTER,
     }]
     expect(exitCodeFor(counts(1, 0), { now: new Date('2026-08-01T00:00:00.000Z') }, findings)).toBe(0)
+  })
+  it('ASC auth finding becomes blocking exactly at the rollout deadline', () => {
+    const findings: Finding[] = [{
+      id: 'ios/asc-key-access',
+      severity: 'error',
+      title: 'authentication failed',
+      enforceAfter: ASC_PRESCAN_AUTH_ENFORCE_AFTER,
+    }]
+    expect(exitCodeFor(counts(1, 0), { now: new Date('2026-08-16T23:59:59.999Z') }, findings)).toBe(0)
+    expect(exitCodeFor(counts(1, 0), { now: new Date(ASC_PRESCAN_AUTH_ENFORCE_AFTER) }, findings)).toBe(1)
   })
 })
 


### PR DESCRIPTION
## Summary

- preserve sanitized App Store Connect status, code, title, and detail in the iOS prescan
- treat HTTP 401 and recognized blocking HTTP 403 responses as deferred errors with a 14-day grace period ending 2026-08-17 00:00 UTC
- report unknown or endpoint-specific HTTP 403 responses, network failures, timeouts, and 5xx responses as warnings instead of incorrectly claiming the API key is invalid

## Root cause

The prescan collapsed nearly every App Store Connect HTTP 401/403 response into a generic “API key rejected” error and blocked builds, even though its `/v1/apps` probe differs from the real Fastlane/TestFlight upload path. This produced false negatives for credentials that successfully shipped builds to TestFlight.

## User impact

Apple’s sanitized structured reason is now visible. Definitive authentication and agreement failures remain visibly critical but non-blocking during the rollout window, then become fatal at the deadline. Ambiguous endpoint-specific denials and transient service failures remain warnings, with `--fail-on-warnings` available for strict CI.

## Validation

- `bun run cli:check`
- focused ASC/prescan regression suite: 58 passing tests
- full prescan suite: 651 passing tests
- independent code review: no critical or important findings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple App Store Connect access error handling with clearer status and reason details.
  * Sensitive credentials, token-like values, and control characters are now removed from displayed error messages.
  * Network, timeout, and server errors are reported as warnings with safer diagnostic information.
  * Apple agreement issues, invalid credentials, and other authorization failures are now distinguished more accurately.

* **Behavior Changes**
  * Authentication checks remain non-blocking until August 17, 2026, then become enforceable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->