### PR TITLE
fix(cli): scope CocoaPods prescan checks to macOS

### DIFF
--- a/cli/src/build/prescan/checks/ios-pods-assets.ts
+++ b/cli/src/build/prescan/checks/ios-pods-assets.ts
@@ -53,6 +53,10 @@ function hasPodfile(ctx: ScanContext): boolean {
   return existsSync(podfilePath(ctx.projectDir))
 }
 
+function hasMacOSPodfile(ctx: ScanContext): boolean {
+  return ctx.hostPlatform === 'darwin' && hasPodfile(ctx)
+}
+
 function hasPackageSwift(ctx: ScanContext): boolean {
   return existsSync(packageSwiftPath(ctx.projectDir))
 }
@@ -84,7 +88,7 @@ function uploading(ctx: ScanContext): boolean {
 export const podsNotInstalled: PrescanCheck = {
   id: 'ios/pods-not-installed',
   platforms: ['ios'],
-  appliesTo: hasPodfile,
+  appliesTo: hasMacOSPodfile,
   async run(ctx): Promise<Finding[]> {
     const appDir = join(ctx.projectDir, 'ios', 'App')
     const podsDir = existsSync(join(appDir, 'Pods'))
@@ -112,7 +116,7 @@ export const podsNotInstalled: PrescanCheck = {
 export const podsLockMissing: PrescanCheck = {
   id: 'ios/pods-lock-missing',
   platforms: ['ios'],
-  appliesTo: hasPodfile,
+  appliesTo: hasMacOSPodfile,
   async run(ctx): Promise<Finding[]> {
     if (readTextIfExists(join(ctx.projectDir, 'ios', 'App', 'Podfile.lock')) !== null)
       return []

--- a/cli/src/build/prescan/context.ts
+++ b/cli/src/build/prescan/context.ts
@@ -34,6 +34,7 @@ export async function buildScanContext(args: BuildScanContextArgs): Promise<Scan
   return {
     appId,
     platform: args.platform,
+    hostPlatform: process.platform,
     projectDir: args.projectDir,
     config,
     credentials,

--- a/cli/src/build/prescan/types.ts
+++ b/cli/src/build/prescan/types.ts
@@ -25,6 +25,8 @@ export interface Finding {
 export interface ScanContext {
   appId: string
   platform: Platform
+  /** Operating system running the prescan, used for host-specific local checks. */
+  hostPlatform: NodeJS.Platform
   projectDir: string
   config?: CapacitorConfig
   /** merged credentials, env-var style keys (BUILD_CERTIFICATE_BASE64, ANDROID_KEYSTORE_FILE, ...) */

--- a/cli/test/prescan/checks-ios-pods-assets.test.ts
+++ b/cli/test/prescan/checks-ios-pods-assets.test.ts
@@ -160,6 +160,11 @@ function cleanPodsFiles(extra: Record<string, string> = {}): Record<string, stri
 // ---------------------------------------------------------------------------
 
 describe('ios/pods-not-installed', () => {
+  it.each(['win32', 'linux'] as const)('does NOT apply on %s', (hostPlatform) => {
+    const ctx = makeCtx({ projectDir: makeProject(cleanPodsFiles()), hostPlatform })
+    expect(podsNotInstalled.appliesTo?.(ctx) ?? true).toBe(false)
+  })
+
   it('does NOT apply to an SPM project (no Podfile)', () => {
     const ctx = makeCtx({ projectDir: makeProject(cleanSpmFiles()) })
     expect(podsNotInstalled.appliesTo?.(ctx) ?? true).toBe(false)
@@ -190,6 +195,11 @@ describe('ios/pods-not-installed', () => {
 })
 
 describe('ios/pods-lock-missing', () => {
+  it.each(['win32', 'linux'] as const)('does NOT apply on %s', (hostPlatform) => {
+    const ctx = makeCtx({ projectDir: makeProject(cleanPodsFiles()), hostPlatform })
+    expect(podsLockMissing.appliesTo?.(ctx) ?? true).toBe(false)
+  })
+
   it('is clean when Podfile.lock exists', async () => {
     const ctx = makeCtx({ projectDir: makeProject(cleanPodsFiles()) })
     expect(await podsLockMissing.run(ctx)).toEqual([])

--- a/cli/test/prescan/helpers.ts
+++ b/cli/test/prescan/helpers.ts
@@ -17,7 +17,7 @@ export function makeProject(files: Record<string, string>): string {
 }
 
 export function makeCtx(partial: Partial<ScanContext> & { projectDir: string }): ScanContext {
-  return { appId: 'com.demo.app', platform: 'ios', ...partial }
+  return { appId: 'com.demo.app', platform: 'ios', hostPlatform: 'darwin', ...partial }
 }
 
 export interface MadeP12 {


### PR DESCRIPTION
## What changed

- record the prescan host operating system in `ScanContext`
- run `ios/pods-not-installed` and `ios/pods-lock-missing` only on macOS hosts with a Podfile
- add regression coverage proving both checks are skipped on Windows and Linux

## Why

Windows and Linux users rely on Capgo Cloud Build because CocoaPods cannot run locally. The cloud builder already runs `pod install`, so warning these users to generate and commit CocoaPods outputs is not actionable. macOS users retain the existing local-project diagnostics.

## Validation

- `bun lint`
- `bun run cli:check`
- full CLI prescan suite: 658 passed, 0 failed

## TDD evidence

- RED: four new Windows/Linux assertions failed before the fix
- GREEN: the focused suite passed 41/41 after the macOS gate

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

