### PR TITLE
fix(frontend): restore typecheck on main for OnboardingSupportUsernames

### DIFF
--- a/src/components/dashboard/OnboardingSupportUsernames.vue
+++ b/src/components/dashboard/OnboardingSupportUsernames.vue
@@ -26,9 +26,9 @@ const props = withDefaults(defineProps<{
 const discordUsername = defineModel<string>('discordUsername', { required: true })
 
 const { t } = useI18n()
-const githubDialog = useTemplateRef('githubDialog')
+const githubDialog = useTemplateRef<InstanceType<typeof GitHubProfileDialog>>('githubDialog')
 
-const githubUsername = computed(() => unref(githubDialog.value?.githubUsername) ?? '')
+const githubUsername = computed((): string => unref(githubDialog.value?.githubUsername) ?? '')
 
 const supportBenefits = computed(() => [
   { icon: IconBadgeCheck, label: t('organization-onboarding-support-benefit-match') },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Fix `vue-tsc` circular inference failures in `OnboardingSupportUsernames.vue` that broke the Lint and typecheck job on `main`
- Explicitly type the `GitHubProfileDialog` template ref as `InstanceType<typeof GitHubProfileDialog>`
- Annotate the `githubUsername` computed return type as `string`

## Motivation (AI generated)

CI run on `main` after #2832 failed at `test / Lint and typecheck` with TS7022/TS7024 circular-type errors around `githubDialog` and `githubUsername`. That blocks releases that need Capgo typecheck.

## Business Impact (AI generated)

Restores a green typecheck gate on `main` so release bumps and frontend merges are not blocked by a typing cycle introduced with onboarding support usernames.

## Test Plan (AI generated)

- [x] `bun run typecheck:frontend` passes
- [x] `bun run typecheck` passes (CLI + backend + frontend)
- [ ] Confirm CI `Lint and typecheck` job is green on this PR

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc7e7-32df-7abf-9e62-630c97942f36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc7e7-32df-7abf-9e62-630c97942f36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript typing for GitHub profile information.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->