### PR TITLE
fix(cli): hide ignored prescan fatal deadlines

### DIFF
--- a/cli/src/build/prescan/command.ts
+++ b/cli/src/build/prescan/command.ts
@@ -94,7 +94,7 @@ export async function prescanCommand(appId: string | undefined, options: Prescan
     console.log(renderJsonReport(report))
   }
   else {
-    log.message(renderTerminalReport(report, { verbose: options.verbose, now: options.now }))
+    log.message(renderTerminalReport(report, { verbose: options.verbose, now: options.now, ignoreFatal: options.ignoreFatal }))
     const outcome = decideOutcome(report, options)
     outro(outcome === 'block' ? 'Prescan found blocking problems — fix them before building.' : 'Prescan finished.')
   }
@@ -171,7 +171,7 @@ export async function runPrescanGate(
     return { decision: 'proceed', report: null, crashed: true, informationOnlyFindings: 0 }
   }
   if (report.findings.length > 0)
-    print(renderTerminalReport(report, { now: opts.now }))
+    print(renderTerminalReport(report, { now: opts.now, ignoreFatal: opts.ignoreFatal }))
   const outcome = decideOutcome(report, { ignoreFatal: opts.ignoreFatal, failOnWarnings: opts.failOnWarnings, now: opts.now })
   let decision: 'proceed' | 'block'
   if (outcome === 'ask')

--- a/cli/src/build/prescan/report.ts
+++ b/cli/src/build/prescan/report.ts
@@ -56,6 +56,7 @@ export function renderTerminalReport(report: PrescanReport, opts: { verbose?: bo
   const summaryCodes = error > 0 ? ANSI.red : warning > 0 ? ANSI.yellow : ANSI.dim
   lines.push(paint(summaryCodes, summary))
   const deferred = informationOnlyFindings(report, now)
+    .filter(finding => !(opts.ignoreFatal && finding.severity === 'error'))
   if (deferred.length > 0)
     lines.push(paint(ANSI.dim, `rollout: ${deferred.length} finding(s) are information only until their enforcement deadline`))
   if (opts.verbose)

--- a/cli/src/build/prescan/report.ts
+++ b/cli/src/build/prescan/report.ts
@@ -19,7 +19,7 @@ function colorEnabledByDefault(): boolean {
   return Boolean(stdout.isTTY) && !env.NO_COLOR
 }
 
-export function renderTerminalReport(report: PrescanReport, opts: { verbose?: boolean, color?: boolean, now?: Date } = {}): string {
+export function renderTerminalReport(report: PrescanReport, opts: { verbose?: boolean, color?: boolean, now?: Date, ignoreFatal?: boolean } = {}): string {
   const enabled = opts.color ?? colorEnabledByDefault()
   const now = opts.now ?? new Date()
   // Wrap whole semantic units only (badge / id / detail / fix / summary) so substring
@@ -40,7 +40,7 @@ export function renderTerminalReport(report: PrescanReport, opts: { verbose?: bo
         lines.push(paint(ANSI.dim, `         fix: ${f.fix}`))
       if (f.docsUrl)
         lines.push(paint(ANSI.dim, `         docs: ${f.docsUrl}`))
-      if (informationOnly && f.enforceAfter) {
+      if (informationOnly && f.enforceAfter && !(opts.ignoreFatal && sev === 'error')) {
         const impact = sev === 'error'
           ? 'this critical finding is information only now and will fail builds'
           : 'this finding is information only now and can affect build outcomes'

--- a/cli/test/prescan/command.test.ts
+++ b/cli/test/prescan/command.test.ts
@@ -109,9 +109,11 @@ describe('runPrescanGate', () => {
       now: new Date('2026-08-01T00:00:00.000Z'),
       print: message => printed.push(message),
     }, async () => report)
+    const output = printed.join('\n')
     expect(r.decision).toBe('proceed')
-    expect(printed.join('\n')).toContain('CRITICAL — INFORMATION ONLY')
-    expect(printed.join('\n')).not.toContain('will fail builds starting 2026-08-14 00:00 UTC')
+    expect(output).toContain('CRITICAL — INFORMATION ONLY')
+    expect(output).not.toContain('will fail builds starting 2026-08-14 00:00 UTC')
+    expect(output).not.toContain('rollout:')
   })
   it('proceeds (non-interactive) on warnings', async () => {
     const r = await runPrescanGate({ enabled: true, interactive: false, silent: true }, async () => fakeReport(0, 1))

--- a/cli/test/prescan/command.test.ts
+++ b/cli/test/prescan/command.test.ts
@@ -99,6 +99,20 @@ describe('runPrescanGate', () => {
     const r = await runPrescanGate({ enabled: true, ignoreFatal: true, silent: true }, async () => fakeReport(1, 0))
     expect(r.decision).toBe('proceed')
   })
+  it('hides deferred critical rollout deadlines with ignoreFatal', async () => {
+    const printed: string[] = []
+    const report = fakeReport(1, 0)
+    report.findings[0].enforceAfter = IOS_PRESCAN_EXPANSION_ENFORCE_AFTER
+    const r = await runPrescanGate({
+      enabled: true,
+      ignoreFatal: true,
+      now: new Date('2026-08-01T00:00:00.000Z'),
+      print: message => printed.push(message),
+    }, async () => report)
+    expect(r.decision).toBe('proceed')
+    expect(printed.join('\n')).toContain('CRITICAL — INFORMATION ONLY')
+    expect(printed.join('\n')).not.toContain('will fail builds starting 2026-08-14 00:00 UTC')
+  })
   it('proceeds (non-interactive) on warnings', async () => {
     const r = await runPrescanGate({ enabled: true, interactive: false, silent: true }, async () => fakeReport(0, 1))
     expect(r.decision).toBe('proceed')


### PR DESCRIPTION
## Summary

- suppress deferred critical rollout deadline sentences when fatal prescan findings are explicitly ignored
- keep the critical finding, information-only badge, summary, and machine-readable enforcement deadline intact
- add regression coverage for the `--prescan-ignore-fatal` build-request path

## Why

When `--prescan-ignore-fatal` is set, the build will proceed regardless of fatal prescan findings. Showing that an information-only critical finding “will fail builds” at its rollout deadline is therefore misleading for that invocation.

## Validation

- `bun lint`
- `bun run cli:check` (lint, typecheck, build, full CLI tests; prescan suite: 655 passed, 0 failed)
- RED/GREEN regression: `bun test cli/test/prescan/command.test.ts cli/test/prescan/report.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated terminal prescan and build-gate reports to accurately reflect fatal-finding bypass behavior.
  * When fatal findings are ignored, critical deferred findings no longer display misleading future build-failure deadlines.

* **Tests**
  * Added coverage confirming gates proceed correctly while still displaying critical finding information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->